### PR TITLE
Fix - parse bkey string with long type, instead of int type.

### DIFF
--- a/src/main/java/net/spy/memcached/collection/BTreeGetByPosition.java
+++ b/src/main/java/net/spy/memcached/collection/BTreeGetByPosition.java
@@ -102,7 +102,7 @@ public class BTreeGetByPosition<T> extends CollectionGet<T> {
 		if (splited[BKEY].startsWith("0x")) {
 			this.bkey = new BKeyObject(splited[0].substring(2));
 		} else {
-			this.bkey = new BKeyObject(Integer.parseInt(splited[0]));
+			this.bkey = new BKeyObject(Long.parseLong(splited[0]));
 		}
 
 		// <eflag> or <bytes>

--- a/src/main/java/net/spy/memcached/collection/BTreeStoreAndGet.java
+++ b/src/main/java/net/spy/memcached/collection/BTreeStoreAndGet.java
@@ -87,7 +87,7 @@ public class BTreeStoreAndGet<T> extends BTreeStore<T> {
 		if (splited[BKEY].startsWith("0x")) {
 			this.bkeyObject = new BKeyObject(splited[0].substring(2));
 		} else {
-			this.bkeyObject = new BKeyObject(Integer.parseInt(splited[0]));
+			this.bkeyObject = new BKeyObject(Long.parseLong(splited[0]));
 		}
 
 		// <eflag> or <bytes>

--- a/src/test/manual/net/spy/memcached/collection/btree/BopGetByPositionTest.java
+++ b/src/test/manual/net/spy/memcached/collection/btree/BopGetByPositionTest.java
@@ -34,8 +34,11 @@ public class BopGetByPositionTest extends BaseIntegrationTest {
 	private String invalidKey = "InvalidBopGetByPositionTest";
 	private String kvKey = "KvBopGetByPositionTest";
 
-	private long[] longBkeys = { 10L, 11L, 12L, 13L, 14L, 15L, 16L, 17L, 18L,
-			19L };
+	/* bkey values larger than maximum value of 4 bytes integer */
+	private long[] longBkeys = { 9000000000L,
+			9000000001L, 9000000002L, 9000000003L,
+			9000000004L, 9000000005L, 9000000006L,
+			9000000007L, 9000000008L, 9000000009L };
 	private byte[][] byteArrayBkeys = { new byte[] { 10 }, new byte[] { 11 },
 			new byte[] { 12 }, new byte[] { 13 }, new byte[] { 14 },
 			new byte[] { 15 }, new byte[] { 16 }, new byte[] { 17 },


### PR DESCRIPTION
Only following operations have this bkey parsing problem.
- b+tree getbyposition
- b+tree storeandget
