### PR TITLE
TEST: fix travis-ci test error due to using memcached

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: java
 
 cache:
   directories:
-  - $HOME/arcus 
+  - $HOME/arcus
   - $HOME/.m2
 
 before_install:
@@ -10,9 +10,10 @@ before_install:
   - bash install-arcus-memcached.sh develop
 
 script:
-  - mvn test -DUSE_ZK=false && mvn test -DUSE_ZK=true
+  - mvn test -DUSE_ZK=false -DARCUS_HOST=127.0.0.1:11212 && mvn test -DUSE_ZK=true
 
 notifications:
   email:
-    - wooseok.son@jam2in.com
-    - whchoi83@jam2in.com
+    - junhyun.park@jam2in.com
+    - minkikim89@jam2in.com
+    - alsdn653@jam2in.com

--- a/mvnTestConf.json
+++ b/mvnTestConf.json
@@ -3,7 +3,7 @@
   , "servers": [
         { "hostname": "localhost", "ip": "127.0.0.1",
           "config": {
-            "port"       : "11211"
+            "port"       : "11212"
           }
         }
     ]

--- a/src/test/java/net/spy/memcached/AsciiClientTest.java
+++ b/src/test/java/net/spy/memcached/AsciiClientTest.java
@@ -36,7 +36,7 @@ public class AsciiClientTest extends ProtocolBaseCase {
 
   @Override
   protected String getExpectedVersionSource() {
-    return "/127.0.0.1:11211";
+    return "/"+ARCUS_HOST;
   }
 
 }

