### PR TITLE
Throw AdminConnectTimeoutException if connecting to arcus admin timed out.

### DIFF
--- a/src/main/java/net/spy/memcached/AdminConnectTimeoutException.java
+++ b/src/main/java/net/spy/memcached/AdminConnectTimeoutException.java
@@ -1,0 +1,27 @@
+/*
+ * arcus-java-client : Arcus Java client
+ * Copyright 2014 JaM2in Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.spy.memcached;
+
+public class AdminConnectTimeoutException extends RuntimeException {
+	
+	private static final long serialVersionUID = -1461409015284668293L;
+
+	public AdminConnectTimeoutException(String message) {
+		super(message);
+	}
+	
+}

--- a/src/main/java/net/spy/memcached/CacheManager.java
+++ b/src/main/java/net/spy/memcached/CacheManager.java
@@ -52,7 +52,7 @@ public class CacheManager extends SpyThread implements Watcher,
 
 	private static final int SESSION_TIMEOUT = 15000;
 	
-	private static final long ZK_CONNECT_TIMEOUT = 2000L;
+	private static final long ZK_CONNECT_TIMEOUT = 5000L;
 
 	private final String hostPort;
 


### PR DESCRIPTION
Arcus java client 시작 시에, 
Arcus admin인 ZK 연결 요청이 connect timeout(2초)안에 완료되지 않으면,
AdminConnectTimeoutException이 발생하도록 하였습니다.
따라서, 사용자가 현재의 이슈 상황을 정확히 이해할 수 있게 됩니다.
