### PR TITLE
FIX: flush by prefix method return false when prefix does not exist

### DIFF
--- a/docs/09-other-API.md
+++ b/docs/09-other-API.md
@@ -13,6 +13,8 @@ Arcus는 prefix단위로 flush하는 기능을 제공한다.
 OperationFuture<Boolean> flush(String prefix)
 ```
 
+정상적으로 prefix가 제거되었을 경우 true를 반환하며 만약 해당 prefix가 존재하지 않아 제거에 실패하였을 경우 false를 반환한다.
+
 **특정 prefix의 모든 item들을 삭제하는 기능이기 때문에 그 사용에 주의하여야 한다.**
 **특히, prefix를 입력하지 않으면, cache node의 모든 item들이 삭제므로 공용으로 사용하는 cloud에선 각별히 주의해야 한다.**
 

--- a/src/main/java/net/spy/memcached/protocol/ascii/FlushByPrefixOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/FlushByPrefixOperationImpl.java
@@ -32,7 +32,7 @@ final class FlushByPrefixOperationImpl extends OperationImpl implements
 		FlushOperation {
 
 	private static final OperationStatus OK = new OperationStatus(true, "OK");
-	private static final OperationStatus NOT_FOUND = new OperationStatus(true, "NOT_FOUND");
+	private static final OperationStatus NOT_FOUND = new OperationStatus(false, "NOT_FOUND");
 
 	private final String prefix;
 	private final int delay;


### PR DESCRIPTION
@jhpark816 
flush prefix에 대한 수정입니다.
key에 대한 validation check를 넣어야되나 고민을 했는데 그렇게 되면 exception을 던져줘야해서 기존 사용자들이 사용함에 문제가 있을 것 같아 넣지 않았습니다.