### PR TITLE
FEATURE: Adding support for SLF4J logging

### DIFF
--- a/docs/02-arcus-java-client.md
+++ b/docs/02-arcus-java-client.md
@@ -244,8 +244,8 @@ ArcusClient client = ArcusClient.createArcusClient(SERVICE_CODE, cfb);
 
 ##### Logger 설정
 
-Arcus client 사용 시에 ArcusClient 자체 logger(DefaultLogger), log4j, JDK logger 등
-3가지 종류의 Logger를 사용할 수 있다.
+Arcus client 사용 시에 ArcusClient 자체 logger(DefaultLogger), log4j, slf4j, JDK logger 등
+4가지 종류의 Logger를 사용할 수 있다.
 사용할 logger를 지정하지 않으면 ArcusClient는 DefaultLogger를 기본으로 사용하며,
 DefaultLogger는 INFO level 이상의 로그를 stderr (System.err) 로 출력한다. (변경 불가)
 
@@ -330,6 +330,45 @@ Ascii Protocol에 대한 자세한 내용은 [Arcus 서버 명령 프로토콜](
 ```
 
 기타 log4j의 자세한 설정 방법은 [log4j 설정 방법](http://logging.apache.org/log4j/1.2/manual.html)을 확인하기 바란다. 
+
+##### SLF4JLogger 사용시 유의 사항
+
+slf4j와 호환되는 log4j 이외의 라이브러리(logback, log4j2, ...)를 쓸 경우, net.spy.memcached.compat.log.SLF4JLogger 클래스를 사용할 것이다. 이 클래스를 사용하기 전에 필수적으로 해야 하는 작업이 있다. (SLF4JLogger와 log4j를 조합해서 사용한다면 하지 않아도 된다.)
+
+ArcusClient는 기본적으로 Zookeeper에 의해서 slf4j의 구현 라이브러리인 slf4j-log4j12를 기본 dependency로 가진다. 따라서 log4j 이외의 라이브러리를 SLF4JLogger와 조합해서 사용하려면 ArcusClient dependency의 exclusion에 slf4j-log4j12를 추가해야 한다. 
+
+예를 들어 ArcusClient 사용자가 SLF4JLogger와 logback을 조합해서 사용할 경우 dependency 설정을 다음과 같이 해야 한다.
+
+```
+<dependency>
+    <groupId>com.navercorp.arcus</groupId>
+    <artifactId>arcus-java-client</artifactId>
+    <version>${arcus-java-client.version}</version>
+    <exclusions>
+        <exclusion>
+             <groupId>org.slf4j</groupId>
+             <artifactId>slf4j-log4j12</artifactId>
+        </exclusion>
+    </exclusions>
+</dependency>
+<dependency>
+	<groupId>ch.qos.logback</groupId>
+	<artifactId>logback-classic</artifactId>
+	<version>${logback.version}</version>
+</dependency>
+<dependency>
+	<groupId>ch.qos.logback</groupId>
+	<artifactId>logback-core</artifactId>
+	<version>${logback.version}</version>
+</dependency>
+```
+
+2개 이상의 slf4j의 구현 라이브러리(logback-classic, slf4j-log4j12, ...)들이 같은 classpath에 존재할 경우, SLF4J에서 [multiple binding error](http://www.slf4j.org/codes.html#multiple_bindings)가 발생하므로 반드시 exclusion 키워드를 이용해 slf4j 구현 라이브러리가 하나만 존재하도록 하여야 한다.
+
+```
+SLF4J: Class path contains multiple SLF4J bindings.
+SLF4J: See http://www.slf4j.org/codes.html#multiple_bindings for an explanation.
+```
 
 ##### Transparent Front Cache 사용
 

--- a/pom.xml
+++ b/pom.xml
@@ -41,9 +41,25 @@
 			<scope>provided</scope>
 		</dependency>
 		<dependency>
+			<groupId>org.slf4j</groupId>
+			<artifactId>slf4j-api</artifactId>
+			<version>1.6.1</version>
+		</dependency>
+		<dependency>
+			<groupId>org.slf4j</groupId>
+			<artifactId>slf4j-log4j12</artifactId>
+			<version>1.6.1</version>
+		</dependency>
+		<dependency>
 			<groupId>net.sf.ehcache</groupId>
 			<artifactId>ehcache-core</artifactId>
 			<version>2.6.0</version>
+			<exclusions>
+				<exclusion>
+					<groupId>org.slf4j</groupId>
+					<artifactId>slf4j-api</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.zookeeper</groupId>
@@ -53,6 +69,14 @@
 				<exclusion>
 					<groupId>log4j</groupId>
 					<artifactId>log4j</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>org.slf4j</groupId>
+					<artifactId>slf4j-api</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>org.slf4j</groupId>
+					<artifactId>slf4j-log4j12</artifactId>
 				</exclusion>
 			</exclusions>
 		</dependency>

--- a/src/main/java/net/spy/memcached/compat/log/AbstractLogger.java
+++ b/src/main/java/net/spy/memcached/compat/log/AbstractLogger.java
@@ -1,4 +1,25 @@
-// Copyright (c) 2002  SPY internetworking <dustin@spy.net>
+/**
+ * Copyright (C) 2006-2009 Dustin Sallings
+ * Copyright (C) 2009-2013 Couchbase, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALING
+ * IN THE SOFTWARE.
+ */
 
 package net.spy.memcached.compat.log;
 
@@ -57,6 +78,37 @@ public abstract class AbstractLogger implements Logger {
    * @return true if info messages would be displayed
    */
   public abstract boolean isInfoEnabled();
+
+  /**
+   * Log a message at trace level.
+   *
+   * @param message   the message to log
+   * @param exception the exception that caused the message to be generated
+   */
+  public void trace(Object message, Throwable exception) {
+    log(Level.TRACE, message, exception);
+  }
+
+  /**
+   * Log a formatted message at trace level.
+   *
+   * @param message the message to log
+   * @param args    the arguments for that message
+   */
+  public void trace(String message, Object... args) {
+    if (isDebugEnabled()) {
+      trace(String.format(message, args), getThrowable(args));
+    }
+  }
+
+  /**
+   * Log a message at trace level.
+   *
+   * @param message the message to log
+   */
+  public void trace(Object message) {
+    trace(message, null);
+  }
 
   /**
    * Log a message at debug level.

--- a/src/main/java/net/spy/memcached/compat/log/DefaultLogger.java
+++ b/src/main/java/net/spy/memcached/compat/log/DefaultLogger.java
@@ -1,4 +1,25 @@
-// Copyright (c) 2002  SPY internetworking <dustin@spy.net>
+/**
+ * Copyright (C) 2006-2009 Dustin Sallings
+ * Copyright (C) 2009-2013 Couchbase, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALING
+ * IN THE SOFTWARE.
+ */
 
 package net.spy.memcached.compat.log;
 
@@ -21,6 +42,14 @@ public class DefaultLogger extends AbstractLogger {
   public DefaultLogger(String name) {
     super(name);
     df = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS");
+  }
+
+  /**
+   * False.
+   */
+  @Override
+  public boolean isTraceEnabled() {
+    return (false);
   }
 
   /**

--- a/src/main/java/net/spy/memcached/compat/log/Level.java
+++ b/src/main/java/net/spy/memcached/compat/log/Level.java
@@ -1,4 +1,25 @@
-// Copyright (c) 2002  Dustin Sallings <dustin@spy.net>
+/**
+ * Copyright (C) 2006-2009 Dustin Sallings
+ * Copyright (C) 2009-2013 Couchbase, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALING
+ * IN THE SOFTWARE.
+ */
 
 package net.spy.memcached.compat.log;
 
@@ -7,6 +28,10 @@ package net.spy.memcached.compat.log;
  */
 public enum Level {
 
+  /**
+   * Trace level.
+   */
+  TRACE,
   /**
    * Debug level.
    */

--- a/src/main/java/net/spy/memcached/compat/log/Log4JLogger.java
+++ b/src/main/java/net/spy/memcached/compat/log/Log4JLogger.java
@@ -1,4 +1,25 @@
-// Copyright (c) 2002  Dustin Sallings <dustin@spy.net>
+/**
+ * Copyright (C) 2006-2009 Dustin Sallings
+ * Copyright (C) 2009-2013 Couchbase, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALING
+ * IN THE SOFTWARE.
+ */
 
 package net.spy.memcached.compat.log;
 
@@ -23,6 +44,14 @@ public class Log4JLogger extends AbstractLogger {
   }
 
   /**
+   * True if the underlying logger would allow trace messages through.
+   */
+  @Override
+  public boolean isTraceEnabled() {
+    return (l4jLogger.isTraceEnabled());
+  }
+
+  /**
    * True if the underlying logger would allow debug messages through.
    */
   @Override
@@ -41,7 +70,7 @@ public class Log4JLogger extends AbstractLogger {
   /**
    * Wrapper around log4j.
    *
-   * @param level   net.spy.compat.log.AbstractLogger level.
+   * @param level   net.spy.compat.log.Level level.
    * @param message object message
    * @param e       optional throwable
    */
@@ -50,6 +79,9 @@ public class Log4JLogger extends AbstractLogger {
     org.apache.log4j.Level pLevel = org.apache.log4j.Level.DEBUG;
 
     switch (level == null ? Level.FATAL : level) {
+      case TRACE:
+        pLevel = org.apache.log4j.Level.TRACE;
+        break;
       case DEBUG:
         pLevel = org.apache.log4j.Level.DEBUG;
         break;

--- a/src/main/java/net/spy/memcached/compat/log/Logger.java
+++ b/src/main/java/net/spy/memcached/compat/log/Logger.java
@@ -1,4 +1,25 @@
-// Copyright (c) 2002  SPY internetworking <dustin@spy.net>
+/**
+ * Copyright (C) 2006-2009 Dustin Sallings
+ * Copyright (C) 2009-2013 Couchbase, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALING
+ * IN THE SOFTWARE.
+ */
 
 package net.spy.memcached.compat.log;
 
@@ -30,6 +51,13 @@ public interface Logger {
    * @return true if info messages would be displayed
    */
   boolean isInfoEnabled();
+  
+  /**
+   * True if info is enabled for this logger.
+   *
+   * @return true if trace messages would be displayed
+   */
+  boolean isTraceEnabled();
 
   /**
    * Log a message at the specified level.
@@ -47,6 +75,29 @@ public interface Logger {
    * @param message the message to log
    */
   void log(Level level, Object message);
+
+  /**
+   * Log a message at trace level.
+   *
+   * @param message   the message to log
+   * @param exception the exception that caused the message to be generated
+   */
+  void trace(Object message, Throwable exception);
+
+  /**
+   * Log a message at trace level.
+   *
+   * @param message the message to log
+   */
+  void trace(Object message);
+
+  /**
+   * Log a formatted message at trace level.
+   *
+   * @param message the message to log
+   * @param args    the arguments for that message
+   */
+  void trace(String message, Object... args);
 
   /**
    * Log a message at debug level.

--- a/src/main/java/net/spy/memcached/compat/log/LoggerFactory.java
+++ b/src/main/java/net/spy/memcached/compat/log/LoggerFactory.java
@@ -1,4 +1,24 @@
-// Copyright (c) 2002  SPY internetworking <dustin@spy.net>
+/**
+ * Copyright (C) 2006-2009 Dustin Sallings
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALING
+ * IN THE SOFTWARE.
+ */
 
 package net.spy.memcached.compat.log;
 

--- a/src/main/java/net/spy/memcached/compat/log/LoggerFactory.java
+++ b/src/main/java/net/spy/memcached/compat/log/LoggerFactory.java
@@ -130,12 +130,12 @@ public final class LoggerFactory extends Object {
     // Find the best constructor
     try {
       // Try to find a constructor that takes a single string
-      Class[] args = {String.class};
+      Class<?>[] args = {String.class};
       instanceConstructor = c.getConstructor(args);
     } catch (NoSuchMethodException e) {
       try {
         // Try to find an empty constructor
-        Class[] args = {};
+        Class<?>[] args = {};
         instanceConstructor = c.getConstructor(args);
       } catch (NoSuchMethodException e2) {
         System.err.println("Warning:  " + className
@@ -143,7 +143,7 @@ public final class LoggerFactory extends Object {
 
         // Try to find a constructor that takes a single string
         try {
-          Class[] args = {String.class};
+          Class<?>[] args = {String.class};
           instanceConstructor =
                   DefaultLogger.class.getConstructor(args);
         } catch (NoSuchMethodException e3) {

--- a/src/main/java/net/spy/memcached/compat/log/SLF4JLogger.java
+++ b/src/main/java/net/spy/memcached/compat/log/SLF4JLogger.java
@@ -1,0 +1,104 @@
+/**
+ * Copyright (C) 2009-2013 Couchbase, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALING
+ * IN THE SOFTWARE.
+ */
+
+package net.spy.memcached.compat.log;
+
+/**
+ * Logging Implementation using the <a href="http://www.slf4j.org/">SLF4J</a>
+ * logging facade.
+ *
+ * <p>Note that by design, the SLF4J facade does not ship with an actual
+ * implementation so that it can be chosen during runtime. If you fail to
+ * provide a logging implementation during runtime, no log messages will
+ * be logged. See the <a href="http://www.slf4j.org/manual.html">SLF4J
+ * Manual</a> for more information on how to do this.</p>
+ *
+ * <p>Since SLF4J does not support a FATAL log level, errors logged at that
+ * level get promoted down to ERROR, since this is the highest level
+ * available.</p>
+ */
+public class SLF4JLogger extends AbstractLogger {
+
+  private final org.slf4j.Logger logger;
+
+  /**
+   * Get an instance of the SLF4JLogger.
+   */
+  public SLF4JLogger(String name) {
+    super(name);
+    logger = org.slf4j.LoggerFactory.getLogger(name);
+  }
+
+  @Override
+  public boolean isTraceEnabled() {
+    return logger.isTraceEnabled();
+  }
+
+  @Override
+  public boolean isDebugEnabled() {
+    return logger.isDebugEnabled();
+  }
+
+  @Override
+  public boolean isInfoEnabled() {
+    return logger.isInfoEnabled();
+  }
+
+  /**
+   * Wrapper around SLF4J logger facade.
+   *
+   * @param level net.spy.compat.log.Level level.
+   * @param message object message
+   * @param e optional throwable
+   */
+  @Override
+  public void log(Level level, Object message, Throwable e) {
+    if(level == null) {
+      level = Level.FATAL;
+    }
+
+    switch(level) {
+    case TRACE:
+      logger.trace(message.toString(), e);
+      break;
+    case DEBUG:
+      logger.debug(message.toString(), e);
+      break;
+    case INFO:
+      logger.info(message.toString(), e);
+      break;
+    case WARN:
+      logger.warn(message.toString(), e);
+      break;
+    case ERROR:
+      logger.error(message.toString(), e);
+      break;
+    case FATAL:
+      logger.error(message.toString(), e);
+      break;
+    default:
+      logger.error("Unhandled Logging Level: " + level
+        + " with log message: " + message.toString(), e);
+    }
+  }
+
+}

--- a/src/main/java/net/spy/memcached/compat/log/SunLogger.java
+++ b/src/main/java/net/spy/memcached/compat/log/SunLogger.java
@@ -1,4 +1,25 @@
-// Copyright (c) 2002  Dustin Sallings <dustin@spy.net>
+/**
+ * Copyright (C) 2006-2009 Dustin Sallings
+ * Copyright (C) 2009-2013 Couchbase, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALING
+ * IN THE SOFTWARE.
+ */
 
 package net.spy.memcached.compat.log;
 
@@ -19,6 +40,14 @@ public class SunLogger extends AbstractLogger {
 
     // Get the sun logger instance.
     sunLogger = java.util.logging.Logger.getLogger(name);
+  }
+
+  /**
+   * True if the underlying logger would allow Level.FINEST through.
+   */
+  @Override
+  public boolean isTraceEnabled() {
+    return (sunLogger.isLoggable(java.util.logging.Level.FINEST));
   }
 
   /**
@@ -49,6 +78,9 @@ public class SunLogger extends AbstractLogger {
     java.util.logging.Level sLevel = java.util.logging.Level.SEVERE;
 
     switch (level == null ? Level.FATAL : level) {
+      case TRACE:
+        sLevel = java.util.logging.Level.FINEST;
+        break;
       case DEBUG:
         sLevel = java.util.logging.Level.FINE;
         break;


### PR DESCRIPTION
original code: couchbase/spymemcached
- https://github.com/couchbase/spymemcached/commit/730fe4f285887ed074c78da84ef58a85bf8abd4d

couchbase/spymemcached의 net.spy.memcached.compat.log 패키지의 코드들을 그대로 적용했습니다.

SLF4J 지원 뿐만 아니라 Trace Logging Level이 추가됐습니다.