### PR TITLE
add timeunit and ommited duration at operation timeout log message

### DIFF
--- a/docs/10-log-message.md
+++ b/docs/10-log-message.md
@@ -113,7 +113,7 @@ net.spy.memcached.internal.CheckedOperationTimeoutException: Timed out waiting f
 
 | 메세지 | 설명 |
 | ------ | ---- |
-| Timed out waiting for operation. > 300 | Timeout 값이 300ms로 지정되어있고 요청의 결과를 받기까지300ms이상 걸려서 timeout되었다.|
+| Timed out waiting for operation. > 300 MILLISECONDS| Timeout 값이 300ms로 지정되어있고 요청의 결과를 받기까지300ms이상 걸려서 timeout되었다.|
 | Failing node: /127.0.0.1:11211 | 해당 요청은 127.0.0.1:11211 에서 수행한다. |
 | [WRITING]	| 해당 요청은 socket write를 위해 대기 중이다. |
 | [READING]	| 해당 요청은 서버로 전달되었고 결과가 돌아오기를 기다리거나, 결과 값을 읽어 들이는 중이다. |

--- a/src/main/java/net/spy/memcached/ArcusClient.java
+++ b/src/main/java/net/spy/memcached/ArcusClient.java
@@ -1092,7 +1092,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
 						MemcachedConnection.opTimedOut(op);
 					}
 					throw new CheckedOperationTimeoutException(
-							"Timed out waiting for operation", ops);
+							"Timed out waiting for operation >" + duration + " " + units, ops);
 				} else {
 					// continuous timeout counter will be reset
 					for (Operation op : ops) {
@@ -2071,7 +2071,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
 						MemcachedConnection.opTimedOut(op);
 					}
 					throw new CheckedOperationTimeoutException(
-							"Timed out waiting for operation. >" + duration, ops);
+							"Timed out waiting for operation. >" + duration + " " + units, ops);
 				} else {
 					// continuous timeout counter will be reset
 					for (Operation op : ops) {
@@ -2409,7 +2409,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
 						MemcachedConnection.opTimedOut(op);
 					}
 					throw new CheckedOperationTimeoutException(
-							"Timed out waiting for operation", ops);
+							"Timed out waiting for operation >" + duration + " " + units, ops);
 				} else {
 					// continuous timeout counter will be reset
 					for (Operation op : ops) {
@@ -2704,7 +2704,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
 						MemcachedConnection.opTimedOut(op);
 					}
 					throw new CheckedOperationTimeoutException(
-							"Timed out waiting for operation", ops);
+							"Timed out waiting for operation >" + duration + " " + units, ops);
 				} else {
 					// continuous timeout counter will be reset
 					for (Operation op : ops) {
@@ -4128,7 +4128,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
 						MemcachedConnection.opTimedOut(op);
 					}
 					throw new CheckedOperationTimeoutException(
-							"Timed out waiting for operation", ops);
+							"Timed out waiting for operation >" + duration + " " + units, ops);
 				} else {
 					// continuous timeout counter will be reset
 					for (Operation op : ops) {
@@ -4404,7 +4404,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
 						MemcachedConnection.opTimedOut(op);
 					}
 					throw new CheckedOperationTimeoutException(
-							"Timed out waiting for bulk operation", ops);
+							"Timed out waiting for bulk operation >" + duration + " " + units, ops);
 				} else {
 					// continuous timeout counter will be reset
 					for (Operation op : ops) {

--- a/src/main/java/net/spy/memcached/MemcachedClient.java
+++ b/src/main/java/net/spy/memcached/MemcachedClient.java
@@ -1692,7 +1692,7 @@ public class MemcachedClient extends SpyThread
 						MemcachedConnection.opTimedOut(op);
 					}
 					throw new CheckedOperationTimeoutException(
-							"Timed out waiting for operation. >" + duration, ops);
+							"Timed out waiting for operation. >" + duration + " " + units, ops);
 				} else {
 					// continuous timeout counter will be reset
 					for (Operation op : ops) {

--- a/src/main/java/net/spy/memcached/internal/CollectionFuture.java
+++ b/src/main/java/net/spy/memcached/internal/CollectionFuture.java
@@ -68,7 +68,7 @@ public class CollectionFuture<T> implements Future<T> {
 			return get(timeout, TimeUnit.MILLISECONDS);
 		} catch (TimeoutException e) {
 			throw new RuntimeException(
-				"Timed out waiting for operation. >" + timeout, e);
+				"Timed out waiting for operation. >" + timeout + " " + TimeUnit.MILLISECONDS, e);
 		}
 	}
 
@@ -78,7 +78,7 @@ public class CollectionFuture<T> implements Future<T> {
 			// whenever timeout occurs, continuous timeout counter will increase by 1.
 			MemcachedConnection.opTimedOut(op);
 			throw new CheckedOperationTimeoutException(
-					"Timed out waiting for operation. >" + duration, op);
+					"Timed out waiting for operation. >" + duration + " " + units, op);
 		} else {
 			// continuous timeout counter will be reset
 		    MemcachedConnection.opSucceeded(op);

--- a/src/main/java/net/spy/memcached/internal/OperationFuture.java
+++ b/src/main/java/net/spy/memcached/internal/OperationFuture.java
@@ -66,7 +66,7 @@ public class OperationFuture<T> implements Future<T> {
 			return get(timeout, TimeUnit.MILLISECONDS);
 		} catch (TimeoutException e) {
 			throw new RuntimeException(
-				"Timed out waiting for operation. >" + timeout, e);
+				"Timed out waiting for operation. >" + timeout + " " + TimeUnit.MILLISECONDS, e);
 		}
 	}
 
@@ -76,7 +76,7 @@ public class OperationFuture<T> implements Future<T> {
 			// whenever timeout occurs, continuous timeout counter will increase by 1.
 			MemcachedConnection.opTimedOut(op);
 			throw new CheckedOperationTimeoutException(
-					"Timed out waiting for operation. >" + duration, op);
+					"Timed out waiting for operation. >" + duration + " " + units, op);
 		} else {
 			// continuous timeout counter will be reset
 		    MemcachedConnection.opSucceeded(op);


### PR DESCRIPTION
timeout 메시지 출력 시 time unit 이 함께 출력되지 않아 단위 확인에 어려움이 있어 메시지를 수정합니다.
https://github.com/naver/arcus-java-client/issues/100 이슈를 해결한 PR 입니다.
timeout duration이 누락된 곳은 단위와 함께 추가했습니다.

리뷰 부탁드립니다.
- [x] @minkikim89 
- [x] @jhpark816 