### PR TITLE
FIX: ZkInitLatch procession when reconnect with ZK session expired

### DIFF
--- a/src/main/java/net/spy/memcached/CacheManager.java
+++ b/src/main/java/net/spy/memcached/CacheManager.java
@@ -246,11 +246,11 @@ public class CacheManager extends SpyThread implements Watcher,
     if (event.getType() == Event.EventType.None) {
       switch (event.getState()) {
         case SyncConnected:
+          zkInitLatch.countDown();
           getLogger().info("Connected to Arcus admin. (%s@%s)", serviceCode, hostPort);
           if (cacheMonitor != null) {
             getLogger().warn("Reconnected to the Arcus admin. " + getInfo());
           } else {
-            zkInitLatch.countDown();
             getLogger().debug("cm is null, servicecode : %s, state:%s, type:%s",
                     serviceCode, event.getState(), event.getType());
           }

--- a/src/main/java/net/spy/memcached/CacheMonitor.java
+++ b/src/main/java/net/spy/memcached/CacheMonitor.java
@@ -135,9 +135,11 @@ public class CacheMonitor extends SpyObject implements Watcher,
    * Shutdown the CacheMonitor.
    */
   public void shutdown() {
-    getLogger().info("Shutting down the CacheMonitor. " + getInfo());
-    dead = true;
-    listener.closing();
+    if (!dead) {
+      getLogger().info("Shutting down the CacheMonitor. " + getInfo());
+      dead = true;
+      listener.closing();
+    }
   }
 
   private String getInfo() {


### PR DESCRIPTION
ZK session expired 이후 reconnect 에서
실제로 reconnect에 성공 했지만,
cacheMonitor != null 로 인해 zkInitLatch.countDown()을 수행하지 못해
initZooKeeperClient() 에서 AdminConnectTimeoutException 이 발생하는 문제가 있습니다.

@jhpark816 
확인 요청 드립니다.

참고 : https://cwiki.apache.org/confluence/display/ZOOKEEPER/FAQ, https://github.com/jam2in/arcus-memcached-EE/issues/595