### PR TITLE
Fixed CollectionGet

### DIFF
--- a/src/main/java/net/spy/memcached/collection/BTreeFindPositionWithGet.java
+++ b/src/main/java/net/spy/memcached/collection/BTreeFindPositionWithGet.java
@@ -99,6 +99,11 @@ public class BTreeFindPositionWithGet extends CollectionGet {
 		return spaceCount == 2;
 	}
 
+	@Override
+	public byte[] getAddtionalArgs() {
+		return null;
+	}
+
 	/*
 	 * VALUE <position> <flags> <count> <index>\r\n
 	 * <bkey> [<eflag>] <bytes> <data>\r\n

--- a/src/main/java/net/spy/memcached/collection/BTreeGet.java
+++ b/src/main/java/net/spy/memcached/collection/BTreeGet.java
@@ -130,6 +130,11 @@ public class BTreeGet extends CollectionGet {
 			return true;
 		}
 	}
+
+	@Override
+	public byte[] getAddtionalArgs() {
+		return null;
+	}
 	
 	@Override
 	public boolean headerReady(int spaceCount) {

--- a/src/main/java/net/spy/memcached/collection/BTreeGetByPosition.java
+++ b/src/main/java/net/spy/memcached/collection/BTreeGetByPosition.java
@@ -85,6 +85,11 @@ public class BTreeGetByPosition extends CollectionGet {
 		return spaceCount == 2;
 	}
 
+	@Override
+	public byte[] getAddtionalArgs() {
+		return null;
+	}
+
 	private static final int BKEY = 0;
 	private static final int EFLAG_OR_BYTES = 1;
 	private static final int BYTES = 2;

--- a/src/main/java/net/spy/memcached/collection/CollectionGet.java
+++ b/src/main/java/net/spy/memcached/collection/CollectionGet.java
@@ -64,7 +64,8 @@ public abstract class CollectionGet<K> {
 	public boolean eachRecordParseCompleted() {
 		return true;
 	}
-	
+
+	public abstract byte[] getAddtionalArgs();
 	public abstract String stringify();
 	public abstract String getCommand();
 	public abstract void decodeItemHeader(String itemHeader);

--- a/src/main/java/net/spy/memcached/collection/ListGet.java
+++ b/src/main/java/net/spy/memcached/collection/ListGet.java
@@ -53,6 +53,11 @@ public class ListGet extends CollectionGet {
 		this.range = range;
 	}
 
+	@Override
+	public byte[] getAddtionalArgs() {
+		return null;
+	}
+
 	public String stringify() {
 		if (str != null) return str;
 		

--- a/src/main/java/net/spy/memcached/collection/SetGet.java
+++ b/src/main/java/net/spy/memcached/collection/SetGet.java
@@ -40,7 +40,12 @@ public class SetGet extends CollectionGet {
 	public void setCount(int count) {
 		this.count = count;
 	}
-	
+
+	@Override
+	public byte[] getAddtionalArgs() {
+		return null;
+	}
+
 	public String stringify() {
 		if (str != null) return str;
 		

--- a/src/main/java/net/spy/memcached/protocol/ascii/CollectionGetOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/CollectionGetOperationImpl.java
@@ -223,10 +223,17 @@ public class CollectionGetOperationImpl extends OperationImpl
 	public void initialize() {
 		String cmd = collectionGet.getCommand();
 		String args = collectionGet.stringify();
-		ByteBuffer bb = ByteBuffer.allocate(KeyUtil.getKeyBytes(key).length
-				+ cmd.length() + args.length() + 16);
+		byte[] additionalArgs = collectionGet.getAddtionalArgs();
+
+		ByteBuffer bb = ByteBuffer.allocate(
+						KeyUtil.getKeyBytes(key).length + cmd.length() + args.length() +
+										(additionalArgs == null ? 0 : additionalArgs.length) + 16);
 
 		setArguments(bb, cmd, key, args);
+		if(additionalArgs != null) {
+			setArguments(bb, additionalArgs);
+		}
+
 		bb.flip();
 		setBuffer(bb);
 

--- a/src/test/manual/net/spy/memcached/MultibyteKeyTest.java
+++ b/src/test/manual/net/spy/memcached/MultibyteKeyTest.java
@@ -87,6 +87,11 @@ public class MultibyteKeyTest {
                 public String stringify() {
                     return "collectionGetString";
                 }
+
+                @Override
+                public byte[] getAddtionalArgs() {
+                    return null;
+                }
                 @Override
                 public String getCommand() {
                     return "collectionGetCommand";


### PR DESCRIPTION
Fixed CollectionGet and its subclasses to be able to accept additional arguments.

[CollectionDelete/Exist 와 마찬가지](https://github.com/naver/arcus-java-client/pull/67/files)로, map collection protocol support 를 위해 CollectionGet 에서도 additional argument 를 받을 수 있도록 수정합니다.

First reviewer
- [x] @whchoi83 

Final Reviewer
- [x] @jhpark816 