### PR TITLE
Remove unnecessary imports that raised mvn build warnings

### DIFF
--- a/src/test/manual/net/spy/memcached/MultibyteKeyTest.java
+++ b/src/test/manual/net/spy/memcached/MultibyteKeyTest.java
@@ -14,9 +14,7 @@ import net.spy.memcached.transcoders.Transcoder;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-import sun.reflect.annotation.ExceptionProxy;
 
-import java.security.Key;
 import java.util.*;
 
 /**


### PR DESCRIPTION
자꾸 번거롭게 해서 죄송합니다. ㅠ 필요없는 import 가 남아서 warning 을 발생시키고 있었네요