### PR TITLE
CLEANUP: solve hash point collision with comparison socket address of node

### DIFF
--- a/src/main/java/net/spy/memcached/MemcachedNodeROImpl.java
+++ b/src/main/java/net/spy/memcached/MemcachedNodeROImpl.java
@@ -29,7 +29,7 @@ import java.util.concurrent.BlockingQueue;
 
 import net.spy.memcached.ops.Operation;
 
-class MemcachedNodeROImpl implements MemcachedNode {
+public class MemcachedNodeROImpl implements MemcachedNode {
 
   private final MemcachedNode root;
 
@@ -42,6 +42,8 @@ class MemcachedNodeROImpl implements MemcachedNode {
   public String toString() {
     return root.toString();
   }
+
+  public MemcachedNode getMemcachedNode() { return root; }
 
   public void addOp(Operation op) {
     throw new UnsupportedOperationException();

--- a/src/main/java/net/spy/memcached/util/ArcusKetamaNodeLocatorConfiguration.java
+++ b/src/main/java/net/spy/memcached/util/ArcusKetamaNodeLocatorConfiguration.java
@@ -17,6 +17,9 @@
 package net.spy.memcached.util;
 
 import net.spy.memcached.MemcachedNode;
+import net.spy.memcached.MemcachedNodeROImpl;
+
+import java.util.Comparator;
 
 public class ArcusKetamaNodeLocatorConfiguration extends
         DefaultKetamaNodeLocatorConfiguration {
@@ -39,4 +42,26 @@ public class ArcusKetamaNodeLocatorConfiguration extends
     super.socketAddresses.remove(node);
   }
 
+  public class NodeNameComparator implements Comparator<MemcachedNode> {
+    /**
+     * compares lexicographically the two socket address string of MemcachedNode node1 and node2.
+     * @param node1
+     * @param node2
+     * @return return the value 0 if the node2 is equal to node1;
+     * a value less than 0 if node1 is lexicographically less than node2;
+     * and a value greater than 0 if node1 is lexicographically greater than the node2.
+     */
+    @Override
+    public int compare(MemcachedNode node1, MemcachedNode node2) {
+      if (node1 instanceof MemcachedNodeROImpl) {
+        node1 = ((MemcachedNodeROImpl)node1).getMemcachedNode();
+      }
+      if (node2 instanceof MemcachedNodeROImpl) {
+        node2 = ((MemcachedNodeROImpl)node2).getMemcachedNode();
+      }
+      String name1 = socketAddresses.get(node1);
+      String name2 = socketAddresses.get(node2);
+      return name1.compareTo(name2);
+    }
+  }
 }

--- a/src/main/java/net/spy/memcached/util/ArcusReplKetamaNodeLocatorConfiguration.java
+++ b/src/main/java/net/spy/memcached/util/ArcusReplKetamaNodeLocatorConfiguration.java
@@ -21,6 +21,8 @@ import net.spy.memcached.MemcachedNode;
 import net.spy.memcached.ArcusReplNodeAddress;
 import net.spy.memcached.MemcachedReplicaGroup;
 
+import java.util.Comparator;
+
 public class ArcusReplKetamaNodeLocatorConfiguration implements
         KetamaNodeLocatorConfiguration {
 
@@ -39,6 +41,24 @@ public class ArcusReplKetamaNodeLocatorConfiguration implements
 
   public int getNodeRepetitions() {
     return NUM_REPS;
+  }
+
+  public static class MemcachedReplicaGroupComparator implements Comparator<MemcachedReplicaGroup> {
+    /**
+     * compares lexicographically the two socket address string of
+     * MemcachedReplicaGroup group1 and group2.
+     * @param group1
+     * @param group2
+     * @return return the value 0 if the group2 is equal to group1;
+     * a value less than 0 if group1 is lexicographically less than group2;
+     * and a value greater than 0 if group1 is lexicographically greater than the group2.
+     */
+    @Override
+    public int compare(MemcachedReplicaGroup group1, MemcachedReplicaGroup group2) {
+      String name1 = group1.getGroupName();
+      String name2 = group2.getGroupName();
+      return name1.compareTo(name2);
+    }
   }
 }
 /* ENABLE_REPLICATION end */


### PR DESCRIPTION
https://github.com/naver/arcus-java-client/issues/204 이슈에 대한 PR입니다.
현재 테스트 중에서 이러한 collision 현상이 발생할 수 있는 테스트가 ConsistentHashingTest이고
간헐적으로 collision 현상으로 인해 해당 테스트가 실패하여 현재는 ignore 처리한 상태입니다.
이번 PR의 경우 코드 구현상 복잡해지는 부분이 있어서 실제 사용중인 ArcusKetamaNodeLocator와 ArcusReplKetamaNodeLocator에 대해서는 collision 관련 수정을 하였고,
KetamaNodeLocator에 대해서는 수정을 하지 않았습니다.
따라서, ConsistentHashingTest 테스트는 여전히 실패할 수 있는 상황입니다.

개인적으로는 KetamaNodeLocator에 대해서는 collision 처리를 하지 않아도 될 것 같기 때문에
기존에 있던 ConsistentHashingTest는 그대로 ignore 시키던지 아니면 ArcusKetamaNodeLocator를 테스트 하도록 수정하면 될 것 같은데, 그에 대한 의견도 주시면 감사하겠습니다.