### PR TITLE
ENHANCE: Skip the canceled operation not has been written to buffer.

### DIFF
--- a/src/main/java/net/spy/memcached/ArcusClient.java
+++ b/src/main/java/net/spy/memcached/ArcusClient.java
@@ -1074,7 +1074,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
         boolean rv = false;
         for (Operation op : ops) {
           op.cancel("by application.");
-          rv |= op.getState() == OperationState.WRITING;
+          rv |= op.getState() == OperationState.WRITE_QUEUED;
         }
         return rv;
       }
@@ -2072,7 +2072,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
         boolean rv = false;
         for (Operation op : ops) {
           op.cancel("by application.");
-          rv |= op.getState() == OperationState.WRITING;
+          rv |= op.getState() == OperationState.WRITE_QUEUED;
         }
         return rv;
       }
@@ -4077,7 +4077,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
         boolean rv = false;
         for (Operation op : ops) {
           op.cancel("by application.");
-          rv |= op.getState() == OperationState.WRITING;
+          rv |= op.getState() == OperationState.WRITE_QUEUED;
         }
         return rv;
       }
@@ -4355,7 +4355,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
         boolean rv = false;
         for (Operation op : ops) {
           op.cancel("by application.");
-          rv |= op.getState() == OperationState.WRITING;
+          rv |= op.getState() == OperationState.WRITE_QUEUED;
         }
         return rv;
       }

--- a/src/main/java/net/spy/memcached/MemcachedClient.java
+++ b/src/main/java/net/spy/memcached/MemcachedClient.java
@@ -1742,7 +1742,7 @@ public class MemcachedClient extends SpyThread
         boolean rv = false;
         for (Operation op : ops) {
           op.cancel("by application.");
-          rv |= op.getState() == OperationState.WRITING;
+          rv |= op.getState() == OperationState.WRITE_QUEUED;
         }
         return rv;
       }

