### PR TITLE
FIX: handling CacheManager exceptions for ZooKeeper

### DIFF
--- a/src/main/java/net/spy/memcached/CacheManager.java
+++ b/src/main/java/net/spy/memcached/CacheManager.java
@@ -272,11 +272,6 @@ public class CacheManager extends SpyThread implements Watcher,
     try {
       synchronized (this) {
         while (!shutdownRequested) {
-          if (zk == null) {
-            getLogger().info("Arcus admin connection is not established. (%s@%s)", serviceCode, hostPort);
-            initZooKeeperClient();
-          }
-
           if (!cacheMonitor.dead) {
             wait();
           } else {
@@ -298,6 +293,7 @@ public class CacheManager extends SpyThread implements Watcher,
       getLogger().warn("current arcus admin is interrupted : %s",
               e.getMessage());
     } finally {
+      getLogger().info("Close cache manager.");
       shutdownZooKeeperClient();
     }
   }


### PR DESCRIPTION
ZK reconnect 과정에서 연속으로 exception이 발생했을 때
zk == null 인 상태로 initZooKeeperClient() 를 수행하여
CacheManager thread가 종료되는 문제가 있었습니다.

ZK reconnect 과정에서 exception이 발생하면, 일정시간 sleep 후
reconnect 시도를 반복하도록 수정 했습니다.

@jhpark816 
확인 요청 드립니다.