### PR TITLE
FIX: when replication switchover, set next opindex of pipedUpdateOp

### DIFF
--- a/src/main/java/net/spy/memcached/collection/CollectionPipedUpdate.java
+++ b/src/main/java/net/spy/memcached/collection/CollectionPipedUpdate.java
@@ -37,6 +37,14 @@ public abstract class CollectionPipedUpdate<T> extends CollectionObject {
   protected int itemCount;
   protected int nextOpIndex = 0;
 
+  /**
+   * set next index of operation
+   * that will be processed after when operation moved by switchover
+   */
+  public void setNextOpIndex(int i) {
+    this.nextOpIndex = i;
+  }
+
   public abstract ByteBuffer getAsciiCommand();
 
   public abstract ByteBuffer getBinaryCommand();

--- a/src/main/java/net/spy/memcached/protocol/ascii/CollectionPipedUpdateOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/CollectionPipedUpdateOperationImpl.java
@@ -91,6 +91,7 @@ public class CollectionPipedUpdateOperationImpl extends OperationImpl implements
 
     /* ENABLE_REPLICATION if */
     if (line.equals("SWITCHOVER") || line.equals("REPL_SLAVE")) {
+      this.update.setNextOpIndex(index);
       receivedMoveOperations(line);
       return;
     }


### PR DESCRIPTION
MemcachedNode 로 부터 replication switchover 응답을 받았을 때
CollectionPipedUpdate 연산에서 실패된 operation index를 기준으로
command를 만들어서 new master에게 보내도록 하는 기능이 빠져있었습니다.

다른 piped operation과 동일하게 next op index를 set 하는 방법으로
실패된 index 부터 command를 만들도록 수정 했습니다.

@minkikim89 @jhpark816 
확인 요청 드립니다.