### PR TITLE
FIX: Bug patch caused by CacheManager(v1.11.0)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: java
 
 cache:
   directories:
-  - $HOME/arcus 
+  - $HOME/arcus
   - $HOME/.m2
 
 before_install:
@@ -10,9 +10,10 @@ before_install:
   - bash install-arcus-memcached.sh develop
 
 script:
-  - mvn test -DUSE_ZK=false && mvn test -DUSE_ZK=true
+  - mvn test -DUSE_ZK=false -DARCUS_HOST=127.0.0.1:11212 && mvn test -DUSE_ZK=true
 
 notifications:
   email:
-    - wooseok.son@jam2in.com
-    - whchoi83@jam2in.com
+    - junhyun.park@jam2in.com
+    - minkikim89@jam2in.com
+    - alsdn653@jam2in.com

--- a/mvnTestConf.json
+++ b/mvnTestConf.json
@@ -3,7 +3,7 @@
   , "servers": [
         { "hostname": "localhost", "ip": "127.0.0.1",
           "config": {
-            "port"       : "11211"
+            "port"       : "11212"
           }
         }
     ]

--- a/src/main/java/net/spy/memcached/CacheManager.java
+++ b/src/main/java/net/spy/memcached/CacheManager.java
@@ -251,11 +251,11 @@ public class CacheManager extends SpyThread implements Watcher,
 		if (event.getType() == Event.EventType.None) {
 			switch (event.getState()) {
 			case SyncConnected:
+				zkInitLatch.countDown();
 				getLogger().info("Connected to Arcus admin. (%s@%s)", serviceCode, hostPort);
 				if (cacheMonitor != null) {
 					getLogger().warn("Reconnected to the Arcus admin. " + getInfo());
 				} else {
-					zkInitLatch.countDown();
 					getLogger().debug("cm is null, servicecode : %s, state:%s, type:%s",
 									serviceCode, event.getState(), event.getType());
 				}
@@ -277,15 +277,11 @@ public class CacheManager extends SpyThread implements Watcher,
 		try {
 			synchronized (this) {
 				while (!shutdownRequested) {
-					if (zk == null) {
-						getLogger().info("Arcus admin connection is not established. (%s@%s)", serviceCode, hostPort);
-						initZooKeeperClient();
-					}
-					
 					if (!cacheMonitor.dead) {
 						wait();
 					} else {
-						getLogger().warn("Unexpected disconnection from Arcus admin. Trying to reconnect to Arcus admin.");
+						getLogger().warn("Unexpected disconnection from Arcus admin. " +
+										"Trying to reconnect to Arcus admin. CacheList =" + prevChildren);
 						try {
 							shutdownZooKeeperClient();
 							initZooKeeperClient();
@@ -301,8 +297,13 @@ public class CacheManager extends SpyThread implements Watcher,
 			}
 		} catch (InterruptedException e) {
 			getLogger().warn("current arcus admin is interrupted : %s",
-					e.getMessage());
+							e.getMessage());
 		} finally {
+			if (shutdownRequested) {
+				getLogger().info("Close cache manager.");
+			} else {
+				getLogger().error("Close cache manager. But, there was no shutdown request.");
+			}
 			shutdownZooKeeperClient();
 		}
 	}

--- a/src/main/java/net/spy/memcached/CacheManager.java
+++ b/src/main/java/net/spy/memcached/CacheManager.java
@@ -167,6 +167,7 @@ public class CacheManager extends SpyThread implements Watcher,
 				String path = getClientInfo();
 				if (path.isEmpty()) {
 					getLogger().fatal("Can't create the znode of client info (" + path + ")");
+					throw new InitializeClientException("Can't create client info");
 				} else {
 					if (zk.exists(path, false) == null) {
 						zk.create(path, null, Ids.OPEN_ACL_UNSAFE, CreateMode.EPHEMERAL);
@@ -176,6 +177,9 @@ public class CacheManager extends SpyThread implements Watcher,
 				shutdownZooKeeperClient();
 				throw e;
 			} catch (NotExistsServiceCodeException e) {
+				shutdownZooKeeperClient();
+				throw e;
+			} catch (InitializeClientException e) {
 				shutdownZooKeeperClient();
 				throw e;
 			} catch (InterruptedException ie) {

--- a/src/main/java/net/spy/memcached/CacheMonitor.java
+++ b/src/main/java/net/spy/memcached/CacheMonitor.java
@@ -137,9 +137,11 @@ public class CacheMonitor extends SpyObject implements Watcher,
 	 * Shutdown the CacheMonitor.
 	 */
 	public void shutdown() {
-		getLogger().info("Shutting down the CacheMonitor. " + getInfo());
-		dead = true;
-		listener.closing();
+		if (!dead) {
+			getLogger().info("Shutting down the CacheMonitor. " + getInfo());
+			dead = true;
+			listener.closing();
+		}
 	}
 	
 	private String getInfo() {

--- a/src/main/java/net/spy/memcached/ops/APIType.java
+++ b/src/main/java/net/spy/memcached/ops/APIType.java
@@ -24,7 +24,7 @@ public enum APIType {
 	CAS(OperationType.WRITE),
 	INCR(OperationType.WRITE), DECR(OperationType.WRITE),
 	DELETE(OperationType.WRITE),
-	GET(OperationType.READ), GETS(OperationType.READ),
+	GET(OperationType.READ), GETS(OperationType.READ), MGET(OperationType.READ),
 	
 	// List API Type
 	LOP_CREATE(OperationType.WRITE),

--- a/src/main/java/net/spy/memcached/protocol/ascii/MGetOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/MGetOperationImpl.java
@@ -15,7 +15,7 @@ public class MGetOperationImpl extends BaseGetOpImpl implements GetOperation {
 
 	public MGetOperationImpl(Collection<String> k, Callback c) {
 		super(CMD, c, new HashSet<String>(k));
-		setAPIType(APIType.GET);
+		setAPIType(APIType.MGET);
 	}
 
 }

--- a/src/main/java/net/spy/memcached/protocol/binary/BinaryMemcachedNodeImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/binary/BinaryMemcachedNodeImpl.java
@@ -25,11 +25,12 @@ public class BinaryMemcachedNodeImpl extends TCPMemcachedNodeImpl {
 			BlockingQueue<Operation> wq, BlockingQueue<Operation> iq,
 			Long opQueueMaxBlockTimeNs, boolean waitForAuth) {
 		super(sa, c, bufSize, rq, wq, iq, opQueueMaxBlockTimeNs,
-			waitForAuth);
+			waitForAuth, false /* binary protocol */);
 	}
 
 	@Override
 	protected void optimize() {
+		// MGetOperation does not support binary protocol
 		Operation firstOp = writeQ.peek();
 		if(firstOp instanceof GetOperation) {
 			optimizeGets();

--- a/src/test/java/net/spy/memcached/AsciiClientTest.java
+++ b/src/test/java/net/spy/memcached/AsciiClientTest.java
@@ -34,7 +34,7 @@ public class AsciiClientTest extends ProtocolBaseCase {
 
 	@Override
 	protected String getExpectedVersionSource() {
-		return "/127.0.0.1:11211";
+		return "/"+ARCUS_HOST;
 	}
 
 }

--- a/src/test/java/net/spy/memcached/BinaryClientTest.java
+++ b/src/test/java/net/spy/memcached/BinaryClientTest.java
@@ -22,7 +22,7 @@ public class BinaryClientTest extends ProtocolBaseCase {
 
 	@Override
 	protected String getExpectedVersionSource() {
-		return "/127.0.0.1:11211";
+		return "/"+ARCUS_HOST;
 	}
 
 	@Override

--- a/src/test/java/net/spy/memcached/CancelFailureModeTest.java
+++ b/src/test/java/net/spy/memcached/CancelFailureModeTest.java
@@ -8,13 +8,13 @@ public class CancelFailureModeTest extends ClientBaseCase {
 
 	@Override
 	protected void setUp() throws Exception {
-		serverList="127.0.0.1:11211 127.0.0.1:11311";
+		serverList=ARCUS_HOST + " 127.0.0.1:11311";
 		super.setUp();
 	}
 
 	@Override
 	protected void tearDown() throws Exception {
-		serverList="127.0.0.1:11211";
+		serverList=ARCUS_HOST;
 		super.tearDown();
 	}
 

--- a/src/test/java/net/spy/memcached/MemcachedClientConstructorTest.java
+++ b/src/test/java/net/spy/memcached/MemcachedClientConstructorTest.java
@@ -17,6 +17,10 @@ public class MemcachedClientConstructorTest extends TestCase {
 
 	private MemcachedClient client=null;
 
+	protected static String ARCUS_HOST = System
+					.getProperty("ARCUS_HOST",
+									"127.0.0.1:11211");
+
 	@Override
 	protected void tearDown() throws Exception {
 		if(client != null) {
@@ -37,7 +41,7 @@ public class MemcachedClientConstructorTest extends TestCase {
 
 	private void assertWorking() throws Exception {
 		Map<SocketAddress, String> versions = client.getVersions();
-		assertEquals("/127.0.0.1:11211",
+		assertEquals("/"+ARCUS_HOST,
 			versions.keySet().iterator().next().toString());
 	}
 
@@ -47,8 +51,11 @@ public class MemcachedClientConstructorTest extends TestCase {
 	}
 
 	public void testVarargConstructor() throws Exception {
+		String tokens[] = ARCUS_HOST.split(":");
+		String ip = tokens[0];
+		int port  = Integer.valueOf(tokens[1]);
 		client = new MemcachedClient(
-			new InetSocketAddress(InetAddress.getByName("127.0.0.1"), 11211));
+			new InetSocketAddress(InetAddress.getByName(ip), port));
 		assertWorking();
 	}
 
@@ -84,7 +91,7 @@ public class MemcachedClientConstructorTest extends TestCase {
 	public void testNullFactoryConstructor() throws Exception {
 		try {
 			client = new MemcachedClient(null,
-				AddrUtil.getAddresses("127.0.0.1:11211"));
+				AddrUtil.getAddresses(ARCUS_HOST));
 			fail("Expected null pointer exception, got " + client);
 		} catch(NullPointerException e) {
 			assertEquals("Connection factory required", e.getMessage());
@@ -98,7 +105,7 @@ public class MemcachedClientConstructorTest extends TestCase {
 				public long getOperationTimeout() {
 					return -1;
 				}},
-				AddrUtil.getAddresses("127.0.0.1:11211"));
+				AddrUtil.getAddresses(ARCUS_HOST));
 			fail("Expected null pointer exception, got " + client);
 		} catch(IllegalArgumentException e) {
 			assertEquals("Operation timeout must be positive.", e.getMessage());
@@ -112,7 +119,7 @@ public class MemcachedClientConstructorTest extends TestCase {
 				public long getOperationTimeout() {
 					return 0;
 				}},
-				AddrUtil.getAddresses("127.0.0.1:11211"));
+				AddrUtil.getAddresses(ARCUS_HOST));
 			fail("Expected null pointer exception, got " + client);
 		} catch(IllegalArgumentException e) {
 			assertEquals("Operation timeout must be positive.", e.getMessage());
@@ -126,7 +133,7 @@ public class MemcachedClientConstructorTest extends TestCase {
 				public OperationFactory getOperationFactory() {
 					return null;
 				}
-			}, AddrUtil.getAddresses("127.0.0.1:11211"));
+			}, AddrUtil.getAddresses(ARCUS_HOST));
 		} catch(AssertionError e) {
 			assertEquals("Connection factory failed to make op factory",
 				e.getMessage());
@@ -141,7 +148,7 @@ public class MemcachedClientConstructorTest extends TestCase {
 						List<InetSocketAddress> addrs) throws IOException {
 					return null;
 				}
-			}, AddrUtil.getAddresses("127.0.0.1:11211"));
+			}, AddrUtil.getAddresses(ARCUS_HOST));
 		} catch(AssertionError e) {
 			assertEquals("Connection factory failed to make a connection",
 				e.getMessage());
@@ -150,7 +157,7 @@ public class MemcachedClientConstructorTest extends TestCase {
 	}
 
 	public void testArraymodNodeLocatorAccessor() throws Exception {
-		client = new MemcachedClient(AddrUtil.getAddresses("127.0.0.1:11211"));
+		client = new MemcachedClient(AddrUtil.getAddresses(ARCUS_HOST));
 		assertTrue(client.getNodeLocator() instanceof ArrayModNodeLocator);
 		assertTrue(client.getNodeLocator().getPrimary("x")
 			instanceof MemcachedNodeROImpl);
@@ -158,7 +165,7 @@ public class MemcachedClientConstructorTest extends TestCase {
 
 	public void testKetamaNodeLocatorAccessor() throws Exception {
 		client = new MemcachedClient(new KetamaConnectionFactory(),
-			AddrUtil.getAddresses("127.0.0.1:11211"));
+			AddrUtil.getAddresses(ARCUS_HOST));
 		assertTrue(client.getNodeLocator() instanceof KetamaNodeLocator);
 		assertTrue(client.getNodeLocator().getPrimary("x")
 			instanceof MemcachedNodeROImpl);

--- a/src/test/java/net/spy/memcached/RedistributeFailureModeTest.java
+++ b/src/test/java/net/spy/memcached/RedistributeFailureModeTest.java
@@ -14,13 +14,13 @@ public class RedistributeFailureModeTest extends ClientBaseCase {
 
 	@Override
 	protected void setUp() throws Exception {
-		serverList="127.0.0.1:11211 127.0.0.1:11311";
+		serverList=ARCUS_HOST + " 127.0.0.1:11311";
 		super.setUp();
 	}
 
 	@Override
 	protected void tearDown() throws Exception {
-		serverList="127.0.0.1:11211";
+		serverList=ARCUS_HOST;
 		super.tearDown();
 	}
 

--- a/src/test/manual/net/spy/memcached/test/ExcessivelyLargeGetTest.java
+++ b/src/test/manual/net/spy/memcached/test/ExcessivelyLargeGetTest.java
@@ -30,10 +30,14 @@ public class ExcessivelyLargeGetTest extends SpyObject implements Runnable {
 	private final Collection<String> keys;
 	private final byte[] value = new byte[4096];
 
+	protected static String ARCUS_HOST = System
+					.getProperty("ARCUS_HOST",
+									"127.0.0.1:11211");
+
 	public ExcessivelyLargeGetTest() throws Exception {
 		client = new MemcachedClient(new ConnectionFactoryBuilder()
 				.setProtocol(Protocol.BINARY).setOpTimeout(15000).build(),
-				AddrUtil.getAddresses("127.0.0.1:11211"));
+				AddrUtil.getAddresses(ARCUS_HOST));
 		keys = new ArrayList<String>(N);
 		new Random().nextBytes(value);
 	}


### PR DESCRIPTION
reviewer
- [x] @minkikim89 
- [ ] @jhpark816 

MGetOperation 관련 commit
- [CLEANUP: do not check enable MGetOperation when use binary protocol](https://github.com/naver/arcus-java-client/commit/c06646bea7fbf4bbd643ff6a48564e37840d0e8f)
- [FIX: check MGetOperation when get next Optimize Op](https://github.com/naver/arcus-java-client/commit/a3944d895f17cdd590f8dd06b2fa46972dfe319b)
- [FIX: ClassCastException error of optimize get operation(MGet to Get)](https://github.com/naver/arcus-java-client/commit/eff908db7fd23543223e574dcea3b1c5a96b06d6)