### PR TITLE
TEST: fix travis failed test case when USE_ZK is true

### DIFF
--- a/src/test/java/net/spy/memcached/CancelFailureModeTest.java
+++ b/src/test/java/net/spy/memcached/CancelFailureModeTest.java
@@ -14,8 +14,9 @@ public class CancelFailureModeTest extends ClientBaseCase {
 
   @Override
   protected void tearDown() throws Exception {
+    // override teardown to avoid the flush phase
     serverList = ARCUS_HOST;
-    super.tearDown();
+    client.shutdown();
   }
 
   @Override

--- a/src/test/java/net/spy/memcached/MemcachedClientConstructorTest.java
+++ b/src/test/java/net/spy/memcached/MemcachedClientConstructorTest.java
@@ -21,6 +21,9 @@ public class MemcachedClientConstructorTest extends TestCase {
           .getProperty("ARCUS_HOST",
                   "127.0.0.1:11211");
 
+  protected static boolean USE_ZK = Boolean.valueOf(System.getProperty(
+          "USE_ZK", "false"));
+
   @Override
   protected void tearDown() throws Exception {
     if (client != null) {
@@ -51,12 +54,14 @@ public class MemcachedClientConstructorTest extends TestCase {
   }
 
   public void testVarargConstructor() throws Exception {
-    String tokens[] = ARCUS_HOST.split(":");
-    String ip = tokens[0];
-    int port  = Integer.valueOf(tokens[1]);
-    client = new MemcachedClient(
-            new InetSocketAddress(InetAddress.getByName(ip), port));
-    assertWorking();
+    if (!USE_ZK) {
+      String tokens[] = ARCUS_HOST.split(":");
+      String ip = tokens[0];
+      int port = Integer.valueOf(tokens[1]);
+      client = new MemcachedClient(
+              new InetSocketAddress(InetAddress.getByName(ip), port));
+      assertWorking();
+    }
   }
 
   public void testEmptyVarargConstructor() throws Exception {


### PR DESCRIPTION
ZK를 사용할 때 두 코드에서 문제가 발생합니다.
- CancelFailureModeTest.java의 testQueueingToDownServer 테스트에서 테스트가 끝난뒤 teardown이 호출되는데 이 때 super.teardown이 호출되면 ARCUS_HOST와 연결을 맺고 flush명령을 날리는데 ARCUS_HOST가 존재하지 않아 flush 명령이 실패하여 테스트가 실패합니다.
- MemcachedClientConstructorTest.java의 testVarargConstructor 테스트는 USE_ZK가 설정되어있어도 cache_list를 사용하지 않고 ARCUS_HOST를 사용해 연결을 시도하고, 연결이 정상적으로 되지 않아 테스트에 실패합니다. 이에 USE_ZK시에는 해당 테스트를 시도하지 않도록 수정하였습니다.
