### PR TITLE
Refactoring: remove warnings

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -84,8 +84,11 @@
 					<debug>true</debug>
 					<optimize>true</optimize>
 					<encoding>utf-8</encoding>
-					<showDeprecations>true</showDeprecations>
-					<!-- <compilerArgument>-Xlint:unchecked</compilerArgument> -->
+					<showWarnings>true</showWarnings>
+					<compilerArgs>
+						<arg>-Werror</arg>
+						<arg>-Xlint:all</arg>
+					</compilerArgs>
 				</configuration>
 			</plugin>
 			<plugin>

--- a/src/main/java/net/spy/memcached/ArcusClientException.java
+++ b/src/main/java/net/spy/memcached/ArcusClientException.java
@@ -16,8 +16,9 @@
  */
 package net.spy.memcached;
 
-@SuppressWarnings("serial")
 public abstract class ArcusClientException extends RuntimeException {
+
+	private static final long serialVersionUID = -4658082759499319120L;
 
 	public ArcusClientException(String message) {
 		super(message);
@@ -28,6 +29,9 @@ public abstract class ArcusClientException extends RuntimeException {
 	}
 
 	public static class InitializeClientException extends ArcusClientException {
+
+		private static final long serialVersionUID = 2001051171343419920L;
+
 		public InitializeClientException(String message) {
 			super(message);
 		}

--- a/src/main/java/net/spy/memcached/MemcachedClient.java
+++ b/src/main/java/net/spy/memcached/MemcachedClient.java
@@ -1073,7 +1073,6 @@ public class MemcachedClient extends SpyThread
 		final Collection<Operation> ops=new ArrayList<Operation>(chunks.size());
 
 		GetOperation.Callback cb=new GetOperation.Callback() {
-				@SuppressWarnings("synthetic-access")
 				public void receivedStatus(OperationStatus status) {
 					if(!status.isSuccess()) {
 						getLogger().warn("Unsuccessful get:  %s", status);
@@ -1299,7 +1298,6 @@ public class MemcachedClient extends SpyThread
 					public void gotStat(String name, String val) {
 						rv.get(sa).put(name, val);
 					}
-					@SuppressWarnings("synthetic-access") // getLogger()
 					public void receivedStatus(OperationStatus status) {
 						if(!status.isSuccess()) {
 							getLogger().warn("Unsuccessful stat fetch:	%s",

--- a/src/main/java/net/spy/memcached/compat/log/LoggerFactory.java
+++ b/src/main/java/net/spy/memcached/compat/log/LoggerFactory.java
@@ -105,14 +105,13 @@ public final class LoggerFactory extends Object {
 	}
 
 	// Find the appropriate constructor
-	@SuppressWarnings("unchecked")
 	private void getConstructor() {
 		Class<? extends Logger> c=DefaultLogger.class;
 		String className=System.getProperty("net.spy.log.LoggerImpl");
 
 		if(className!=null) {
 			try {
-				c=(Class<? extends Logger>) Class.forName(className);
+				c= Class.forName(className).asSubclass(Logger.class);
 			} catch(NoClassDefFoundError e) {
 				System.err.println("Warning:  " + className
 					+ " not found while initializing"

--- a/src/main/java/net/spy/memcached/internal/CheckedOperationTimeoutException.java
+++ b/src/main/java/net/spy/memcached/internal/CheckedOperationTimeoutException.java
@@ -28,6 +28,7 @@ import net.spy.memcached.ops.Operation;
  */
 public class CheckedOperationTimeoutException extends TimeoutException {
 
+	private static final long serialVersionUID = 5187393339735774489L;
 	private final Collection<Operation> operations;
 
 	/**

--- a/src/main/java/net/spy/memcached/ops/OperationException.java
+++ b/src/main/java/net/spy/memcached/ops/OperationException.java
@@ -8,6 +8,7 @@ import java.io.IOException;
  */
 public final class OperationException extends IOException {
 
+	private static final long serialVersionUID = 2457625388445818437L;
 	private final OperationErrorType type;
 
 	/**

--- a/src/main/java/net/spy/memcached/plugin/LocalCacheManager.java
+++ b/src/main/java/net/spy/memcached/plugin/LocalCacheManager.java
@@ -65,7 +65,6 @@ public class LocalCacheManager {
 		}
 	}
 	
-	@SuppressWarnings("unchecked")
 	public <T> T get(String key, Transcoder<T> tc) {
 		if (cache == null) {
 			return null;
@@ -73,11 +72,16 @@ public class LocalCacheManager {
 		
 		try {
 			Element element = cache.get(key);
-			return element == null ? null : (T) element.getObjectValue();
+			if(null != element) {
+				@SuppressWarnings("unchecked") T ret = (T) element.getObjectValue();
+				return ret;
+			}
 		} catch (Exception e) {
 			logger.info("failed to get from the local cache : %s", e.getMessage());
 			return null;
 		}
+
+		return null;
 	}
 	
 	public <T> Future<T> asyncGet(final String key, final Transcoder<T> tc) {

--- a/src/test/java/net/spy/memcached/OperationFactoryTestBase.java
+++ b/src/test/java/net/spy/memcached/OperationFactoryTestBase.java
@@ -241,12 +241,11 @@ public abstract class OperationFactoryTestBase extends MockObjectTestCase {
 		assertTrue(Arrays.equals(testData, bytes));
 	}
 
-	@SuppressWarnings("unchecked")
-	private <T> T assertOne(Class<T> class1,
-			Collection<Operation> ops) {
+	private <T> T assertOne(Class<T> class1, Collection<Operation> ops) {
 		assertEquals(1, ops.size());
-		Operation op = ops.iterator().next();
-		return (T) op;
+
+		@SuppressWarnings("unchecked") T op = (T) ops.iterator().next();
+		return op;
 	}
 
 	protected <T> T cloneOne(Class<T> c, KeyedOperation t) {

--- a/src/test/manual/net/spy/memcached/btreesmget/ByteArrayBKeySMGetErrorTest.java
+++ b/src/test/manual/net/spy/memcached/btreesmget/ByteArrayBKeySMGetErrorTest.java
@@ -233,7 +233,7 @@ public class ByteArrayBKeySMGetErrorTest extends BaseIntegrationTest {
 
 		SMGetFuture<List<SMGetElement<Object>>> future = mc
 				.asyncBopSortMergeGet(KEY_LIST, from, to,
-						ElementFlagFilter.DO_NOT_FILTER, (int) count, (SMGetMode) smgetMode);
+						ElementFlagFilter.DO_NOT_FILTER, (int) count, smgetMode);
 		try {
 			List<SMGetElement<Object>> map = future
 					.get(1000L, TimeUnit.SECONDS);
@@ -300,7 +300,7 @@ public class ByteArrayBKeySMGetErrorTest extends BaseIntegrationTest {
 		
 		SMGetFuture<List<SMGetElement<Object>>> future = mc
 				.asyncBopSortMergeGet(KEY_LIST, from, to,
-						ElementFlagFilter.DO_NOT_FILTER, (int) count, (SMGetMode) smgetMode);
+						ElementFlagFilter.DO_NOT_FILTER, (int) count, smgetMode);
 		try {
 			List<SMGetElement<Object>> map = future
 					.get(1000L, TimeUnit.SECONDS);

--- a/src/test/manual/net/spy/memcached/btreesmget/ByteArrayBKeySMGetIrregularEflagTest.java
+++ b/src/test/manual/net/spy/memcached/btreesmget/ByteArrayBKeySMGetIrregularEflagTest.java
@@ -40,6 +40,9 @@ public class ByteArrayBKeySMGetIrregularEflagTest extends BaseIntegrationTest {
 
 	public void testGetAll_1() {
 		SMGetMode smgetMode = SMGetMode.UNIQUE;
+		ArrayList<String> testKeyList = new ArrayList<String>();
+		testKeyList.add(key1);
+		testKeyList.add(key2);
 		
 		/* old SMGetIrregularEflagTest */
 		try {
@@ -61,13 +64,8 @@ public class ByteArrayBKeySMGetIrregularEflagTest extends BaseIntegrationTest {
 					new CollectionAttributes()).get();
 
 			List<SMGetElement<Object>> list = mc.asyncBopSortMergeGet(
-					new ArrayList<String>() {
-						{
-							add(key1);
-							add(key2);
-						}
-					}, new byte[] { 0 }, new byte[] { 10 },
-					ElementFlagFilter.DO_NOT_FILTER, 0, 10).get();
+							testKeyList, new byte[] { 0 }, new byte[] { 10 },
+							ElementFlagFilter.DO_NOT_FILTER, 0, 10).get();
 
 			for (int i = 0; i < list.size(); i++) {
 				System.out.println(list.get(i));
@@ -96,13 +94,8 @@ public class ByteArrayBKeySMGetIrregularEflagTest extends BaseIntegrationTest {
 					new CollectionAttributes()).get();
 
 			List<SMGetElement<Object>> list = mc.asyncBopSortMergeGet(
-					new ArrayList<String>() {
-						{
-							add(key1);
-							add(key2);
-						}
-					}, new byte[] { 0 }, new byte[] { 10 },
-					ElementFlagFilter.DO_NOT_FILTER, 10, smgetMode).get();
+							testKeyList, new byte[] { 0 }, new byte[] { 10 },
+							ElementFlagFilter.DO_NOT_FILTER, 10, smgetMode).get();
 
 			for (int i = 0; i < list.size(); i++) {
 				System.out.println(list.get(i));

--- a/src/test/manual/net/spy/memcached/btreesmget/SMGetErrorTest.java
+++ b/src/test/manual/net/spy/memcached/btreesmget/SMGetErrorTest.java
@@ -254,7 +254,7 @@ public class SMGetErrorTest extends BaseIntegrationTest {
 		
 		SMGetFuture<List<SMGetElement<Object>>> future = mc
 				.asyncBopSortMergeGet(KEY_LIST, from, to,
-						ElementFlagFilter.DO_NOT_FILTER, (int) count, (SMGetMode) smgetMode);
+						ElementFlagFilter.DO_NOT_FILTER, (int) count, smgetMode);
 		try {
 			List<SMGetElement<Object>> map = future
 					.get(1000L, TimeUnit.SECONDS);
@@ -347,7 +347,7 @@ public class SMGetErrorTest extends BaseIntegrationTest {
 		
 		SMGetFuture<List<SMGetElement<Object>>> future = mc
 				.asyncBopSortMergeGet(KEY_LIST, from, to,
-						ElementFlagFilter.DO_NOT_FILTER, (int) count, (SMGetMode) smgetMode);
+						ElementFlagFilter.DO_NOT_FILTER, (int) count, smgetMode);
 		try {
 			List<SMGetElement<Object>> map = future
 					.get(1000L, TimeUnit.SECONDS);
@@ -433,15 +433,14 @@ public class SMGetErrorTest extends BaseIntegrationTest {
 
 		// sort merge get
 		SMGetMode smgetMode = SMGetMode.UNIQUE;
+
+		ArrayList<String> testKeyList = new ArrayList<String>();
+		testKeyList.add(KEY_LIST.get(0));
+		testKeyList.add(KEY_LIST.get(1));
 		
 		/* old SMGetErrorTest */
 		SMGetFuture<List<SMGetElement<Object>>> oldFuture = mc
-				.asyncBopSortMergeGet(new ArrayList<String>() {
-					{
-						add(KEY_LIST.get(0));
-						add(KEY_LIST.get(1));
-					}
-				}, 10, 0, ElementFlagFilter.DO_NOT_FILTER, 0, 10);
+				.asyncBopSortMergeGet(testKeyList, 10, 0, ElementFlagFilter.DO_NOT_FILTER, 0, 10);
 		try {
 			List<SMGetElement<Object>> map = oldFuture
 					.get(1000L, TimeUnit.SECONDS);
@@ -454,12 +453,7 @@ public class SMGetErrorTest extends BaseIntegrationTest {
 		}
 		
 		SMGetFuture<List<SMGetElement<Object>>> future = mc
-				.asyncBopSortMergeGet(new ArrayList<String>() {
-					{
-						add(KEY_LIST.get(0));
-						add(KEY_LIST.get(1));
-					}
-				}, 10, 0, ElementFlagFilter.DO_NOT_FILTER, 10, smgetMode);
+				.asyncBopSortMergeGet(testKeyList, 10, 0, ElementFlagFilter.DO_NOT_FILTER, 10, smgetMode);
 		try {
 			List<SMGetElement<Object>> map = future
 					.get(1000L, TimeUnit.SECONDS);
@@ -473,6 +467,10 @@ public class SMGetErrorTest extends BaseIntegrationTest {
 	}
 
 	public void testInvalidArgumentException() {
+		ArrayList<String> testKeyList = new ArrayList<String>();
+		testKeyList.add(KEY_LIST.get(0));
+		testKeyList.add(KEY_LIST.get(1));
+
 		// insert test data
 		try {
 			CollectionAttributes attr = new CollectionAttributes();
@@ -510,12 +508,7 @@ public class SMGetErrorTest extends BaseIntegrationTest {
 
 		// offset < 0
 		try {
-			mc.asyncBopSortMergeGet(new ArrayList<String>() {
-							{
-								add(KEY_LIST.get(0));
-								add(KEY_LIST.get(1));
-							}
-						}, 10, 0, ElementFlagFilter.DO_NOT_FILTER, -1, 10);
+			mc.asyncBopSortMergeGet(testKeyList, 10, 0, ElementFlagFilter.DO_NOT_FILTER, -1, 10);
 			fail("This should be an exception");
 		} catch (Exception e) {
 			assertEquals("Offset must be 0 or positive integer.", e.getMessage());
@@ -523,12 +516,7 @@ public class SMGetErrorTest extends BaseIntegrationTest {
 
 		// count == 0 
 		try {
-			mc.asyncBopSortMergeGet(new ArrayList<String>() {
-							{
-								add(KEY_LIST.get(0));
-								add(KEY_LIST.get(1));
-							}
-						}, 10, 0, ElementFlagFilter.DO_NOT_FILTER, 0, 0);
+			mc.asyncBopSortMergeGet(testKeyList, 10, 0, ElementFlagFilter.DO_NOT_FILTER, 0, 0);
 			fail("This should be an exception");
 		} catch (Exception e) {
 			assertEquals("Count must be larger than 0.", e.getMessage());
@@ -536,12 +524,7 @@ public class SMGetErrorTest extends BaseIntegrationTest {
 
 		// offset + count > 1000
 		try {
-			mc.asyncBopSortMergeGet(new ArrayList<String>() {
-							{
-								add(KEY_LIST.get(0));
-								add(KEY_LIST.get(1));
-							}
-						}, 10, 0, ElementFlagFilter.DO_NOT_FILTER, 0, 1001);
+			mc.asyncBopSortMergeGet(testKeyList, 10, 0, ElementFlagFilter.DO_NOT_FILTER, 0, 1001);
 			fail("This should be an exception");
 		} catch (Exception e) {
 			assertEquals("The sum of offset and count must not exceed a maximum of 1000.", e.getMessage());
@@ -549,13 +532,9 @@ public class SMGetErrorTest extends BaseIntegrationTest {
 
 		// duplicate keys
 		try {
-			mc.asyncBopSortMergeGet(new ArrayList<String>() {
-							{
-								add(KEY_LIST.get(0));
-								add(KEY_LIST.get(1));
-								add(KEY_LIST.get(1));
-							}
-						}, 10, 0, ElementFlagFilter.DO_NOT_FILTER, 0, 10);
+			// add duplicate key to testKeyList
+			testKeyList.add(KEY_LIST.get(1));
+			mc.asyncBopSortMergeGet(testKeyList, 10, 0, ElementFlagFilter.DO_NOT_FILTER, 0, 10);
 			fail("This should be an exception");
 		} catch (Exception e) {
 			assertEquals("Duplicate keys exist in key list.", e.getMessage());

--- a/src/test/manual/net/spy/memcached/collection/CollectionFutureTest.java
+++ b/src/test/manual/net/spy/memcached/collection/CollectionFutureTest.java
@@ -36,8 +36,7 @@ public class CollectionFutureTest extends BaseIntegrationTest {
 		CollectionFuture<Boolean> future;
 		OperationStatus status;
 
-		future = (CollectionFuture<Boolean>) mc.asyncBopInsert(key, 0, null,
-				"hello", new CollectionAttributes());
+		future = mc.asyncBopInsert(key, 0, null, "hello", new CollectionAttributes());
 
 		// OperationStatus should be null before operation completion
 		// status = future.getOperationStatus();
@@ -57,16 +56,14 @@ public class CollectionFutureTest extends BaseIntegrationTest {
 		CollectionFuture<Map<Long, Element<Object>>> future;
 		OperationStatus status;
 
-		future = (CollectionFuture<Map<Long, Element<Object>>>) mc.asyncBopGet(
-				key, 0, ElementFlagFilter.DO_NOT_FILTER, false, false);
+		future = mc.asyncBopGet(key, 0, ElementFlagFilter.DO_NOT_FILTER, false, false);
 
 		// OperationStatus should be null before operation completion
 		// status = future.getOperationStatus();
 		// assertNull(status);
 
 		// After operation completion (FAILURE)
-		Map<Long, Element<Object>> result = future.get(1000,
-				TimeUnit.MILLISECONDS);
+		Map<Long, Element<Object>> result = future.get(1000, TimeUnit.MILLISECONDS);
 		status = future.getOperationStatus();
 
 		assertNull(result);
@@ -79,8 +76,7 @@ public class CollectionFutureTest extends BaseIntegrationTest {
 		CollectionFuture<Boolean> future;
 		OperationStatus status;
 
-		future = (CollectionFuture<Boolean>) mc.asyncBopInsert(key, 0, null,
-				"hello", new CollectionAttributes());
+		future = mc.asyncBopInsert(key, 0, null, "hello", new CollectionAttributes());
 
 		try {
 			future.get(1, TimeUnit.NANOSECONDS);

--- a/src/test/manual/net/spy/memcached/collection/btree/BopFindPositionWithGetTest.java
+++ b/src/test/manual/net/spy/memcached/collection/btree/BopFindPositionWithGetTest.java
@@ -241,7 +241,7 @@ public class BopFindPositionWithGetTest extends BaseIntegrationTest {
 		CollectionAttributes attrs = new CollectionAttributes();
 		attrs.setReadable(false);
 		for (long i = 0; i < 100; i++) {
-			mc.asyncBopInsert(key, (long)i, null, "val", attrs).get();
+			mc.asyncBopInsert(key, i, null, "val", attrs).get();
 		}
 
 		// set a test key

--- a/src/test/manual/net/spy/memcached/collection/btree/BopMutateTest.java
+++ b/src/test/manual/net/spy/memcached/collection/btree/BopMutateTest.java
@@ -33,7 +33,7 @@ public class BopMutateTest extends BaseIntegrationTest {
 		try {
 			super.setUp();
 			mc.delete(key);
-		} catch (Exception e) {
+		} catch (Exception ignored) {
 		}
 	}
 
@@ -42,20 +42,20 @@ public class BopMutateTest extends BaseIntegrationTest {
 		addToBTree(key, items9);
 
 		// incr 2
-		assertTrue(mc.asyncBopIncr(key, 1L, (int) 2)
+		assertTrue(mc.asyncBopIncr(key, 1L, 2)
 				.get(1000, TimeUnit.MILLISECONDS).equals(4L));
 		// incr 10
-		assertTrue(mc.asyncBopIncr(key, 1L, (int) 10)
+		assertTrue(mc.asyncBopIncr(key, 1L, 10)
 				.get(1000, TimeUnit.MILLISECONDS).equals(14L));
 
 		// decr 1
-		assertTrue(mc.asyncBopDecr(key, 1L, (int) 1)
+		assertTrue(mc.asyncBopDecr(key, 1L, 1)
 				.get(1000, TimeUnit.MILLISECONDS).equals(13L));
 		// decr 11
-		assertTrue(mc.asyncBopDecr(key, 1L, (int) 11)
+		assertTrue(mc.asyncBopDecr(key, 1L, 11)
 				.get(1000, TimeUnit.MILLISECONDS).equals(2L));
 		// decr 4
-		assertTrue(mc.asyncBopDecr(key, 1L, (int) 4)
+		assertTrue(mc.asyncBopDecr(key, 1L, 4)
 				.get(1000, TimeUnit.MILLISECONDS).equals(0L));
 	}
 
@@ -64,7 +64,7 @@ public class BopMutateTest extends BaseIntegrationTest {
 		addToBTree(key, items9);
 
 		// decr 10
-		assertTrue(mc.asyncBopDecr(key, 1L, (int) 10)
+		assertTrue(mc.asyncBopDecr(key, 1L, 10)
 				.get(1000, TimeUnit.MILLISECONDS).equals(0L));
 	}
 
@@ -73,13 +73,13 @@ public class BopMutateTest extends BaseIntegrationTest {
 		addToBTree(key, items9);
 
 		// not exists the key
-		CollectionFuture<Long> future = mc.asyncBopIncr("aaaaa", 0L, (int) 2);
+		CollectionFuture<Long> future = mc.asyncBopIncr("aaaaa", 0L, 2);
 		Long result = future.get(1000, TimeUnit.MILLISECONDS);
 		CollectionResponse response = future.getOperationStatus().getResponse();
 		assertTrue(response.toString() == "NOT_FOUND");
 
 		// not exists the bkey
-		CollectionFuture<Long> future2 = mc.asyncBopIncr(key, 10L, (int) 2);
+		CollectionFuture<Long> future2 = mc.asyncBopIncr(key, 10L, 2);
 		Long result2 = future2.get(1000, TimeUnit.MILLISECONDS);
 		CollectionResponse response2 = future2.getOperationStatus()
 				.getResponse();
@@ -92,7 +92,7 @@ public class BopMutateTest extends BaseIntegrationTest {
 
 		try {
 			// incr string value
-			CollectionFuture<Long> future3 = mc.asyncBopIncr(key, 9L, (int) 2);
+			CollectionFuture<Long> future3 = mc.asyncBopIncr(key, 9L, 2);
 			Long result3 = future3.get(1000, TimeUnit.MILLISECONDS);
 			CollectionResponse response3 = future3.getOperationStatus()
 					.getResponse();

--- a/src/test/manual/net/spy/memcached/collection/btree/BopServerMessageTest.java
+++ b/src/test/manual/net/spy/memcached/collection/btree/BopServerMessageTest.java
@@ -44,9 +44,8 @@ public class BopServerMessageTest extends BaseIntegrationTest {
 	}
 
 	public void testNotFound() throws Exception {
-		CollectionFuture<Map<Long, Element<Object>>> future = (CollectionFuture<Map<Long, Element<Object>>>) mc
-				.asyncBopGet(key, 0, ElementFlagFilter.DO_NOT_FILTER, false,
-						false);
+		CollectionFuture<Map<Long, Element<Object>>> future = mc.asyncBopGet(
+						key, 0, ElementFlagFilter.DO_NOT_FILTER, false,	false);
 		assertNull(future.get(1000, TimeUnit.MILLISECONDS));
 
 		OperationStatus status = future.getOperationStatus();
@@ -55,13 +54,11 @@ public class BopServerMessageTest extends BaseIntegrationTest {
 	}
 
 	public void testNotFoundElement() throws Exception {
-		CollectionFuture<Boolean> future = (CollectionFuture<Boolean>) mc
-				.asyncBopInsert(key, 0, null, 0, new CollectionAttributes());
+		CollectionFuture<Boolean> future = mc.asyncBopInsert(key, 0, null, 0, new CollectionAttributes());
 		assertTrue(future.get(1000, TimeUnit.MILLISECONDS));
 
-		CollectionFuture<Map<Long, Element<Object>>> future2 = (CollectionFuture<Map<Long, Element<Object>>>) mc
-				.asyncBopGet(key, 1, ElementFlagFilter.DO_NOT_FILTER, false,
-						false);
+		CollectionFuture<Map<Long, Element<Object>>> future2 = mc.asyncBopGet(
+						key, 1, ElementFlagFilter.DO_NOT_FILTER, false,	false);
 		assertNotNull(future2.get(1000, TimeUnit.MILLISECONDS));
 
 		OperationStatus status = future2.getOperationStatus();
@@ -70,8 +67,7 @@ public class BopServerMessageTest extends BaseIntegrationTest {
 	}
 
 	public void testCreatedStored() throws Exception {
-		CollectionFuture<Boolean> future = (CollectionFuture<Boolean>) mc
-				.asyncBopInsert(key, 0, null, 0, new CollectionAttributes());
+		CollectionFuture<Boolean> future = mc.asyncBopInsert(key, 0, null, 0, new CollectionAttributes());
 		assertTrue(future.get(1000, TimeUnit.MILLISECONDS));
 
 		OperationStatus status = future.getOperationStatus();
@@ -80,12 +76,10 @@ public class BopServerMessageTest extends BaseIntegrationTest {
 	}
 
 	public void testStored() throws Exception {
-		CollectionFuture<Boolean> future = (CollectionFuture<Boolean>) mc
-				.asyncBopInsert(key, 0, null, 0, new CollectionAttributes());
+		CollectionFuture<Boolean> future = mc.asyncBopInsert(key, 0, null, 0, new CollectionAttributes());
 		assertTrue(future.get(1000, TimeUnit.MILLISECONDS));
 
-		future = (CollectionFuture<Boolean>) mc.asyncBopInsert(key, 1, null, 1,
-				new CollectionAttributes());
+		future = mc.asyncBopInsert(key, 1, null, 1,	new CollectionAttributes());
 		assertTrue(future.get(1000, TimeUnit.MILLISECONDS));
 
 		OperationStatus status = future.getOperationStatus();
@@ -94,16 +88,14 @@ public class BopServerMessageTest extends BaseIntegrationTest {
 	}
 
 	public void testOutOfRange() throws Exception {
-		CollectionFuture<Boolean> future = (CollectionFuture<Boolean>) mc
-				.asyncBopInsert(key, 1, null, "aaa", new CollectionAttributes());
+		CollectionFuture<Boolean> future = mc.asyncBopInsert(key, 1, null, "aaa", new CollectionAttributes());
 		assertTrue(future.get(1000, TimeUnit.MILLISECONDS));
 
-		assertTrue(mc.asyncSetAttr(key,
-				new CollectionAttributes(null, 1L, CollectionOverflowAction.largest_trim)).get(1000,
-				TimeUnit.MILLISECONDS));
+		assertTrue(mc.asyncSetAttr(
+						key,	new CollectionAttributes(null, 1L, CollectionOverflowAction.largest_trim))
+						.get(1000,TimeUnit.MILLISECONDS));
 
-		future = (CollectionFuture<Boolean>) mc.asyncBopInsert(key, 2, null,
-				"bbbb", new CollectionAttributes());
+		future = mc.asyncBopInsert(key, 2, null, "bbbb", new CollectionAttributes());
 		assertFalse(future.get(1000, TimeUnit.MILLISECONDS));
 
 		OperationStatus status = future.getOperationStatus();
@@ -112,16 +104,13 @@ public class BopServerMessageTest extends BaseIntegrationTest {
 	}
 
 	public void testOverflowed() throws Exception {
-		CollectionFuture<Boolean> future = (CollectionFuture<Boolean>) mc
-				.asyncBopInsert(key, 0, null, "aaa", new CollectionAttributes());
+		CollectionFuture<Boolean> future = mc.asyncBopInsert(key, 0, null, "aaa", new CollectionAttributes());
 		assertTrue(future.get(1000, TimeUnit.MILLISECONDS));
 
-		assertTrue(mc.asyncSetAttr(key,
-				new CollectionAttributes(null, 1L, CollectionOverflowAction.error))
+		assertTrue(mc.asyncSetAttr(key, new CollectionAttributes(null, 1L, CollectionOverflowAction.error))
 				.get(1000, TimeUnit.MILLISECONDS));
 
-		future = (CollectionFuture<Boolean>) mc.asyncBopInsert(key, 1, null,
-				"aaa", new CollectionAttributes());
+		future = mc.asyncBopInsert(key, 1, null, "aaa", new CollectionAttributes());
 		assertFalse(future.get(1000, TimeUnit.MILLISECONDS));
 
 		OperationStatus status = future.getOperationStatus();
@@ -131,13 +120,11 @@ public class BopServerMessageTest extends BaseIntegrationTest {
 
 	public void testElementExists() throws Exception {
 		// create
-		CollectionFuture<Boolean> future = (CollectionFuture<Boolean>) mc
-				.asyncBopInsert(key, 0, null, "aaa", new CollectionAttributes());
+		CollectionFuture<Boolean> future = mc.asyncBopInsert(key, 0, null, "aaa", new CollectionAttributes());
 		assertTrue(future.get(1000, TimeUnit.MILLISECONDS));
 
 		// insert an item with same bkey
-		future = (CollectionFuture<Boolean>) mc.asyncBopInsert(key, 0, null,
-				"bbbb", new CollectionAttributes());
+		future = mc.asyncBopInsert(key, 0, null, "bbbb", new CollectionAttributes());
 		assertFalse(future.get(1000, TimeUnit.MILLISECONDS));
 
 		OperationStatus status = future.getOperationStatus();
@@ -147,13 +134,11 @@ public class BopServerMessageTest extends BaseIntegrationTest {
 
 	public void testDeletedDropped() throws Exception {
 		// create
-		CollectionFuture<Boolean> future = (CollectionFuture<Boolean>) mc
-				.asyncBopInsert(key, 0, null, "aaa", new CollectionAttributes());
+		CollectionFuture<Boolean> future = mc.asyncBopInsert(key, 0, null, "aaa", new CollectionAttributes());
 		assertTrue(future.get(1000, TimeUnit.MILLISECONDS));
 
 		// delete
-		future = (CollectionFuture<Boolean>) mc.asyncBopDelete(key, 0,
-				ElementFlagFilter.DO_NOT_FILTER, true);
+		future = mc.asyncBopDelete(key, 0, ElementFlagFilter.DO_NOT_FILTER, true);
 		assertTrue(future.get(1000, TimeUnit.MILLISECONDS));
 
 		OperationStatus status = future.getOperationStatus();
@@ -163,18 +148,15 @@ public class BopServerMessageTest extends BaseIntegrationTest {
 
 	public void testDeleted() throws Exception {
 		// create
-		CollectionFuture<Boolean> future = (CollectionFuture<Boolean>) mc
-				.asyncBopInsert(key, 0, null, "aaa", new CollectionAttributes());
+		CollectionFuture<Boolean> future = mc.asyncBopInsert(key, 0, null, "aaa", new CollectionAttributes());
 		assertTrue(future.get(1000, TimeUnit.MILLISECONDS));
 
 		// insert
-		future = (CollectionFuture<Boolean>) mc.asyncBopInsert(key, 1, null,
-				"bbbb", null);
+		future = mc.asyncBopInsert(key, 1, null, "bbbb", null);
 		assertTrue(future.get(1000, TimeUnit.MILLISECONDS));
 
 		// delete
-		future = (CollectionFuture<Boolean>) mc.asyncBopDelete(key, 0,
-				ElementFlagFilter.DO_NOT_FILTER, false);
+		future = mc.asyncBopDelete(key, 0, ElementFlagFilter.DO_NOT_FILTER, false);
 		assertTrue(future.get(1000, TimeUnit.MILLISECONDS));
 
 		OperationStatus status = future.getOperationStatus();
@@ -184,14 +166,12 @@ public class BopServerMessageTest extends BaseIntegrationTest {
 
 	public void testDeletedDroppedAfterRetrieval() throws Exception {
 		// create
-		CollectionFuture<Boolean> future = (CollectionFuture<Boolean>) mc
-				.asyncBopInsert(key, 0, null, "aaa", new CollectionAttributes());
+		CollectionFuture<Boolean> future = mc.asyncBopInsert(key, 0, null, "aaa", new CollectionAttributes());
 		assertTrue(future.get(1000, TimeUnit.MILLISECONDS));
 
 		// get
-		CollectionFuture<Map<Long, Element<Object>>> future2 = (CollectionFuture<Map<Long, Element<Object>>>) mc
-				.asyncBopGet(key, 0, ElementFlagFilter.DO_NOT_FILTER, true,
-						true);
+		CollectionFuture<Map<Long, Element<Object>>> future2 = mc.asyncBopGet(
+						key, 0, ElementFlagFilter.DO_NOT_FILTER, true, true);
 		assertNotNull(future2.get(1000, TimeUnit.MILLISECONDS));
 
 		OperationStatus status = future2.getOperationStatus();
@@ -201,19 +181,16 @@ public class BopServerMessageTest extends BaseIntegrationTest {
 
 	public void testDeletedAfterRetrieval() throws Exception {
 		// create
-		CollectionFuture<Boolean> future = (CollectionFuture<Boolean>) mc
-				.asyncBopInsert(key, 0, null, "aaa", new CollectionAttributes());
+		CollectionFuture<Boolean> future = mc.asyncBopInsert(key, 0, null, "aaa", new CollectionAttributes());
 		assertTrue(future.get(1000, TimeUnit.MILLISECONDS));
 
 		// insert
-		future = (CollectionFuture<Boolean>) mc.asyncBopInsert(key, 1, null,
-				"bbbb", null);
+		future = mc.asyncBopInsert(key, 1, null, "bbbb", null);
 		assertTrue(future.get(1000, TimeUnit.MILLISECONDS));
 
 		// get
-		CollectionFuture<Map<Long, Element<Object>>> future2 = (CollectionFuture<Map<Long, Element<Object>>>) mc
-				.asyncBopGet(key, 0, ElementFlagFilter.DO_NOT_FILTER, true,
-						true);
+		CollectionFuture<Map<Long, Element<Object>>> future2 = mc.asyncBopGet(
+						key, 0, ElementFlagFilter.DO_NOT_FILTER, true, true);
 		assertNotNull(future2.get(1000, TimeUnit.MILLISECONDS));
 
 		OperationStatus status = future2.getOperationStatus();

--- a/src/test/manual/net/spy/memcached/collection/btree/BopServerMessageTest.java
+++ b/src/test/manual/net/spy/memcached/collection/btree/BopServerMessageTest.java
@@ -45,7 +45,7 @@ public class BopServerMessageTest extends BaseIntegrationTest {
 
 	public void testNotFound() throws Exception {
 		CollectionFuture<Map<Long, Element<Object>>> future = mc.asyncBopGet(
-						key, 0, ElementFlagFilter.DO_NOT_FILTER, false,	false);
+						key, 0, ElementFlagFilter.DO_NOT_FILTER, false, false);
 		assertNull(future.get(1000, TimeUnit.MILLISECONDS));
 
 		OperationStatus status = future.getOperationStatus();
@@ -58,7 +58,7 @@ public class BopServerMessageTest extends BaseIntegrationTest {
 		assertTrue(future.get(1000, TimeUnit.MILLISECONDS));
 
 		CollectionFuture<Map<Long, Element<Object>>> future2 = mc.asyncBopGet(
-						key, 1, ElementFlagFilter.DO_NOT_FILTER, false,	false);
+						key, 1, ElementFlagFilter.DO_NOT_FILTER, false, false);
 		assertNotNull(future2.get(1000, TimeUnit.MILLISECONDS));
 
 		OperationStatus status = future2.getOperationStatus();
@@ -79,7 +79,7 @@ public class BopServerMessageTest extends BaseIntegrationTest {
 		CollectionFuture<Boolean> future = mc.asyncBopInsert(key, 0, null, 0, new CollectionAttributes());
 		assertTrue(future.get(1000, TimeUnit.MILLISECONDS));
 
-		future = mc.asyncBopInsert(key, 1, null, 1,	new CollectionAttributes());
+		future = mc.asyncBopInsert(key, 1, null, 1, new CollectionAttributes());
 		assertTrue(future.get(1000, TimeUnit.MILLISECONDS));
 
 		OperationStatus status = future.getOperationStatus();
@@ -91,8 +91,7 @@ public class BopServerMessageTest extends BaseIntegrationTest {
 		CollectionFuture<Boolean> future = mc.asyncBopInsert(key, 1, null, "aaa", new CollectionAttributes());
 		assertTrue(future.get(1000, TimeUnit.MILLISECONDS));
 
-		assertTrue(mc.asyncSetAttr(
-						key,	new CollectionAttributes(null, 1L, CollectionOverflowAction.largest_trim))
+		assertTrue(mc.asyncSetAttr(key, new CollectionAttributes(null, 1L, CollectionOverflowAction.largest_trim))
 						.get(1000,TimeUnit.MILLISECONDS));
 
 		future = mc.asyncBopInsert(key, 2, null, "bbbb", new CollectionAttributes());
@@ -170,8 +169,8 @@ public class BopServerMessageTest extends BaseIntegrationTest {
 		assertTrue(future.get(1000, TimeUnit.MILLISECONDS));
 
 		// get
-		CollectionFuture<Map<Long, Element<Object>>> future2 = mc.asyncBopGet(
-						key, 0, ElementFlagFilter.DO_NOT_FILTER, true, true);
+		CollectionFuture<Map<Long, Element<Object>>> future2 =
+						mc.asyncBopGet( key, 0, ElementFlagFilter.DO_NOT_FILTER, true, true);
 		assertNotNull(future2.get(1000, TimeUnit.MILLISECONDS));
 
 		OperationStatus status = future2.getOperationStatus();

--- a/src/test/manual/net/spy/memcached/collection/list/LopServerMessageTest.java
+++ b/src/test/manual/net/spy/memcached/collection/list/LopServerMessageTest.java
@@ -87,7 +87,7 @@ public class LopServerMessageTest extends BaseIntegrationTest {
 				new CollectionAttributes(null, 1L, CollectionOverflowAction.error))
 				.get(1000, TimeUnit.MILLISECONDS));
 
-		future = mc.asyncLopInsert(key, 1, 1,	new CollectionAttributes());
+		future = mc.asyncLopInsert(key, 1, 1, new CollectionAttributes());
 		assertFalse(future.get(1000, TimeUnit.MILLISECONDS));
 
 		OperationStatus status = future.getOperationStatus();
@@ -103,10 +103,10 @@ public class LopServerMessageTest extends BaseIntegrationTest {
 				new CollectionAttributes(null, 2L, CollectionOverflowAction.error))
 				.get(1000, TimeUnit.MILLISECONDS));
 
-		future = mc.asyncLopInsert(key, 0, 1,	new CollectionAttributes());
+		future = mc.asyncLopInsert(key, 0, 1, new CollectionAttributes());
 		assertTrue(future.get(1000, TimeUnit.MILLISECONDS));
 
-		future = mc.asyncLopInsert(key, 0, 1,	new CollectionAttributes());
+		future = mc.asyncLopInsert(key, 0, 1, new CollectionAttributes());
 		assertFalse(future.get(1000, TimeUnit.MILLISECONDS));
 
 		OperationStatus status = future.getOperationStatus();

--- a/src/test/manual/net/spy/memcached/collection/list/LopServerMessageTest.java
+++ b/src/test/manual/net/spy/memcached/collection/list/LopServerMessageTest.java
@@ -41,8 +41,7 @@ public class LopServerMessageTest extends BaseIntegrationTest {
 	}
 
 	public void testNotFound() throws Exception {
-		CollectionFuture<List<Object>> future = (CollectionFuture<List<Object>>) mc
-				.asyncLopGet(key, 0, false, false);
+		CollectionFuture<List<Object>> future = mc.asyncLopGet(key, 0, false, false);
 		assertNull(future.get(1000, TimeUnit.MILLISECONDS));
 
 		OperationStatus status = future.getOperationStatus();
@@ -51,8 +50,7 @@ public class LopServerMessageTest extends BaseIntegrationTest {
 	}
 
 	public void testCreatedStored() throws Exception {
-		CollectionFuture<Boolean> future = (CollectionFuture<Boolean>) mc
-				.asyncLopInsert(key, 0, 0, new CollectionAttributes());
+		CollectionFuture<Boolean> future = mc.asyncLopInsert(key, 0, 0, new CollectionAttributes());
 		assertTrue(future.get(1000, TimeUnit.MILLISECONDS));
 
 		OperationStatus status = future.getOperationStatus();
@@ -61,12 +59,10 @@ public class LopServerMessageTest extends BaseIntegrationTest {
 	}
 
 	public void testStored() throws Exception {
-		CollectionFuture<Boolean> future = (CollectionFuture<Boolean>) mc
-				.asyncLopInsert(key, 0, 0, new CollectionAttributes());
+		CollectionFuture<Boolean> future = mc.asyncLopInsert(key, 0, 0, new CollectionAttributes());
 		assertTrue(future.get(1000, TimeUnit.MILLISECONDS));
 
-		future = (CollectionFuture<Boolean>) mc.asyncLopInsert(key, 1, 1,
-				new CollectionAttributes());
+		future = mc.asyncLopInsert(key, 1, 1, new CollectionAttributes());
 		assertTrue(future.get(1000, TimeUnit.MILLISECONDS));
 
 		OperationStatus status = future.getOperationStatus();
@@ -75,8 +71,7 @@ public class LopServerMessageTest extends BaseIntegrationTest {
 	}
 
 	public void testOutOfRange() throws Exception {
-		CollectionFuture<Boolean> future = (CollectionFuture<Boolean>) mc
-				.asyncLopInsert(key, 1, 1, new CollectionAttributes());
+		CollectionFuture<Boolean> future = mc.asyncLopInsert(key, 1, 1, new CollectionAttributes());
 		assertFalse(future.get(1000, TimeUnit.MILLISECONDS));
 
 		OperationStatus status = future.getOperationStatus();
@@ -85,16 +80,14 @@ public class LopServerMessageTest extends BaseIntegrationTest {
 	}
 
 	public void testOutOfRange2() throws Exception {
-		CollectionFuture<Boolean> future = (CollectionFuture<Boolean>) mc
-				.asyncLopInsert(key, 0, 0, new CollectionAttributes());
+		CollectionFuture<Boolean> future = mc.asyncLopInsert(key, 0, 0, new CollectionAttributes());
 		assertTrue(future.get(1000, TimeUnit.MILLISECONDS));
 
 		assertTrue(mc.asyncSetAttr(key,
 				new CollectionAttributes(null, 1L, CollectionOverflowAction.error))
 				.get(1000, TimeUnit.MILLISECONDS));
 
-		future = (CollectionFuture<Boolean>) mc.asyncLopInsert(key, 1, 1,
-				new CollectionAttributes());
+		future = mc.asyncLopInsert(key, 1, 1,	new CollectionAttributes());
 		assertFalse(future.get(1000, TimeUnit.MILLISECONDS));
 
 		OperationStatus status = future.getOperationStatus();
@@ -103,20 +96,17 @@ public class LopServerMessageTest extends BaseIntegrationTest {
 	}
 
 	public void testOverflowed() throws Exception {
-		CollectionFuture<Boolean> future = (CollectionFuture<Boolean>) mc
-				.asyncLopInsert(key, 0, 0, new CollectionAttributes());
+		CollectionFuture<Boolean> future = mc.asyncLopInsert(key, 0, 0, new CollectionAttributes());
 		assertTrue(future.get(1000, TimeUnit.MILLISECONDS));
 
 		assertTrue(mc.asyncSetAttr(key,
 				new CollectionAttributes(null, 2L, CollectionOverflowAction.error))
 				.get(1000, TimeUnit.MILLISECONDS));
 
-		future = (CollectionFuture<Boolean>) mc.asyncLopInsert(key, 0, 1,
-				new CollectionAttributes());
+		future = mc.asyncLopInsert(key, 0, 1,	new CollectionAttributes());
 		assertTrue(future.get(1000, TimeUnit.MILLISECONDS));
 
-		future = (CollectionFuture<Boolean>) mc.asyncLopInsert(key, 0, 1,
-				new CollectionAttributes());
+		future = mc.asyncLopInsert(key, 0, 1,	new CollectionAttributes());
 		assertFalse(future.get(1000, TimeUnit.MILLISECONDS));
 
 		OperationStatus status = future.getOperationStatus();
@@ -126,12 +116,11 @@ public class LopServerMessageTest extends BaseIntegrationTest {
 
 	public void testDeletedDropped() throws Exception {
 		// create
-		CollectionFuture<Boolean> future = (CollectionFuture<Boolean>) mc
-				.asyncLopInsert(key, 0, "aaa", new CollectionAttributes());
+		CollectionFuture<Boolean> future = mc.asyncLopInsert(key, 0, "aaa", new CollectionAttributes());
 		assertTrue(future.get(1000, TimeUnit.MILLISECONDS));
 
 		// delete
-		future = (CollectionFuture<Boolean>) mc.asyncLopDelete(key, 0, true);
+		future = mc.asyncLopDelete(key, 0, true);
 		assertTrue(future.get(1000, TimeUnit.MILLISECONDS));
 
 		OperationStatus status = future.getOperationStatus();
@@ -141,17 +130,15 @@ public class LopServerMessageTest extends BaseIntegrationTest {
 
 	public void testDeleted() throws Exception {
 		// create
-		CollectionFuture<Boolean> future = (CollectionFuture<Boolean>) mc
-				.asyncLopInsert(key, 0, "aaa", new CollectionAttributes());
+		CollectionFuture<Boolean> future = mc.asyncLopInsert(key, 0, "aaa", new CollectionAttributes());
 		assertTrue(future.get(1000, TimeUnit.MILLISECONDS));
 
 		// insert
-		future = (CollectionFuture<Boolean>) mc.asyncLopInsert(key, -1, "bbb",
-				new CollectionAttributes());
+		future = mc.asyncLopInsert(key, -1, "bbb", new CollectionAttributes());
 		assertTrue(future.get(1000, TimeUnit.MILLISECONDS));
 
 		// delete
-		future = (CollectionFuture<Boolean>) mc.asyncLopDelete(key, 0, false);
+		future = mc.asyncLopDelete(key, 0, false);
 		assertTrue(future.get(1000, TimeUnit.MILLISECONDS));
 
 		OperationStatus status = future.getOperationStatus();
@@ -161,13 +148,11 @@ public class LopServerMessageTest extends BaseIntegrationTest {
 
 	public void testDeletedDroppedAfterRetrieval() throws Exception {
 		// create
-		CollectionFuture<Boolean> future = (CollectionFuture<Boolean>) mc
-				.asyncLopInsert(key, 0, "aaa", new CollectionAttributes());
+		CollectionFuture<Boolean> future = mc.asyncLopInsert(key, 0, "aaa", new CollectionAttributes());
 		assertTrue(future.get(1000, TimeUnit.MILLISECONDS));
 
 		// get
-		CollectionFuture<List<Object>> future2 = (CollectionFuture<List<Object>>) mc
-				.asyncLopGet(key, 0, true, true);
+		CollectionFuture<List<Object>> future2 = mc.asyncLopGet(key, 0, true, true);
 		assertNotNull(future2.get(1000, TimeUnit.MILLISECONDS));
 
 		OperationStatus status = future2.getOperationStatus();
@@ -177,18 +162,15 @@ public class LopServerMessageTest extends BaseIntegrationTest {
 
 	public void testDeletedAfterRetrieval() throws Exception {
 		// create
-		CollectionFuture<Boolean> future = (CollectionFuture<Boolean>) mc
-				.asyncLopInsert(key, 0, "aaa", new CollectionAttributes());
+		CollectionFuture<Boolean> future = mc.asyncLopInsert(key, 0, "aaa", new CollectionAttributes());
 		assertTrue(future.get(1000, TimeUnit.MILLISECONDS));
 
 		// insert
-		future = (CollectionFuture<Boolean>) mc.asyncLopInsert(key, -1, "bbb",
-				new CollectionAttributes());
+		future = mc.asyncLopInsert(key, -1, "bbb", new CollectionAttributes());
 		assertTrue(future.get(1000, TimeUnit.MILLISECONDS));
 
 		// get
-		CollectionFuture<List<Object>> future2 = (CollectionFuture<List<Object>>) mc
-				.asyncLopGet(key, 0, true, false);
+		CollectionFuture<List<Object>> future2 = mc.asyncLopGet(key, 0, true, false);
 		assertNotNull(future2.get(1000, TimeUnit.MILLISECONDS));
 
 		OperationStatus status = future2.getOperationStatus();

--- a/src/test/manual/net/spy/memcached/collection/set/SopServerMessageTest.java
+++ b/src/test/manual/net/spy/memcached/collection/set/SopServerMessageTest.java
@@ -42,8 +42,7 @@ public class SopServerMessageTest extends BaseIntegrationTest {
 	}
 
 	public void testNotFound() throws Exception {
-		CollectionFuture<Set<Object>> future = (CollectionFuture<Set<Object>>) mc
-				.asyncSopGet(key, 1, false, false);
+		CollectionFuture<Set<Object>> future = mc.asyncSopGet(key, 1, false, false);
 		assertNull(future.get(1000, TimeUnit.MILLISECONDS));
 
 		OperationStatus status = future.getOperationStatus();
@@ -52,8 +51,7 @@ public class SopServerMessageTest extends BaseIntegrationTest {
 	}
 
 	public void testCreatedStored() throws Exception {
-		CollectionFuture<Boolean> future = (CollectionFuture<Boolean>) mc
-				.asyncSopInsert(key, "aaa", new CollectionAttributes());
+		CollectionFuture<Boolean> future = mc.asyncSopInsert(key, "aaa", new CollectionAttributes());
 		assertTrue(future.get(1000, TimeUnit.MILLISECONDS));
 
 		OperationStatus status = future.getOperationStatus();
@@ -62,12 +60,10 @@ public class SopServerMessageTest extends BaseIntegrationTest {
 	}
 
 	public void testStored() throws Exception {
-		CollectionFuture<Boolean> future = (CollectionFuture<Boolean>) mc
-				.asyncSopInsert(key, "aaa", new CollectionAttributes());
+		CollectionFuture<Boolean> future = mc.asyncSopInsert(key, "aaa", new CollectionAttributes());
 		assertTrue(future.get(1000, TimeUnit.MILLISECONDS));
 
-		future = (CollectionFuture<Boolean>) mc.asyncSopInsert(key, "bbbb",
-				new CollectionAttributes());
+		future = mc.asyncSopInsert(key, "bbbb",	new CollectionAttributes());
 		assertTrue(future.get(1000, TimeUnit.MILLISECONDS));
 
 		OperationStatus status = future.getOperationStatus();
@@ -76,15 +72,13 @@ public class SopServerMessageTest extends BaseIntegrationTest {
 	}
 
 	public void testOverflowed() throws Exception {
-		CollectionFuture<Boolean> future = (CollectionFuture<Boolean>) mc
-				.asyncSopInsert(key, "aaa", new CollectionAttributes());
+		CollectionFuture<Boolean> future = mc.asyncSopInsert(key, "aaa", new CollectionAttributes());
 		assertTrue(future.get(1000, TimeUnit.MILLISECONDS));
 
 		assertTrue(mc.asyncSetAttr(key, new CollectionAttributes(null, 1L, CollectionOverflowAction.error))
 				.get(1000, TimeUnit.MILLISECONDS));
 
-		future = (CollectionFuture<Boolean>) mc.asyncSopInsert(key, "bbbb",
-				new CollectionAttributes());
+		future = mc.asyncSopInsert(key, "bbbb", new CollectionAttributes());
 		assertFalse(future.get(1000, TimeUnit.MILLISECONDS));
 
 		OperationStatus status = future.getOperationStatus();
@@ -93,12 +87,10 @@ public class SopServerMessageTest extends BaseIntegrationTest {
 	}
 
 	public void testElementExists() throws Exception {
-		CollectionFuture<Boolean> future = (CollectionFuture<Boolean>) mc
-				.asyncSopInsert(key, "aaa", new CollectionAttributes());
+		CollectionFuture<Boolean> future = mc.asyncSopInsert(key, "aaa", new CollectionAttributes());
 		assertTrue(future.get(1000, TimeUnit.MILLISECONDS));
 
-		future = (CollectionFuture<Boolean>) mc.asyncSopInsert(key, "aaa",
-				new CollectionAttributes());
+		future = mc.asyncSopInsert(key, "aaa", new CollectionAttributes());
 		assertFalse(future.get(1000, TimeUnit.MILLISECONDS));
 
 		OperationStatus status = future.getOperationStatus();
@@ -108,13 +100,11 @@ public class SopServerMessageTest extends BaseIntegrationTest {
 
 	public void testDeletedDropped() throws Exception {
 		// create
-		CollectionFuture<Boolean> future = (CollectionFuture<Boolean>) mc
-				.asyncSopInsert(key, "aaa", new CollectionAttributes());
+		CollectionFuture<Boolean> future = mc.asyncSopInsert(key, "aaa", new CollectionAttributes());
 		assertTrue(future.get(1000, TimeUnit.MILLISECONDS));
 
 		// delete
-		future = (CollectionFuture<Boolean>) mc
-				.asyncSopDelete(key, "aaa", true);
+		future = mc.asyncSopDelete(key, "aaa", true);
 		assertTrue(future.get(1000, TimeUnit.MILLISECONDS));
 
 		OperationStatus status = future.getOperationStatus();
@@ -124,18 +114,15 @@ public class SopServerMessageTest extends BaseIntegrationTest {
 
 	public void testDeleted() throws Exception {
 		// create
-		CollectionFuture<Boolean> future = (CollectionFuture<Boolean>) mc
-				.asyncSopInsert(key, "aaa", new CollectionAttributes());
+		CollectionFuture<Boolean> future = mc.asyncSopInsert(key, "aaa", new CollectionAttributes());
 		assertTrue(future.get(1000, TimeUnit.MILLISECONDS));
 
 		// insert
-		future = (CollectionFuture<Boolean>) mc.asyncSopInsert(key, "bbbb",
-				new CollectionAttributes());
+		future = mc.asyncSopInsert(key, "bbbb", new CollectionAttributes());
 		assertTrue(future.get(1000, TimeUnit.MILLISECONDS));
 
 		// delete
-		future = (CollectionFuture<Boolean>) mc.asyncSopDelete(key, "aaa",
-				false);
+		future = mc.asyncSopDelete(key, "aaa", false);
 		assertTrue(future.get(1000, TimeUnit.MILLISECONDS));
 
 		OperationStatus status = future.getOperationStatus();
@@ -145,13 +132,11 @@ public class SopServerMessageTest extends BaseIntegrationTest {
 
 	public void testDeletedDroppedAfterRetrieval() throws Exception {
 		// create
-		CollectionFuture<Boolean> future = (CollectionFuture<Boolean>) mc
-				.asyncSopInsert(key, "aaa", new CollectionAttributes());
+		CollectionFuture<Boolean> future = mc.asyncSopInsert(key, "aaa", new CollectionAttributes());
 		assertTrue(future.get(1000, TimeUnit.MILLISECONDS));
 
 		// get
-		CollectionFuture<Set<Object>> future2 = (CollectionFuture<Set<Object>>) mc
-				.asyncSopGet(key, 1, true, true);
+		CollectionFuture<Set<Object>> future2 = mc.asyncSopGet(key, 1, true, true);
 		assertNotNull(future2.get(1000, TimeUnit.MILLISECONDS));
 
 		OperationStatus status = future2.getOperationStatus();
@@ -161,18 +146,15 @@ public class SopServerMessageTest extends BaseIntegrationTest {
 
 	public void testDeletedAfterRetrieval() throws Exception {
 		// create
-		CollectionFuture<Boolean> future = (CollectionFuture<Boolean>) mc
-				.asyncSopInsert(key, "aaa", new CollectionAttributes());
+		CollectionFuture<Boolean> future = mc.asyncSopInsert(key, "aaa", new CollectionAttributes());
 		assertTrue(future.get(1000, TimeUnit.MILLISECONDS));
 
 		// insert
-		future = (CollectionFuture<Boolean>) mc.asyncSopInsert(key, "bbbb",
-				new CollectionAttributes());
+		future = mc.asyncSopInsert(key, "bbbb",	new CollectionAttributes());
 		assertTrue(future.get(1000, TimeUnit.MILLISECONDS));
 
 		// get
-		CollectionFuture<Set<Object>> future2 = (CollectionFuture<Set<Object>>) mc
-				.asyncSopGet(key, 1, true, false);
+		CollectionFuture<Set<Object>> future2 = mc.asyncSopGet(key, 1, true, false);
 		assertNotNull(future2.get(1000, TimeUnit.MILLISECONDS));
 
 		OperationStatus status = future2.getOperationStatus();


### PR DESCRIPTION
Fix from https://github.com/jam2in/arcus-task/issues/116

1. maven compiler 옵션에 build warning 발생시 error 로 취급하여 build failure 되도록 변경
2. test code 에 존재하던 build warning 제거 (기존에는 maven compiler 의 `showWarnings` 옵션이 default false 여서 나오지 않았던 warning 들입니다)

로컬에서 mvn clean install, mvn test 실행 완료 확인하였습니다. branch pull 해서 빌드해 보는 정도로 확인해 주시면 될 것 같습니다.

- [x] @whchoi83
- [x] @jhpark816