### PR TITLE
CLEANUP: change max element size

### DIFF
--- a/docs/01-arcus-cloud-basics.md
+++ b/docs/01-arcus-cloud-basics.md
@@ -11,7 +11,7 @@ Arcus cache server의 key-value 모델은 아래의 기본 제약 사항을 가�
   - Value의 최대 크기는 1MB이다.
 - Collection 제약 사항
   - 하나의 collection이 가지는 최대 element 개수는 50,000개이다.
-  - Collection element가 저장하는 value의 최대 크기는 4KB이다.
+  - Collection element가 저장하는 value의 최대 크기는 16KB이다.
 
 아래에서 Arcus cloud를 이해하는 데 있어 기본 사항들을 기술한다.
 

--- a/docs/04-list-API.md
+++ b/docs/04-list-API.md
@@ -5,7 +5,7 @@ List collection은 하나의 key에 대해 여러 value들을 double linked list
 
 **제약 조건**
 - 저장 가능한 최대 element 개수 : 디폴트 4,000개 (attribute 설정으로 최대 50,000개 확장 가능)
-- 각 element에서 value 최대 크기 : 4KB
+- 각 element에서 value 최대 크기 : 16KB
 - List의 앞, 뒤에서 element를 삽입/삭제하기를 권한다. 임의의 index 위치에서 element 삽입/삭제가 가능하지만,
   임의의 index 위치를 신속히 찾아가기 위한 자료구조가 현재 없는 상태라서 비용이 많이 든다.
 

--- a/docs/05-set-API.md
+++ b/docs/05-set-API.md
@@ -5,7 +5,7 @@ Set item은 하나의 key에 대해 unique value의 집합을 저장한다.
 
 **제약 조건**
 - 저장 가능한 최대 element 개수 : 디폴트 4,000개 (attribute 설정으로 최대 50,000개 확장 가능)
-- 각 element에서 value 최대 크기 : 4KB
+- 각 element에서 value 최대 크기 : 16KB
 - Element 값의 중복을 허용하지 않는다.
 
 Set item에 수행가능한 기본 연산들은 다음과 같다.

--- a/docs/06-map-API.md
+++ b/docs/06-map-API.md
@@ -5,7 +5,7 @@ Map을 Java의 Map 자료형을 저장하는 용도로 사용하길 권장한다
 
 **제약 조건**
 - 저장 가능한 최대 element 개수 : 디폴트 4,000개 (attribute 설정으로 최대 50,000개 확장 가능)
-- 각 element에서 value 최대 크기 : 4KB
+- 각 element에서 value 최대 크기 : 16KB
 - mkey의 입력, Java map type에서 key는 string type만 가능하다. mkey 최대 길이는 250 바이트 이고, 하나의 map에 중복된 mkey는 허용하지 않는다.
 
 Map item에 대해 수행가능한 기본 연산은 다음과 같다.

--- a/docs/07-btree-API.md
+++ b/docs/07-btree-API.md
@@ -4,7 +4,7 @@ B+tree item은 하나의 key에 대해 b+tree 구조 기반으로 b+tree key(bke
 
 **제약 조건**
 - 저장 가능한 최대 element 개수 : 디폴트 4,000개 (attribute 설정으로 최대 50,000개 확장 가능)
-- 각 element에서 value 최대 크기 : 4KB
+- 각 element에서 value 최대 크기 : 16KB
 - 하나의 b+tree 내에서 모든 element는 동일한 bkey 유형을 가져야 한다.
   즉, long bkey 유형과 byte array bkey 유형이 혼재할 수 없다.
 

--- a/src/main/java/net/spy/memcached/transcoders/CollectionTranscoder.java
+++ b/src/main/java/net/spy/memcached/transcoders/CollectionTranscoder.java
@@ -29,14 +29,16 @@ public class CollectionTranscoder extends SerializingTranscoder implements
 
   /**
    * Maximum element size allowed by memcached collections.
+   * The cache server's default setting of max_element_bytes is 16KB
+   * and it can be changed up to 32KB
    */
-  public static final int MAX_SIZE = 4 * 1024;
+  public static final int MAX_ELEMENT_BYTES = 32 * 1024;
 
   /**
    * Get a serializing transcoder with the default max data size.
    */
   public CollectionTranscoder() {
-    this(MAX_SIZE);
+    this(MAX_ELEMENT_BYTES);
   }
 
   /**

--- a/src/test/manual/net/spy/memcached/collection/CollectionMaxElementSize.java
+++ b/src/test/manual/net/spy/memcached/collection/CollectionMaxElementSize.java
@@ -17,7 +17,7 @@
 package net.spy.memcached.collection;
 
 import java.util.concurrent.TimeUnit;
-
+import java.util.Map;
 import net.spy.memcached.internal.CollectionFuture;
 import net.spy.memcached.transcoders.CollectionTranscoder;
 
@@ -25,18 +25,39 @@ public class CollectionMaxElementSize extends BaseIntegrationTest {
 
   private String key = "CollectionMaxElementSize";
 
+  protected void tearDown() throws Exception {
+    mc.delete(key).get();
+    super.tearDown();
+  }
+
+  public void testlargeSize() throws Exception {
+    int largeSize = 16*1024-2; //16KB
+    StringBuilder sb = new StringBuilder();
+    for (int i = 0; i < largeSize; i++) {
+      sb.append(i % 9);
+    }
+
+    String largeValue = sb.toString();
+
+    assertTrue(mc.asyncBopInsert(key, 0, null, largeValue, new CollectionAttributes())
+            .get(1000, TimeUnit.MILLISECONDS));
+    Map<Long, Element<Object>> m = mc.asyncBopGet(key, 0, 1, ElementFlagFilter.DO_NOT_FILTER, 0,
+            1, false, false).get(1000, TimeUnit.MILLISECONDS);
+    assertEquals(largeValue, m.get(0L).getValue());
+  }
+
   public void testExceed() throws Exception {
     CollectionFuture<Boolean> future;
     future = mc.asyncLopInsert(key, -1, "test", new CollectionAttributes());
     assertTrue(future.get(1000, TimeUnit.MILLISECONDS));
 
     StringBuilder sb = new StringBuilder();
-    for (int i = 0; i < CollectionTranscoder.MAX_SIZE + 1; i++) {
+    for (int i = 0; i < CollectionTranscoder.MAX_ELEMENT_BYTES + 1; i++) {
       sb.append(i % 9);
     }
 
     String tooLargeValue = sb.toString();
-    assertEquals(CollectionTranscoder.MAX_SIZE + 1, tooLargeValue.length());
+    assertEquals(CollectionTranscoder.MAX_ELEMENT_BYTES + 1, tooLargeValue.length());
 
     try {
       future = mc.asyncLopInsert(key, -1, tooLargeValue,
@@ -47,5 +68,4 @@ public class CollectionMaxElementSize extends BaseIntegrationTest {
       assertTrue(e.getMessage().contains("Cannot cache data larger than"));
     }
   }
-
 }


### PR DESCRIPTION
element 최대 크기 변경하였습니다.

@jhpark816 
실제 서버에서는 16KB가 기본 제약인데,
java docs에는 32KB로 써야하는 상태인데,
그대로 가도 괜찮을까요?
아니면, 캐시서버는 16KB가 기본인 것을 언급해야할까요?