### PR TITLE
CLEANUP: refactor version operation handling

### DIFF
--- a/src/main/java/net/spy/memcached/protocol/ascii/VersionOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/VersionOperationImpl.java
@@ -28,9 +28,13 @@ final class VersionOperationImpl extends OperationImpl
 
   @Override
   public void handleLine(String line) {
-    assert line.startsWith("VERSION ");
-    getCallback().receivedStatus(
-            new OperationStatus(true, line.substring("VERSION ".length())));
+    OperationStatus cause;
+    if (line.startsWith("VERSION ")) {
+      cause = new OperationStatus(true, line.substring("VERSION ".length()));
+    } else {
+      cause = new OperationStatus(false, line);
+    }
+    getCallback().receivedStatus(cause);
     transitionState(OperationState.COMPLETE);
   }
 


### PR DESCRIPTION
version operation이 input queue overflow로 인해 exception이 나는 경우를 없애기 위한 PR입니다.
handleIO에서 node.getVersion==null일 경우 operation을 보내도록 수정하려 했지만, 그렇게 구현할 경우 operation을 이미 보낸 상황임에도 아직 version이 set 되지 않은 상태라면 계속해서 operation을 보내는 문제가 있어 HashSet을 사용하여 version operaation을 보내야하는 상태의 노드를 구분하도록 하였습니다.