### PR TITLE
CLEANUP: do not check enable MGetOperation when use binary protocol

### DIFF
--- a/src/main/java/net/spy/memcached/protocol/ascii/AsciiMemcachedNodeImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/AsciiMemcachedNodeImpl.java
@@ -15,11 +15,10 @@ import net.spy.memcached.protocol.TCPMemcachedNodeImpl;
  * Memcached node for the ASCII protocol.
  */
 public final class AsciiMemcachedNodeImpl extends TCPMemcachedNodeImpl {
-
 	public AsciiMemcachedNodeImpl(SocketAddress sa, SocketChannel c,
 			int bufSize, BlockingQueue<Operation> rq,
 			BlockingQueue<Operation> wq, BlockingQueue<Operation> iq, Long opQueueMaxBlockTimeNs) {
-		super(sa, c, bufSize, rq, wq, iq, opQueueMaxBlockTimeNs, false); /* ascii never does auth */
+		super(sa, c, bufSize, rq, wq, iq, opQueueMaxBlockTimeNs, false /* ascii never does auth */ , true /* ascii protocol */);
 	}
 
 	@Override

--- a/src/main/java/net/spy/memcached/protocol/binary/BinaryMemcachedNodeImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/binary/BinaryMemcachedNodeImpl.java
@@ -25,7 +25,7 @@ public class BinaryMemcachedNodeImpl extends TCPMemcachedNodeImpl {
 			BlockingQueue<Operation> wq, BlockingQueue<Operation> iq,
 			Long opQueueMaxBlockTimeNs, boolean waitForAuth) {
 		super(sa, c, bufSize, rq, wq, iq, opQueueMaxBlockTimeNs,
-			waitForAuth);
+			waitForAuth, false /* binary protocol */);
 	}
 
 	@Override


### PR DESCRIPTION
binary protocol 일 경우, asyncGetBulk 요청에 대해
MGetOperation enable 여부를 확인하지 않고
항상 GetOperation 으로만 보내도록 동작합니다.