### PR TITLE
Move operations to the new master node when replication switchover/failover occur

### DIFF
--- a/src/main/java/net/spy/memcached/ArcusReplKetamaNodeLocator.java
+++ b/src/main/java/net/spy/memcached/ArcusReplKetamaNodeLocator.java
@@ -281,6 +281,14 @@ public class ArcusReplKetamaNodeLocator extends SpyObject implements NodeLocator
 		}
 	}
 
+	/* WHCHOI83_MEMCACHED_REPLICA_GROUP if */
+	public void switchoverReplGroup(MemcachedReplicaGroup group) {
+		lock.lock();
+		group.changeRole();
+		lock.unlock();
+	}
+
+	/* WHCHOI83_MEMCACHED_REPLICA_GROUP end */
 	private void updateHash(MemcachedReplicaGroup group, boolean remove) {
 		// Ketama does some special work with md5 where it reuses chunks.
 		for (int i = 0; i < config.getNodeRepetitions() / 4; i++) {

--- a/src/main/java/net/spy/memcached/MemcachedConnection.java
+++ b/src/main/java/net/spy/memcached/MemcachedConnection.java
@@ -250,14 +250,15 @@ public final class MemcachedConnection extends SpyObject {
 	public void updateConnections(List<InetSocketAddress> addrs) throws IOException {
 		List<MemcachedNode> attachNodes = new ArrayList<MemcachedNode>();
 		List<MemcachedNode> removeNodes = new ArrayList<MemcachedNode>();
-		/* ENABLE_REPLICATION if */
-		List<MemcachedReplicaGroup> changeRoleGroups = new ArrayList<MemcachedReplicaGroup>();
-		/* ENABLE_REPLICATION end */
 
 		// Classify the incoming node list.
 		/* ENABLE_REPLICATION if */
 		if (arcusReplEnabled) {
-			Map<String, List<ArcusReplNodeAddress>> newAllGroups = 
+			List<MemcachedReplicaGroup> changeRoleGroups = new ArrayList<MemcachedReplicaGroup>();
+			/* WHCHOI83_MEMCACHED_REPLICA_GROUP if */
+			List<MoveOperationTask> taskList = new ArrayList<MoveOperationTask>();
+			/* WHCHOI83_MEMCACHED_REPLICA_GROUP if */
+			Map<String, List<ArcusReplNodeAddress>> newAllGroups =
 					ArcusReplNodeAddress.makeGroupAddrsList(addrs);
 			
 			Map<String, MemcachedReplicaGroup> oldAllGroups = 
@@ -295,23 +296,64 @@ public final class MemcachedConnection extends SpyObject {
 						if (newGroupAddrs.get(0).getIPPort().equals(oldMasterAddr.getIPPort())) {
 							/* The same master node. Do nothing. */
 						} else {
+							/* WHCHOI83_MEMCACHED_REPLICA_GROUP if */
+							MemcachedNode newMasterNode;
+							/* WHCHOI83_MEMCACHED_REPLICA_GROUP end */
 							/* The master of the group has changed to the new one. */
 							removeNodes.add(oldGroup.getMasterNode());
-							attachNodes.add(attachMemcachedNode(newGroupAddrs.get(0)));
-						} 
+							/* WHCHOI83_MEMCACHED_REPLICA_GROUP if */
+							attachNodes.add(newMasterNode = attachMemcachedNode(newGroupAddrs.get(0)));
+
+							/* move operation old master -> new master */
+							oldGroup.getMasterNode().setupResend(false, "Discarded all pending reading state operation to move operations.");
+							taskList.add(new MoveOperationTask(oldGroup.getMasterNode(), newMasterNode));
+							/* WHCHOI83_MEMCACHED_REPLICA_GROUP else */
+							/*
+							attachNodes.add(attachMemcachedNode(newGroupAddrs.get()));
+							*/
+							/* WHCHOI83_MEMCACHED_REPLICA_GROUP end */
+						}
 					} else { /* Old group has both a master node and a slave node. */
 						if (newGroupAddrs.get(0).getIPPort().equals(oldMasterAddr.getIPPort())) {
 							/* The old slave has disappeared. */
 							removeNodes.add(oldGroup.getSlaveNode());
+							/* WHCHOI83_MEMCACHED_REPLICA_GROUP if */
+
+							/* move operation slave -> master */
+							oldGroup.getSlaveNode().setupResend(false, "Discarded all pending reading state operation to move operations.");
+							taskList.add(new MoveOperationTask(oldGroup.getSlaveNode(), oldGroup.getMasterNode()));
+							/* WHCHOI83_MEMCACHED_REPLICA_GROUP end */
 						} else if (newGroupAddrs.get(0).getIPPort().equals(oldSlaveAddr.getIPPort())) {
 							/* The old slave has failovered to the master with new slave */
 							removeNodes.add(oldGroup.getMasterNode());
 							changeRoleGroups.add(oldGroup);
+							/* WHCHOI83_MEMCACHED_REPLICA_GROUP if */
+
+							/* move operation master -> slave */
+							oldGroup.getMasterNode().setupResend(false, "Discarded all pending reading state operation to move operations.");
+							taskList.add(new MoveOperationTask(oldGroup.getMasterNode(), oldGroup.getSlaveNode()));
+							/* WHCHOI83_MEMCACHED_REPLICA_GROUP end */
 						} else {
+							/* WHCHOI83_MEMCACHED_REPLICA_GROUP if */
+							MemcachedNode newMasterNode;
+							/* WHCHOI83_MEMCACHED_REPLICA_GROUP end */
 							/* All nodes of old group have gone away. And, new master has appeared. */
 							removeNodes.add(oldGroup.getMasterNode());
 							removeNodes.add(oldGroup.getSlaveNode());
+							/* WHCHOI83_MEMCACHED_REPLICA_GROUP if */
+							attachNodes.add(newMasterNode = attachMemcachedNode(newGroupAddrs.get(0)));
+
+							/* move operation old master -> new master */
+							oldGroup.getMasterNode().setupResend(false, "Discarded all pending reading state operation to move operations.");
+							taskList.add(new MoveOperationTask(oldGroup.getMasterNode(), newMasterNode));
+							/* move operation old slave -> new master */
+							oldGroup.getSlaveNode().setupResend(false, "Discarded all pending reading state operation to move operations.");
+							taskList.add(new MoveOperationTask(oldGroup.getSlaveNode(), newMasterNode));
+							/* WHCHOI83_MEMCACHED_REPLICA_GROUP else */
+							/*
 							attachNodes.add(attachMemcachedNode(newGroupAddrs.get(0)));
+							*/
+							/* WHCHOI83_MEMCACHED_REPLICA_GROUP end */
 						}
 					}
 				} else { /* New group has both a master node and a slave node */
@@ -320,50 +362,148 @@ public final class MemcachedConnection extends SpyObject {
 							/* New slave node has appeared. */
 							attachNodes.add(attachMemcachedNode(newGroupAddrs.get(1)));
 						} else if (newGroupAddrs.get(1).getIPPort().equals(oldMasterAddr.getIPPort())) {
+							/* WHCHOI83_MEMCACHED_REPLICA_GROUP if */
+							MemcachedNode newMasterNode;
+							/* WHCHOI83_MEMCACHED_REPLICA_GROUP end */
 							/* Really rare case: old master => slave, A new master */
 							changeRoleGroups.add(oldGroup);
+							/* WHCHOI83_MEMCACHED_REPLICA_GROUP if */
+							attachNodes.add(newMasterNode = attachMemcachedNode(newGroupAddrs.get(0)));
+
+							/* move operation old master -> new master */
+							queueReconnect(oldGroup.getMasterNode(), ReconnDelay.IMMEDIATE, "Discarded all pending reading state operation to move operations.");
+							taskList.add(new MoveOperationTask(oldGroup.getMasterNode(), newMasterNode));
+							/* WHCHOI83_MEMCACHED_REPLICA_GROUP else */
+							/*
 							attachNodes.add(attachMemcachedNode(newGroupAddrs.get(0)));
+							*/
+							/* WHCHOI83_MEMCACHED_REPLICA_GROUP end */
 						} else {
+							/* WHCHOI83_MEMCACHED_REPLICA_GROUP if */
+							MemcachedNode newMasterNode;
+							/* WHCHOI83_MEMCACHED_REPLICA_GROUP end */
 							/* Old master has gone away. And, new group has appeared. */
 							removeNodes.add(oldGroup.getMasterNode());
+							/* WHCHOI83_MEMCACHED_REPLICA_GROUP if */
+							attachNodes.add(newMasterNode = attachMemcachedNode(newGroupAddrs.get(0)));
+							/* WHCHOI83_MEMCACHED_REPLICA_GROUP else */
+							/*
 							attachNodes.add(attachMemcachedNode(newGroupAddrs.get(0)));
+							*/
+							/* WHCHOI83_MEMCACHED_REPLICA_GROUP end */
 							attachNodes.add(attachMemcachedNode(newGroupAddrs.get(1)));
+
+							/* WHCHOI83_MEMCACHED_REPLICA_GROUP if */
+							/* move operation old master -> new master */
+							oldGroup.getMasterNode().setupResend(false, "Discarded all pending reading state operation to move operations.");
+							taskList.add(new MoveOperationTask(oldGroup.getMasterNode(), newMasterNode));
+							/* WHCHOI83_MEMCACHED_REPLICA_GROUP end */
 						}
 					} else { /* Old group has both a master node and a slave node. */
 						if (newGroupAddrs.get(0).getIPPort().equals(oldMasterAddr.getIPPort())) {
 							if (newGroupAddrs.get(1).getIPPort().equals(oldSlaveAddr.getIPPort())) {
 								/* The same master and slave nodes. Do nothing. */
 							} else {
+								/* WHCHOI83_MEMCACHED_REPLICA_GROUP if */
+								MemcachedNode newSlaveNode;
+								/* WHCHOI83_MEMCACHED_REPLICA_GROUP end */
 								/* Only old slave has changed to the new one. */
 								removeNodes.add(oldGroup.getSlaveNode());
+								/* WHCHOI83_MEMCACHED_REPLICA_GROUP if */
+								attachNodes.add(newSlaveNode = attachMemcachedNode(newGroupAddrs.get(1)));
+
+								/* move operation old slave -> new slave */
+								oldGroup.getSlaveNode().setupResend(false, "Discarded all pending reading state operation to move operations.");
+								taskList.add(new MoveOperationTask(oldGroup.getSlaveNode(), newSlaveNode));
+								/* WHCHOI83_MEMCACHED_REPLICA_GROUP else */
+								/*
 								attachNodes.add(attachMemcachedNode(newGroupAddrs.get(1)));
+								 */
+								/* WHCHOI83_MEMCACHED_REPLICA_GROUP end */
 							}
 						} else if (newGroupAddrs.get(0).getIPPort().equals(oldSlaveAddr.getIPPort())) {
 							if (newGroupAddrs.get(1).getIPPort().equals(oldMasterAddr.getIPPort())) {
 								/* Switchover */
 								changeRoleGroups.add(oldGroup);
+								/* WHCHOI83_MEMCACHED_REPLICA_GROUP if */
+
+								/* move operation master -> slave */
+								queueReconnect(oldGroup.getMasterNode(), ReconnDelay.IMMEDIATE, "Discarded all pending reading state operation to move operations.");
+								taskList.add(new MoveOperationTask(oldGroup.getMasterNode(), oldGroup.getSlaveNode()));
+								/* WHCHOI83_MEMCACHED_REPLICA_GROUP end */
 							} else {
 								/* Failover. And, new slave has appeared */
 								removeNodes.add(oldGroup.getMasterNode());
 								changeRoleGroups.add(oldGroup);
 								attachNodes.add(attachMemcachedNode(newGroupAddrs.get(1)));
+								/* WHCHOI83_MEMCACHED_REPLICA_GROUP if */
+
+								/* move operation old master -> old slave */
+								oldGroup.getMasterNode().setupResend(false, "Discarded all pending reading state operation to move operations.");
+								taskList.add(new MoveOperationTask(oldGroup.getMasterNode(), oldGroup.getSlaveNode()));
+								/* WHCHOI83_MEMCACHED_REPLICA_GROUP end */
 							}
 						} else {
 							/* A completely new master has appered. */
 							if (newGroupAddrs.get(1).getIPPort().equals(oldMasterAddr.getIPPort())) {
 								/* Old slave disappeared. Old master has changed to the slave. */
+								/* WHCHOI83_MEMCACHED_REPLICA_GROUP if */
+								MemcachedNode newMasterNode;
+								/* WHCHOI83_MEMCACHED_REPLICA_GROUP end */
 								removeNodes.add(oldGroup.getSlaveNode());
 								changeRoleGroups.add(oldGroup);
+								attachNodes.add(newMasterNode = attachMemcachedNode(newGroupAddrs.get(0)));
+								/* WHCHOI83_MEMCACHED_REPLICA_GROUP if */
+
+								/* move operation old master -> new master */
+								queueReconnect(oldGroup.getMasterNode(), ReconnDelay.IMMEDIATE, "Discarded all pending reading state operation to move operations.");
+								taskList.add(new MoveOperationTask(oldGroup.getMasterNode(), newMasterNode));
+
+								/* move operation old slave -> old master(slave) */
+								oldGroup.getSlaveNode().setupResend(false, "Discarded all pending reading state operation to move operations.");
+								taskList.add(new MoveOperationTask(oldGroup.getSlaveNode(), oldGroup.getMasterNode()));
+								/* WHCHOI83_MEMCACHED_REPLICA_GROUP end */
 							} else if (newGroupAddrs.get(1).getIPPort().equals(oldSlaveAddr.getIPPort())) {
+								/* WHCHOI83_MEMCACHED_REPLICA_GROUP if */
+								MemcachedNode newMasterNode;
+								/* WHCHOI83_MEMCACHED_REPLICA_GROUP end */
 								/* Only old master has disappeared. */
 								removeNodes.add(oldGroup.getMasterNode());
+								/* WHCHOI83_MEMCACHED_REPLICA_GROUP if */
+								attachNodes.add(newMasterNode = attachMemcachedNode(newGroupAddrs.get(0)));
+
+								/* move operation old master -> new master */
+								oldGroup.getMasterNode().setupResend(false, "Discarded all pending reading state operation to move operations.");
+								taskList.add(new MoveOperationTask(oldGroup.getMasterNode(), newMasterNode));
+								/* WHCHOI83_MEMCACHED_REPLICA_GROUP end */
 							} else {
-								/* Old groyp has completely changed to the new group. */
+								/* WHCHOI83_MEMCACHED_REPLICA_GROUP if */
+								MemcachedNode newMasterNode;
+								MemcachedNode newSlaveNode;
+								/* WHCHOI83_MEMCACHED_REPLICA_GROUP end */
+								/* Old group has completely changed to the new group. */
 								removeNodes.add(oldGroup.getMasterNode());
 								removeNodes.add(oldGroup.getSlaveNode());
-								attachNodes.add(attachMemcachedNode(newGroupAddrs.get(1)));
+								/* WHCHOI83_MEMCACHED_REPLICA_GROUP if */
+								attachNodes.add(newMasterNode = attachMemcachedNode(newGroupAddrs.get(0)));
+								/* WHCHOI83_MEMCACHED_REPLICA_GROUP end */
+								attachNodes.add(newSlaveNode = attachMemcachedNode(newGroupAddrs.get(1)));
+								/* WHCHOI83_MEMCACHED_REPLICA_GROUP if */
+
+								/* move operation old master -> new master */
+								oldGroup.getMasterNode().setupResend(false, "Discarded all pending reading state operation to move operations.");
+								taskList.add(new MoveOperationTask(oldGroup.getMasterNode(), newMasterNode));
+
+								/* move operation old slave -> new slave */
+								oldGroup.getSlaveNode().setupResend(false, "Discarded all pending reading state operation to move operations.");
+								taskList.add(new MoveOperationTask(oldGroup.getSlaveNode(), newSlaveNode));
+								/* WHCHOI83_MEMCACHED_REPLICA_GROUP end */
 							}
+							/* WHCHOI83_MEMCACHED_REPLICA_GROUP if */
+							/*
 							attachNodes.add(attachMemcachedNode(newGroupAddrs.get(0)));
+							*/
+							/* WHCHOI83_MEMCACHED_REPLICA_GROUP end */
 						}
 					}
 				}
@@ -383,6 +523,10 @@ public final class MemcachedConnection extends SpyObject {
 
 			// Update the hash.
 			((ArcusReplKetamaNodeLocator)locator).update(attachNodes, removeNodes, changeRoleGroups);
+			/* WHCHOI83_MEMCACHED_REPLICA_GROUP if */
+			for (MoveOperationTask task : taskList)
+				task.moveOperations();
+			/* WHCHOI83_MEMCACHED_REPLICA_GROUP end */
 		} else {
 			for (MemcachedNode node : locator.getAll()) {
 				if (addrs.contains((InetSocketAddress) node.getSocketAddress())) {
@@ -439,6 +583,34 @@ public final class MemcachedConnection extends SpyObject {
 		}
 	}
 	
+	/* ENABLE_REPLICATION if */
+	/* WHCHOI83_MEMCACHED_REPLICA_GROUP if */
+	private void switchoverMemcachedReplGroup(MemcachedNode node) {
+		MemcachedReplicaGroup group = node.getReplicaGroup();
+
+		/*  must keep the following execution order when switchover
+		 * - first moveOperations
+		 * - second, queueReconnect
+		 *
+		 * because moves all operations
+		 */
+		if (group.getMasterNode() != null && group.getSlaveNode() != null) {
+			if (((ArcusReplNodeAddress)node.getSocketAddress()).master) {
+				node.moveOperations(group.getSlaveNode());
+				addedQueue.offer(group.getSlaveNode());
+				((ArcusReplKetamaNodeLocator)locator).switchoverReplGroup(group);
+			} else {
+				node.moveOperations(group.getMasterNode());
+				addedQueue.offer(group.getMasterNode());
+			}
+			queueReconnect(node, ReconnDelay.IMMEDIATE, "Discarded all pending reading state operation to move operations.");
+		} else {
+			getLogger().warn("Delay switchover because invalid group state : " + group);
+		}
+	}
+
+	/* WHCHOI83_MEMCACHED_REPLICA_GROUP end */
+	/* ENABLE_REPLICATION end */
 	MemcachedNode attachMemcachedNode(SocketAddress sa) throws IOException {
 		SocketChannel ch = SocketChannel.open();
 		ch.configureBlocking(false);
@@ -683,7 +855,24 @@ public final class MemcachedConnection extends SpyObject {
 					: "Expected to pop " + currentOp + " got " + op;
 					currentOp=qa.getCurrentReadOp();
 				}
+				/* ENABLE_REPLICATION if */
+				/* WHCHOI83_MEMCACHED_REPLICA_GROUP if */
+				else if (currentOp.getState() == OperationState.MOVING) {
+					break;
+				}
+				/* WHCHOI83_MEMCACHED_REPLICA_GROUP end */
+				/* ENABLE_REPLICATION end */
 			}
+			/* ENABLE_REPLICATION if */
+			/* WHCHOI83_MEMCACHED_REPLICA_GROUP if */
+
+			if (currentOp != null && currentOp.getState() == OperationState.MOVING) {
+				rbuf.clear();
+				switchoverMemcachedReplGroup(qa);
+				break;
+			}
+			/* WHCHOI83_MEMCACHED_REPLICA_GROUP end */
+			/* ENABLE_REPLICATION end */
 			rbuf.clear();
 			read=channel.read(rbuf);
 		}
@@ -870,7 +1059,7 @@ public final class MemcachedConnection extends SpyObject {
 	public void addOperation(final String key, final Operation o) {
 		MemcachedNode placeIn=null;
 		/* ENABLE_REPLICATION if */
-		MemcachedNode primary = null;
+		MemcachedNode primary;
 		if (this.arcusReplEnabled) {
 			primary = ((ArcusReplKetamaNodeLocator)locator).getPrimary(key, getReplicaPick(o));
 		} else
@@ -1139,4 +1328,21 @@ public final class MemcachedConnection extends SpyObject {
 	public int getAddedQueueSize() {
 		return addedQueue.size();
 	}
+	/* WHCHOI83_MEMCACHED_REPLICA_GROUP if */
+
+	private class MoveOperationTask {
+		MemcachedNode fromNode;
+		MemcachedNode toNode;
+
+		public MoveOperationTask(MemcachedNode from, MemcachedNode to) {
+			fromNode = from;
+			toNode = to;
+		}
+
+		public void moveOperations() {
+			if (fromNode.moveOperations(toNode) > 0)
+				addedQueue.offer(toNode);
+		}
+	}
+	/* WHCHOI83_MEMCACHED_REPLICA_GROUP end */
 }

--- a/src/main/java/net/spy/memcached/MemcachedNode.java
+++ b/src/main/java/net/spy/memcached/MemcachedNode.java
@@ -22,6 +22,7 @@ import java.nio.ByteBuffer;
 import java.nio.channels.SelectionKey;
 import java.nio.channels.SocketChannel;
 import java.util.Collection;
+import java.util.concurrent.BlockingQueue;
 
 import net.spy.memcached.ops.Operation;
 
@@ -243,4 +244,16 @@ public interface MemcachedNode {
 	 * @return status string
 	 */
 	String getStatus();
+	/* ENABLE_REPLICATION if */
+	/* WHCHOI83_MEMCACHED_REPLICA_GROUP if */
+
+	void setReplicaGroup(MemcachedReplicaGroup g);
+
+	MemcachedReplicaGroup getReplicaGroup();
+
+	void addAllOpToInputQ(BlockingQueue<Operation> allOp);
+
+	int moveOperations(final MemcachedNode toNode);
+	/* WHCHOI83_MEMCACHED_REPLICA_GROUP end */
+	/* ENABLE_REPLICATION end */
 }

--- a/src/main/java/net/spy/memcached/MemcachedNodeROImpl.java
+++ b/src/main/java/net/spy/memcached/MemcachedNodeROImpl.java
@@ -25,6 +25,7 @@ import java.nio.ByteBuffer;
 import java.nio.channels.SelectionKey;
 import java.nio.channels.SocketChannel;
 import java.util.Collection;
+import java.util.concurrent.BlockingQueue;
 
 import net.spy.memcached.ops.Operation;
 
@@ -197,4 +198,24 @@ class MemcachedNodeROImpl implements MemcachedNode {
 	public String getStatus() {
 		throw new UnsupportedOperationException();
 	}
+	/* ENABLE_REPLICATION if */
+	/* WHCHOI83_MEMCACHED_REPLICA_GROUP if */
+
+	public void setReplicaGroup(MemcachedReplicaGroup g) {
+		throw new UnsupportedOperationException();
+	}
+
+	public MemcachedReplicaGroup getReplicaGroup() {
+		throw new UnsupportedOperationException();
+	}
+
+	public void addAllOpToInputQ(BlockingQueue<Operation> allOp) {
+		throw new UnsupportedOperationException();
+	}
+
+	public int moveOperations(final MemcachedNode toNode) {
+		throw new UnsupportedOperationException();
+	}
+	/* WHCHOI83_MEMCACHED_REPLICA_GROUP end */
+	/* ENABLE_REPLICATION end */
 }

--- a/src/main/java/net/spy/memcached/MemcachedReplicaGroup.java
+++ b/src/main/java/net/spy/memcached/MemcachedReplicaGroup.java
@@ -17,7 +17,15 @@
 /* ENABLE_REPLICATION if */
 package net.spy.memcached;
 
+import net.spy.memcached.compat.SpyObject;
+
+/* WHCHOI83_MEMCACHED_REPLICA_GROUP if */
+public abstract class MemcachedReplicaGroup extends SpyObject {
+/* WHCHOI83_MEMCACHED_REPLICA_GROUP else */
+/*
 public abstract class MemcachedReplicaGroup {
+*/
+/* WHCHOI83_MEMCACHED_REPLICA_GROUP end */
 	protected final String group;
 	protected MemcachedNode masterNode;
 	protected MemcachedNode slaveNode;

--- a/src/main/java/net/spy/memcached/MemcachedReplicaGroupImpl.java
+++ b/src/main/java/net/spy/memcached/MemcachedReplicaGroupImpl.java
@@ -31,13 +31,17 @@ public class MemcachedReplicaGroupImpl extends MemcachedReplicaGroup {
 	
 	public boolean setMemcachedNode(final MemcachedNode node) {
 		if (node == null)
-			return false;		
+			return false;
 
 		if (this.group.equals(getGroupNameForNode(node))) {
 			if (((ArcusReplNodeAddress)node.getSocketAddress()).master)
 				this.masterNode = node;
 			else
 				this.slaveNode = node;
+			/* WHCHOI83_MEMCACHED_REPLICA_GROUP if */
+
+			node.setReplicaGroup(this);
+			/* WHCHOI83_MEMCACHED_REPLICA_GROUP end */
 			return true;
 		} else {
 			return false;

--- a/src/main/java/net/spy/memcached/ops/Operation.java
+++ b/src/main/java/net/spy/memcached/ops/Operation.java
@@ -46,6 +46,17 @@ public interface Operation {
 	 */
 	OperationState getState();
 
+	/* ENABLE_REPLICATION if */
+	/* WHCHOI83_MEMCACHED_REPLICA_GROUP if */
+	/**
+	 * reset operation state to WRITING
+	 */
+	void resetState();
+
+	void setMoved(boolean s);
+
+	/* WHCHOI83_MEMCACHED_REPLICA_GROUP end */
+	/* ENABLE_REPLICATION end */
 	/**
 	 * Get the write buffer for this operation.
 	 */

--- a/src/main/java/net/spy/memcached/ops/OperationState.java
+++ b/src/main/java/net/spy/memcached/ops/OperationState.java
@@ -36,4 +36,12 @@ public enum OperationState {
 	 * State indicating this operation timed out without completing.
 	 */
 	TIMEDOUT
+	/* ENABLE_REPLICATION if */
+	/* WHCHOI83_MEMCACHED_REPLICA_GROUP if */
+	/**
+	 * State indicating this operation will be moved by switchover or failover
+	 */
+	, MOVING
+	/* WHCHOI83_MEMCACHED_REPLICA_GROUP end */
+	/* ENABLE_REPLICATION end */
 }

--- a/src/main/java/net/spy/memcached/protocol/BaseOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/BaseOperationImpl.java
@@ -50,6 +50,11 @@ public abstract class BaseOperationImpl extends SpyObject {
 
 	private OperationType opType = OperationType.UNDEFINED;
 	private APIType apiType = APIType.UNDEFINED;
+	/* ENABLE_REPLICATION if */
+	/* WHCHOI83_MEMCACHED_REPLICA_GROUP if */
+	private boolean moved = false;
+	/* WHCHOI83_MEMCACHED_REPLICA_GROUP end */
+	/* ENABLE_REPLICATION end */
 
 	public BaseOperationImpl() {
 		super();
@@ -102,6 +107,26 @@ public abstract class BaseOperationImpl extends SpyObject {
 	public final OperationState getState() {
 		return state;
 	}
+	/* ENABLE_REPLICATION if */
+	/* WHCHOI83_MEMCACHED_REPLICA_GROUP if */
+
+	/**
+	 * reset operation state to WRITING
+	 */
+	public final void resetState() {
+		transitionState(OperationState.WRITING);
+	}
+
+	public final void setMoved(boolean m) {
+		this.moved = m;
+	}
+
+	protected final void receivedMoveOperations(String cause) {
+		getLogger().info("%s message received by %s operation from %s", cause, this, handlingNode);
+		transitionState(OperationState.MOVING);
+	}
+	/* WHCHOI83_MEMCACHED_REPLICA_GROUP end */
+	/* ENABLE_REPLICATION end */
 
 	public final ByteBuffer getBuffer() {
 		return cmd;
@@ -127,6 +152,12 @@ public abstract class BaseOperationImpl extends SpyObject {
 			cmd=null;
 		}
 		if(state == OperationState.COMPLETE) {
+		/* ENABLE_REPLICATION if */
+		/* WHCHOI83_MEMCACHED_REPLICA_GROUP if */
+			if (moved)
+				getLogger().debug("Operation move completed : %s at %s", this, getHandlingNode());
+		/* WHCHOI83_MEMCACHED_REPLICA_GROUP end */
+		/* ENABLE_REPLICATION end */
 			callback.complete();
 		}
 		if(state == OperationState.TIMEDOUT) {

--- a/src/main/java/net/spy/memcached/protocol/ascii/BTreeStoreAndGetOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/BTreeStoreAndGetOperationImpl.java
@@ -113,6 +113,15 @@ public class BTreeStoreAndGetOperationImpl extends OperationImpl implements
 			getLogger().debug("Got line %s", line);
 		}
 
+		/* ENABLE_REPLICATION if */
+		/* WHCHOI83_MEMCACHED_REPLICA_GROUP if */
+		if (line.equals("SWITCHOVER") || line.equals("REPL_SLAVE")) {
+			receivedMoveOperations(line);
+			return;
+		}
+
+		/* WHCHOI83_MEMCACHED_REPLICA_GROUP end */
+		/* ENABLE_REPLICATION end */
 		// VALUE <flags> <count>\r\n
 		if (line.startsWith("VALUE ")) {
 			String[] stuff = line.split(" ");

--- a/src/main/java/net/spy/memcached/protocol/ascii/BaseStoreOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/BaseStoreOperationImpl.java
@@ -55,6 +55,15 @@ abstract class BaseStoreOperationImpl extends OperationImpl {
 	public void handleLine(String line) {
 		assert getState() == OperationState.READING
 			: "Read ``" + line + "'' when in " + getState() + " state";
+		/* ENABLE_REPLICATION if */
+		/* WHCHOI83_MEMCACHED_REPLICA_GROUP if */
+		if (line.equals("SWITCHOVER") || line.equals("REPL_SLAVE")) {
+			receivedMoveOperations(line);
+			return;
+		}
+
+		/* WHCHOI83_MEMCACHED_REPLICA_GROUP end */
+		/* ENABLE_REPLICATION end */
 		getCallback().receivedStatus(matchStatus(line, STORED));
 		transitionState(OperationState.COMPLETE);
 	}

--- a/src/main/java/net/spy/memcached/protocol/ascii/CASOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/CASOperationImpl.java
@@ -51,6 +51,15 @@ class CASOperationImpl extends OperationImpl implements CASOperation {
 	public void handleLine(String line) {
 		assert getState() == OperationState.READING
 			: "Read ``" + line + "'' when in " + getState() + " state";
+		/* ENABLE_REPLICATION if */
+		/* WHCHOI83_MEMCACHED_REPLICA_GROUP if */
+		if (line.equals("SWITCHOVER") || line.equals("REPL_SLAVE")) {
+			receivedMoveOperations(line);
+			return;
+		}
+
+		/* WHCHOI83_MEMCACHED_REPLICA_GROUP end */
+		/* ENABLE_REPLICATION end */
 		getCallback().receivedStatus(matchStatus(line,
 			STORED, NOT_FOUND, EXISTS));
 		transitionState(OperationState.COMPLETE);

--- a/src/main/java/net/spy/memcached/protocol/ascii/CollectionBulkStoreOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/CollectionBulkStoreOperationImpl.java
@@ -89,6 +89,16 @@ public class CollectionBulkStoreOperationImpl extends OperationImpl
 	public void handleLine(String line) {
 		assert getState() == OperationState.READING
 			: "Read ``" + line + "'' when in " + getState() + " state";
+		/* ENABLE_REPLICATION if */
+		/* WHCHOI83_MEMCACHED_REPLICA_GROUP if */
+		if (line.equals("SWITCHOVER") || line.equals("REPL_SLAVE")) {
+			this.store.setNextOpIndex(index);
+			receivedMoveOperations(line);
+			return;
+		}
+
+		/* WHCHOI83_MEMCACHED_REPLICA_GROUP end */
+		/* ENABLE_REPLICATION end */
 		if (line.startsWith("END") || store.getItemCount() == 1) {
 			cb.receivedStatus((successAll)? END : FAILED_END);
 			transitionState(OperationState.COMPLETE);

--- a/src/main/java/net/spy/memcached/protocol/ascii/CollectionCreateOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/CollectionCreateOperationImpl.java
@@ -73,6 +73,15 @@ public class CollectionCreateOperationImpl extends OperationImpl
 	public void handleLine(String line) {
 		assert getState() == OperationState.READING
 			: "Read ``" + line + "'' when in " + getState() + " state";
+		/* ENABLE_REPLICATION if */
+		/* WHCHOI83_MEMCACHED_REPLICA_GROUP if */
+		if (line.equals("SWITCHOVER") || line.equals("REPL_SLAVE")) {
+			receivedMoveOperations(line);
+			return;
+		}
+
+		/* WHCHOI83_MEMCACHED_REPLICA_GROUP end */
+		/* ENABLE_REPLICATION end */
 		getCallback().receivedStatus(
 				matchStatus(line, CREATED, EXISTS, SERVER_ERROR));
 		transitionState(OperationState.COMPLETE);

--- a/src/main/java/net/spy/memcached/protocol/ascii/CollectionDeleteOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/CollectionDeleteOperationImpl.java
@@ -79,6 +79,15 @@ public class CollectionDeleteOperationImpl extends OperationImpl
 	public void handleLine(String line) {
 		assert getState() == OperationState.READING
 		: "Read ``" + line + "'' when in " + getState() + " state";
+		/* ENABLE_REPLICATION if */
+		/* WHCHOI83_MEMCACHED_REPLICA_GROUP if */
+		if (line.equals("SWITCHOVER") || line.equals("REPL_SLAVE")) {
+			receivedMoveOperations(line);
+			return;
+		}
+
+		/* WHCHOI83_MEMCACHED_REPLICA_GROUP end */
+		/* ENABLE_REPLICATION end */
 		OperationStatus status = matchStatus(line, DELETED, DELETED_DROPPED,
 				NOT_FOUND, NOT_FOUND_ELEMENT, OUT_OF_RANGE, TYPE_MISMATCH,
 				BKEY_MISMATCH);

--- a/src/main/java/net/spy/memcached/protocol/ascii/CollectionGetOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/CollectionGetOperationImpl.java
@@ -98,6 +98,15 @@ public class CollectionGetOperationImpl extends OperationImpl
 	 * VALUE <flag> <count>\r\n
 	 */
 	public void handleLine(String line) {
+		/* ENABLE_REPLICATION if */
+		/* WHCHOI83_MEMCACHED_REPLICA_GROUP if */
+		if (line.equals("SWITCHOVER") || line.equals("REPL_SLAVE")) {
+			receivedMoveOperations(line);
+			return;
+		}
+
+		/* WHCHOI83_MEMCACHED_REPLICA_GROUP end */
+		/* ENABLE_REPLICATION end */
 		if (line.startsWith("VALUE ")) {
 			// Response header
 			getLogger().debug("Got line %s", line);

--- a/src/main/java/net/spy/memcached/protocol/ascii/CollectionMutateOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/CollectionMutateOperationImpl.java
@@ -78,6 +78,15 @@ public class CollectionMutateOperationImpl extends OperationImpl implements
 
 		OperationStatus status = null;
 
+		/* ENABLE_REPLICATION if */
+		/* WHCHOI83_MEMCACHED_REPLICA_GROUP if */
+		if (line.equals("SWITCHOVER") || line.equals("REPL_SLAVE")) {
+			receivedMoveOperations(line);
+			return;
+		}
+
+		/* WHCHOI83_MEMCACHED_REPLICA_GROUP end */
+		/* ENABLE_REPLICATION end */
 		try {
 			Long.valueOf(line);
 			getCallback().receivedStatus(new OperationStatus(true, line));

--- a/src/main/java/net/spy/memcached/protocol/ascii/CollectionPipedExistOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/CollectionPipedExistOperationImpl.java
@@ -107,6 +107,11 @@ public class CollectionPipedExistOperationImpl extends OperationImpl implements
 				successAll = false;
 			}
 			cb.gotStatus(index, status);
+			/* ENABLE_REPLICATION if */
+			/* WHCHOI83_MEMCACHED_REPLICA_GROUP if */
+			this.setPipedExist.setNextOpIndex(index);
+			/* WHCHOI83_MEMCACHED_REPLICA_GROUP end */
+			/* ENABLE_REPLICATION end */
 			index++;
 		}
 	}

--- a/src/main/java/net/spy/memcached/protocol/ascii/CollectionPipedStoreOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/CollectionPipedStoreOperationImpl.java
@@ -91,6 +91,16 @@ public class CollectionPipedStoreOperationImpl extends OperationImpl
 		assert getState() == OperationState.READING
 			: "Read ``" + line + "'' when in " + getState() + " state";
 
+		/* ENABLE_REPLICATION if */
+		/* WHCHOI83_MEMCACHED_REPLICA_GROUP if */
+		if (line.equals("SWITCHOVER") || line.equals("REPL_SLAVE")) {
+			this.store.setNextOpIndex(index);
+			receivedMoveOperations(line);
+			return;
+		}
+
+		/* WHCHOI83_MEMCACHED_REPLICA_GROUP end */
+		/* ENABLE_REPLICATION end */
 		if (store.getItemCount() == 1) {
 			OperationStatus status = matchStatus(line, STORED, CREATED_STORED,
 					NOT_FOUND, ELEMENT_EXISTS, OVERFLOWED, OUT_OF_RANGE,

--- a/src/main/java/net/spy/memcached/protocol/ascii/CollectionPipedUpdateOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/CollectionPipedUpdateOperationImpl.java
@@ -86,6 +86,15 @@ public class CollectionPipedUpdateOperationImpl extends OperationImpl implements
 		assert getState() == OperationState.READING : "Read ``" + line
 				+ "'' when in " + getState() + " state";
 
+		/* ENABLE_REPLICATION if */
+		/* WHCHOI83_MEMCACHED_REPLICA_GROUP if */
+		if (line.equals("SWITCHOVER") || line.equals("REPL_SLAVE")) {
+			receivedMoveOperations(line);
+			return;
+		}
+
+		/* WHCHOI83_MEMCACHED_REPLICA_GROUP end */
+		/* ENABLE_REPLICATION end */
 		if (update.getItemCount() == 1) {
 			OperationStatus status = matchStatus(line, UPDATED, NOT_FOUND,
 					NOT_FOUND_ELEMENT, NOTHING_TO_UPDATE, TYPE_MISMATCH,

--- a/src/main/java/net/spy/memcached/protocol/ascii/CollectionStoreOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/CollectionStoreOperationImpl.java
@@ -87,6 +87,15 @@ public class CollectionStoreOperationImpl extends OperationImpl
 	public void handleLine(String line) {
 		assert getState() == OperationState.READING
 			: "Read ``" + line + "'' when in " + getState() + " state";
+		/* ENABLE_REPLICATION if */
+		/* WHCHOI83_MEMCACHED_REPLICA_GROUP if */
+		if (line.equals("SWITCHOVER") || line.equals("REPL_SLAVE")) {
+			receivedMoveOperations(line);
+			return;
+		}
+
+		/* WHCHOI83_MEMCACHED_REPLICA_GROUP end */
+		/* ENABLE_REPLICATION end */
 		getCallback().receivedStatus(
 				matchStatus(line, STORED, CREATED_STORED, NOT_FOUND, ELEMENT_EXISTS,
 						OVERFLOWED, OUT_OF_RANGE, TYPE_MISMATCH, BKEY_MISMATCH));

--- a/src/main/java/net/spy/memcached/protocol/ascii/CollectionUpdateOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/CollectionUpdateOperationImpl.java
@@ -82,6 +82,15 @@ public class CollectionUpdateOperationImpl extends OperationImpl implements
 	public void handleLine(String line) {
 		assert getState() == OperationState.READING : "Read ``" + line
 				+ "'' when in " + getState() + " state";
+		/* ENABLE_REPLICATION if */
+		/* WHCHOI83_MEMCACHED_REPLICA_GROUP if */
+		if (line.equals("SWITCHOVER") || line.equals("REPL_SLAVE")) {
+			receivedMoveOperations(line);
+			return;
+		}
+
+		/* WHCHOI83_MEMCACHED_REPLICA_GROUP end */
+		/* ENABLE_REPLICATION end */
 		getCallback().receivedStatus(
 				matchStatus(line, UPDATED, NOT_FOUND, NOT_FOUND_ELEMENT,
 						NOTHING_TO_UPDATE, TYPE_MISMATCH, BKEY_MISMATCH,

--- a/src/main/java/net/spy/memcached/protocol/ascii/CollectionUpsertOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/CollectionUpsertOperationImpl.java
@@ -84,6 +84,15 @@ public class CollectionUpsertOperationImpl extends OperationImpl implements
 	public void handleLine(String line) {
 		assert getState() == OperationState.READING : "Read ``" + line
 				+ "'' when in " + getState() + " state";
+		/* ENABLE_REPLICATION if */
+		/* WHCHOI83_MEMCACHED_REPLICA_GROUP if */
+		if (line.equals("SWITCHOVER") || line.equals("REPL_SLAVE")) {
+			receivedMoveOperations(line);
+			return;
+		}
+
+		/* WHCHOI83_MEMCACHED_REPLICA_GROUP end */
+		/* ENABLE_REPLICATION end */
 		getCallback().receivedStatus(
 				matchStatus(line, STORED, REPLACED, CREATED_STORED, NOT_FOUND,
 						ELEMENT_EXISTS, OVERFLOWED, OUT_OF_RANGE,

--- a/src/main/java/net/spy/memcached/protocol/ascii/DeleteOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/DeleteOperationImpl.java
@@ -39,6 +39,15 @@ final class DeleteOperationImpl extends OperationImpl
 	@Override
 	public void handleLine(String line) {
 		getLogger().debug("Delete of %s returned %s", key, line);
+		/* ENABLE_REPLICATION if */
+		/* WHCHOI83_MEMCACHED_REPLICA_GROUP if */
+		if (line.equals("SWITCHOVER") || line.equals("REPL_SLAVE")) {
+			receivedMoveOperations(line);
+			return;
+		}
+
+		/* WHCHOI83_MEMCACHED_REPLICA_GROUP end */
+		/* ENABLE_REPLICATION end */
 		getCallback().receivedStatus(matchStatus(line, DELETED, NOT_FOUND));
 		transitionState(OperationState.COMPLETE);
 	}

--- a/src/main/java/net/spy/memcached/protocol/ascii/ExtendedBTreeGetOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/ExtendedBTreeGetOperationImpl.java
@@ -92,6 +92,15 @@ public class ExtendedBTreeGetOperationImpl extends OperationImpl
 	 * VALUE <flag> <count>\r\n
 	 */
 	public void handleLine(String line) {
+		/* ENABLE_REPLICATION if */
+		/* WHCHOI83_MEMCACHED_REPLICA_GROUP if */
+		if (line.equals("SWITCHOVER") || line.equals("REPL_SLAVE")) {
+			receivedMoveOperations(line);
+			return;
+		}
+
+		/* WHCHOI83_MEMCACHED_REPLICA_GROUP end */
+		/* ENABLE_REPLICATION end */
 		if (line.startsWith("VALUE ")) {
 			// Response header
 			getLogger().debug("Got line %s", line);

--- a/src/main/java/net/spy/memcached/protocol/ascii/FlushByPrefixOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/FlushByPrefixOperationImpl.java
@@ -51,6 +51,15 @@ final class FlushByPrefixOperationImpl extends OperationImpl implements
 	@Override
 	public void handleLine(String line) {
 		getLogger().debug("Flush completed successfully");
+		/* ENABLE_REPLICATION if */
+		/* WHCHOI83_MEMCACHED_REPLICA_GROUP if */
+		if (line.equals("SWITCHOVER") || line.equals("REPL_SLAVE")) {
+			receivedMoveOperations(line);
+			return;
+		}
+
+		/* WHCHOI83_MEMCACHED_REPLICA_GROUP end */
+		/* ENABLE_REPLICATION end */
 		getCallback().receivedStatus(matchStatus(line, OK, NOT_FOUND));
 		transitionState(OperationState.COMPLETE);
 	}

--- a/src/main/java/net/spy/memcached/protocol/ascii/FlushOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/FlushOperationImpl.java
@@ -34,6 +34,15 @@ final class FlushOperationImpl extends OperationImpl
 	@Override
 	public void handleLine(String line) {
 		getLogger().debug("Flush completed successfully");
+		/* ENABLE_REPLICATION if */
+		/* WHCHOI83_MEMCACHED_REPLICA_GROUP if */
+		if (line.equals("SWITCHOVER") || line.equals("REPL_SLAVE")) {
+			receivedMoveOperations(line);
+			return;
+		}
+
+		/* WHCHOI83_MEMCACHED_REPLICA_GROUP end */
+		/* ENABLE_REPLICATION end */
 		getCallback().receivedStatus(matchStatus(line, OK));
 		transitionState(OperationState.COMPLETE);
 	}

--- a/src/main/java/net/spy/memcached/protocol/ascii/MutatorOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/MutatorOperationImpl.java
@@ -67,6 +67,14 @@ final class MutatorOperationImpl extends OperationImpl
 
 	@Override
 	public void handleLine(String line) {
+		/* ENABLE_REPLICATION if */
+		/* WHCHOI83_MEMCACHED_REPLICA_GROUP if */
+		if (line.equals("SWITCHOVER") || line.equals("REPL_SLAVE")) {
+			receivedMoveOperations(line);
+		}
+
+		/* WHCHOI83_MEMCACHED_REPLICA_GROUP end */
+		/* ENABLE_REPLICATION end */
 		OperationStatus status=null;
 		try {
 			Long.valueOf(line);

--- a/src/main/java/net/spy/memcached/protocol/ascii/OperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/OperationImpl.java
@@ -70,6 +70,11 @@ abstract class OperationImpl extends BaseOperationImpl implements Operation {
 		}
 		if(rv == null) {
 			rv=new OperationStatus(false, line);
+			/* ENABLE_REPLICATION if */
+			/* WHCHOI83_MEMCACHED_REPLICA_GROUP if */
+			getLogger().error("Unexpected operation status : %s", line);
+			/* WHCHOI83_MEMCACHED_REPLICA_GROUP end */
+			/* ENABLE_REPLICATION end */
 		}
 		return rv;
 	}
@@ -150,6 +155,13 @@ abstract class OperationImpl extends BaseOperationImpl implements Operation {
 					}
 				}
 			}
+			/* ENABLE_REPLICATION if */
+			/* WHCHOI83_MEMCACHED_REPLICA_GROUP if */
+			if (getState() == OperationState.MOVING) {
+				break;
+			}
+			/* WHCHOI83_MEMCACHED_REPLICA_GROUP end */
+			/* ENABLE_REPLICATION end */
 		}
 	}
 

--- a/src/main/java/net/spy/memcached/protocol/ascii/SetAttrOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/SetAttrOperationImpl.java
@@ -66,6 +66,14 @@ class SetAttrOperationImpl extends OperationImpl
 	public void handleLine(String line) {
 		assert getState() == OperationState.READING
 			: "Read ``" + line + "'' when in " + getState() + " state";
+		/* ENABLE_REPLICATION if */
+		/* WHCHOI83_MEMCACHED_REPLICA_GROUP if */
+		if (line.equals("SWITCHOVER") || line.equals("REPL_SLAVE")) {
+			receivedMoveOperations(line);
+		}
+
+		/* WHCHOI83_MEMCACHED_REPLICA_GROUP end */
+		/* ENABLE_REPLICATION end */
 		getCallback().receivedStatus(
 				matchStatus(line, OK, NOT_FOUND, ATTR_ERROR_NOT_FOUND,
 						ATTR_ERROR_BAD_VALUE));

--- a/src/test/java/net/spy/memcached/MockMemcachedNode.java
+++ b/src/test/java/net/spy/memcached/MockMemcachedNode.java
@@ -26,6 +26,7 @@ import java.nio.ByteBuffer;
 import java.nio.channels.SelectionKey;
 import java.nio.channels.SocketChannel;
 import java.util.Collection;
+import java.util.concurrent.BlockingQueue;
 
 import net.spy.memcached.ops.Operation;
 
@@ -158,4 +159,30 @@ public class MockMemcachedNode implements MemcachedNode {
 	public String getStatus() {
 		return "MOCK_STATE";
 	}
+	/* ENABLE_REPLICATION if */
+	/* WHCHOI83_MEMCACHED_REPLICA_GROUP if */
+
+	@Override
+	public void setReplicaGroup(MemcachedReplicaGroup g) {
+		// noop
+	}
+
+	@Override
+	public MemcachedReplicaGroup getReplicaGroup() {
+		// noop
+		return null;
+	}
+
+	@Override
+	public void addAllOpToInputQ(BlockingQueue<Operation> allOp) {
+		// noop
+	}
+
+	@Override
+	public int moveOperations(final MemcachedNode toNode) {
+		// noop
+		return 0;
+	}
+	/* WHCHOI83_MEMCACHED_REPLICA_GROUP end */
+	/* ENABLE_REPLICATION end */
 }


### PR DESCRIPTION
memcached node 에서 switchover 또는 failover 발생 시 기존 operation 을 move 해주는 내용의 PR입니다.

@aiceru, @jhpark816 리뷰 부탁드립니다. :smiley: 