### PR TITLE
Remove compiler options "-Werror", "-Xlint"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -84,11 +84,6 @@
 					<debug>true</debug>
 					<optimize>true</optimize>
 					<encoding>utf-8</encoding>
-					<showWarnings>true</showWarnings>
-					<compilerArgs>
-						<arg>-Werror</arg>
-						<arg>-Xlint:all</arg>
-					</compilerArgs>
 				</configuration>
 			</plugin>
 			<plugin>


### PR DESCRIPTION
remove compiler options that make compiler to treat warnings as error