--- a/src/test/java/net/spy/memcached/BinaryClientTest.java
+++ b/src/test/java/net/spy/memcached/BinaryClientTest.java
@@ -23,7 +23,7 @@ public class BinaryClientTest extends ProtocolBaseCase {
 
   @Override
   protected String getExpectedVersionSource() {
-    return "/127.0.0.1:11211";
+    return "/"+ARCUS_HOST;
   }
 
   @Override

--- a/src/test/java/net/spy/memcached/CancelFailureModeTest.java
+++ b/src/test/java/net/spy/memcached/CancelFailureModeTest.java
@@ -8,13 +8,13 @@ public class CancelFailureModeTest extends ClientBaseCase {
 
   @Override
   protected void setUp() throws Exception {
-    serverList = "127.0.0.1:11211 127.0.0.1:11311";
+    serverList = ARCUS_HOST + " 127.0.0.1:11311";
     super.setUp();
   }
 
   @Override
   protected void tearDown() throws Exception {
-    serverList = "127.0.0.1:11211";
+    serverList = ARCUS_HOST;
     super.tearDown();
   }
 

--- a/src/test/java/net/spy/memcached/MemcachedClientConstructorTest.java
+++ b/src/test/java/net/spy/memcached/MemcachedClientConstructorTest.java
@@ -17,6 +17,10 @@ public class MemcachedClientConstructorTest extends TestCase {
 
   private MemcachedClient client = null;
 
+  protected static String ARCUS_HOST = System
+          .getProperty("ARCUS_HOST",
+                  "127.0.0.1:11211");
+
   @Override
   protected void tearDown() throws Exception {
     if (client != null) {
@@ -37,7 +41,7 @@ public class MemcachedClientConstructorTest extends TestCase {
 
   private void assertWorking() throws Exception {
     Map<SocketAddress, String> versions = client.getVersions();
-    assertEquals("/127.0.0.1:11211",
+    assertEquals("/"+ARCUS_HOST,
             versions.keySet().iterator().next().toString());
   }
 
@@ -47,8 +51,11 @@ public class MemcachedClientConstructorTest extends TestCase {
   }
 
   public void testVarargConstructor() throws Exception {
+    String tokens[] = ARCUS_HOST.split(":");
+    String ip = tokens[0];
+    int port  = Integer.valueOf(tokens[1]);
     client = new MemcachedClient(
-            new InetSocketAddress(InetAddress.getByName("127.0.0.1"), 11211));
+            new InetSocketAddress(InetAddress.getByName(ip), port));
     assertWorking();
   }
 
@@ -84,7 +91,7 @@ public class MemcachedClientConstructorTest extends TestCase {
   public void testNullFactoryConstructor() throws Exception {
     try {
       client = new MemcachedClient(null,
-              AddrUtil.getAddresses("127.0.0.1:11211"));
+              AddrUtil.getAddresses(ARCUS_HOST));
       fail("Expected null pointer exception, got " + client);
     } catch (NullPointerException e) {
       assertEquals("Connection factory required", e.getMessage());
@@ -99,7 +106,7 @@ public class MemcachedClientConstructorTest extends TestCase {
           return -1;
         }
       },
-              AddrUtil.getAddresses("127.0.0.1:11211"));
+              AddrUtil.getAddresses(ARCUS_HOST));
       fail("Expected null pointer exception, got " + client);
     } catch (IllegalArgumentException e) {
       assertEquals("Operation timeout must be positive.", e.getMessage());
@@ -114,7 +121,7 @@ public class MemcachedClientConstructorTest extends TestCase {
           return 0;
         }
       },
-              AddrUtil.getAddresses("127.0.0.1:11211"));
+              AddrUtil.getAddresses(ARCUS_HOST));
       fail("Expected null pointer exception, got " + client);
     } catch (IllegalArgumentException e) {
       assertEquals("Operation timeout must be positive.", e.getMessage());
@@ -128,7 +135,7 @@ public class MemcachedClientConstructorTest extends TestCase {
         public OperationFactory getOperationFactory() {
           return null;
         }
-      }, AddrUtil.getAddresses("127.0.0.1:11211"));
+      }, AddrUtil.getAddresses(ARCUS_HOST));
     } catch (AssertionError e) {
       assertEquals("Connection factory failed to make op factory",
               e.getMessage());
@@ -143,7 +150,7 @@ public class MemcachedClientConstructorTest extends TestCase {
                 List<InetSocketAddress> addrs) throws IOException {
           return null;
         }
-      }, AddrUtil.getAddresses("127.0.0.1:11211"));
+      }, AddrUtil.getAddresses(ARCUS_HOST));
     } catch (AssertionError e) {
       assertEquals("Connection factory failed to make a connection",
               e.getMessage());
@@ -152,7 +159,7 @@ public class MemcachedClientConstructorTest extends TestCase {
   }
 
   public void testArraymodNodeLocatorAccessor() throws Exception {
-    client = new MemcachedClient(AddrUtil.getAddresses("127.0.0.1:11211"));
+    client = new MemcachedClient(AddrUtil.getAddresses(ARCUS_HOST));
     assertTrue(client.getNodeLocator() instanceof ArrayModNodeLocator);
     assertTrue(client.getNodeLocator().getPrimary("x")
             instanceof MemcachedNodeROImpl);
@@ -160,7 +167,7 @@ public class MemcachedClientConstructorTest extends TestCase {
 
   public void testKetamaNodeLocatorAccessor() throws Exception {
     client = new MemcachedClient(new KetamaConnectionFactory(),
-            AddrUtil.getAddresses("127.0.0.1:11211"));
+            AddrUtil.getAddresses(ARCUS_HOST));
     assertTrue(client.getNodeLocator() instanceof KetamaNodeLocator);
     assertTrue(client.getNodeLocator().getPrimary("x")
             instanceof MemcachedNodeROImpl);

--- a/src/test/java/net/spy/memcached/RedistributeFailureModeTest.java
+++ b/src/test/java/net/spy/memcached/RedistributeFailureModeTest.java
@@ -14,13 +14,13 @@ public class RedistributeFailureModeTest extends ClientBaseCase {
 
   @Override
   protected void setUp() throws Exception {
-    serverList = "127.0.0.1:11211 127.0.0.1:11311";
+    serverList = ARCUS_HOST + " 127.0.0.1:11311";
     super.setUp();
   }
 
   @Override
   protected void tearDown() throws Exception {
-    serverList = "127.0.0.1:11211";
+    serverList = ARCUS_HOST;
     super.tearDown();
   }
 

--- a/src/test/manual/net/spy/memcached/test/ExcessivelyLargeGetTest.java
+++ b/src/test/manual/net/spy/memcached/test/ExcessivelyLargeGetTest.java
@@ -30,10 +30,14 @@ public class ExcessivelyLargeGetTest extends SpyObject implements Runnable {
   private final Collection<String> keys;
   private final byte[] value = new byte[4096];
 
+  protected static String ARCUS_HOST = System
+          .getProperty("ARCUS_HOST",
+                  "127.0.0.1:11211");
+
   public ExcessivelyLargeGetTest() throws Exception {
     client = new MemcachedClient(new ConnectionFactoryBuilder()
             .setProtocol(Protocol.BINARY).setOpTimeout(15000).build(),
-            AddrUtil.getAddresses("127.0.0.1:11211"));
+            AddrUtil.getAddresses(ARCUS_HOST));
     keys = new ArrayList<String>(N);
     new Random().nextBytes(value);
   }


### PR DESCRIPTION
travis-ci test error에 대한 수정 입니다.
travis-ci 에서, memcached 를 사용 하면서
default port 중복 문제로 인한 에러가 발생 했었습니다.

arcus-java-client  test를 위한 arcus-memcached port를
default port를 회피하도록 수정 했습니다.

reviewer
- [x] @minkikim89 
- [x] @jhpark816 

확인 요청 드립니다.