### PR TITLE
FIX: check MGetOperation when get next Optimize Op

### DIFF
--- a/src/main/java/net/spy/memcached/protocol/TCPMemcachedNodeImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/TCPMemcachedNodeImpl.java
@@ -297,13 +297,7 @@ public abstract class TCPMemcachedNodeImpl extends SpyObject
 
 					preparePending();
 					if(shouldOptimize) {
-						/* FIXME
-						 * MGetOperation needs optimization.
-						 * Temporarily do not optimize on MGetOperation.
-						 */
-						if (writeQ.peek() != null && writeQ.peek().getAPIType() != APIType.MGET) {
-							optimize();
-						}
+						optimize();
 					}
 
 					o=getCurrentWriteOp();

--- a/src/main/java/net/spy/memcached/protocol/ascii/AsciiMemcachedNodeImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/AsciiMemcachedNodeImpl.java
@@ -5,6 +5,7 @@ import java.nio.channels.SocketChannel;
 import java.util.concurrent.BlockingQueue;
 
 import net.spy.memcached.ops.GetOperation;
+import net.spy.memcached.ops.APIType;
 import net.spy.memcached.ops.Operation;
 import net.spy.memcached.ops.OperationState;
 import net.spy.memcached.protocol.ProxyCallback;
@@ -25,26 +26,30 @@ public final class AsciiMemcachedNodeImpl extends TCPMemcachedNodeImpl {
 	protected void optimize() {
 		// make sure there are at least two get operations in a row before
 		// attempting to optimize them.
-		if(writeQ.peek() instanceof GetOperation) {
+		Operation nxtOp = writeQ.peek();
+		if (nxtOp instanceof GetOperation && nxtOp.getAPIType() != APIType.MGET) {
 			optimizedOp=writeQ.remove();
-			if(writeQ.peek() instanceof GetOperation) {
+			nxtOp = writeQ.peek();
+			if (nxtOp instanceof GetOperation && nxtOp.getAPIType() != APIType.MGET) {
 				OptimizedGetImpl og=new OptimizedGetImpl(
 						(GetOperation)optimizedOp);
 				optimizedOp=og;
 
-				while(writeQ.peek() instanceof GetOperation) {
+				do {
 					GetOperationImpl o=(GetOperationImpl) writeQ.remove();
 					if(!o.isCancelled()) {
 						og.addOperation(o);
 					}
-				}
+					nxtOp = writeQ.peek();
+				} while (nxtOp instanceof GetOperation &&
+						nxtOp.getAPIType() != APIType.MGET);
 
 				// Initialize the new mega get
 				optimizedOp.initialize();
 				assert optimizedOp.getState() == OperationState.WRITING;
 				ProxyCallback pcb=(ProxyCallback) og.getCallback();
 				getLogger().debug("Set up %s with %s keys and %s callbacks",
-					this, pcb.numKeys(), pcb.numCallbacks());
+						this, pcb.numKeys(), pcb.numCallbacks());
 			}
 		}
 	}

--- a/src/main/java/net/spy/memcached/protocol/binary/BinaryMemcachedNodeImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/binary/BinaryMemcachedNodeImpl.java
@@ -30,6 +30,7 @@ public class BinaryMemcachedNodeImpl extends TCPMemcachedNodeImpl {
 
 	@Override
 	protected void optimize() {
+		// MGetOperation does not support binary protocol
 		Operation firstOp = writeQ.peek();
 		if(firstOp instanceof GetOperation) {
 			optimizeGets();


### PR DESCRIPTION
shouldOptimize 사용에서,
optimize 대상이 되는 GetOperation 을 확인하는 과정 중
MGetOperation filtering이 모든 case를 확인할 수 있도록
수정하기 위한 PR 입니다.