--- a/src/main/java/net/spy/memcached/internal/BulkGetFuture.java
+++ b/src/main/java/net/spy/memcached/internal/BulkGetFuture.java
@@ -70,7 +70,7 @@ public class BulkGetFuture<T> implements BulkFuture<Map<String, T>> {
   public boolean cancel(boolean ign) {
     boolean rv = false;
     for (Operation op : ops) {
-      rv |= op.getState() == OperationState.WRITING;
+      rv |= op.getState() == OperationState.WRITE_QUEUED;
       op.cancel("by application.");
     }
     for (Future<T> v : rvMap.values()) {

--- a/src/main/java/net/spy/memcached/internal/CollectionFuture.java
+++ b/src/main/java/net/spy/memcached/internal/CollectionFuture.java
@@ -60,7 +60,7 @@ public class CollectionFuture<T> implements Future<T> {
     op.cancel("by application.");
     // This isn't exactly correct, but it's close enough.  If we're in
     // a writing state, we *probably* haven't started.
-    return op.getState() == OperationState.WRITING;
+    return op.getState() == OperationState.WRITE_QUEUED;
   }
 
   public T get() throws InterruptedException, ExecutionException {

--- a/src/main/java/net/spy/memcached/internal/CollectionGetBulkFuture.java
+++ b/src/main/java/net/spy/memcached/internal/CollectionGetBulkFuture.java
@@ -82,7 +82,7 @@ public class CollectionGetBulkFuture<T> implements Future<T> {
     boolean rv = false;
     for (Operation op : ops) {
       op.cancel("by application.");
-      rv |= op.getState() == OperationState.WRITING;
+      rv |= op.getState() == OperationState.WRITE_QUEUED;
     }
     return rv;
   }

--- a/src/main/java/net/spy/memcached/internal/OperationFuture.java
+++ b/src/main/java/net/spy/memcached/internal/OperationFuture.java
@@ -58,7 +58,7 @@ public class OperationFuture<T> implements Future<T> {
     op.cancel("by application.");
     // This isn't exactly correct, but it's close enough.  If we're in
     // a writing state, we *probably* haven't started.
-    return op.getState() == OperationState.WRITING;
+    return op.getState() == OperationState.WRITE_QUEUED;
   }
 
   public T get() throws InterruptedException, ExecutionException {

--- a/src/main/java/net/spy/memcached/internal/SMGetFuture.java
+++ b/src/main/java/net/spy/memcached/internal/SMGetFuture.java
@@ -53,7 +53,7 @@ public abstract class SMGetFuture<T> implements Future<T> {
     boolean rv = false;
     for (Operation op : ops) {
       op.cancel("by application.");
-      rv |= op.getState() == OperationState.WRITING;
+      rv |= op.getState() == OperationState.WRITE_QUEUED;
     }
     return rv;
   }

--- a/src/main/java/net/spy/memcached/ops/BaseOperationFactory.java
+++ b/src/main/java/net/spy/memcached/ops/BaseOperationFactory.java
@@ -36,7 +36,7 @@ public abstract class BaseOperationFactory implements OperationFactory {
   }
 
   public Collection<Operation> clone(KeyedOperation op) {
-    assert op.getState() == OperationState.WRITING
+    assert op.getState() == OperationState.WRITE_QUEUED
             : "Who passed me an operation in the " + op.getState() + "state?";
     assert !op.isCancelled() : "Attempted to clone a canceled op";
     assert !op.hasErrored() : "Attempted to clone an errored op";

--- a/src/main/java/net/spy/memcached/ops/Operation.java
+++ b/src/main/java/net/spy/memcached/ops/Operation.java
@@ -49,7 +49,7 @@ public interface Operation {
   /* ENABLE_REPLICATION if */
 
   /**
-   * reset operation state to WRITING
+   * reset operation state to WRITE_QUEUED
    */
   void resetState();
 
@@ -61,6 +61,12 @@ public interface Operation {
    * Get the write buffer for this operation.
    */
   ByteBuffer getBuffer();
+
+  /**
+   * Invoked when we start writing all of the bytes from this operation to
+   * the sockets write buffer.
+   */
+  void writing();
 
   /**
    * Invoked after having written all of the bytes from the supplied output

--- a/src/main/java/net/spy/memcached/ops/OperationState.java
+++ b/src/main/java/net/spy/memcached/ops/OperationState.java
@@ -21,6 +21,10 @@ package net.spy.memcached.ops;
  */
 public enum OperationState {
   /**
+   * State indicating this operation is waiting to be written to the server.
+   */
+  WRITE_QUEUED,
+  /**
    * State indicating this operation is writing data to the server.
    */
   WRITING,

--- a/src/main/java/net/spy/memcached/protocol/BaseOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/BaseOperationImpl.java
@@ -40,7 +40,7 @@ public abstract class BaseOperationImpl extends SpyObject {
    */
   public static final OperationStatus CANCELLED =
           new CancelledOperationStatus();
-  private OperationState state = OperationState.WRITING;
+  private OperationState state = OperationState.WRITE_QUEUED;
   private ByteBuffer cmd = null;
   private boolean cancelled = false;
   private String cancelCause = null;
@@ -108,10 +108,10 @@ public abstract class BaseOperationImpl extends SpyObject {
   /* ENABLE_REPLICATION if */
 
   /**
-   * reset operation state to WRITING
+   * reset operation state to WRITE_QUEUED
    */
   public final void resetState() {
-    transitionState(OperationState.WRITING);
+    transitionState(OperationState.WRITE_QUEUED);
   }
 
   public final void setMoved(boolean m) {
@@ -144,7 +144,8 @@ public abstract class BaseOperationImpl extends SpyObject {
     getLogger().debug("Transitioned state from %s to %s", state, newState);
     state = newState;
     // Discard our buffer when we no longer need it.
-    if (state != OperationState.WRITING) {
+    if (state != OperationState.WRITE_QUEUED &&
+        state != OperationState.WRITING) {
       cmd = null;
     }
     if (state == OperationState.COMPLETE) {
@@ -154,6 +155,10 @@ public abstract class BaseOperationImpl extends SpyObject {
       /* ENABLE_REPLICATION end */
       callback.complete();
     }
+  }
+
+  public final void writing() {
+    transitionState(OperationState.WRITING);
   }
 
   public final void writeComplete() {

--- a/src/main/java/net/spy/memcached/protocol/ascii/AsciiMemcachedNodeImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/AsciiMemcachedNodeImpl.java
@@ -45,7 +45,7 @@ public final class AsciiMemcachedNodeImpl extends TCPMemcachedNodeImpl {
 
         // Initialize the new mega get
         optimizedOp.initialize();
-        assert optimizedOp.getState() == OperationState.WRITING;
+        assert optimizedOp.getState() == OperationState.WRITE_QUEUED;
         ProxyCallback pcb = (ProxyCallback) og.getCallback();
         getLogger().debug("Set up %s with %s keys and %s callbacks",
                 this, pcb.numKeys(), pcb.numCallbacks());

--- a/src/main/java/net/spy/memcached/protocol/binary/BinaryMemcachedNodeImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/binary/BinaryMemcachedNodeImpl.java
@@ -57,7 +57,7 @@ public class BinaryMemcachedNodeImpl extends TCPMemcachedNodeImpl {
 
       // Initialize the new mega get
       optimizedOp.initialize();
-      assert optimizedOp.getState() == OperationState.WRITING;
+      assert optimizedOp.getState() == OperationState.WRITE_QUEUED;
       ProxyCallback pcb = (ProxyCallback) og.getCallback();
       getLogger().debug("Set up %s with %s keys and %s callbacks",
               this, pcb.numKeys(), pcb.numCallbacks());
@@ -84,7 +84,7 @@ public class BinaryMemcachedNodeImpl extends TCPMemcachedNodeImpl {
 
       // Initialize the new mega set
       optimizedOp.initialize();
-      assert optimizedOp.getState() == OperationState.WRITING;
+      assert optimizedOp.getState() == OperationState.WRITE_QUEUED;
     }
   }
 }

--- a/src/test/java/net/spy/memcached/internal/CheckedOperationTimeoutExceptionTest.java
+++ b/src/test/java/net/spy/memcached/internal/CheckedOperationTimeoutExceptionTest.java
@@ -32,14 +32,14 @@ public class CheckedOperationTimeoutExceptionTest extends TestCase {
   public void testSingleOperation() {
     Operation op = buildOp(11211);
     assertEquals(CheckedOperationTimeoutException.class.getName()
-                    + ": test - failing node: localhost:11211 [WRITING] [MOCK_STATE]",
+                    + ": test - failing node: localhost:11211 [WRITE_QUEUED] [MOCK_STATE]",
             new CheckedOperationTimeoutException("test", op).toString());
   }
 
   public void testNullNode() {
     Operation op = new TestOperation();
     assertEquals(CheckedOperationTimeoutException.class.getName()
-                    + ": test - failing node: <unknown> [WRITING]",
+                    + ": test - failing node: <unknown> [WRITE_QUEUED]",
             new CheckedOperationTimeoutException("test", op).toString());
   }
 
@@ -56,7 +56,7 @@ public class CheckedOperationTimeoutExceptionTest extends TestCase {
     ops.add(buildOp(11211));
     ops.add(buildOp(64212));
     assertEquals(CheckedOperationTimeoutException.class.getName()
-                    + ": test - failing nodes: localhost:11211 [WRITING] [MOCK_STATE], localhost:64212 [WRITING] [MOCK_STATE]",
+                    + ": test - failing nodes: localhost:11211 [WRITE_QUEUED] [MOCK_STATE], localhost:64212 [WRITE_QUEUED] [MOCK_STATE]",
             new CheckedOperationTimeoutException("test", ops).toString());
   }
 


### PR DESCRIPTION
cancel된 Operation이 Operation의 write buffer에 기록되지 않았다면, write을 스킵하는 내용입니다.

기존 코드의 로직을 아래와 같이 정리합니다.

1. 응용이 Operation을 요청하고, future.get을 waiting함
2. future.get의 타임아웃이 발생되어, future.cancel 호출
3. MemcachedConnection의 handleIO에서 Operation write 준비
https://github.com/naver/arcus-java-client/blob/master/src/main/java/net/spy/memcached/MemcachedConnection.java#L791
4. MemcachedNode의 writeQ에 가장 앞단에 위치한 Operation을 꺼내서 status(cancel 유무)를 확인하지 않고, Operation의 write buffer에 기록
https://github.com/naver/arcus-java-client/blob/master/src/main/java/net/spy/memcached/protocol/TCPMemcachedNodeImpl.java#L281
5. inputQ, writeQ에 남아있는 Operation들은 status(cancel 유무)를 확인하고, cancel이 되었다면, writeQ에 제거
https://github.com/naver/arcus-java-client/blob/master/src/main/java/net/spy/memcached/protocol/TCPMemcachedNodeImpl.java#L305
6. writeQ에 앞단에 위치해있었던 cancel된 Operation의 write buffer에 담긴 내용을 서버에 전송하고 서버의 응답을 read

4번 로직에서 Operation의 cancel 유무를 확인하고, writeQ에 제거하여, 해당 Operation을 서버에 전송하지 못하게도록 처리하였습니다.









