### PR TITLE
Fixed bug in CollectionGetOperationImpl

### DIFF
--- a/src/main/java/net/spy/memcached/protocol/ascii/CollectionGetOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/CollectionGetOperationImpl.java
@@ -231,7 +231,8 @@ public class CollectionGetOperationImpl extends OperationImpl
 
 		setArguments(bb, cmd, key, args);
 		if(additionalArgs != null) {
-			setArguments(bb, additionalArgs);
+			bb.put(additionalArgs);
+			bb.put(CRLF);
 		}
 
 		bb.flip();


### PR DESCRIPTION
byte[] additionalArgs must not go through setArguments() method.
Instead, put it directly to ByteBuffer using bb.put().