### PR TITLE
FIX: May produce NullPointerException when checking that the operatio…

### DIFF
--- a/src/main/java/net/spy/memcached/ArcusClient.java
+++ b/src/main/java/net/spy/memcached/ArcusClient.java
@@ -1111,7 +1111,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
             throw new ExecutionException(op.getException());
           }
 
-          if (op.isCancelled()) {
+          if (op != null && op.isCancelled()) {
             throw new ExecutionException(new RuntimeException(op.getCancelCause()));
           }
         }
@@ -2453,7 +2453,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
             throw new ExecutionException(op.getException());
           }
 
-          if (op.isCancelled()) {
+          if (op != null && op.isCancelled()) {
             throw new ExecutionException(new RuntimeException(
                     op.getCancelCause()));
           }
@@ -2711,7 +2711,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
             throw new ExecutionException(op.getException());
           }
 
-          if (op.isCancelled()) {
+          if (op != null && op.isCancelled()) {
             throw new ExecutionException(new RuntimeException(op.getCancelCause()));
           }
         }
@@ -4114,7 +4114,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
             throw new ExecutionException(op.getException());
           }
 
-          if (op.isCancelled()) {
+          if (op != null && op.isCancelled()) {
             throw new ExecutionException(new RuntimeException(op.getCancelCause()));
           }
         }
@@ -4391,7 +4391,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
             throw new ExecutionException(op.getException());
           }
 
-          if (op.isCancelled()) {
+          if (op != null && op.isCancelled()) {
             throw new ExecutionException(new RuntimeException(op.getCancelCause()));
           }
         }

--- a/src/main/java/net/spy/memcached/internal/CollectionGetBulkFuture.java
+++ b/src/main/java/net/spy/memcached/internal/CollectionGetBulkFuture.java
@@ -69,7 +69,7 @@ public class CollectionGetBulkFuture<T> implements Future<T> {
       if (op != null && op.hasErrored()) {
         throw new ExecutionException(op.getException());
       }
-      if (op.isCancelled()) {
+      if (op != null && op.isCancelled()) {
         throw new ExecutionException(new RuntimeException(op.getCancelCause()));
       }
     }


### PR DESCRIPTION
operation의 isCanceled() 호출 시 null 검사를 할 수 있도록 수정하였습니다. 
Client에서 operation이 null로 할당되는 상황은 전혀 없을 것으로 보입니다만,
앞의 hasErrored 코드에 null 검사를 하기 때문에 warning 코드(Method invocation ... may produce NullPointerException)가 발생되어 이를 제거하는 목적으로 PR 보냅니다.