### PR TITLE
FIX: ClassCastException error of optimize get operation(MGet to Get)

### DIFF
--- a/src/main/java/net/spy/memcached/ops/APIType.java
+++ b/src/main/java/net/spy/memcached/ops/APIType.java
@@ -24,7 +24,7 @@ public enum APIType {
 	CAS(OperationType.WRITE),
 	INCR(OperationType.WRITE), DECR(OperationType.WRITE),
 	DELETE(OperationType.WRITE),
-	GET(OperationType.READ), GETS(OperationType.READ),
+	GET(OperationType.READ), GETS(OperationType.READ), MGET(OperationType.READ),
 	
 	// List API Type
 	LOP_CREATE(OperationType.WRITE),

--- a/src/main/java/net/spy/memcached/protocol/TCPMemcachedNodeImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/TCPMemcachedNodeImpl.java
@@ -38,6 +38,7 @@ import net.spy.memcached.CacheManager;
 import net.spy.memcached.MemcachedNode;
 import net.spy.memcached.MemcachedReplicaGroup;
 import net.spy.memcached.compat.SpyObject;
+import net.spy.memcached.ops.APIType;
 import net.spy.memcached.ops.Operation;
 import net.spy.memcached.ops.OperationState;
 
@@ -296,7 +297,13 @@ public abstract class TCPMemcachedNodeImpl extends SpyObject
 
 					preparePending();
 					if(shouldOptimize) {
-						optimize();
+						/* FIXME
+						 * MGetOperation needs optimization.
+						 * Temporarily do not optimize on MGetOperation.
+						 */
+						if (writeQ.peek().getAPIType() != APIType.MGET) {
+							optimize();
+						}
 					}
 
 					o=getCurrentWriteOp();

--- a/src/main/java/net/spy/memcached/protocol/ascii/MGetOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/MGetOperationImpl.java
@@ -15,7 +15,7 @@ public class MGetOperationImpl extends BaseGetOpImpl implements GetOperation {
 
 	public MGetOperationImpl(Collection<String> k, Callback c) {
 		super(CMD, c, new HashSet<String>(k));
-		setAPIType(APIType.GET);
+		setAPIType(APIType.MGET);
 	}
 
 }


### PR DESCRIPTION
@jhpark816 
get operation에 대해 optimize를 수행할 때
MGetOperation으로 인해 ClassCastException 발생에 대한 수정 입니다.

MGetOperationImpl, GetOperationImpl 모두 operation 에 대한 구현체로
MGetOperation 전용의 interface를 새로 만들어서 사용하는 것 보다
optimize 내부에서만 APIType을 구분하여 사용하는게 낫다고 판단했습니다.