### PR TITLE
CLEANUP: throw exception when can't create the znode of client info

### DIFF
--- a/src/main/java/net/spy/memcached/CacheManager.java
+++ b/src/main/java/net/spy/memcached/CacheManager.java
@@ -166,6 +166,7 @@ public class CacheManager extends SpyThread implements Watcher,
         String path = getClientInfo();
         if (path.isEmpty()) {
           getLogger().fatal("Can't create the znode of client info (" + path + ")");
+          throw new InitializeClientException("Can't create client info");
         } else {
           if (zk.exists(path, false) == null) {
             zk.create(path, null, Ids.OPEN_ACL_UNSAFE, CreateMode.EPHEMERAL);
@@ -175,6 +176,9 @@ public class CacheManager extends SpyThread implements Watcher,
         shutdownZooKeeperClient();
         throw e;
       } catch (NotExistsServiceCodeException e) {
+        shutdownZooKeeperClient();
+        throw e;
+      } catch (InitializeClientException e) {
         shutdownZooKeeperClient();
         throw e;
       } catch (InterruptedException ie) {


### PR DESCRIPTION
client info 를 create 할 수 없을 때
exception 을 생성하도록 수정 했습니다.
(기존 코드로 원복하기 위한 수정 입니다.)

@jhpark816 
확인 요청 드립니다.