### PR TITLE
Removed duplications on CollectionDelete and its subclasses

### DIFF
--- a/src/main/java/net/spy/memcached/collection/BTreeDelete.java
+++ b/src/main/java/net/spy/memcached/collection/BTreeDelete.java
@@ -101,6 +101,15 @@ public class BTreeDelete extends CollectionDelete {
 		this.elementFlagFilter = (ElementFlagFilter)elementMultiFlagsFilter;
 	}
 
+	@Override
+	public byte[] getData() {
+		return null;
+	}
+
+	@Override
+	public void setData(byte[] data) {
+	}
+
 	public String stringify() {
 		if (str != null) return str;
 		

--- a/src/main/java/net/spy/memcached/collection/CollectionDelete.java
+++ b/src/main/java/net/spy/memcached/collection/CollectionDelete.java
@@ -23,7 +23,6 @@ public abstract class CollectionDelete {
 	protected boolean dropIfEmpty = true;
 	
 	protected String str;
-	protected byte[] data = { };
 
 	public String getRange() {
 		return range;
@@ -41,14 +40,8 @@ public abstract class CollectionDelete {
 		this.noreply = noreply;
 	}
 
-	public byte[] getData() {
-		return data;
-	}
-
-	public void setData(byte[] data) {
-		this.data = data;
-	}
-
+	public abstract byte[] getData();
+	public abstract void setData(byte[] data);
 	public abstract String stringify();
 	public abstract String getCommand();
 

--- a/src/main/java/net/spy/memcached/collection/ListDelete.java
+++ b/src/main/java/net/spy/memcached/collection/ListDelete.java
@@ -40,6 +40,15 @@ public class ListDelete extends CollectionDelete {
 		this.dropIfEmpty = dropIfEmpty;
 	}
 	
+	@Override
+	public byte[] getData() {
+		return null;
+	}
+
+	@Override
+	public void setData(byte[] data) {
+	}
+
 	public String stringify() {
 		if (str != null) return str;
 		

--- a/src/main/java/net/spy/memcached/protocol/ascii/CollectionDeleteOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/CollectionDeleteOperationImpl.java
@@ -93,14 +93,11 @@ public class CollectionDeleteOperationImpl extends OperationImpl
 		byte[] data = collectionDelete.getData();
 
 		ByteBuffer bb = ByteBuffer.allocate(KeyUtil.getKeyBytes(key).length
-				+ cmd.length() + args.length() + data.length + 16);
+				+ cmd.length() + args.length() + ((null != data)? data.length : 0) + 16);
 
 		setArguments(bb, cmd, key, args);
 
-		if ("sop delete".equals(cmd)) {
-			bb.put(data);
-			bb.put(CRLF);
-		} else if (data.length > 0) {
+		if (null != data) {
 			bb.put(data);
 			bb.put(CRLF);
 		}


### PR DESCRIPTION
CollectionDelete 의 `getData()`, `setData()` 를 abstract method 로 전환하고
SetDelete, BTreeDelete, ListDelete 에서 각각의 용도에 맞게 구현했습니다.

BTreeDelete와 ListDelete 의 `getData()` 에서는 `return null` 하고
CollectionDeleteOperationImpl 에서는 `CollectionDelete.getData()` 값이 null 인지를 검사합니다.

나중에 value 를 이용하여 delete 하는 연산을 추가하게 되더라도,
"sop_delete" 문자열과 cmd 를 비교하는 것보다 확장성은 좋을 것이라고 판단됩니다.

@whchoi83 리뷰 부탁합니다~