### PR TITLE
Fix several mistakes in using elementFlag.

### DIFF
--- a/src/main/java/net/spy/memcached/collection/CollectionPipedUpdate.java
+++ b/src/main/java/net/spy/memcached/collection/CollectionPipedUpdate.java
@@ -69,26 +69,18 @@ public abstract class CollectionPipedUpdate<T> extends CollectionObject {
 
 			// estimate the buffer capacity
 			int i = 0;
-			ElementFlagUpdate elementFlagUpdate;
-			byte[] elementFlag;
-			int flagOffset;
-			BitWiseOperands bitOp;
+			ElementFlagUpdate eflagUpdate;
 			byte[] value;
 			StringBuilder b;
 
 			for (Element<T> each : elements) {
-				elementFlagUpdate = each.getElementFlagUpdate();
-				if (elementFlagUpdate != null) {
+				eflagUpdate = each.getElementFlagUpdate();
+				if (eflagUpdate != null) {
 					// eflag
-					elementFlag = elementFlagUpdate.getElementFlag();
-					if (elementFlag != null) {
-						capacity += KeyUtil.getKeyBytes(elementFlagUpdate
-								.getElementFlagByHex()).length;
-
-						// fwhere bitwop
-						if (elementFlagUpdate.getElementFlagOffset() > -1) {
-							capacity += 6;
-						}
+					capacity += KeyUtil.getKeyBytes(eflagUpdate.getElementFlagByHex()).length;
+					// fwhere bitwop
+					if (eflagUpdate.getElementFlagOffset() > -1) {
+						capacity += 6;
 					}
 				}
 
@@ -111,31 +103,18 @@ public abstract class CollectionPipedUpdate<T> extends CollectionObject {
 			while (iterator.hasNext()) {
 				Element<T> element = iterator.next();
 
-				flagOffset = -1;
-				bitOp = null;
-				elementFlag = null;
 				value = decodedList.get(i++);
-				elementFlagUpdate = element.getElementFlagUpdate();
+				eflagUpdate = element.getElementFlagUpdate();
 				b = new StringBuilder();
 
 				// has element eflag update
-				if (elementFlagUpdate != null) {
-					elementFlag = elementFlagUpdate.getElementFlag();
-					if (elementFlag != null) {
-						if (elementFlag.length > 0) {
-							// use fwhere bitop
-							flagOffset = elementFlagUpdate.getElementFlagOffset();
-							bitOp = elementFlagUpdate.getBitOp();
-							if (flagOffset > -1 && bitOp != null) {
-								b.append(flagOffset).append(" ").append(bitOp)
-										.append(" ");
-							}
-
-							b.append(elementFlagUpdate.getElementFlagByHex());
-						} else {
-							b.append("0");
-						}
+				if (eflagUpdate != null) {
+					// use fwhere bitop
+					if (eflagUpdate.getElementFlagOffset() > -1 && eflagUpdate.getBitOp() != null) {
+						b.append(eflagUpdate.getElementFlagOffset()).append(" ");
+						b.append(eflagUpdate.getBitOp()).append(" ");
 					}
+					b.append(eflagUpdate.getElementFlagByHex());
 				}
 
 				setArguments(bb, COMMAND, key,

--- a/src/main/java/net/spy/memcached/collection/CollectionStore.java
+++ b/src/main/java/net/spy/memcached/collection/CollectionStore.java
@@ -34,8 +34,11 @@ public abstract class CollectionStore<T> {
 	public CollectionStore() { }
 
 	public CollectionStore(T value, byte[] elementFlag, boolean createKeyIfNotExists, RequestMode requestMode, CollectionAttributes attr) {
-		if (elementFlag != null && elementFlag.length > ElementFlagFilter.MAX_EFLAG_LENGTH) {
-			throw new IllegalArgumentException("Length of elementFlag must be less than " + ElementFlagFilter.MAX_EFLAG_LENGTH);
+		if (elementFlag != null) {
+			if (elementFlag.length < 1 || elementFlag.length > ElementFlagFilter.MAX_EFLAG_LENGTH) {
+				throw new IllegalArgumentException("Length of elementFlag must be between 1 and "
+						+ ElementFlagFilter.MAX_EFLAG_LENGTH + ".");
+			}
 		}
 
 		this.value = value;
@@ -91,11 +94,6 @@ public abstract class CollectionStore<T> {
 		if (elementFlag == null) {
 			return "";
 		}
-
-		if (elementFlag.length == 0) {
-			return "0";
-		}
-		
 		return BTreeUtil.toHex(elementFlag);
 	}
 	

--- a/src/main/java/net/spy/memcached/collection/CollectionUpdate.java
+++ b/src/main/java/net/spy/memcached/collection/CollectionUpdate.java
@@ -16,47 +16,32 @@
  */
 package net.spy.memcached.collection;
 
-import net.spy.memcached.collection.ElementFlagFilter.BitWiseOperands;
-import net.spy.memcached.util.BTreeUtil;
-
 public abstract class CollectionUpdate<T> {
 
-	protected boolean createKeyIfNotExists = false;
 	protected int flags = 0;
 	protected T newValue;
+	protected ElementFlagUpdate eflagUpdate;
 	protected boolean noreply = false;
-
-	protected int flagOffset = -1;
-	protected BitWiseOperands bitOp;
-	protected byte[] elementFlag;
-
 	protected String str;
 
-	public CollectionUpdate() {
-	}
+	public CollectionUpdate(T newValue, ElementFlagUpdate eflagUpdate, boolean noreply) {
 
-	public CollectionUpdate(T newValue, ElementFlagUpdate elementFlagUpdate, boolean noreply) {
-		if (elementFlagUpdate == null) {
-			this.newValue = newValue;
-			this.flagOffset = -1;
-			this.bitOp = null;
-			this.elementFlag = null;
-		} else {
-			if (newValue == null && elementFlagUpdate.getElementFlag() == null) {
+		if (newValue == null) {
+			if (eflagUpdate == null || eflagUpdate.getElementFlag() == null) {
 				throw new IllegalArgumentException(
 						"One of the newValue or elementFlag must not be null.");
 			}
+		}
+		this.newValue = newValue;
 
-			if (elementFlagUpdate.getElementFlag().length > ElementFlagFilter.MAX_EFLAG_LENGTH) {
-				throw new IllegalArgumentException(
-						"length of element flag cannot exceed "
-								+ ElementFlagFilter.MAX_EFLAG_LENGTH);
+		if (eflagUpdate == null || eflagUpdate.getElementFlag() == null) {
+			this.eflagUpdate = null;
+		} else {		
+			if (eflagUpdate.getElementFlag().length > ElementFlagFilter.MAX_EFLAG_LENGTH) {
+				throw new IllegalArgumentException("length of element flag cannot exceed "
+						+ ElementFlagFilter.MAX_EFLAG_LENGTH + ".");
 			}
-
-			this.newValue = newValue;
-			this.flagOffset = elementFlagUpdate.getElementFlagOffset();
-			this.bitOp = elementFlagUpdate.getBitOp();
-			this.elementFlag = elementFlagUpdate.getElementFlag();
+			this.eflagUpdate = eflagUpdate;
 		}
 
 		this.noreply = noreply;
@@ -68,40 +53,12 @@ public abstract class CollectionUpdate<T> {
 
 		StringBuilder b = new StringBuilder();
 
-		if (flagOffset > -1 && bitOp != null && elementFlag != null) {
-			b.append(flagOffset).append(" ").append(bitOp).append(" ");
-		}
-
-		if (elementFlag != null) {
-			b.append(getElementFlagByHex());
-		}
-
 		if (noreply) {
 			b.append((b.length() <= 0) ? "" : " ").append("noreply");
 		}
 
 		str = b.toString();
 		return str;
-	}
-
-	public String getElementFlagByHex() {
-		if (elementFlag == null) {
-			return "";
-		}
-
-		if (elementFlag.length == 0) {
-			return "0";
-		}
-		
-		return BTreeUtil.toHex(elementFlag);
-	}
-
-	public boolean iscreateKeyIfNotExists() {
-		return createKeyIfNotExists;
-	}
-
-	public void setcreateKeyIfNotExists(boolean createKeyIfNotExists) {
-		this.createKeyIfNotExists = createKeyIfNotExists;
 	}
 
 	public int getFlags() {
@@ -120,16 +77,20 @@ public abstract class CollectionUpdate<T> {
 		this.newValue = newValue;
 	}
 
+	public ElementFlagUpdate getElementFlagUpdate() {
+		return eflagUpdate;
+	}
+
+	public void setElementFlagUpdate(ElementFlagUpdate eflagUpdate) {
+		this.eflagUpdate = eflagUpdate;
+	}
+
 	public boolean isNoreply() {
 		return noreply;
 	}
 
 	public void setNoreply(boolean noreply) {
 		this.noreply = noreply;
-	}
-
-	public void setElementFlag(byte[] elementFlag) {
-		this.elementFlag = elementFlag;
 	}
 
 	public String toString() {

--- a/src/main/java/net/spy/memcached/collection/CollectionUpdate.java
+++ b/src/main/java/net/spy/memcached/collection/CollectionUpdate.java
@@ -26,24 +26,19 @@ public abstract class CollectionUpdate<T> {
 
 	public CollectionUpdate(T newValue, ElementFlagUpdate eflagUpdate, boolean noreply) {
 
-		if (newValue == null) {
-			if (eflagUpdate == null || eflagUpdate.getElementFlag() == null) {
+		if (eflagUpdate == null) {
+			if (newValue == null) {
 				throw new IllegalArgumentException(
 						"One of the newValue or elementFlag must not be null.");
 			}
-		}
-		this.newValue = newValue;
-
-		if (eflagUpdate == null || eflagUpdate.getElementFlag() == null) {
-			this.eflagUpdate = null;
 		} else {		
 			if (eflagUpdate.getElementFlag().length > ElementFlagFilter.MAX_EFLAG_LENGTH) {
 				throw new IllegalArgumentException("length of element flag cannot exceed "
 						+ ElementFlagFilter.MAX_EFLAG_LENGTH + ".");
 			}
-			this.eflagUpdate = eflagUpdate;
 		}
-
+		this.newValue = newValue;
+		this.eflagUpdate = eflagUpdate;
 		this.noreply = noreply;
 	}
 

--- a/src/main/java/net/spy/memcached/collection/Element.java
+++ b/src/main/java/net/spy/memcached/collection/Element.java
@@ -86,10 +86,6 @@ public class Element<T> {
 			return "";
 		}
 
-		if (eflag.length == 0) {
-			return "0";
-		}
-
 		return BTreeUtil.toHex(eflag);
 	}
 

--- a/src/main/java/net/spy/memcached/collection/ElementFlagUpdate.java
+++ b/src/main/java/net/spy/memcached/collection/ElementFlagUpdate.java
@@ -46,9 +46,9 @@ public class ElementFlagUpdate {
 		if (elementFlag == null) {
 			throw new IllegalArgumentException("element flag may not null.");
 		}
-		if (elementFlag.length < 1 || elementFlag.length > 31) {
-			throw new IllegalArgumentException(
-					"length of element flag must be between 1 and 31");
+		if (elementFlag.length < 1 || elementFlag.length > ElementFlagFilter.MAX_EFLAG_LENGTH) {
+			throw new IllegalArgumentException("length of element flag must be between 1 and "
+					+ ElementFlagFilter.MAX_EFLAG_LENGTH + ".");
 		}
 		this.elementFlag = elementFlag;
 		this.elementFlagOffset = -1;
@@ -77,9 +77,9 @@ public class ElementFlagUpdate {
 		if (elementFlag == null) {
 			throw new IllegalArgumentException("element flag may not null.");
 		}
-		if (elementFlag.length < 1 || elementFlag.length > 31) {
-			throw new IllegalArgumentException(
-					"length of element flag must be between 1 and 31");
+		if (elementFlag.length < 1 || elementFlag.length > ElementFlagFilter.MAX_EFLAG_LENGTH) {
+			throw new IllegalArgumentException("length of element flag must be between 1 and "
+					+ ElementFlagFilter.MAX_EFLAG_LENGTH + ".");
 		}
 		this.elementFlagOffset = elementFlagOffset;
 		this.bitOp = bitOp;
@@ -104,6 +104,9 @@ public class ElementFlagUpdate {
 	 * @return element flag by hex (e.g. 0x01)
 	 */
 	public String getElementFlagByHex() {
+		if (elementFlag.length == 0) {
+			return "0"; // special meaning: remove eflag
+		}
 		// convert to hex based on its real byte array
 		return BTreeUtil.toHex(elementFlag);
 	}

--- a/src/main/java/net/spy/memcached/protocol/ascii/CollectionUpdateOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/CollectionUpdateOperationImpl.java
@@ -24,6 +24,7 @@ import net.spy.memcached.KeyUtil;
 import net.spy.memcached.collection.BTreeUpdate;
 import net.spy.memcached.collection.CollectionResponse;
 import net.spy.memcached.collection.CollectionUpdate;
+import net.spy.memcached.collection.ElementFlagUpdate;
 import net.spy.memcached.ops.APIType;
 import net.spy.memcached.ops.CollectionOperationStatus;
 import net.spy.memcached.ops.CollectionUpdateOperation;
@@ -100,16 +101,26 @@ public class CollectionUpdateOperationImpl extends OperationImpl implements
 	public void initialize() {
 		String args = collectionUpdate.stringify();
 
+		StringBuilder b = new StringBuilder();
+		ElementFlagUpdate eflagUpdate = collectionUpdate.getElementFlagUpdate();
+		if (eflagUpdate != null) {
+			if (eflagUpdate.getElementFlagOffset() > -1 && eflagUpdate.getBitOp() != null) {
+				b.append(eflagUpdate.getElementFlagOffset()).append(" ");
+				b.append(eflagUpdate.getBitOp()).append(" ");
+			}
+			b.append(eflagUpdate.getElementFlagByHex());
+		}
+		String eflagStr = b.toString();
+
 		ByteBuffer bb = ByteBuffer
 				.allocate(((data != null) ? data.length : 0)
 						+ KeyUtil.getKeyBytes(key).length
 						+ KeyUtil.getKeyBytes(subkey).length
-						+ KeyUtil.getKeyBytes(collectionUpdate
-								.getElementFlagByHex()).length + args.length()
+						+ eflagStr.length() + args.length()
 						+ OVERHEAD);
 
-		setArguments(bb, collectionUpdate.getCommand(), key, subkey, args,
-				((data != null) ? data.length : "-1"));
+		setArguments(bb, collectionUpdate.getCommand(), key, subkey,
+				 eflagStr, (data != null ? data.length : "-1"), args);
 
 		if (data != null) {
 			bb.put(data);


### PR DESCRIPTION
elementFlag를 사용하는 데 있어, 아래 문제들을 해결하였습니다.
- elementFlag에 대한 정확한 validation check.
- eflag 값을 저장하는 경우는 0-length byte array를 허용하지 않음
- eflag 값을 삭제하는 경우만 0-length byte array를 허용
- bop update command string 생성 시에 noreply 와 value length의 순서가 바뀐 문제 해결
- 기타 코드 간결히 : ElementFlagUpdate 객체를 활용.

reviewer
- [x] @minkikim89
- [x] @aiceru 
- [ ] @whchoi83 
