### PR TITLE
modify that next index will be processed when bulk and pipe opeartion moved by switchover

### DIFF
--- a/src/main/java/net/spy/memcached/collection/CollectionBulkStore.java
+++ b/src/main/java/net/spy/memcached/collection/CollectionBulkStore.java
@@ -17,7 +17,6 @@
 package net.spy.memcached.collection;
 
 import java.nio.ByteBuffer;
-import java.util.Iterator;
 import java.util.List;
 
 import net.spy.memcached.CachedData;
@@ -38,6 +37,16 @@ public abstract class CollectionBulkStore<T> extends CollectionObject {
 	protected int itemCount;
 
 	protected CollectionAttributes attribute;
+
+	protected int nextOpIndex = 0;
+
+	/**
+	 * set next index of operation
+	 * that will be processed after when operation moved by switchover
+	 */
+	public void setNextOperatedIndex(int i) {
+		this.nextOpIndex = i;
+	}
 
 	public abstract ByteBuffer getAsciiCommand();
 
@@ -96,10 +105,9 @@ public abstract class CollectionBulkStore<T> extends CollectionObject {
 			ByteBuffer bb = ByteBuffer.allocate(capacity);
 
 			// create ascii operation string
-			Iterator<String> iterator = keyList.iterator();
-
-			while (iterator.hasNext()) {
-				String key = iterator.next();
+			int kSize = this.keyList.size();
+			for (int i = this.nextOpIndex; i < kSize; i++) {
+				String key = keyList.get(i);
 				byte[] value = cachedData.getData();
 
 				setArguments(
@@ -119,7 +127,7 @@ public abstract class CollectionBulkStore<T> extends CollectionObject {
 								.getMaxCount() != null) ? attribute
 								.getMaxCount()
 								: CollectionAttributes.DEFAULT_MAXCOUNT : "",
-						(iterator.hasNext()) ? PIPE : "");
+						(i < kSize - 1) ? PIPE : "");
 				bb.put(value);
 				bb.put(CRLF);
 			}
@@ -164,10 +172,9 @@ public abstract class CollectionBulkStore<T> extends CollectionObject {
 			ByteBuffer bb = ByteBuffer.allocate(capacity);
 
 			// create ascii operation string
-			Iterator<String> iterator = keyList.iterator();
-
-			while (iterator.hasNext()) {
-				String key = iterator.next();
+			int kSize = this.keyList.size();
+			for (int i = this.nextOpIndex; i < kSize; i++) {
+				String key = keyList.get(i);
 				byte[] value = cachedData.getData();
 
 				setArguments(
@@ -185,7 +192,7 @@ public abstract class CollectionBulkStore<T> extends CollectionObject {
 								.getMaxCount() != null) ? attribute
 								.getMaxCount()
 								: CollectionAttributes.DEFAULT_MAXCOUNT : "",
-						(iterator.hasNext()) ? PIPE : "");
+						(i < kSize - 1) ? PIPE : "");
 				bb.put(value);
 				bb.put(CRLF);
 			}
@@ -232,10 +239,9 @@ public abstract class CollectionBulkStore<T> extends CollectionObject {
 			ByteBuffer bb = ByteBuffer.allocate(capacity);
 
 			// create ascii operation string
-			Iterator<String> iterator = keyList.iterator();
-
-			while (iterator.hasNext()) {
-				String key = iterator.next();
+			int kSize = keyList.size();
+			for (int i = this.nextOpIndex; i < kSize; i++) {
+				String key = this.keyList.get(i);
 				byte[] value = cachedData.getData();
 
 				setArguments(
@@ -254,7 +260,7 @@ public abstract class CollectionBulkStore<T> extends CollectionObject {
 								.getMaxCount() != null) ? attribute
 								.getMaxCount()
 								: CollectionAttributes.DEFAULT_MAXCOUNT : "",
-						(iterator.hasNext()) ? PIPE : "");
+						(i < kSize - 1) ? PIPE : "");
 				bb.put(value);
 				bb.put(CRLF);
 			}

--- a/src/main/java/net/spy/memcached/collection/CollectionBulkStore.java
+++ b/src/main/java/net/spy/memcached/collection/CollectionBulkStore.java
@@ -44,7 +44,7 @@ public abstract class CollectionBulkStore<T> extends CollectionObject {
 	 * set next index of operation
 	 * that will be processed after when operation moved by switchover
 	 */
-	public void setNextOperatedIndex(int i) {
+	public void setNextOpIndex(int i) {
 		this.nextOpIndex = i;
 	}
 

--- a/src/main/java/net/spy/memcached/collection/CollectionPipedStore.java
+++ b/src/main/java/net/spy/memcached/collection/CollectionPipedStore.java
@@ -19,7 +19,6 @@ package net.spy.memcached.collection;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
@@ -39,6 +38,16 @@ public abstract class CollectionPipedStore<T> extends CollectionObject {
 
 	protected CollectionAttributes attribute;
 	
+	protected int nextOpIndex = 0;
+
+	/**
+	 * set next index of operation
+	 * that will be processed after when operation moved by switchover
+	 */
+	public void setNextOperatedIndex(int i) {
+		this.nextOpIndex = i;
+	}
+
 	public abstract ByteBuffer getAsciiCommand();
 	public abstract ByteBuffer getBinaryCommand();
 	
@@ -66,7 +75,7 @@ public abstract class CollectionPipedStore<T> extends CollectionObject {
 			int capacity = 0;
 
 			// decode values
-			Collection<byte[]> encodedList = new ArrayList<byte[]>(list.size());
+			List<byte[]> encodedList = new ArrayList<byte[]>(list.size());
 			CachedData cd = null;
 			for (T each : list) {
 				cd = tc.encode(each);
@@ -84,14 +93,14 @@ public abstract class CollectionPipedStore<T> extends CollectionObject {
 			ByteBuffer bb = ByteBuffer.allocate(capacity);
 
 			// create ascii operation string
-			Iterator<byte[]> iterator = encodedList.iterator();
-			while (iterator.hasNext()) {
-				byte[] each = iterator.next();
+			int eSize = encodedList.size();
+			for (int i = this.nextOpIndex; i < eSize; i++) {
+				byte[] each = encodedList.get(i);
 				setArguments(bb, COMMAND, key, index, each.length,
 						(createKeyIfNotExists) ? "create" : "", (createKeyIfNotExists) ? cd.getFlags() : "",
 						(createKeyIfNotExists) ? (attribute != null && attribute.getExpireTime() != null) ? attribute.getExpireTime() : CollectionAttributes.DEFAULT_EXPIRETIME : "",
 						(createKeyIfNotExists) ? (attribute != null && attribute.getMaxCount() != null) ? attribute.getMaxCount() : CollectionAttributes.DEFAULT_MAXCOUNT : "",
-						(iterator.hasNext()) ? PIPE : "");
+						(i < eSize - 1) ? PIPE : "");
 				bb.put(each);
 				bb.put(CRLF);
 			}
@@ -129,7 +138,7 @@ public abstract class CollectionPipedStore<T> extends CollectionObject {
 			int capacity = 0;
 
 			// decode values
-			Collection<byte[]> encodedList = new ArrayList<byte[]>(set.size());
+			List<byte[]> encodedList = new ArrayList<byte[]>(set.size());
 			CachedData cd = null;
 			for (T each : set) {
 				cd = tc.encode(each);
@@ -147,15 +156,15 @@ public abstract class CollectionPipedStore<T> extends CollectionObject {
 			ByteBuffer bb = ByteBuffer.allocate(capacity);
 
 			// create ascii operation string
-			Iterator<byte[]> iterator = encodedList.iterator();
-			while (iterator.hasNext()) {
-				byte[] each = iterator.next();
-				
+			int eSize = encodedList.size();
+			for (int i = this.nextOpIndex; i < eSize; i++) {
+				byte[] each = encodedList.get(i);
+
 				setArguments(bb, COMMAND, key, each.length,
 						(createKeyIfNotExists) ? "create" : "", (createKeyIfNotExists) ? cd.getFlags() : "",
 						(createKeyIfNotExists) ? (attribute != null && attribute.getExpireTime() != null) ? attribute.getExpireTime() : CollectionAttributes.DEFAULT_EXPIRETIME : "",
 						(createKeyIfNotExists) ? (attribute != null && attribute.getMaxCount() != null) ? attribute.getMaxCount() : CollectionAttributes.DEFAULT_MAXCOUNT : "",
-						(iterator.hasNext()) ? PIPE : "");
+						(i < eSize - 1) ? PIPE : "");
 				bb.put(each);
 				bb.put(CRLF);
 			}
@@ -212,17 +221,17 @@ public abstract class CollectionPipedStore<T> extends CollectionObject {
 			ByteBuffer bb = ByteBuffer.allocate(capacity);
 
 			// create ascii operation string
-			i = 0;
-			Iterator<Long> iterator = map.keySet().iterator();
-			while (iterator.hasNext()) {
-				Long bkey = iterator.next();
-				byte[] value = decodedList.get(i++);
+			int keySize = map.keySet().size();
+			List<Long> keyList = new ArrayList<Long>(map.keySet());
+			for (i = this.nextOpIndex; i < keySize; i++) {
+				Long bkey = keyList.get(i);
+				byte[] value = decodedList.get(i);
 
 				setArguments(bb, COMMAND, key, bkey, value.length,
 						(createKeyIfNotExists) ? "create" : "", (createKeyIfNotExists) ? cd.getFlags() : "",
 						(createKeyIfNotExists) ? (attribute != null && attribute.getExpireTime() != null) ? attribute.getExpireTime() : CollectionAttributes.DEFAULT_EXPIRETIME : "",
 						(createKeyIfNotExists) ? (attribute != null && attribute.getMaxCount() != null) ? attribute.getMaxCount() : CollectionAttributes.DEFAULT_MAXCOUNT : "",
-						(iterator.hasNext()) ? PIPE : "");
+						(i < keySize - 1) ? PIPE : "");
 				bb.put(value);
 				bb.put(CRLF);
 			}
@@ -284,11 +293,10 @@ public abstract class CollectionPipedStore<T> extends CollectionObject {
 			ByteBuffer bb = ByteBuffer.allocate(capacity);
 
 			// create ascii operation string
-			i = 0;
-			Iterator<Element<T>> iterator = elements.iterator();
-			while (iterator.hasNext()) {
-				Element<T> element = iterator.next();
-				byte[] value = decodedList.get(i++);
+			int eSize = elements.size();
+			for (i = this.nextOpIndex; i < eSize; i++) {
+				Element<T> element = elements.get(i);
+				byte[] value = decodedList.get(i);
 
 				setArguments(
 						bb,
@@ -315,7 +323,7 @@ public abstract class CollectionPipedStore<T> extends CollectionObject {
 						(createKeyIfNotExists) ? (attribute != null && attribute
 								.getReadable() != null && !attribute.getReadable()) ?
 								"unreadable" : "" : "",
-						(iterator.hasNext()) ? PIPE : "");
+						(i < eSize - 1) ? PIPE : "");
 				bb.put(value);
 				bb.put(CRLF);
 			}

--- a/src/main/java/net/spy/memcached/collection/CollectionPipedStore.java
+++ b/src/main/java/net/spy/memcached/collection/CollectionPipedStore.java
@@ -44,7 +44,7 @@ public abstract class CollectionPipedStore<T> extends CollectionObject {
 	 * set next index of operation
 	 * that will be processed after when operation moved by switchover
 	 */
-	public void setNextOperatedIndex(int i) {
+	public void setNextOpIndex(int i) {
 		this.nextOpIndex = i;
 	}
 

--- a/src/main/java/net/spy/memcached/collection/SetPipedExist.java
+++ b/src/main/java/net/spy/memcached/collection/SetPipedExist.java
@@ -42,7 +42,7 @@ public class SetPipedExist<T> extends CollectionObject {
 	 * set next index of operation
 	 * that will be processed after when operation moved by switchover
 	 */
-	public void setNextOperatedIndex(int i) {
+	public void setNextOpIndex(int i) {
 		this.nextOpIndex = i;
 	}
 


### PR DESCRIPTION
bulk 혹은 pip operation 이 swithcover 에 의해 master 에서 slave 로 이동되는 경우,
전체 operation 이 재수행되는 것이 아니라 가장 마지막에 수행된 operation 의 다음부터 처리될 수 있도록 수정한 내용입니다.

@aiceru, @jhpark816 review 부탁드립니다.