### PR TITLE
fixed CollectionDelete/Exist to accept additional ascii protocol argument

### DIFF
--- a/src/main/java/net/spy/memcached/ArcusClient.java
+++ b/src/main/java/net/spy/memcached/ArcusClient.java
@@ -556,8 +556,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
 	@Override
 	public <T> CollectionFuture<Boolean> asyncSopExist(String key, T value,
 			Transcoder<T> tc) {
-		SetExist<T> exist = new SetExist<T>();
-		exist.setValue(value);
+		SetExist<T> exist = new SetExist<T>(value, tc);
 		return asyncCollectionExist(key, "", exist, tc);
 	}
 
@@ -566,8 +565,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
 	 */
 	@Override
 	public CollectionFuture<Boolean> asyncSopExist(String key, Object value) {
-		SetExist<Object> exist = new SetExist<Object>();
-		exist.setValue(value);
+		SetExist<Object> exist = new SetExist<Object>(value, collectionTranscoder);
 		return asyncCollectionExist(key, "", exist, collectionTranscoder);
 	}
 
@@ -1102,13 +1100,10 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
 	 */
 	private <T> CollectionFuture<Boolean> asyncCollectionExist(
 			final String key, final String subkey,
-			final CollectionExist<T> collectionExist, Transcoder<T> tc) {
+			final CollectionExist collectionExist, Transcoder<T> tc) {
 		final CountDownLatch latch = new CountDownLatch(1);
 		final CollectionFuture<Boolean> rv = new CollectionFuture<Boolean>(
 				latch, operationTimeout);
-		CachedData cd = tc.encode(collectionExist.getValue());
-		collectionExist.setData(cd.getData());
-
 		Operation op = opFact.collectionExist(key, subkey, collectionExist,
 				new OperationCallback() {
 					public void receivedStatus(OperationStatus status) {

--- a/src/main/java/net/spy/memcached/ArcusClient.java
+++ b/src/main/java/net/spy/memcached/ArcusClient.java
@@ -1451,8 +1451,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
 	public CollectionFuture<Boolean> asyncSopDelete(String key, Object value,
 			boolean dropIfEmpty) {
 		SetDelete<Object> delete = new SetDelete<Object>(value, false,
-				dropIfEmpty);
-		delete.setData(collectionTranscoder.encode(value).getData());
+				dropIfEmpty, collectionTranscoder);
 		return asyncCollectionDelete(key, delete);
 	}
 
@@ -1463,8 +1462,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
 	@Override
 	public <T> CollectionFuture<Boolean> asyncSopDelete(String key, T value,
 			boolean dropIfEmpty, Transcoder<T> tc) {
-		SetDelete<Object> delete = new SetDelete<Object>(value, false, dropIfEmpty);
-		delete.setData(tc.encode(value).getData());
+		SetDelete<T> delete = new SetDelete<T>(value, false, dropIfEmpty, tc);
 		return asyncCollectionDelete(key, delete);
 	}
 

--- a/src/main/java/net/spy/memcached/OperationFactory.java
+++ b/src/main/java/net/spy/memcached/OperationFactory.java
@@ -306,7 +306,7 @@ public interface OperationFactory {
 	 * @return a new CollectionExistOperation
 	 */
 	CollectionExistOperation collectionExist(String key, String subkey, 
-			CollectionExist<?> collectionExist, OperationCallback cb); 
+			CollectionExist collectionExist, OperationCallback cb);
 	
 	/**
 	 * Clone an operation.

--- a/src/main/java/net/spy/memcached/collection/BTreeDelete.java
+++ b/src/main/java/net/spy/memcached/collection/BTreeDelete.java
@@ -101,6 +101,11 @@ public class BTreeDelete extends CollectionDelete {
 		this.elementFlagFilter = (ElementFlagFilter)elementMultiFlagsFilter;
 	}
 
+	@Override
+	public byte[] getAdditionalArgs() {
+		return null;
+	}
+
 	public String stringify() {
 		if (str != null) return str;
 		

--- a/src/main/java/net/spy/memcached/collection/CollectionDelete.java
+++ b/src/main/java/net/spy/memcached/collection/CollectionDelete.java
@@ -23,7 +23,6 @@ public abstract class CollectionDelete {
 	protected boolean dropIfEmpty = true;
 	
 	protected String str;
-	protected byte[] data = { };
 
 	public String getRange() {
 		return range;
@@ -41,14 +40,8 @@ public abstract class CollectionDelete {
 		this.noreply = noreply;
 	}
 
-	public byte[] getData() {
-		return data;
-	}
 
-	public void setData(byte[] data) {
-		this.data = data;
-	}
-
+	public abstract byte[] getAdditionalArgs();
 	public abstract String stringify();
 	public abstract String getCommand();
 

--- a/src/main/java/net/spy/memcached/collection/CollectionExist.java
+++ b/src/main/java/net/spy/memcached/collection/CollectionExist.java
@@ -16,44 +16,11 @@
  */
 package net.spy.memcached.collection;
 
-public abstract class CollectionExist<T> {
+public abstract class CollectionExist {
 
-	protected T value;
-	protected byte[] data;
-	
 	protected String str;
-	
-	public CollectionExist() { }
-	
-	public CollectionExist(T value, byte[] data) {
-		this.value = value;
-		this.data = data;
-	}
-	
-	public void setValue(T value) {
-		this.value = value;
-	}
-	
-	public T getValue() {
-		return value;
-	}
-	
-	public byte[] getData() {
-		return data;
-	}
-	
-	public void setData(byte[] data) {
-		this.data = data;
-	}
 
-	public String stringify() {
-		return "";
-	}
-	
-	public String toString() {
-		return (str != null)? str : stringify();
-	}
-	
+	public abstract byte[] getAdditionalArgs();
+	public abstract String stringify();
 	public abstract String getCommand();
-	
 }

--- a/src/main/java/net/spy/memcached/collection/ListDelete.java
+++ b/src/main/java/net/spy/memcached/collection/ListDelete.java
@@ -40,6 +40,11 @@ public class ListDelete extends CollectionDelete {
 		this.dropIfEmpty = dropIfEmpty;
 	}
 	
+	@Override
+	public byte[] getAdditionalArgs() {
+		return null;
+	}
+
 	public String stringify() {
 		if (str != null) return str;
 		

--- a/src/main/java/net/spy/memcached/collection/SetDelete.java
+++ b/src/main/java/net/spy/memcached/collection/SetDelete.java
@@ -16,20 +16,24 @@
  */
 package net.spy.memcached.collection;
 
+import net.spy.memcached.transcoders.Transcoder;
+
 public class SetDelete<T> extends CollectionDelete {
 
 	private static final String command = "sop delete";
 	
 	protected T value;
-	protected byte[] data;
+	protected byte[] additionalArgs;
+	protected Transcoder<T> tc;
 	
-	public SetDelete(T value, boolean noreply) {
+	public SetDelete(T value, boolean noreply, Transcoder tc) {
 		this.value = value;
 		this.noreply = noreply;
+		this.additionalArgs = tc.encode(value).getData();
 	}
 
-	public SetDelete(T value, boolean noreply, boolean dropIfEmpty) {
-		this(value, noreply);
+	public SetDelete(T value, boolean noreply, boolean dropIfEmpty, Transcoder<T> tc) {
+		this(value, noreply, tc);
 		this.dropIfEmpty = dropIfEmpty;
 	}
 	
@@ -41,17 +45,13 @@ public class SetDelete<T> extends CollectionDelete {
 		this.value = value;
 	}
 	
-	public byte[] getData() {
-		return data;
-	}
-
-	public void setData(byte[] data) {
-		this.data = data;
+	public byte[] getAdditionalArgs() {
+		return additionalArgs;
 	}
 
 	public String stringify() {
 		StringBuilder b = new StringBuilder();
-		b.append(data.length);
+		b.append(additionalArgs.length);
 		
 		if (dropIfEmpty) {
 			b.append(" drop");

--- a/src/main/java/net/spy/memcached/collection/SetDelete.java
+++ b/src/main/java/net/spy/memcached/collection/SetDelete.java
@@ -29,6 +29,7 @@ public class SetDelete<T> extends CollectionDelete {
 	public SetDelete(T value, boolean noreply, Transcoder tc) {
 		this.value = value;
 		this.noreply = noreply;
+		this.tc = tc;
 		this.additionalArgs = tc.encode(value).getData();
 	}
 

--- a/src/main/java/net/spy/memcached/collection/SetExist.java
+++ b/src/main/java/net/spy/memcached/collection/SetExist.java
@@ -16,14 +16,29 @@
  */
 package net.spy.memcached.collection;
 
-public class SetExist<T> extends CollectionExist<T> {
+import net.spy.memcached.transcoders.Transcoder;
+
+public class SetExist<T> extends CollectionExist {
 
 	private static final String command = "sop exist";
-	
-	public SetExist() { }
 
-	public SetExist(T value, byte[] data) {
-		super(value, data);
+	protected T value;
+	protected byte[] additionalArgs;
+	protected Transcoder<T> tc;
+	
+	public SetExist(T value, Transcoder tc) {
+		this.value = value;
+		this.tc = tc;
+		this.additionalArgs = tc.encode(value).getData();
+	}
+
+	@Override
+	public byte[] getAdditionalArgs() {
+		return additionalArgs;
+	}
+
+	public String stringify() {
+		return String.valueOf(additionalArgs.length);
 	}
 
 	public String getCommand() {

--- a/src/main/java/net/spy/memcached/ops/CollectionExistOperation.java
+++ b/src/main/java/net/spy/memcached/ops/CollectionExistOperation.java
@@ -25,6 +25,6 @@ public interface CollectionExistOperation extends KeyedOperation {
 
 	String getSubKey();
 
-	CollectionExist<?> getExist();
+	CollectionExist getExist();
 
 }

--- a/src/main/java/net/spy/memcached/protocol/ascii/AsciiOperationFactory.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/AsciiOperationFactory.java
@@ -202,7 +202,7 @@ public class AsciiOperationFactory extends BaseOperationFactory {
 	}
 	
 	public CollectionExistOperation collectionExist(String key, String subkey,
-			CollectionExist<?> collectionExist, OperationCallback cb) {
+			CollectionExist collectionExist, OperationCallback cb) {
 		return new CollectionExistOperationImpl(key, subkey, collectionExist, cb);
 	}
 

--- a/src/main/java/net/spy/memcached/protocol/ascii/CollectionDeleteOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/CollectionDeleteOperationImpl.java
@@ -90,18 +90,16 @@ public class CollectionDeleteOperationImpl extends OperationImpl
 	public void initialize() {
 		String cmd = collectionDelete.getCommand();
 		String args = collectionDelete.stringify();
-		byte[] data = collectionDelete.getData();
+		byte[] additionalArgs = collectionDelete.getAdditionalArgs();
 
 		ByteBuffer bb = ByteBuffer.allocate(KeyUtil.getKeyBytes(key).length
-				+ cmd.length() + args.length() + data.length + 16);
+						+ cmd.length() + args.length() +
+						((null == additionalArgs)? 0 : additionalArgs.length) + 16);
 
 		setArguments(bb, cmd, key, args);
 
-		if ("sop delete".equals(cmd)) {
-			bb.put(data);
-			bb.put(CRLF);
-		} else if (data.length > 0) {
-			bb.put(data);
+		if (null != additionalArgs) {
+			bb.put(additionalArgs);
 			bb.put(CRLF);
 		}
 

--- a/src/main/java/net/spy/memcached/protocol/ascii/CollectionExistOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/CollectionExistOperationImpl.java
@@ -56,16 +56,14 @@ public class CollectionExistOperationImpl extends OperationImpl
 
 	protected final String key;
 	protected final String subkey;
-	protected final CollectionExist<?> collectionExist;
-	protected final byte[] data;
+	protected final CollectionExist collectionExist;
 
 	public CollectionExistOperationImpl(String key, String subkey,
-			CollectionExist<?> collectionExist, OperationCallback cb) {
+			CollectionExist collectionExist, OperationCallback cb) {
 		super(cb);
 		this.key = key;
 		this.subkey = subkey;
 		this.collectionExist = collectionExist;
-		this.data = collectionExist.getData();
 		if (this.collectionExist instanceof SetExist)
 			setAPIType(APIType.SOP_EXIST);
 		setOperationType(OperationType.READ);
@@ -84,14 +82,20 @@ public class CollectionExistOperationImpl extends OperationImpl
 	@Override
 	public void initialize() {
 		String args = collectionExist.stringify();
-		ByteBuffer bb = ByteBuffer.allocate(data.length
+		byte[] additionalArgs = collectionExist.getAdditionalArgs();
+		ByteBuffer bb = ByteBuffer.allocate(null == additionalArgs ? 0 : additionalArgs.length +
 				+ KeyUtil.getKeyBytes(key).length
 				+ KeyUtil.getKeyBytes(subkey).length
 				+ args.length()
 				+ OVERHEAD);
-		setArguments(bb, collectionExist.getCommand(), key, subkey, data.length, args);
-		bb.put(data);
-		bb.put(CRLF);
+		setArguments(bb, collectionExist.getCommand(), key, subkey,
+						null == additionalArgs ? 0 : additionalArgs.length, args);
+
+		if (null != additionalArgs) {
+			bb.put(additionalArgs);
+			bb.put(CRLF);
+		}
+
 		bb.flip();
 		setBuffer(bb);
 
@@ -114,12 +118,7 @@ public class CollectionExistOperationImpl extends OperationImpl
 		return subkey;
 	}
 
-	public CollectionExist<?> getExist() {
+	public CollectionExist getExist() {
 		return collectionExist;
 	}
-
-	public byte[] getData() {
-		return data;
-	}
-
 }

--- a/src/main/java/net/spy/memcached/protocol/binary/BinaryOperationFactory.java
+++ b/src/main/java/net/spy/memcached/protocol/binary/BinaryOperationFactory.java
@@ -231,7 +231,7 @@ public class BinaryOperationFactory extends BaseOperationFactory {
 	}
 
 	public CollectionExistOperation collectionExist(String key, String subkey,
-			CollectionExist<?> collectionExist, OperationCallback cb) {
+			CollectionExist collectionExist, OperationCallback cb) {
 		throw new RuntimeException(
 			"CollectionExistOperation is not supported in binary protocol yet.");
 	}

--- a/src/test/manual/net/spy/memcached/MultibyteKeyTest.java
+++ b/src/test/manual/net/spy/memcached/MultibyteKeyTest.java
@@ -137,10 +137,10 @@ public class MultibyteKeyTest {
     }
 
     @Test
-    public void CollectionExistOperationImplTest() {
+    public void SetExistOperationImplTest() {
         try {
             opFact.collectionExist(MULTIBYTE_KEY, "",
-                    new CollectionExist<Integer>(new Random().nextInt(), testData) {
+                    new SetExist<Integer>(new Random().nextInt(), new CollectionTranscoder()) {
                         @Override
                         public String getCommand() {
                             return "CollectionExistCommand";

--- a/src/test/manual/net/spy/memcached/emptycollection/ProtocolSetDeleteTest.java
+++ b/src/test/manual/net/spy/memcached/emptycollection/ProtocolSetDeleteTest.java
@@ -19,34 +19,32 @@ package net.spy.memcached.emptycollection;
 import junit.framework.Assert;
 import junit.framework.TestCase;
 import net.spy.memcached.collection.SetDelete;
+import net.spy.memcached.transcoders.CollectionTranscoder;
+import net.spy.memcached.transcoders.Transcoder;
 
 public class ProtocolSetDeleteTest extends TestCase {
 
-	public void testStringfy() {
+	public void testObjectfy() {
 		// default setting : dropIfEmpty = true
+		Object value = "value";
+		Transcoder<Object> testTranscoder = new CollectionTranscoder();
 
-		SetDelete<String> del = new SetDelete<String>("value", false);
-		del.setData("value".getBytes());
+		SetDelete<Object> del = new SetDelete<Object>("value", false, testTranscoder);
 		Assert.assertEquals("5 drop", del.stringify());
 
-		del = new SetDelete<String>("value", false, false);
-		del.setData("value".getBytes());
+		del = new SetDelete<Object>("value", false, false, testTranscoder);
 		Assert.assertEquals("5", del.stringify());
 
-		del = new SetDelete<String>("value", false, true);
-		del.setData("value".getBytes());
+		del = new SetDelete<Object>("value", false, true, testTranscoder);
 		Assert.assertEquals("5 drop", del.stringify());
 
-		del = new SetDelete<String>("value", true);
-		del.setData("value".getBytes());
+		del = new SetDelete<Object>("value", true, testTranscoder);
 		Assert.assertEquals("5 drop noreply", del.stringify());
 
-		del = new SetDelete<String>("value", true, false);
-		del.setData("value".getBytes());
+		del = new SetDelete<Object>("value", true, false, testTranscoder);
 		Assert.assertEquals("5 noreply", del.stringify());
 
-		del = new SetDelete<String>("value", true, true);
-		del.setData("value".getBytes());
+		del = new SetDelete<Object>("value", true, true, testTranscoder);
 		Assert.assertEquals("5 drop noreply", del.stringify());
 	}
 }

--- a/src/test/manual/net/spy/memcached/emptycollection/ProtocolSetDeleteTest.java
+++ b/src/test/manual/net/spy/memcached/emptycollection/ProtocolSetDeleteTest.java
@@ -16,35 +16,56 @@
  */
 package net.spy.memcached.emptycollection;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import junit.framework.TestCase;
 import net.spy.memcached.collection.SetDelete;
 import net.spy.memcached.transcoders.CollectionTranscoder;
 import net.spy.memcached.transcoders.Transcoder;
 
 public class ProtocolSetDeleteTest extends TestCase {
+	Object value = "value";
+	Transcoder<Object> testTranscoder = new CollectionTranscoder();
 
-	public void testObjectfy() {
+	public void testStringify() {
 		// default setting : dropIfEmpty = true
-		Object value = "value";
-		Transcoder<Object> testTranscoder = new CollectionTranscoder();
 
-		SetDelete<Object> del = new SetDelete<Object>("value", false, testTranscoder);
+		SetDelete<Object> del = new SetDelete<Object>(value, false, testTranscoder);
 		Assert.assertEquals("5 drop", del.stringify());
 
-		del = new SetDelete<Object>("value", false, false, testTranscoder);
+		del = new SetDelete<Object>(value, false, false, testTranscoder);
 		Assert.assertEquals("5", del.stringify());
 
-		del = new SetDelete<Object>("value", false, true, testTranscoder);
+		del = new SetDelete<Object>(value, false, true, testTranscoder);
 		Assert.assertEquals("5 drop", del.stringify());
 
-		del = new SetDelete<Object>("value", true, testTranscoder);
+		del = new SetDelete<Object>(value, true, testTranscoder);
 		Assert.assertEquals("5 drop noreply", del.stringify());
 
-		del = new SetDelete<Object>("value", true, false, testTranscoder);
+		del = new SetDelete<Object>(value, true, false, testTranscoder);
 		Assert.assertEquals("5 noreply", del.stringify());
 
-		del = new SetDelete<Object>("value", true, true, testTranscoder);
+		del = new SetDelete<Object>(value, true, true, testTranscoder);
 		Assert.assertEquals("5 drop noreply", del.stringify());
+	}
+
+	public void testGetAdditionalArgs() {
+		byte[] expected = new byte[]{'v','a','l','u','e'};
+		SetDelete<Object> del = new SetDelete<Object>(value, false, testTranscoder);
+		Assert.assertArrayEquals(expected, del.getAdditionalArgs());
+
+		del = new SetDelete<Object>(value, false, false, testTranscoder);
+		Assert.assertArrayEquals(expected, del.getAdditionalArgs());
+
+		del = new SetDelete<Object>(value, false, true, testTranscoder);
+		Assert.assertArrayEquals(expected, del.getAdditionalArgs());
+
+		del = new SetDelete<Object>(value, true, testTranscoder);
+		Assert.assertArrayEquals(expected, del.getAdditionalArgs());
+
+		del = new SetDelete<Object>(value, true, false, testTranscoder);
+		Assert.assertArrayEquals(expected, del.getAdditionalArgs());
+
+		del = new SetDelete<Object>(value, true, true, testTranscoder);
+		Assert.assertArrayEquals(expected, del.getAdditionalArgs());
 	}
 }

--- a/src/test/manual/net/spy/memcached/emptycollection/ProtocolSetExistTest.java
+++ b/src/test/manual/net/spy/memcached/emptycollection/ProtocolSetExistTest.java
@@ -1,0 +1,38 @@
+/*
+ * arcus-java-client : Arcus Java client
+ * Copyright 2010-2014 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.spy.memcached.emptycollection;
+
+import junit.framework.TestCase;
+import org.junit.Assert;
+import net.spy.memcached.collection.SetExist;
+import net.spy.memcached.transcoders.CollectionTranscoder;
+import net.spy.memcached.transcoders.Transcoder;
+
+public class ProtocolSetExistTest extends TestCase {
+  Object value = "value";
+  Transcoder<Object> testTranscoder = new CollectionTranscoder();
+
+  public void testStringify() {
+    SetExist<Object> exist = new SetExist<Object>(value, testTranscoder);
+    Assert.assertEquals("5", exist.stringify());
+  }
+
+  public void testGetAdditionalArgs() {
+    SetExist<Object> exist = new SetExist<Object>(value, testTranscoder);
+    Assert.assertArrayEquals(new byte[]{'v','a','l','u','e'}, exist.getAdditionalArgs());
+  }
+}


### PR DESCRIPTION
- CollectionDelete 의 기존 `data` member variable 을`additionalArgs` 로 naming 변경
- 해당 변수의 setter method 를 삭제하고 생성자에 transcoder 를 추가
  - 추후 오사용 방지 및 이미 기존의 생성자가 `T value` 를 포함하고 있어 transcoder 를 함께 가지고 있다가 `getAdditionalArgs` (수정 전의 `getData` 역할) 에서 byte encoding 하여 return 하도록 하였습니다.

근거 논의 사항은 [Closed PR#66](https://github.com/naver/arcus-java-client/pull/66) 참조.