### PR TITLE
TEST : fix smget test

### DIFF
--- a/src/test/manual/net/spy/memcached/LongKeyTest/BaseLongKeyTest.java
+++ b/src/test/manual/net/spy/memcached/LongKeyTest/BaseLongKeyTest.java
@@ -12,6 +12,7 @@ import java.util.List;
 import java.util.Random;
 import java.util.Set;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 public class BaseLongKeyTest extends BaseIntegrationTest {
 
@@ -144,7 +145,7 @@ public class BaseLongKeyTest extends BaseIntegrationTest {
 		// Btree Collection BulkGet
 		CollectionGetBulkFuture<Map<String, BTreeGetResult<Long, Object>>> f = mc
 				.asyncBopGetBulk(keys, 0, 100, ElementFlagFilter.DO_NOT_FILTER, 0, 10);
-		Map<String, BTreeGetResult<Long, Object>> results = f.get();
+		Map<String, BTreeGetResult<Long, Object>> results = f.get(3000L, TimeUnit.MILLISECONDS);
 		assertEquals(keySize, results.size());
 
 		// Delete Key
@@ -167,7 +168,7 @@ public class BaseLongKeyTest extends BaseIntegrationTest {
 						ElementFlagFilter.DO_NOT_FILTER, 0, 10);
 		try {
 			List<SMGetElement<Object>> map = oldFuture
-					.get();
+					.get(3000L, TimeUnit.MILLISECONDS);
 
 			Assert.assertEquals(10, map.size());
 			Assert.assertTrue(oldFuture.getMissedKeyList().isEmpty());
@@ -188,7 +189,7 @@ public class BaseLongKeyTest extends BaseIntegrationTest {
 						ElementFlagFilter.DO_NOT_FILTER, 10, smgetMode);
 		try {
 			List<SMGetElement<Object>> map = future
-					.get();
+					.get(3000L, TimeUnit.MILLISECONDS);
 
 			Assert.assertEquals(10, map.size());
 			Assert.assertTrue(future.getMissedKeyList().isEmpty());

--- a/src/test/manual/net/spy/memcached/btreesmget/SMGetTest.java
+++ b/src/test/manual/net/spy/memcached/btreesmget/SMGetTest.java
@@ -636,7 +636,7 @@ public class SMGetTest extends BaseIntegrationTest {
 			}
 			for (int i = 0; i < testSize; i++) {
 				mc.asyncBopInsert(KEY + i, i, ByteBuffer.allocate(4).putInt(i).array(), "VALUE" + i,
-								new CollectionAttributes()).get();
+								new CollectionAttributes()).get(1000L, TimeUnit.MILLISECONDS);
 			}
 		} catch (Exception e) {
 			fail(e.getMessage());
@@ -694,7 +694,7 @@ public class SMGetTest extends BaseIntegrationTest {
 			for (int i = 0; i < testSize; i++) {
 				mc.asyncBopInsert(KEY + i, ByteBuffer.allocate(4).putInt(i).array(),
 								ByteBuffer.allocate(4).putInt(i).array(), "VALUE" + i,
-								new CollectionAttributes()).get();
+								new CollectionAttributes()).get(1000L, TimeUnit.MILLISECONDS);
 			}
 		} catch (Exception e) {
 			fail(e.getMessage());

--- a/src/test/manual/net/spy/memcached/btreesmget/SMGetTestWithCombinationEflag.java
+++ b/src/test/manual/net/spy/memcached/btreesmget/SMGetTestWithCombinationEflag.java
@@ -97,7 +97,7 @@ public class SMGetTestWithCombinationEflag extends BaseIntegrationTest {
 
 			Assert.assertTrue(map.isEmpty());
 			Assert.assertEquals(future.getMissedKeyList().toString(), 10,
-					future.getMissedKeyList().size());
+					future.getMissedKeys().size());
 		} catch (Exception e) {
 			future.cancel(true);
 			e.printStackTrace();
@@ -224,9 +224,9 @@ public class SMGetTestWithCombinationEflag extends BaseIntegrationTest {
 			Assert.assertTrue(future.getMissedKeyList().isEmpty());
 
 			for (int i = 0; i < map.size(); i++) {
-				Assert.assertEquals(KEY + (i + 1), map.get(i).getKey());
-				Assert.assertEquals(i + 1, map.get(i).getBkey());
-				Assert.assertEquals("VALUE" + (i + 1), map.get(i).getValue());
+				Assert.assertEquals(keyList.get(i), map.get(i).getKey());
+				Assert.assertEquals(i, map.get(i).getBkey());
+				Assert.assertEquals("VALUE" + i, map.get(i).getValue());
 			}
 		} catch (Exception e) {
 			future.cancel(true);
@@ -285,13 +285,13 @@ public class SMGetTestWithCombinationEflag extends BaseIntegrationTest {
 			List<SMGetElement<Object>> map = future
 					.get(1000L, TimeUnit.SECONDS);
 
-			Assert.assertEquals(9, map.size());
+			Assert.assertEquals(10, map.size());
 			Assert.assertTrue(future.getMissedKeyList().isEmpty());
 
 			for (int i = 0; i < map.size(); i++) {
-				Assert.assertEquals(KEY + (i + 1), map.get(i).getKey());
-				Assert.assertEquals(i + 1, map.get(i).getBkey());
-				Assert.assertEquals("VALUE" + (i + 1), map.get(i).getValue());
+				Assert.assertEquals(keyList.get(i), map.get(i).getKey());
+				Assert.assertEquals(i, map.get(i).getBkey());
+				Assert.assertEquals("VALUE" + i, map.get(i).getValue());
 			}
 		} catch (Exception e) {
 			future.cancel(true);
@@ -350,13 +350,13 @@ public class SMGetTestWithCombinationEflag extends BaseIntegrationTest {
 			List<SMGetElement<Object>> map = future
 					.get(1000L, TimeUnit.SECONDS);
 
-			Assert.assertEquals(8, map.size());
+			Assert.assertEquals(9, map.size());
 			Assert.assertTrue(future.getMissedKeyList().isEmpty());
 
 			for (int i = 0; i < map.size(); i++) {
-				Assert.assertEquals(KEY + (i + 1), map.get(i).getKey());
-				Assert.assertEquals(i + 1, map.get(i).getBkey());
-				Assert.assertEquals("VALUE" + (i + 1), map.get(i).getValue());
+				Assert.assertEquals(keyList.get(i), map.get(i).getKey());
+				Assert.assertEquals(i, map.get(i).getBkey());
+				Assert.assertEquals("VALUE" +i, map.get(i).getValue());
 			}
 		} catch (Exception e) {
 			future.cancel(true);
@@ -468,7 +468,7 @@ public class SMGetTestWithCombinationEflag extends BaseIntegrationTest {
 			assertEquals(5, map.size());
 
 			assertEquals(future.getMissedKeyList().toString(), 5, future
-					.getMissedKeyList().size());
+					.getMissedKeys().size());
 		} catch (Exception e) {
 			future.cancel(true);
 			e.printStackTrace();
@@ -526,7 +526,7 @@ public class SMGetTestWithCombinationEflag extends BaseIntegrationTest {
 			assertEquals(5, map.size());
 
 			assertEquals(future.getMissedKeyList().toString(), 5, future
-					.getMissedKeyList().size());
+					.getMissedKeys().size());
 		} catch (Exception e) {
 			future.cancel(true);
 			e.printStackTrace();

--- a/src/test/manual/net/spy/memcached/btreesmget/SMGetTestWithEflag.java
+++ b/src/test/manual/net/spy/memcached/btreesmget/SMGetTestWithEflag.java
@@ -96,7 +96,7 @@ public class SMGetTestWithEflag extends BaseIntegrationTest {
 
 			Assert.assertTrue(map.isEmpty());
 			Assert.assertEquals(future.getMissedKeyList().toString(), 10,
-					future.getMissedKeyList().size());
+					future.getMissedKeys().size());
 		} catch (Exception e) {
 			future.cancel(true);
 			e.printStackTrace();
@@ -215,9 +215,9 @@ public class SMGetTestWithEflag extends BaseIntegrationTest {
 			Assert.assertTrue(future.getMissedKeyList().isEmpty());
 
 			for (int i = 0; i < map.size(); i++) {
-				Assert.assertEquals(KEY + (i + 1), map.get(i).getKey());
-				Assert.assertEquals(i + 1, map.get(i).getBkey());
-				Assert.assertEquals("VALUE" + (i + 1), map.get(i).getValue());
+				Assert.assertEquals(keyList.get(i), map.get(i).getKey());
+				Assert.assertEquals(i, map.get(i).getBkey());
+				Assert.assertEquals("VALUE" + i, map.get(i).getValue());
 			}
 		} catch (Exception e) {
 			future.cancel(true);
@@ -272,13 +272,13 @@ public class SMGetTestWithEflag extends BaseIntegrationTest {
 			List<SMGetElement<Object>> map = future
 					.get(1000L, TimeUnit.SECONDS);
 
-			Assert.assertEquals(9, map.size());
+			Assert.assertEquals(10, map.size());
 			Assert.assertTrue(future.getMissedKeyList().isEmpty());
 
 			for (int i = 0; i < map.size(); i++) {
-				Assert.assertEquals(KEY + (i + 1), map.get(i).getKey());
-				Assert.assertEquals(i + 1, map.get(i).getBkey());
-				Assert.assertEquals("VALUE" + (i + 1), map.get(i).getValue());
+				Assert.assertEquals(keyList.get(i), map.get(i).getKey());
+				Assert.assertEquals(i, map.get(i).getBkey());
+				Assert.assertEquals("VALUE" + i, map.get(i).getValue());
 			}
 		} catch (Exception e) {
 			future.cancel(true);
@@ -333,13 +333,13 @@ public class SMGetTestWithEflag extends BaseIntegrationTest {
 			List<SMGetElement<Object>> map = future
 					.get(1000L, TimeUnit.SECONDS);
 
-			Assert.assertEquals(8, map.size());
+			Assert.assertEquals(9, map.size());
 			Assert.assertTrue(future.getMissedKeyList().isEmpty());
 
 			for (int i = 0; i < map.size(); i++) {
-				Assert.assertEquals(KEY + (i + 1), map.get(i).getKey());
-				Assert.assertEquals(i + 1, map.get(i).getBkey());
-				Assert.assertEquals("VALUE" + (i + 1), map.get(i).getValue());
+				Assert.assertEquals(keyList.get(i), map.get(i).getKey());
+				Assert.assertEquals(i, map.get(i).getBkey());
+				Assert.assertEquals("VALUE" + i, map.get(i).getValue());
 			}
 		} catch (Exception e) {
 			future.cancel(true);
@@ -443,7 +443,7 @@ public class SMGetTestWithEflag extends BaseIntegrationTest {
 			assertEquals(5, map.size());
 
 			assertEquals(future.getMissedKeyList().toString(), 5, future
-					.getMissedKeyList().size());
+					.getMissedKeys().size());
 		} catch (Exception e) {
 			future.cancel(true);
 			e.printStackTrace();
@@ -497,7 +497,7 @@ public class SMGetTestWithEflag extends BaseIntegrationTest {
 			assertEquals(5, map.size());
 
 			assertEquals(future.getMissedKeyList().toString(), 5, future
-					.getMissedKeyList().size());
+					.getMissedKeys().size());
 		} catch (Exception e) {
 			future.cancel(true);
 			e.printStackTrace();


### PR DESCRIPTION
@jhpark816 

mvn test 후 몇몇 테스트 코드를 수정하였는데 대략적인 내용은 아래와 같습니다.

- case1 : operation timeout ==> 응답시간이 긴 operation의 경우 테스트를 목적으로 하는 코드니까 timeout시간을 비교적 더 줌.
- case2 : 함수의 잘못된 사용 (getMissedKeyList().size() -> getMissedKeys().size() )
- case3 : 잘못된 값의 assert check

```
new smget command에서 count 10조회하고 assert 10 check,  ==> success
old smget command에서 offset 1 count 10 조회하고 assert 10 check  ==> fail
```

task/ver_1_11 branch 코드로 클러스터 생성 후 테스트하였을 때 모든 테스트가 통과되는 것을 확인하였습니다.