### PR TITLE
Add bop incr/decr with initial value

### DIFF
--- a/docs/06-btree-API.md
+++ b/docs/06-btree-API.md
@@ -703,11 +703,21 @@ CollectionFuture<Long> asyncBopDecr(String key, long bkey, int by)
 
 CollectionFuture<Long> asyncBopIncr(String key, Byte[] bkey, int by)
 CollectionFuture<Long> asyncBopDecr(String key, Byte[] bkey, int by)
+
+CollectionFuture<Long> asyncBopIncr(String key, long subkey, int by, long initial, byte[] eFlag);
+CollectionFuture<Long> asyncBopDecr(String key, long subkey, int by, long initial, byte[] eFlag);
+
+CollectionFuture<Long> asyncBopIncr(String key, byte[] subkey, int by, long initial, byte[] eFlag);
+CollectionFuture<Long> asyncBopDecr(String key, byte[] subkey, int by, long initial, byte[] eFlag);
 ```
 
 - key: b+tree item의 key
 - bkey: 대상 element의 bkey
-- by: 증감시킬 값 (감소시킬 값이 element 값보다 크면, 0으로 설정한다.)
+- by: 증감시킬 값 (1 이상의 값이어야 한다. 만약 감소시킬 값이 element 값보다 크면, 감소 후의 결과값은 0으로 저장된다)
+
+아래 값들은 대상 element가 존재하지 않을 때 새롭게 삽입되는 값들이다. (optional)
+- initial: 삽입할 element의 value (0 이상의 값[64bit unsigned integer]이어야 한다)
+- eFlag: 삽입할 element의 eflag(element flag)
 
 수행 결과는 future 객체를 통해 얻는다.
 
@@ -715,9 +725,12 @@ future.get() | future.operationStatus().getResponse() | 설명
 ------------ | -------------------------------------- | ---------
 element 값   |                                        | 증감 정상 수행
 null         | CollectionResponse.NOT_FOUND           | Key miss (주어진 key에 해당하는 item이 없음)
+             | CollectionResponse.NOT_FOUND_ELEMENT   | 주어진 bkey를 가진 element가 없음
              | CollectionResponse.TYPE_MISMATCH       | 해당 item이 b+tree가 아님
              | CollectionResponse.BKEY_MISMATCH       | 주어진 bkey 유형이 기존 bkey 유형과 다름
              | CollectionResponse.UNREADABLE          | 해당 key를 읽을 수 없는 상태임. (unreadable item상태)
+             | CollectionResponse.OVERFLOWED          | 최대 저장가능한 개수만큼 element들이 존재함
+             | CollectionResponse.OUT_OF_RANGE        | 조회된 element가 없음, 조회 범위에 b+tree trim 영역 있음
 
 B+tree element 값을 증가시키는 예저는 다음과 같다.
 

--- a/src/main/java/net/spy/memcached/ArcusClient.java
+++ b/src/main/java/net/spy/memcached/ArcusClient.java
@@ -4264,7 +4264,21 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
 	public CollectionFuture<Long> asyncBopIncr(String key, byte[] subkey,
 			int by) {
 		CollectionMutate collectionMutate = new BTreeMutate(Mutator.incr, by);
-		return asyncCollectionMutate(key,BTreeUtil.toHex(subkey), collectionMutate);
+		return asyncCollectionMutate(key, BTreeUtil.toHex(subkey), collectionMutate);
+	}
+
+	@Override
+	public CollectionFuture<Long> asyncBopIncr(String key, long subkey,
+			int by, long initial, byte[] eFlag) {
+		CollectionMutate collectionMutate = new BTreeMutate(Mutator.incr, by, initial, eFlag);
+		return asyncCollectionMutate(key, String.valueOf(subkey), collectionMutate);
+	}
+
+	@Override
+	public CollectionFuture<Long> asyncBopIncr(String key, byte[] subkey,
+			int by, long initial, byte[] eFlag) {
+		CollectionMutate collectionMutate = new BTreeMutate(Mutator.incr, by, initial, eFlag);
+		return asyncCollectionMutate(key, BTreeUtil.toHex(subkey), collectionMutate);
 	}
 
 	@Override
@@ -4278,9 +4292,23 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
 	public CollectionFuture<Long> asyncBopDecr(String key, byte[] subkey,
 			int by) {
 		CollectionMutate collectionMutate = new BTreeMutate(Mutator.decr, by);
-		return asyncCollectionMutate(key,BTreeUtil.toHex(subkey), collectionMutate);
+		return asyncCollectionMutate(key, BTreeUtil.toHex(subkey), collectionMutate);
 	}
-	
+
+	@Override
+	public CollectionFuture<Long> asyncBopDecr(String key, long subkey,
+			int by, long initial, byte[] eFlag) {
+		CollectionMutate collectionMutate = new BTreeMutate(Mutator.decr, by, initial, eFlag);
+		return asyncCollectionMutate(key, String.valueOf(subkey), collectionMutate);
+	}
+
+	@Override
+	public CollectionFuture<Long> asyncBopDecr(String key, byte[] subkey,
+			int by, long initial, byte[] eFlag) {
+		CollectionMutate collectionMutate = new BTreeMutate(Mutator.decr, by, initial, eFlag);
+		return asyncCollectionMutate(key, BTreeUtil.toHex(subkey), collectionMutate);
+	}
+
 	/**
 	 * Generic increment/decrement operation for b+tree items. Public methods call this method.
 	 *

--- a/src/main/java/net/spy/memcached/ArcusClientIF.java
+++ b/src/main/java/net/spy/memcached/ArcusClientIF.java
@@ -1511,6 +1511,32 @@ public interface ArcusClientIF {
 	 * @return future holding the incremented value
 	 */
 	public CollectionFuture<Long> asyncBopIncr(String key, byte[] subkey, int by);
+
+	/**
+	 * Increment the element's value in b+tree.
+	 *
+	 * @param key  b+tree item's key
+	 * @param subkey  element's key (byte-array type key)
+	 * @param by  increment amount
+	 * @param initial  optional element's initial value
+	 * @param eFlag  optional element flag
+	 * @return future holding the incremented value
+	 */
+	public CollectionFuture<Long> asyncBopIncr(String key, long subkey,
+			int by, long initial, byte[] eFlag);
+
+	/**
+	 * Increment the element's value in b+tree.
+	 *
+	 * @param key  b+tree item's key
+	 * @param subkey  element's key (byte-array type key)
+	 * @param by  increment amount
+	 * @param initial  optional element's initial value
+	 * @param eFlag  optional element flag
+	 * @return future holding the incremented value
+	 */
+	public CollectionFuture<Long> asyncBopIncr(String key, byte[] subkey,
+			int by, long initial, byte[] eFlag);
 	
 	/**
 	 * Decrement the element's value in b+tree.
@@ -1531,6 +1557,32 @@ public interface ArcusClientIF {
 	 * @return future holding the decremented value
 	 */
 	public CollectionFuture<Long> asyncBopDecr(String key, byte[] subkey, int by);
+
+	/**
+	 * Decrement the element's value in b+tree.
+	 *
+	 * @param key  b+tree item's key
+	 * @param subkey  element's key (byte-array type key)
+	 * @param by  decrement amount
+	 * @param initial  optional element's initial value
+	 * @param eFlag  optional element flag
+	 * @return future holding the decremented value
+	 */
+	public CollectionFuture<Long> asyncBopDecr(String key, long subkey,
+			int by, long initial, byte[] eFlag);
+
+	/**
+	 * Decrement the element's value in b+tree.
+	 *
+	 * @param key  b+tree item's key
+	 * @param subkey  element's key (byte-array type key)
+	 * @param by  decrement amount
+	 * @param initial  optional element's initial value
+	 * @param eFlag  optional element flag
+	 * @return future holding the decremented value
+	 */
+	public CollectionFuture<Long> asyncBopDecr(String key, byte[] subkey,
+			int by, long initial, byte[] eFlag);
 
 	/**
 	 * Get an element from b+tree using its position.

--- a/src/main/java/net/spy/memcached/ArcusClientPool.java
+++ b/src/main/java/net/spy/memcached/ArcusClientPool.java
@@ -910,6 +910,18 @@ public class ArcusClientPool implements ArcusClientIF {
 	}
 
 	@Override
+	public CollectionFuture<Long> asyncBopIncr(String key, long subkey,
+			int by, long initial, byte[] eFlag) {
+		return this.getClient().asyncBopIncr(key, subkey, by, initial, eFlag);
+	}
+
+	@Override
+	public CollectionFuture<Long> asyncBopIncr(String key, byte[] subkey,
+			int by, long initial, byte[] eFlag) {
+		return this.getClient().asyncBopIncr(key, subkey, by, initial, eFlag);
+	}
+
+	@Override
 	public CollectionFuture<Long> asyncBopDecr(String key, long subkey, int by) {
 		return this.getClient().asyncBopIncr(key, subkey, by);
 	}
@@ -917,6 +929,18 @@ public class ArcusClientPool implements ArcusClientIF {
 	@Override
 	public CollectionFuture<Long> asyncBopDecr(String key, byte[] subkey, int by) {
 		return this.getClient().asyncBopIncr(key, subkey, by);
+	}
+
+	@Override
+	public CollectionFuture<Long> asyncBopDecr(String key, long subkey,
+			int by, long initial, byte[] eFlag) {
+		return this.getClient().asyncBopIncr(key, subkey, by, initial, eFlag);
+	}
+
+	@Override
+	public CollectionFuture<Long> asyncBopDecr(String key, byte[] subkey,
+			int by, long initial, byte[] eFlag) {
+		return this.getClient().asyncBopIncr(key, subkey, by, initial, eFlag);
 	}
 
 	@Override

--- a/src/main/java/net/spy/memcached/protocol/ascii/CollectionMutateOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/CollectionMutateOperationImpl.java
@@ -43,14 +43,18 @@ public class CollectionMutateOperationImpl extends OperationImpl implements
 			false, "collection canceled", CollectionResponse.CANCELED);
 	private static final OperationStatus NOT_FOUND = new CollectionOperationStatus(
 			false, "NOT_FOUND", CollectionResponse.NOT_FOUND);
+	private static final OperationStatus NOT_FOUND_ELEMENT = new CollectionOperationStatus(
+			false, "NOT_FOUND_ELEMENT", CollectionResponse.NOT_FOUND_ELEMENT);
 	private static final OperationStatus TYPE_MISMATCH = new CollectionOperationStatus(
 			false, "TYPE_MISMATCH", CollectionResponse.TYPE_MISMATCH);
 	private static final OperationStatus BKEY_MISMATCH = new CollectionOperationStatus(
 			false, "BKEY_MISMATCH", CollectionResponse.BKEY_MISMATCH);
 	private static final OperationStatus UNREADABLE = new CollectionOperationStatus(
 			false, "UNREADABLE", CollectionResponse.UNREADABLE);
-	private static final OperationStatus NOT_FOUND_ELEMENT = new CollectionOperationStatus(
-			false, "NOT_FOUND_ELEMENT", CollectionResponse.NOT_FOUND_ELEMENT);
+	private static final OperationStatus OVERFLOWED = new CollectionOperationStatus(
+			false, "OVERFLOWED", CollectionResponse.OVERFLOWED);
+	private static final OperationStatus OUT_OF_RANGE = new CollectionOperationStatus(
+			false, "OUT_OF_RANGE", CollectionResponse.OUT_OF_RANGE);
 
 	protected final String key;
 	protected final String subkey;
@@ -82,8 +86,8 @@ public class CollectionMutateOperationImpl extends OperationImpl implements
 			Long.valueOf(line);
 			getCallback().receivedStatus(new OperationStatus(true, line));
 		} catch (NumberFormatException e) {
-			status = matchStatus(line, NOT_FOUND, TYPE_MISMATCH, BKEY_MISMATCH,
-					UNREADABLE, NOT_FOUND_ELEMENT);
+			status = matchStatus(line, NOT_FOUND, NOT_FOUND_ELEMENT, TYPE_MISMATCH, BKEY_MISMATCH,
+					UNREADABLE, OVERFLOWED, OUT_OF_RANGE);
 
 			getLogger().debug(status);
 			getCallback().receivedStatus(status);

--- a/src/test/manual/net/spy/memcached/collection/btree/BopMutateTest.java
+++ b/src/test/manual/net/spy/memcached/collection/btree/BopMutateTest.java
@@ -16,10 +16,13 @@
  */
 package net.spy.memcached.collection.btree;
 
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 import net.spy.memcached.collection.BaseIntegrationTest;
 import net.spy.memcached.collection.CollectionResponse;
+import net.spy.memcached.collection.Element;
+import net.spy.memcached.collection.ElementFlagFilter;
 import net.spy.memcached.internal.CollectionFuture;
 
 public class BopMutateTest extends BaseIntegrationTest {
@@ -57,6 +60,42 @@ public class BopMutateTest extends BaseIntegrationTest {
 		// decr 4
 		assertTrue(mc.asyncBopDecr(key, 1L, (int) 4)
 				.get(1000, TimeUnit.MILLISECONDS).equals(0L));
+	}
+
+	public void testBopIncrDecr_InitialValue() throws Exception {
+		// Create a list and add it 9 items
+		addToBTree(key, items9);
+
+		// incr 2, initial value 4L, etag
+		assertTrue(mc.asyncBopIncr(key, 10L, (int) 2, 4L, new byte[] { 0 })
+				.get(1000, TimeUnit.MILLISECONDS).equals(4L));
+		// incr 10
+		assertTrue(mc.asyncBopIncr(key, 10L, (int) 10, 6L, new byte[] { 1 })
+				.get(1000, TimeUnit.MILLISECONDS).equals(14L));
+
+		// decr 1, initial value 8L
+		assertTrue(mc.asyncBopDecr(key, 11L, (int) 1, 8L, null)
+				.get(1000, TimeUnit.MILLISECONDS).equals(8L));
+		// decr 2
+		assertTrue(mc.asyncBopDecr(key, 11L, (int) 2, 10L, null)
+				.get(1000, TimeUnit.MILLISECONDS).equals(6L));
+
+		// eFlag length 0
+		try {
+			assertTrue(mc.asyncBopIncr(key, 12L, (int) 2, 6L, new byte[] { })
+					.get(1000, TimeUnit.MILLISECONDS).equals(6L));
+		} catch (Exception e) {
+			assertEquals("length of eFlag must be between 1 and " + ElementFlagFilter.MAX_EFLAG_LENGTH + "." , e.getMessage());
+		}
+
+		ElementFlagFilter filter = new ElementFlagFilter(ElementFlagFilter.CompOperands.Equal,
+				new byte[] { 0 });
+		filter.setBitOperand(ElementFlagFilter.BitWiseOperands.AND, new byte[] { 0 });
+
+		Map<Long, Element<Object>> map = mc.asyncBopGet(key, 10L, filter,
+				false, false).get();
+
+		assertEquals(map.get(10L).getValue(), "14");
 	}
 
 	public void testBopIncrDecr_Minus() throws Exception {


### PR DESCRIPTION
bop incr/decr 에서 initial value를 설정할 수 있는 함수들을 추가했습니다.
null key혹은 음수 값이 들어왔을 때에 대해 exception을 발생시키는 코드를 추가해야할지 고민이 됩니다.

reviewer
- [x] @aiceru 
- [ ] @whchoi83 
- [x] @jhpark816 