### PR TITLE
CLEANUP: add CacheManager log message

### DIFF
--- a/src/main/java/net/spy/memcached/CacheManager.java
+++ b/src/main/java/net/spy/memcached/CacheManager.java
@@ -279,7 +279,8 @@ public class CacheManager extends SpyThread implements Watcher,
           if (!cacheMonitor.dead) {
             wait();
           } else {
-            getLogger().warn("Unexpected disconnection from Arcus admin. Trying to reconnect to Arcus admin.");
+            getLogger().warn("Unexpected disconnection from Arcus admin. " +
+                    "Trying to reconnect to Arcus admin. CacheList =" + prevChildren);
             try {
               shutdownZooKeeperClient();
               initZooKeeperClient();
@@ -297,7 +298,11 @@ public class CacheManager extends SpyThread implements Watcher,
       getLogger().warn("current arcus admin is interrupted : %s",
               e.getMessage());
     } finally {
-      getLogger().info("Close cache manager.");
+      if (shutdownRequested) {
+        getLogger().info("Close cache manager.");
+      } else {
+        getLogger().error("Close cache manager. But, there was no shutdown request.");
+      }
       shutdownZooKeeperClient();
     }
   }


### PR DESCRIPTION
CacheManager log message 관련 수정 입니다.
Reconnect message에 CacheList 를 추가하고,
CacheManager 종료 시 shutdownRequested flag 세팅에 따라
log message level 과 내용을 다르게 출력하도록 했습니다.

@jhpark816 
확인 요청 드립니다.