### PR TITLE
ENHAHCE: destroy read queue of removed node

### DIFF
--- a/src/main/java/net/spy/memcached/MemcachedConnection.java
+++ b/src/main/java/net/spy/memcached/MemcachedConnection.java
@@ -528,9 +528,11 @@ public final class MemcachedConnection extends SpyObject {
       }
       String cause = "node removed.";
       if (failureMode == FailureMode.Cancel) {
+        cancelOperations(node.destroyReadQueue(false), cause);
         cancelOperations(node.destroyWriteQueue(false), cause);
         cancelOperations(node.destroyInputQueue(), cause);
       } else if (failureMode == FailureMode.Redistribute || failureMode == FailureMode.Retry) {
+        redistributeOperations(node.destroyReadQueue(true), cause);
         redistributeOperations(node.destroyWriteQueue(true), cause);
         redistributeOperations(node.destroyInputQueue(), cause);
       }

--- a/src/main/java/net/spy/memcached/MemcachedNode.java
+++ b/src/main/java/net/spy/memcached/MemcachedNode.java
@@ -52,6 +52,13 @@ public interface MemcachedNode {
   Collection<Operation> destroyWriteQueue(boolean resend);
 
   /**
+   * Extract all queued items for this node destructively.
+   *
+   * This is useful for redistributing items.
+   */
+  Collection<Operation> destroyReadQueue(boolean resend);
+
+  /**
    * Clear the queue of currently processing operations by either cancelling
    * them or setting them up to be reapplied after a reconnect.
    *

--- a/src/main/java/net/spy/memcached/MemcachedNodeROImpl.java
+++ b/src/main/java/net/spy/memcached/MemcachedNodeROImpl.java
@@ -179,6 +179,10 @@ class MemcachedNodeROImpl implements MemcachedNode {
     throw new UnsupportedOperationException();
   }
 
+  public Collection<Operation> destroyReadQueue(boolean resend) {
+    throw new UnsupportedOperationException();
+  }
+
   public void authComplete() {
     throw new UnsupportedOperationException();
   }

--- a/src/main/java/net/spy/memcached/protocol/TCPMemcachedNodeImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/TCPMemcachedNodeImpl.java
@@ -25,6 +25,7 @@ import java.nio.channels.SelectionKey;
 import java.nio.channels.SocketChannel;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Queue;
 import java.util.StringTokenizer;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CountDownLatch;
@@ -194,11 +195,11 @@ public abstract class TCPMemcachedNodeImpl extends SpyObject
   }
 
   /* (non-Javadoc)
-   * @see net.spy.memcached.MemcachedNode#destroyWriteQueue()
+   * @see net.spy.memcached.MemcachedNode#destroyQueue()
    */
-  public Collection<Operation> destroyWriteQueue(boolean resend) {
+  private Collection<Operation> destroyQueue(BlockingQueue<Operation> queue, boolean resend) {
     Collection<Operation> rv = new ArrayList<Operation>();
-    writeQ.drainTo(rv);
+    queue.drainTo(rv);
     if (resend) {
       for (Operation o : rv) {
         if ((o.getState() == OperationState.WRITE_QUEUED ||
@@ -211,6 +212,20 @@ public abstract class TCPMemcachedNodeImpl extends SpyObject
     }
 
     return rv;
+  }
+
+  /* (non-Javadoc)
+   * @see net.spy.memcached.MemcachedNode#destroyWriteQueue()
+   */
+  public Collection<Operation> destroyWriteQueue(boolean resend) {
+    return destroyQueue(writeQ, resend);
+  }
+
+  /* (non-Javadoc)
+   * @see net.spy.memcached.MemcachedNode#destroyReadQueue()
+   */
+  public Collection<Operation> destroyReadQueue(boolean resend) {
+    return destroyQueue(readQ, resend);
   }
 
   /* (non-Javadoc)

--- a/src/test/java/net/spy/memcached/MockMemcachedNode.java
+++ b/src/test/java/net/spy/memcached/MockMemcachedNode.java
@@ -198,6 +198,10 @@ public class MockMemcachedNode implements MemcachedNode {
     return null;
   }
 
+  public Collection<Operation> destroyReadQueue(boolean resend) {
+    return null;
+  }
+
   public void authComplete() {
     // noop
   }


### PR DESCRIPTION
https://github.com/jam2in/arcus-works/issues/151 이슈에 대한 PR입니다.

제거된 노드에 대한 readQ의 operation들을 제거하였습니다.