### PR TITLE
FIX: change FAKE_SERVER_NODE check method

### DIFF
--- a/src/main/java/net/spy/memcached/MemcachedConnection.java
+++ b/src/main/java/net/spy/memcached/MemcachedConnection.java
@@ -568,6 +568,7 @@ public final class MemcachedConnection extends SpyObject {
     // and keep failing/reconnecting.
     if (qa.isFake()) {
       // Locator assumes non-null selectionkey.  So add a dummy one...
+      ops = SelectionKey.OP_CONNECT;
       qa.setSk(ch.register(selector, ops, qa));
       getLogger().info("new fake memcached node added %s to connect queue", qa);
       return qa;

--- a/src/main/java/net/spy/memcached/protocol/TCPMemcachedNodeImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/TCPMemcachedNodeImpl.java
@@ -168,7 +168,7 @@ public abstract class TCPMemcachedNodeImpl extends SpyObject
     if (sa instanceof InetSocketAddress) {
       InetSocketAddress inetSockAddr = (InetSocketAddress) sa;
       String ipport = inetSockAddr.getAddress() + ":" + inetSockAddr.getPort();
-      isFake = CacheManager.FAKE_SERVER_NODE.equals(ipport);
+      isFake = ("/" + CacheManager.FAKE_SERVER_NODE).equals(ipport);
     }
   }
 


### PR DESCRIPTION
reviewer
- [x] @minkikim89 
- [x] @jhpark816 

java client의 FAKE_SERVER_NODE 여부를 판단하는 방법에 오류가 있습니다.
fake server address를 변환 한 ipport string에 "/" 가 포함되어 있기때문에
fake server 여부를 address로 판별하기 위해 "/"를 포함하여 확인해야 합니다.

확인 요청 드립니다.

참고로, 기존코드에서 변경된 commit은 아래와 같습니다.
commit : https://github.com/naver/arcus-java-client/commit/2659175c7bdd8ead98a221255b09dabdfdafaa40