### PR TITLE
CLEANUP: refactor test codes related setUp and tearDown

### DIFF
--- a/src/test/java/net/spy/memcached/ArcusTimeoutTest.java
+++ b/src/test/java/net/spy/memcached/ArcusTimeoutTest.java
@@ -16,7 +16,7 @@
  */
 package net.spy.memcached;
 
-import net.spy.memcached.collection.BaseIntegrationTest;
+import junit.framework.TestCase;
 import net.spy.memcached.collection.CollectionAttributes;
 import net.spy.memcached.collection.ElementFlagFilter;
 import net.spy.memcached.collection.SMGetElement;
@@ -45,17 +45,19 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
 @RunWith(JUnit4ClassRunner.class)
-public class ArcusTimeoutTest extends BaseIntegrationTest {
+public class ArcusTimeoutTest extends TestCase {
+  private ArcusClient mc = null;
+
   private final String KEY = this.getClass().getSimpleName();
 
   @Before
   @Override
   public void setUp() throws Exception {
-    Assume.assumeTrue(!USE_ZK);
+    super.setUp();
     initClient();
   }
 
-  protected void initClient() throws IOException {
+  private void initClient() throws IOException {
     mc = new ArcusClient(new DefaultConnectionFactory() {
       @Override
       public long getOperationTimeout() {
@@ -76,6 +78,7 @@ public class ArcusTimeoutTest extends BaseIntegrationTest {
     if (mc != null) {
       mc.shutdown();
     }
+    super.tearDown();
   }
 
   @Test(expected = TimeoutException.class)
@@ -91,8 +94,10 @@ public class ArcusTimeoutTest extends BaseIntegrationTest {
   public void testBulkSetTimeout()
           throws InterruptedException, ExecutionException, TimeoutException {
     // recreate arcus client with BulkServiceThreadCount 6
+    if (mc != null) {
+      mc.shutdown();
+    }
     try {
-      tearDown();
       mc = new ArcusClient(new DefaultConnectionFactory() {
         @Override
         public int getBulkServiceThreadCount() {

--- a/src/test/java/net/spy/memcached/CacheMonitorTest.java
+++ b/src/test/java/net/spy/memcached/CacheMonitorTest.java
@@ -43,6 +43,7 @@ public class CacheMonitorTest extends MockObjectTestCase {
 
   @Override
   public void setUp() throws Exception {
+    super.setUp();
     listener = mock(CacheMonitorListener.class);
     watcher = mock(Watcher.class);
     zooKeeper = new ZooKeeper("", 15000, (Watcher) watcher.proxy()); // can't mock
@@ -55,6 +56,7 @@ public class CacheMonitorTest extends MockObjectTestCase {
   @Override
   public void tearDown() throws Exception {
     zooKeeper.close();
+    super.tearDown();
   }
 
   public void testProcessResult() {

--- a/src/test/java/net/spy/memcached/CancelFailureModeTest.java
+++ b/src/test/java/net/spy/memcached/CancelFailureModeTest.java
@@ -1,42 +1,31 @@
 package net.spy.memcached;
 
+import junit.framework.TestCase;
+
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 
-public class CancelFailureModeTest extends ClientBaseCase {
-  private String serverList;
+public class CancelFailureModeTest extends TestCase {
+  private String serverList= "127.0.0.1:11311";
+  private MemcachedClient client = null;
 
   @Override
   protected void setUp() throws Exception {
-    serverList = ARCUS_HOST + " 127.0.0.1:11311";
     super.setUp();
-  }
-
-  @Override
-  protected void tearDown() throws Exception {
-    // override teardown to avoid the flush phase
-    serverList = ARCUS_HOST;
-    client.shutdown();
-  }
-
-  @Override
-  protected void initClient(ConnectionFactory cf) throws Exception {
-    client = new MemcachedClient(cf, AddrUtil.getAddresses(serverList));
-  }
-
-  @Override
-  protected void initClient() throws Exception {
-    initClient(new DefaultConnectionFactory() {
+    client = new MemcachedClient(new DefaultConnectionFactory() {
       @Override
       public FailureMode getFailureMode() {
         return FailureMode.Cancel;
       }
-    });
+    }, AddrUtil.getAddresses(serverList));
   }
 
   @Override
-  protected void flushPause() throws InterruptedException {
-    Thread.sleep(100);
+  protected void tearDown() throws Exception {
+    if (client != null) {
+      client.shutdown();
+    }
+    super.tearDown();
   }
 
   public void testQueueingToDownServer() throws Exception {

--- a/src/test/java/net/spy/memcached/ClientBaseCase.java
+++ b/src/test/java/net/spy/memcached/ClientBaseCase.java
@@ -35,18 +35,26 @@ import net.spy.memcached.transcoders.Transcoder;
 
 public abstract class ClientBaseCase extends TestCase {
 
-  protected static String ZK_HOST = System.getProperty("ZK_HOST",
+  public static String ZK_HOST = System.getProperty("ZK_HOST",
           "127.0.0.1:2181");
 
-  protected static String ZK_SERVICE_ID = System.getProperty("ZK_SERVICE_ID",
+  public static String ZK_SERVICE_ID = System.getProperty("ZK_SERVICE_ID",
           "test");
 
-  protected static String ARCUS_HOST = System
+  public static String ARCUS_HOST = System
           .getProperty("ARCUS_HOST",
                   "127.0.0.1:11211");
 
-  protected static boolean USE_ZK = Boolean.valueOf(System.getProperty(
+  public static boolean USE_ZK = Boolean.valueOf(System.getProperty(
           "USE_ZK", "false"));
+
+  public static Collection<String> stringify(Collection<?> c) {
+    Collection<String> rv = new ArrayList<String>();
+    for (Object o : c) {
+      rv.add(String.valueOf(o));
+    }
+    return rv;
+  }
 
   protected static boolean SHUTDOWN_AFTER_EACH_TEST = USE_ZK;
 
@@ -296,14 +304,6 @@ public abstract class ClientBaseCase extends TestCase {
 
   protected void openDirect(ConnectionFactory cf) throws Exception {
     client = new ArcusClient(cf, AddrUtil.getAddresses(ARCUS_HOST));
-  }
-
-  protected Collection<String> stringify(Collection<?> c) {
-    Collection<String> rv = new ArrayList<String>();
-    for (Object o : c) {
-      rv.add(String.valueOf(o));
-    }
-    return rv;
   }
 
   @Override

--- a/src/test/java/net/spy/memcached/MemcachedClientConstructorTest.java
+++ b/src/test/java/net/spy/memcached/MemcachedClientConstructorTest.java
@@ -27,17 +27,7 @@ public class MemcachedClientConstructorTest extends TestCase {
   @Override
   protected void tearDown() throws Exception {
     if (client != null) {
-      try {
         client.shutdown();
-      } catch (NullPointerException e) {
-        // This is a workaround for a disagreement betweewn how things
-        // should work in eclipse and buildr.  My plan is to upgrade to
-        // junit4 all around and write some tests that are a bit easier
-        // to follow.
-
-        // The actual problem here is a client that isn't properly
-        // initialized is attempting to be shut down.
-      }
     }
     super.tearDown();
   }

--- a/src/test/java/net/spy/memcached/MemcachedConnectionTest.java
+++ b/src/test/java/net/spy/memcached/MemcachedConnectionTest.java
@@ -33,6 +33,7 @@ public class MemcachedConnectionTest extends TestCase {
 
   @Override
   protected void setUp() throws Exception {
+    super.setUp();
     ConnectionFactoryBuilder cfb = new ConnectionFactoryBuilder();
     ConnectionFactory cf = cfb.build();
     List<InetSocketAddress> addrs = new ArrayList<InetSocketAddress>();
@@ -44,6 +45,7 @@ public class MemcachedConnectionTest extends TestCase {
   @Override
   protected void tearDown() throws Exception {
     conn.shutdown();
+    super.tearDown();
   }
 
   public void testDebugBuffer() throws Exception {

--- a/src/test/java/net/spy/memcached/TimeoutTest.java
+++ b/src/test/java/net/spy/memcached/TimeoutTest.java
@@ -1,15 +1,13 @@
 package net.spy.memcached;
 
-public class TimeoutTest extends ClientBaseCase {
+import junit.framework.TestCase;
+
+public class TimeoutTest extends TestCase {
+  private MemcachedClient client = null;
 
   @Override
-  protected void tearDown() throws Exception {
-    // override teardown to avoid the flush phase
-    client.shutdown();
-  }
-
-  @Override
-  protected void initClient() throws Exception {
+  protected void setUp() throws Exception {
+    super.setUp();
     client = new MemcachedClient(new DefaultConnectionFactory() {
       @Override
       public long getOperationTimeout() {
@@ -22,6 +20,14 @@ public class TimeoutTest extends ClientBaseCase {
       }
     },
             AddrUtil.getAddresses("127.0.0.1:64213"));
+  }
+
+  @Override
+  protected void tearDown() throws Exception {
+    if (client != null) {
+      client.shutdown();
+    }
+    super.tearDown();
   }
 
   private void tryTimeout(String name, Runnable r) {

--- a/src/test/java/net/spy/memcached/compat/log/LoggingTest.java
+++ b/src/test/java/net/spy/memcached/compat/log/LoggingTest.java
@@ -24,7 +24,8 @@ public class LoggingTest extends TestCase {
    * Set up logging.
    */
   @Override
-  public void setUp() {
+  public void setUp() throws Exception {
+    super.setUp();
     logger = LoggerFactory.getLogger(getClass());
   }
 

--- a/src/test/java/net/spy/memcached/internal/SingleElementInfiniteIteratorTest.java
+++ b/src/test/java/net/spy/memcached/internal/SingleElementInfiniteIteratorTest.java
@@ -9,7 +9,8 @@ public class SingleElementInfiniteIteratorTest extends TestCase {
   private SingleElementInfiniteIterator<String> iterator;
 
   @Override
-  protected void setUp() {
+  protected void setUp() throws Exception {
+    super.setUp();
     iterator = new SingleElementInfiniteIterator<String>(CONSTANT);
   }
 

--- a/src/test/manual/net/spy/memcached/ArcusClientConnectTest.java
+++ b/src/test/manual/net/spy/memcached/ArcusClientConnectTest.java
@@ -16,9 +16,8 @@
  */
 package net.spy.memcached;
 
-import junit.framework.Assert;
+import junit.framework.TestCase;
 import net.spy.memcached.collection.BaseIntegrationTest;
-import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.internal.runners.JUnit4ClassRunner;
@@ -27,27 +26,21 @@ import org.junit.runner.RunWith;
 import static org.junit.Assume.assumeTrue;
 
 @RunWith(JUnit4ClassRunner.class)
-public class ArcusClientConnectTest extends BaseIntegrationTest {
+public class ArcusClientConnectTest extends TestCase {
 
   @Before
   @Override
   public void setUp() throws Exception {
+    super.setUp();
     // This test assumes we use ZK
-    assumeTrue(USE_ZK);
-    openFromZK();
-  }
-
-  @After
-  @Override
-  public void tearDown() throws Exception {
-    // do nothing
+    assumeTrue(BaseIntegrationTest.USE_ZK);
   }
 
   @Test
   public void testOpenAndWait() {
     ConnectionFactoryBuilder cfb = new ConnectionFactoryBuilder();
-    ArcusClient client = ArcusClient.createArcusClient(ZK_HOST,
-            ZK_SERVICE_ID, cfb);
+    ArcusClient client = ArcusClient.createArcusClient(BaseIntegrationTest.ZK_HOST,
+            BaseIntegrationTest.ZK_SERVICE_ID, cfb);
     client.shutdown();
   }
 }

--- a/src/test/manual/net/spy/memcached/ArcusClientFrontCacheTest.java
+++ b/src/test/manual/net/spy/memcached/ArcusClientFrontCacheTest.java
@@ -17,6 +17,7 @@
 package net.spy.memcached;
 
 import junit.framework.Assert;
+import junit.framework.TestCase;
 import net.spy.memcached.collection.BaseIntegrationTest;
 import org.junit.After;
 import org.junit.Before;
@@ -27,20 +28,14 @@ import org.junit.runner.RunWith;
 import static org.junit.Assume.assumeTrue;
 
 @RunWith(JUnit4ClassRunner.class)
-public class ArcusClientFrontCacheTest extends BaseIntegrationTest {
+public class ArcusClientFrontCacheTest extends TestCase {
 
   @Before
   @Override
   public void setUp() throws Exception {
+    super.setUp();
     // This test assumes we use ZK
-    assumeTrue(USE_ZK);
-    openFromZK();
-  }
-
-  @After
-  @Override
-  public void tearDown() throws Exception {
-    super.tearDown();
+    assumeTrue(BaseIntegrationTest.USE_ZK);
   }
 
   @Test
@@ -49,7 +44,8 @@ public class ArcusClientFrontCacheTest extends BaseIntegrationTest {
     cfb.setFrontCacheExpireTime(10);
     cfb.setMaxFrontCacheElements(10);
 
-    ArcusClient.createArcusClient(ZK_HOST, ZK_SERVICE_ID, cfb);
+    ArcusClient.createArcusClient(BaseIntegrationTest.ZK_HOST,
+            BaseIntegrationTest.ZK_SERVICE_ID, cfb);
   }
 
   @Test
@@ -58,7 +54,8 @@ public class ArcusClientFrontCacheTest extends BaseIntegrationTest {
     cfb.setFrontCacheExpireTime(10);
     cfb.setMaxFrontCacheElements(10);
 
-    ArcusClient.createArcusClientPool(ZK_HOST, ZK_SERVICE_ID, cfb, 4);
+    ArcusClient.createArcusClientPool(BaseIntegrationTest.ZK_HOST,
+            BaseIntegrationTest.ZK_SERVICE_ID, cfb, 4);
   }
 
   @Test
@@ -67,8 +64,8 @@ public class ArcusClientFrontCacheTest extends BaseIntegrationTest {
     cfb.setFrontCacheExpireTime(10);
     cfb.setMaxFrontCacheElements(10);
 
-    ArcusClient client = ArcusClient.createArcusClient(ZK_HOST,
-            ZK_SERVICE_ID, cfb);
+    ArcusClient client = ArcusClient.createArcusClient(BaseIntegrationTest.ZK_HOST,
+            BaseIntegrationTest.ZK_SERVICE_ID, cfb);
 
     try {
       Assert.assertTrue(client.set("test:key", 100, "value").get());

--- a/src/test/manual/net/spy/memcached/ArcusClientNotExistsServiceCodeTest.java
+++ b/src/test/manual/net/spy/memcached/ArcusClientNotExistsServiceCodeTest.java
@@ -16,34 +16,22 @@
  */
 package net.spy.memcached;
 
+import junit.framework.TestCase;
 import org.junit.Ignore;
 
 import net.spy.memcached.collection.BaseIntegrationTest;
 
 @Ignore
-public class ArcusClientNotExistsServiceCodeTest extends BaseIntegrationTest {
-
-  @Override
-  protected void setUp() throws Exception {
-    // do nothing
-  }
-
-  ;
-
-  @Override
-  protected void tearDown() throws Exception {
-    // do nothing
-  }
-
-  ;
+public class ArcusClientNotExistsServiceCodeTest extends TestCase {
 
   public void testNotExistsServiceCode() {
-    if (!USE_ZK)
+    if (!BaseIntegrationTest.USE_ZK)
       return;
 
     ConnectionFactoryBuilder cfb = new ConnectionFactoryBuilder();
     try {
-      ArcusClient.createArcusClient(ZK_HOST, "NOT_EXISTS_SVC_CODE", cfb);
+      ArcusClient.createArcusClient(BaseIntegrationTest.ZK_HOST,
+              "NOT_EXISTS_SVC_CODE", cfb);
     } catch (NotExistsServiceCodeException e) {
       return;
     }

--- a/src/test/manual/net/spy/memcached/ArcusClientPoolReconnectTest.java
+++ b/src/test/manual/net/spy/memcached/ArcusClientPoolReconnectTest.java
@@ -16,31 +16,18 @@
  */
 package net.spy.memcached;
 
+import junit.framework.TestCase;
 import net.spy.memcached.collection.BaseIntegrationTest;
 
 import org.junit.Ignore;
 
 @Ignore
-public class ArcusClientPoolReconnectTest extends BaseIntegrationTest {
-
-  @Override
-  protected void setUp() throws Exception {
-    // do nothing
-  }
-
-  ;
-
-  @Override
-  protected void tearDown() throws Exception {
-    // do nothing
-  }
-
-  ;
+public class ArcusClientPoolReconnectTest extends TestCase {
 
   public void testOpenAndWait() {
     ConnectionFactoryBuilder cfb = new ConnectionFactoryBuilder();
-    ArcusClientPool client = ArcusClient.createArcusClientPool(ZK_HOST,
-            ZK_SERVICE_ID, cfb, 2);
+    ArcusClientPool client = ArcusClient.createArcusClientPool(BaseIntegrationTest.ZK_HOST,
+            BaseIntegrationTest.ZK_SERVICE_ID, cfb, 2);
 
     try {
       Thread.sleep(120000L);

--- a/src/test/manual/net/spy/memcached/ArcusClientPoolShutdownTest.java
+++ b/src/test/manual/net/spy/memcached/ArcusClientPoolShutdownTest.java
@@ -20,38 +20,30 @@ import java.util.ArrayList;
 import java.util.List;
 
 import junit.framework.Assert;
+import junit.framework.TestCase;
 import net.spy.memcached.collection.BaseIntegrationTest;
 
 import org.junit.Ignore;
 
 @Ignore
-public class ArcusClientPoolShutdownTest extends BaseIntegrationTest {
-
-  @Override
-  protected void setUp() throws Exception {
-    // do nothing
-  }
-
-  @Override
-  protected void tearDown() throws Exception {
-    // do nothing
-  }
+public class ArcusClientPoolShutdownTest extends TestCase {
 
   public void testOpenAndWait() {
-    if (!USE_ZK) {
+    if (!BaseIntegrationTest.USE_ZK) {
       return;
     }
 
     ConnectionFactoryBuilder cfb = new ConnectionFactoryBuilder();
-    ArcusClientPool client = ArcusClient.createArcusClientPool(ZK_HOST,
-            ZK_SERVICE_ID, cfb, 2);
+    ArcusClientPool client = ArcusClient.createArcusClientPool(BaseIntegrationTest.ZK_HOST,
+            BaseIntegrationTest.ZK_SERVICE_ID, cfb, 2);
 
     // This threads must be stopped after client is shutdown.
     List<String> threadNames = new ArrayList<String>();
     threadNames.add("main-EventThread");
-    threadNames.add("main-SendThread(" + ZK_HOST + ")");
+    threadNames.add("main-SendThread(" + BaseIntegrationTest.ZK_HOST + ")");
     threadNames
-            .add("Cache Manager IO for " + ZK_SERVICE_ID + "@" + ZK_HOST);
+            .add("Cache Manager IO for " + BaseIntegrationTest.ZK_SERVICE_ID +
+                    "@" + BaseIntegrationTest.ZK_HOST);
 
     // Check exists threads
     List<String> currentThreads = new ArrayList<String>();

--- a/src/test/manual/net/spy/memcached/ArcusClientReconnectTest.java
+++ b/src/test/manual/net/spy/memcached/ArcusClientReconnectTest.java
@@ -16,31 +16,22 @@
  */
 package net.spy.memcached;
 
+import junit.framework.TestCase;
 import org.junit.Ignore;
 
 import net.spy.memcached.collection.BaseIntegrationTest;
 
 @Ignore
-public class ArcusClientReconnectTest extends BaseIntegrationTest {
-
-  @Override
-  protected void setUp() throws Exception {
-    // do nothing
-  }
-
-  @Override
-  protected void tearDown() throws Exception {
-    // do nothing
-  }
+public class ArcusClientReconnectTest extends TestCase {
 
   public void testOpenAndWait() {
-    if (!USE_ZK) {
+    if (!BaseIntegrationTest.USE_ZK) {
       return;
     }
 
     ConnectionFactoryBuilder cfb = new ConnectionFactoryBuilder();
-    ArcusClient client = ArcusClient.createArcusClient(ZK_HOST,
-            ZK_SERVICE_ID, cfb);
+    ArcusClient client = ArcusClient.createArcusClient(BaseIntegrationTest.ZK_HOST,
+            BaseIntegrationTest.ZK_SERVICE_ID, cfb);
 
     try {
       Thread.sleep(120000L);

--- a/src/test/manual/net/spy/memcached/ArcusClientShutdownTest.java
+++ b/src/test/manual/net/spy/memcached/ArcusClientShutdownTest.java
@@ -20,36 +20,30 @@ import java.util.ArrayList;
 import java.util.List;
 
 import junit.framework.Assert;
+import junit.framework.TestCase;
 import net.spy.memcached.collection.BaseIntegrationTest;
 
 import org.junit.Ignore;
 
 @Ignore
-public class ArcusClientShutdownTest extends BaseIntegrationTest {
-
-  @Override
-  protected void setUp() throws Exception {
-  }
-
-  @Override
-  protected void tearDown() throws Exception {
-  }
+public class ArcusClientShutdownTest extends TestCase {
 
   public void testOpenAndWait() {
-    if (!USE_ZK) {
+    if (!BaseIntegrationTest.USE_ZK) {
       return;
     }
 
     ConnectionFactoryBuilder cfb = new ConnectionFactoryBuilder();
-    ArcusClient client = ArcusClient.createArcusClient(ZK_HOST,
-            ZK_SERVICE_ID, cfb);
+    ArcusClient client = ArcusClient.createArcusClient(BaseIntegrationTest.ZK_HOST,
+            BaseIntegrationTest.ZK_SERVICE_ID, cfb);
 
     // This threads must be stopped after client is shutdown.
     List<String> threadNames = new ArrayList<String>();
     threadNames.add("main-EventThread");
-    threadNames.add("main-SendThread(" + ZK_HOST + ")");
+    threadNames.add("main-SendThread(" + BaseIntegrationTest.ZK_HOST + ")");
     threadNames
-            .add("Cache Manager IO for " + ZK_SERVICE_ID + "@" + ZK_HOST);
+            .add("Cache Manager IO for " + BaseIntegrationTest.ZK_SERVICE_ID +
+                    "@" + BaseIntegrationTest.ZK_HOST);
 
     // Check exists threads
     List<String> currentThreads = new ArrayList<String>();

--- a/src/test/manual/net/spy/memcached/LongKeyTest/BaseLongKeyTest.java
+++ b/src/test/manual/net/spy/memcached/LongKeyTest/BaseLongKeyTest.java
@@ -33,10 +33,6 @@ public class BaseLongKeyTest extends BaseIntegrationTest {
     }
   };
 
-  protected void setUp() throws Exception {
-    super.setUp();
-  }
-
   public void testKV_Long() throws Exception {
     // KV Set
     assertTrue(mc.set(keys.get(0), 10, "value1").get());

--- a/src/test/manual/net/spy/memcached/MultibyteKeyTest.java
+++ b/src/test/manual/net/spy/memcached/MultibyteKeyTest.java
@@ -1,7 +1,19 @@
 /*
- * Copyright (c) 2015. aiceru@gmail.com
+ * arcus-java-client : Arcus Java client
+ * Copyright 2015 JaM2in Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-
 package net.spy.memcached;
 
 import junit.framework.Assert;
@@ -11,15 +23,10 @@ import net.spy.memcached.protocol.ascii.AsciiOperationFactory;
 import net.spy.memcached.transcoders.CollectionTranscoder;
 import net.spy.memcached.transcoders.IntegerTranscoder;
 import net.spy.memcached.transcoders.Transcoder;
-import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
 import java.util.*;
-
-/**
- * Created by iceru on 2015. 12. 30..
- */
 
 public class MultibyteKeyTest {
   private static final String MULTIBYTE_KEY = "아커스프리픽스:아커스멀티바이트키스트링";
@@ -45,10 +52,6 @@ public class MultibyteKeyTest {
     for (int i = 0; i < 10; i++) {
       keyList.add(MULTIBYTE_KEY + String.valueOf(i));
     }
-  }
-
-  @After
-  public void tearDown() throws Exception {
   }
 
   @Test

--- a/src/test/manual/net/spy/memcached/btreesmget/ByteArrayBKeySMGetTest.java
+++ b/src/test/manual/net/spy/memcached/btreesmget/ByteArrayBKeySMGetTest.java
@@ -40,21 +40,13 @@ public class ByteArrayBKeySMGetTest extends BaseIntegrationTest {
   @Override
   protected void setUp() throws Exception {
     super.setUp();
-    try {
-      mc.delete(KEY).get();
-    } catch (Exception e) {
-
-    }
+    mc.delete(KEY).get();
     Assert.assertNull(mc.asyncGetAttr(KEY).get());
   }
 
   @Override
   protected void tearDown() throws Exception {
-    try {
-      mc.delete(KEY).get();
-    } catch (Exception e) {
-
-    }
+    mc.delete(KEY).get();
     super.tearDown();
   }
 

--- a/src/test/manual/net/spy/memcached/btreesmget/SMGetTest.java
+++ b/src/test/manual/net/spy/memcached/btreesmget/SMGetTest.java
@@ -41,21 +41,13 @@ public class SMGetTest extends BaseIntegrationTest {
   @Override
   protected void setUp() throws Exception {
     super.setUp();
-    try {
-      mc.delete(KEY).get();
-    } catch (Exception e) {
-
-    }
+    mc.delete(KEY).get();
     Assert.assertNull(mc.asyncGetAttr(KEY).get());
   }
 
   @Override
   protected void tearDown() throws Exception {
-    try {
-      mc.delete(KEY).get();
-    } catch (Exception e) {
-
-    }
+    mc.delete(KEY).get();
     super.tearDown();
   }
 

--- a/src/test/manual/net/spy/memcached/btreesmget/SMGetWithCombinationEflagTest.java
+++ b/src/test/manual/net/spy/memcached/btreesmget/SMGetWithCombinationEflagTest.java
@@ -49,11 +49,7 @@ public class SMGetWithCombinationEflagTest extends BaseIntegrationTest {
 
   @Override
   protected void tearDown() throws Exception {
-    try {
-      mc.delete(KEY).get();
-    } catch (Exception e) {
-
-    }
+    mc.delete(KEY).get();
     super.tearDown();
   }
 

--- a/src/test/manual/net/spy/memcached/btreesmget/SMGetWithEflagTest.java
+++ b/src/test/manual/net/spy/memcached/btreesmget/SMGetWithEflagTest.java
@@ -39,21 +39,13 @@ public class SMGetWithEflagTest extends BaseIntegrationTest {
   @Override
   protected void setUp() throws Exception {
     super.setUp();
-    try {
-      mc.delete(KEY).get();
-    } catch (Exception e) {
-
-    }
+    mc.delete(KEY).get();
     Assert.assertNull(mc.asyncGetAttr(KEY).get());
   }
 
   @Override
   protected void tearDown() throws Exception {
-    try {
-      mc.delete(KEY).get();
-    } catch (Exception e) {
-
-    }
+    mc.delete(KEY).get();
     super.tearDown();
   }
 

--- a/src/test/manual/net/spy/memcached/bulkoperation/BopInsertBulkTest.java
+++ b/src/test/manual/net/spy/memcached/bulkoperation/BopInsertBulkTest.java
@@ -34,11 +34,6 @@ public class BopInsertBulkTest extends BaseIntegrationTest {
 
   private static final byte[] EFLAG = new byte[]{0, 0, 1, 1};
 
-  @Override
-  protected void setUp() throws Exception {
-    super.setUp();
-  }
-
   public void testInsertAndGet() {
     String value = "MyValue";
     long bkey = Long.MAX_VALUE;

--- a/src/test/manual/net/spy/memcached/bulkoperation/BopPipeUpdateTest.java
+++ b/src/test/manual/net/spy/memcached/bulkoperation/BopPipeUpdateTest.java
@@ -50,31 +50,25 @@ public class BopPipeUpdateTest extends BaseIntegrationTest {
               1, 1}));
     }
 
-    try {
-      // long start = System.currentTimeMillis();
+    // long start = System.currentTimeMillis();
 
-      CollectionAttributes attr = new CollectionAttributes();
-      attr.setMaxCount(10000L);
+    CollectionAttributes attr = new CollectionAttributes();
+    attr.setMaxCount(10000L);
 
-      CollectionFuture<Map<Integer, CollectionOperationStatus>> future = mc
-              .asyncBopPipedInsertBulk(KEY, elements, attr);
+    CollectionFuture<Map<Integer, CollectionOperationStatus>> future = mc
+            .asyncBopPipedInsertBulk(KEY, elements, attr);
 
-      Map<Integer, CollectionOperationStatus> map = future.get(5000L,
-              TimeUnit.MILLISECONDS);
+    Map<Integer, CollectionOperationStatus> map = future.get(5000L,
+            TimeUnit.MILLISECONDS);
 
-      // System.out.println(System.currentTimeMillis() - start + "ms");
+    // System.out.println(System.currentTimeMillis() - start + "ms");
 
-      Assert.assertTrue(map.isEmpty());
+    Assert.assertTrue(map.isEmpty());
 
-      Map<Long, Element<Object>> map3 = mc.asyncBopGet(KEY, 0, 9999,
-              ElementFlagFilter.DO_NOT_FILTER, 0, 0, false, false).get();
+    Map<Long, Element<Object>> map3 = mc.asyncBopGet(KEY, 0, 9999,
+            ElementFlagFilter.DO_NOT_FILTER, 0, 0, false, false).get();
 
-      Assert.assertEquals(elementCount, map3.size());
-
-    } catch (Exception e) {
-      e.printStackTrace();
-      Assert.fail(e.getMessage());
-    }
+    Assert.assertEquals(elementCount, map3.size());
   }
 
   @Override

--- a/src/test/manual/net/spy/memcached/bulkoperation/LopInsertBulkMultipleValueTest.java
+++ b/src/test/manual/net/spy/memcached/bulkoperation/LopInsertBulkMultipleValueTest.java
@@ -33,14 +33,9 @@ public class LopInsertBulkMultipleValueTest extends BaseIntegrationTest {
   private String key = "LopInsertBulkMultipleValueTest";
 
   @Override
-  protected void tearDown() {
-    try {
-      mc.delete(key).get();
-      super.tearDown();
-    } catch (Exception e) {
-      e.printStackTrace();
-      Assert.fail(e.getMessage());
-    }
+  protected void tearDown() throws Exception {
+    mc.delete(key).get();
+    super.tearDown();
   }
 
   public void testInsertAndGet() {

--- a/src/test/manual/net/spy/memcached/collection/BaseIntegrationTest.java
+++ b/src/test/manual/net/spy/memcached/collection/BaseIntegrationTest.java
@@ -32,16 +32,16 @@ import org.junit.Ignore;
 @Ignore
 public class BaseIntegrationTest extends TestCase {
 
-  protected static String ZK_HOST = System.getProperty("ZK_HOST",
+  public static String ZK_HOST = System.getProperty("ZK_HOST",
           "127.0.0.1:2181");
 
-  protected static String ZK_SERVICE_ID = System.getProperty("ZK_SERVICE_ID",
+  public static String ZK_SERVICE_ID = System.getProperty("ZK_SERVICE_ID",
           "test");
 
-  protected static String ARCUS_HOST = System.getProperty("ARCUS_HOST",
+  public static String ARCUS_HOST = System.getProperty("ARCUS_HOST",
           "127.0.0.1:11211");
 
-  protected static boolean USE_ZK = Boolean.valueOf(System.getProperty(
+  public static boolean USE_ZK = Boolean.valueOf(System.getProperty(
           "USE_ZK", "false"));
 
   protected static boolean SHUTDOWN_AFTER_EACH_TEST = USE_ZK;

--- a/src/test/manual/net/spy/memcached/collection/btree/BopDeleteTest.java
+++ b/src/test/manual/net/spy/memcached/collection/btree/BopDeleteTest.java
@@ -32,6 +32,7 @@ public class BopDeleteTest extends BaseIntegrationTest {
 
   private Long[] items9 = {0L, 1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L};
 
+  @Override
   protected void setUp() throws Exception {
     super.setUp();
 
@@ -44,6 +45,7 @@ public class BopDeleteTest extends BaseIntegrationTest {
     assertTrue(mc.asyncSetAttr(key, attrs).get(1000, TimeUnit.MILLISECONDS));
   }
 
+  @Override
   protected void tearDown() throws Exception {
     super.tearDown();
   }

--- a/src/test/manual/net/spy/memcached/collection/btree/BopFindPositionTest.java
+++ b/src/test/manual/net/spy/memcached/collection/btree/BopFindPositionTest.java
@@ -37,13 +37,10 @@ public class BopFindPositionTest extends BaseIntegrationTest {
           new byte[]{15}, new byte[]{16}, new byte[]{17},
           new byte[]{18}, new byte[]{19}};
 
+  @Override
   protected void setUp() throws Exception {
     super.setUp();
     mc.delete(key).get(1000, TimeUnit.MILLISECONDS);
-  }
-
-  protected void tearDown() throws Exception {
-    super.tearDown();
   }
 
   public void testLongBKeyAsc() throws Exception {

--- a/src/test/manual/net/spy/memcached/collection/btree/BopFindPositionWithGetTest.java
+++ b/src/test/manual/net/spy/memcached/collection/btree/BopFindPositionWithGetTest.java
@@ -34,13 +34,10 @@ public class BopFindPositionWithGetTest extends BaseIntegrationTest {
   private String invalidKey = "InvalidBopFindPositionWithGetTest";
   private String kvKey = "KvBopFindPositionWithGetTest";
 
+  @Override
   protected void setUp() throws Exception {
     super.setUp();
     mc.delete(key).get(1000, TimeUnit.MILLISECONDS);
-  }
-
-  protected void tearDown() throws Exception {
-    super.tearDown();
   }
 
   public void testLongBKeyAsc() throws Exception {

--- a/src/test/manual/net/spy/memcached/collection/btree/BopGetBulkTest.java
+++ b/src/test/manual/net/spy/memcached/collection/btree/BopGetBulkTest.java
@@ -53,21 +53,15 @@ public class BopGetBulkTest extends BaseIntegrationTest {
   @Override
   protected void setUp() throws Exception {
     super.setUp();
-    try {
-      for (int i = 0; i < keyList.size(); i++) {
-        mc.delete(keyList.get(i)).get();
-        mc.asyncBopInsert(keyList.get(i), 0, null, value + "0",
-                new CollectionAttributes()).get();
-        mc.asyncBopInsert(keyList.get(i), 1, eFlag, value + "1",
-                new CollectionAttributes()).get();
-        mc.asyncBopInsert(keyList.get(i), 2, null, value + "2",
-                new CollectionAttributes()).get();
-      }
-    } catch (Exception e) {
-      e.printStackTrace();
-      Assert.fail(e.getMessage());
+    for (int i = 0; i < keyList.size(); i++) {
+      mc.delete(keyList.get(i)).get();
+      mc.asyncBopInsert(keyList.get(i), 0, null, value + "0",
+              new CollectionAttributes()).get();
+      mc.asyncBopInsert(keyList.get(i), 1, eFlag, value + "1",
+              new CollectionAttributes()).get();
+      mc.asyncBopInsert(keyList.get(i), 2, null, value + "2",
+              new CollectionAttributes()).get();
     }
-
   }
 
   public void testGetBulkLongBkeyGetAll() {

--- a/src/test/manual/net/spy/memcached/collection/btree/BopGetByPositionTest.java
+++ b/src/test/manual/net/spy/memcached/collection/btree/BopGetByPositionTest.java
@@ -50,11 +50,13 @@ public class BopGetByPositionTest extends BaseIntegrationTest {
           21, 22, 23, 24, 25, 26, 27, 28, 29, 30,
           31};
 
+  @Override
   protected void setUp() throws Exception {
     super.setUp();
     mc.delete(key).get(1000, TimeUnit.MILLISECONDS);
   }
 
+  @Override
   protected void tearDown() throws Exception {
     super.tearDown();
   }

--- a/src/test/manual/net/spy/memcached/collection/btree/BopGetExceptionTest.java
+++ b/src/test/manual/net/spy/memcached/collection/btree/BopGetExceptionTest.java
@@ -31,14 +31,11 @@ public class BopGetExceptionTest extends BaseIntegrationTest {
 
   private Long[] items10 = {1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L, 9L, 10L};
 
-  protected void setUp() {
-    try {
-      super.setUp();
-      mc.asyncBopDelete(key, 0, 100, ElementFlagFilter.DO_NOT_FILTER, 0,
-              true).get(1000, TimeUnit.MILLISECONDS);
-    } catch (Exception e) {
-      e.printStackTrace();
-    }
+  @Override
+  protected void setUp() throws Exception {
+    super.setUp();
+    mc.asyncBopDelete(key, 0, 100, ElementFlagFilter.DO_NOT_FILTER, 0,
+            true).get(1000, TimeUnit.MILLISECONDS);
   }
 
   public void testBopGet_OutOfBound() throws Exception {

--- a/src/test/manual/net/spy/memcached/collection/btree/BopGetOffsetSupportTest.java
+++ b/src/test/manual/net/spy/memcached/collection/btree/BopGetOffsetSupportTest.java
@@ -31,13 +31,10 @@ public class BopGetOffsetSupportTest extends BaseIntegrationTest {
 
   private Long[] items10 = {1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L, 9L, 10L};
 
-  protected void tearDown() {
-    try {
-      deleteBTree(key, items10);
-      super.tearDown();
-    } catch (Exception e) {
-      e.printStackTrace();
-    }
+  @Override
+  protected void tearDown() throws Exception {
+    deleteBTree(key, items10);
+    super.tearDown();
   }
 
   public void testBopGetOffset_Normal() throws Exception {

--- a/src/test/manual/net/spy/memcached/collection/btree/BopGetSortTest.java
+++ b/src/test/manual/net/spy/memcached/collection/btree/BopGetSortTest.java
@@ -32,13 +32,10 @@ public class BopGetSortTest extends BaseIntegrationTest {
 
   private Long[] items10 = {1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L, 9L, 10L};
 
-  protected void tearDown() {
-    try {
-      deleteBTree(key, items10);
-      super.tearDown();
-    } catch (Exception e) {
-      e.printStackTrace();
-    }
+  @Override
+  protected void tearDown() throws Exception {
+    deleteBTree(key, items10);
+    super.tearDown();
   }
 
   public void testBopGet_Asc() throws Exception {

--- a/src/test/manual/net/spy/memcached/collection/btree/BopInsertAndGetTest.java
+++ b/src/test/manual/net/spy/memcached/collection/btree/BopInsertAndGetTest.java
@@ -48,11 +48,6 @@ public class BopInsertAndGetTest extends BaseIntegrationTest {
     mc.delete(kvKey).get();
   }
 
-  @Override
-  protected void tearDown() throws Exception {
-    super.tearDown();
-  }
-
   public void testInsertAndGetTrimmedLongBKey() throws Exception {
     // insert test data
     CollectionAttributes attrs = new CollectionAttributes();

--- a/src/test/manual/net/spy/memcached/collection/btree/BopInsertWhenKeyExists.java
+++ b/src/test/manual/net/spy/memcached/collection/btree/BopInsertWhenKeyExists.java
@@ -36,15 +36,12 @@ public class BopInsertWhenKeyExists extends BaseIntegrationTest {
 
   private Long[] items9 = {1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L, 9L};
 
-  protected void tearDown() {
-    try {
-      mc.asyncBopDelete(key, 0, 4000, ElementFlagFilter.DO_NOT_FILTER, 0,
-              true).get(1000, TimeUnit.MILLISECONDS);
-      mc.delete(key).get();
-      super.tearDown();
-    } catch (Exception e) {
-      e.printStackTrace();
-    }
+  @Override
+  protected void tearDown() throws Exception {
+    mc.asyncBopDelete(key, 0, 4000, ElementFlagFilter.DO_NOT_FILTER, 0,
+            true).get(1000, TimeUnit.MILLISECONDS);
+    mc.delete(key).get();
+    super.tearDown();
   }
 
   public void testBopInsert_unreadable_largestTrim() throws Exception {

--- a/src/test/manual/net/spy/memcached/collection/btree/BopInsertWhenKeyNotExist.java
+++ b/src/test/manual/net/spy/memcached/collection/btree/BopInsertWhenKeyNotExist.java
@@ -28,12 +28,10 @@ public class BopInsertWhenKeyNotExist extends BaseIntegrationTest {
   private String[] items9 = {"value0", "value1", "value2", "value3",
           "value4", "value5", "value6", "value7", "value8",};
 
-  protected void tearDown() {
-    try {
-      deleteBTree(key, items9);
-      super.tearDown();
-    } catch (Exception e) {
-    }
+  @Override
+  protected void tearDown() throws Exception {
+    deleteBTree(key, items9);
+    super.tearDown();
   }
 
   /**

--- a/src/test/manual/net/spy/memcached/collection/btree/BopMutateTest.java
+++ b/src/test/manual/net/spy/memcached/collection/btree/BopMutateTest.java
@@ -32,12 +32,10 @@ public class BopMutateTest extends BaseIntegrationTest {
   private String[] items9 = {"1", "2", "3", "4", "5", "6", "7", "8", "9",
           "a"};
 
-  protected void setUp() {
-    try {
-      super.setUp();
-      mc.delete(key);
-    } catch (Exception ignored) {
-    }
+  @Override
+  protected void setUp() throws Exception {
+    super.setUp();
+    mc.delete(key);
   }
 
   public void testBopIncrDecr_Basic() throws Exception {

--- a/src/test/manual/net/spy/memcached/collection/btree/BopOverflowActionTest.java
+++ b/src/test/manual/net/spy/memcached/collection/btree/BopOverflowActionTest.java
@@ -36,16 +36,13 @@ public class BopOverflowActionTest extends BaseIntegrationTest {
   private String key = "BopGetBoundaryTest";
   private List<String> keyList = new ArrayList<String>();
 
-  protected void setUp() {
+  @Override
+  protected void setUp() throws Exception {
+    super.setUp();
     keyList.add(key);
-    try {
-      super.setUp();
-      mc.delete(key);
+    mc.delete(key);
       // mc.asyncBopDelete(key, 0, 20000, ElementFlagFilter.DO_NOT_FILTER,
       // 0, true).get(1000, TimeUnit.MILLISECONDS);
-    } catch (Exception e) {
-      e.printStackTrace();
-    }
   }
 
   public void testBopGet_Maxcount() throws Exception {

--- a/src/test/manual/net/spy/memcached/collection/btree/BopSortMergeOldTest.java
+++ b/src/test/manual/net/spy/memcached/collection/btree/BopSortMergeOldTest.java
@@ -38,22 +38,16 @@ public class BopSortMergeOldTest extends BaseIntegrationTest {
     add("key1");
   }};
 
+  @Override
   protected void setUp() throws Exception {
-    try {
-      super.setUp();
-      for (int i = 0; i < keyList3.size(); i++) {
-        mc.delete(keyList3.get(i));
-      }
-
-      for (int i = 0; i < keyList2.size(); i++) {
-        mc.delete(keyList2.get(i));
-      }
-    } catch (Exception ignored) {
+    super.setUp();
+    for (int i = 0; i < keyList3.size(); i++) {
+      mc.delete(keyList3.get(i));
     }
-  }
 
-  protected void tearDown() throws Exception {
-    super.tearDown();
+    for (int i = 0; i < keyList2.size(); i++) {
+      mc.delete(keyList2.get(i));
+    }
   }
 
   public void testBopSortMergeOldDesc1() throws Exception {

--- a/src/test/manual/net/spy/memcached/collection/btree/BopSortMergeTest.java
+++ b/src/test/manual/net/spy/memcached/collection/btree/BopSortMergeTest.java
@@ -40,21 +40,15 @@ public class BopSortMergeTest extends BaseIntegrationTest {
     add("key1");
   }};
 
+  @Override
   protected void setUp() throws Exception {
-    try {
-      super.setUp();
-      for (int i = 0; i < keyList3.size(); i++) {
-        mc.delete(keyList3.get(i));
-      }
-      for (int i = 0; i < keyList2.size(); i++) {
-        mc.delete(keyList2.get(i));
-      }
-    } catch (Exception ignored) {
+    super.setUp();
+    for (int i = 0; i < keyList3.size(); i++) {
+      mc.delete(keyList3.get(i));
     }
-  }
-
-  protected void tearDown() throws Exception {
-    super.tearDown();
+    for (int i = 0; i < keyList2.size(); i++) {
+      mc.delete(keyList2.get(i));
+    }
   }
 
   public void testBopSortMergeAscDuplicate1() throws Exception {

--- a/src/test/manual/net/spy/memcached/collection/btree/longbkey/BopGetBulkTest.java
+++ b/src/test/manual/net/spy/memcached/collection/btree/longbkey/BopGetBulkTest.java
@@ -64,21 +64,15 @@ public class BopGetBulkTest extends BaseIntegrationTest {
   @Override
   protected void setUp() throws Exception {
     super.setUp();
-    try {
-      for (int i = 0; i < keyList.size(); i++) {
-        mc.delete(keyList.get(i)).get();
-        mc.asyncBopInsert(keyList.get(i), new byte[]{0}, null,
-                value + "0", new CollectionAttributes()).get();
-        mc.asyncBopInsert(keyList.get(i), new byte[]{1}, eFlag,
-                value + "1", new CollectionAttributes()).get();
-        mc.asyncBopInsert(keyList.get(i), new byte[]{2}, null,
-                value + "2", new CollectionAttributes()).get();
-      }
-    } catch (Exception e) {
-      e.printStackTrace();
-      Assert.fail(e.getMessage());
+    for (int i = 0; i < keyList.size(); i++) {
+      mc.delete(keyList.get(i)).get();
+      mc.asyncBopInsert(keyList.get(i), new byte[]{0}, null,
+              value + "0", new CollectionAttributes()).get();
+      mc.asyncBopInsert(keyList.get(i), new byte[]{1}, eFlag,
+              value + "1", new CollectionAttributes()).get();
+      mc.asyncBopInsert(keyList.get(i), new byte[]{2}, null,
+              value + "2", new CollectionAttributes()).get();
     }
-
   }
 
   public void testGetBulkLongBkeyGetAll() {

--- a/src/test/manual/net/spy/memcached/collection/list/LopBulkAPITest.java
+++ b/src/test/manual/net/spy/memcached/collection/list/LopBulkAPITest.java
@@ -39,6 +39,7 @@ public class LopBulkAPITest extends BaseIntegrationTest {
     return mc.getMaxPipedItemCount();
   }
 
+  @Override
   protected void setUp() throws Exception {
     super.setUp();
     for (long i = 0; i < getValueCount(); i++) {
@@ -46,6 +47,7 @@ public class LopBulkAPITest extends BaseIntegrationTest {
     }
   }
 
+  @Override
   protected void tearDown() throws Exception {
     super.tearDown();
   }

--- a/src/test/manual/net/spy/memcached/collection/list/LopDeleteTest.java
+++ b/src/test/manual/net/spy/memcached/collection/list/LopDeleteTest.java
@@ -28,6 +28,7 @@ public class LopDeleteTest extends BaseIntegrationTest {
 
   private Long[] items9 = {1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L, 9L};
 
+  @Override
   protected void setUp() throws Exception {
     super.setUp();
 
@@ -39,12 +40,10 @@ public class LopDeleteTest extends BaseIntegrationTest {
     assertTrue(mc.asyncSetAttr(key, attrs).get(1000, TimeUnit.MILLISECONDS));
   }
 
+  @Override
   protected void tearDown() throws Exception {
-    try {
-      deleteList(key, 1000);
-      super.tearDown();
-    } catch (Exception e) {
-    }
+    deleteList(key, 1000);
+    super.tearDown();
   }
 
   public void testLopDelete_NoKey() throws Exception {

--- a/src/test/manual/net/spy/memcached/collection/list/LopGetTest.java
+++ b/src/test/manual/net/spy/memcached/collection/list/LopGetTest.java
@@ -28,6 +28,7 @@ public class LopGetTest extends BaseIntegrationTest {
 
   private Long[] items9 = {1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L, 9L};
 
+  @Override
   protected void setUp() throws Exception {
     super.setUp();
 
@@ -39,12 +40,10 @@ public class LopGetTest extends BaseIntegrationTest {
     assertTrue(mc.asyncSetAttr(key, attrs).get(1000, TimeUnit.MILLISECONDS));
   }
 
+  @Override
   protected void tearDown() throws Exception {
-    try {
-      deleteList(key, 1000);
-      super.tearDown();
-    } catch (Exception e) {
-    }
+    deleteList(key, 1000);
+    super.tearDown();
   }
 
   public void testLopGet_NoKey() throws Exception {

--- a/src/test/manual/net/spy/memcached/collection/list/LopInsertBoundary.java
+++ b/src/test/manual/net/spy/memcached/collection/list/LopInsertBoundary.java
@@ -30,6 +30,7 @@ public class LopInsertBoundary extends BaseIntegrationTest {
 
   private Long[] items9 = {1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L, 9L};
 
+  @Override
   protected void setUp() throws Exception {
     super.setUp();
 
@@ -41,12 +42,10 @@ public class LopInsertBoundary extends BaseIntegrationTest {
     assertTrue(mc.asyncSetAttr(key, attrs).get(1000, TimeUnit.MILLISECONDS));
   }
 
-  protected void tearDown() {
-    try {
-      deleteList(key, 1000);
-      super.tearDown();
-    } catch (Exception e) {
-    }
+  @Override
+  protected void tearDown() throws Exception {
+    deleteList(key, 1000);
+    super.tearDown();
   }
 
   public void testLopInsert_IndexOutOfRange() throws Exception {

--- a/src/test/manual/net/spy/memcached/collection/list/LopInsertDataType.java
+++ b/src/test/manual/net/spy/memcached/collection/list/LopInsertDataType.java
@@ -29,12 +29,10 @@ public class LopInsertDataType extends BaseIntegrationTest {
   private String key = "LopInsertDataType";
   private Random rand = new Random(new Date().getTime());
 
-  protected void tearDown() {
-    try {
-      deleteList(key, 1000);
-      super.tearDown();
-    } catch (Exception e) {
-    }
+  @Override
+  protected void tearDown() throws Exception {
+    deleteList(key, 1000);
+    super.tearDown();
   }
 
   public void testLopInsert_ElementCountLimit() throws Exception {

--- a/src/test/manual/net/spy/memcached/collection/list/LopInsertWhenKeyExists.java
+++ b/src/test/manual/net/spy/memcached/collection/list/LopInsertWhenKeyExists.java
@@ -30,12 +30,10 @@ public class LopInsertWhenKeyExists extends BaseIntegrationTest {
   private Long[] items8 = {1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L};
   private Long[] items9 = {1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L, 9L};
 
-  protected void tearDown() {
-    try {
-      deleteList(key, 1000);
-      super.tearDown();
-    } catch (Exception e) {
-    }
+  @Override
+  protected void tearDown() throws Exception {
+    deleteList(key, 1000);
+    super.tearDown();
   }
 
   public void testLopInsert_Normal() throws Exception {

--- a/src/test/manual/net/spy/memcached/collection/list/LopOverflowActionTest.java
+++ b/src/test/manual/net/spy/memcached/collection/list/LopOverflowActionTest.java
@@ -32,14 +32,11 @@ public class LopOverflowActionTest extends BaseIntegrationTest {
   private String key = "LopOverflowActionTest";
   private List<String> keyList = new ArrayList<String>();
 
-  protected void setUp() {
+  @Override
+  protected void setUp() throws Exception {
+    super.setUp();
     keyList.add(key);
-    try {
-      super.setUp();
-      mc.delete(key).get();
-    } catch (Exception e) {
-      e.printStackTrace();
-    }
+    mc.delete(key).get();
   }
 
   public void testLopGet_Maxcount() throws Exception {

--- a/src/test/manual/net/spy/memcached/collection/list/LopServerMessageTest.java
+++ b/src/test/manual/net/spy/memcached/collection/list/LopServerMessageTest.java
@@ -35,11 +35,6 @@ public class LopServerMessageTest extends BaseIntegrationTest {
     mc.delete(key).get();
   }
 
-  @Override
-  protected void tearDown() throws Exception {
-    super.tearDown();
-  }
-
   public void testNotFound() throws Exception {
     CollectionFuture<List<Object>> future = mc.asyncLopGet(key, 0, false, false);
     assertNull(future.get(1000, TimeUnit.MILLISECONDS));

--- a/src/test/manual/net/spy/memcached/collection/map/MopBulkAPITest.java
+++ b/src/test/manual/net/spy/memcached/collection/map/MopBulkAPITest.java
@@ -39,6 +39,7 @@ public class MopBulkAPITest extends BaseIntegrationTest {
     return mc.getMaxPipedItemCount();
   }
 
+  @Override
   protected void setUp() throws Exception {
     super.setUp();
     for (long i = 0; i < getValueCount(); i++) {
@@ -47,10 +48,6 @@ public class MopBulkAPITest extends BaseIntegrationTest {
       updateMap.put("mkey" + String.valueOf(i),
               "newvalue" + String.valueOf(i));
     }
-  }
-
-  protected void tearDown() throws Exception {
-    super.tearDown();
   }
 
   public void testBulk() throws Exception {

--- a/src/test/manual/net/spy/memcached/collection/map/MopDeleteTest.java
+++ b/src/test/manual/net/spy/memcached/collection/map/MopDeleteTest.java
@@ -31,6 +31,7 @@ public class MopDeleteTest extends BaseIntegrationTest {
 
   private Long[] items9 = {0L, 1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L};
 
+  @Override
   protected void setUp() throws Exception {
     super.setUp();
 
@@ -42,12 +43,10 @@ public class MopDeleteTest extends BaseIntegrationTest {
     assertTrue(mc.asyncSetAttr(key, attrs).get(1000, TimeUnit.MILLISECONDS));
   }
 
+  @Override
   protected void tearDown() throws Exception {
-    try {
-      deleteMap(key);
-      super.tearDown();
-    } catch (Exception e) {
-    }
+    deleteMap(key);
+    super.tearDown();
   }
 
   public void testMopDelete_NoKey() throws Exception {

--- a/src/test/manual/net/spy/memcached/collection/map/MopGetTest.java
+++ b/src/test/manual/net/spy/memcached/collection/map/MopGetTest.java
@@ -30,6 +30,7 @@ public class MopGetTest extends BaseIntegrationTest {
 
   private Long[] items9 = {1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L, 9L};
 
+  @Override
   protected void setUp() throws Exception {
     super.setUp();
 
@@ -41,12 +42,10 @@ public class MopGetTest extends BaseIntegrationTest {
     assertTrue(mc.asyncSetAttr(key, attrs).get(1000, TimeUnit.MILLISECONDS));
   }
 
+  @Override
   protected void tearDown() throws Exception {
-    try {
-      deleteMap(key);
-      super.tearDown();
-    } catch (Exception e) {
-    }
+    deleteMap(key);
+    super.tearDown();
   }
 
   public void testMopGet_NoKey() throws Exception {

--- a/src/test/manual/net/spy/memcached/collection/map/MopInsertWhenKeyExists.java
+++ b/src/test/manual/net/spy/memcached/collection/map/MopInsertWhenKeyExists.java
@@ -29,14 +29,11 @@ public class MopInsertWhenKeyExists extends BaseIntegrationTest {
 
   private Long[] items9 = {1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L, 9L};
 
-  protected void tearDown() {
-    try {
-      mc.asyncMopDelete(key, true).get(1000, TimeUnit.MILLISECONDS);
-      mc.delete(key).get();
-      super.tearDown();
-    } catch (Exception e) {
-      e.printStackTrace();
-    }
+  @Override
+  protected void tearDown() throws Exception {
+    mc.asyncMopDelete(key, true).get(1000, TimeUnit.MILLISECONDS);
+    mc.delete(key).get();
+    super.tearDown();
   }
 
   public void testMopInsert_Normal() throws Exception {

--- a/src/test/manual/net/spy/memcached/collection/map/MopInsertWhenKeyNotExist.java
+++ b/src/test/manual/net/spy/memcached/collection/map/MopInsertWhenKeyNotExist.java
@@ -28,12 +28,10 @@ public class MopInsertWhenKeyNotExist extends BaseIntegrationTest {
   private String[] items9 = {"value0", "value1", "value2", "value3",
           "value4", "value5", "value6", "value7", "value8",};
 
-  protected void tearDown() {
-    try {
-      deleteMap(key);
-      super.tearDown();
-    } catch (Exception e) {
-    }
+  @Override
+  protected void tearDown() throws Exception {
+    deleteMap(key);
+    super.tearDown();
   }
 
   /**

--- a/src/test/manual/net/spy/memcached/collection/map/MopOverflowActionTest.java
+++ b/src/test/manual/net/spy/memcached/collection/map/MopOverflowActionTest.java
@@ -32,13 +32,10 @@ public class MopOverflowActionTest extends BaseIntegrationTest {
   private String key = "MopOverflowActionTest";
   private List<String> keyList = new ArrayList<String>();
 
-  protected void setUp() {
+  @Override
+  protected void setUp() throws Exception {
+    super.setUp();
     keyList.add(key);
-    try {
-      super.setUp();
-    } catch (Exception e) {
-      e.printStackTrace();
-    }
   }
 
   public void testMopGet_Maxcount() throws Exception {

--- a/src/test/manual/net/spy/memcached/collection/map/MopServerMessageTest.java
+++ b/src/test/manual/net/spy/memcached/collection/map/MopServerMessageTest.java
@@ -37,11 +37,6 @@ public class MopServerMessageTest extends BaseIntegrationTest {
     mc.delete(key).get();
   }
 
-  @Override
-  protected void tearDown() throws Exception {
-    super.tearDown();
-  }
-
   public void testNotFound() throws Exception {
     CollectionFuture<Map<String, Object>> future = (CollectionFuture<Map<String, Object>>) mc
             .asyncMopGet(key, false, false);

--- a/src/test/manual/net/spy/memcached/collection/set/SopBulkAPITest.java
+++ b/src/test/manual/net/spy/memcached/collection/set/SopBulkAPITest.java
@@ -38,15 +38,12 @@ public class SopBulkAPITest extends BaseIntegrationTest {
     return mc.getMaxPipedItemCount();
   }
 
+  @Override
   protected void setUp() throws Exception {
     super.setUp();
     for (long i = 0; i < getValueCount(); i++) {
       valueList.add("value" + String.valueOf(i));
     }
-  }
-
-  protected void tearDown() throws Exception {
-    super.tearDown();
   }
 
   public void testBulk() throws Exception {

--- a/src/test/manual/net/spy/memcached/collection/set/SopExistTest.java
+++ b/src/test/manual/net/spy/memcached/collection/set/SopExistTest.java
@@ -28,6 +28,7 @@ public class SopExistTest extends BaseIntegrationTest {
   String key = "SopExistTest";
   String value = "value";
 
+  @Override
   protected void setUp() throws Exception {
     super.setUp();
     mc.delete(key).get();

--- a/src/test/manual/net/spy/memcached/collection/set/SopInsertWhenKeyExists.java
+++ b/src/test/manual/net/spy/memcached/collection/set/SopInsertWhenKeyExists.java
@@ -30,13 +30,10 @@ public class SopInsertWhenKeyExists extends BaseIntegrationTest {
   private Long[] items9 = {1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L, 9L};
   private Long[] items10 = {1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L, 9L, 10L};
 
-  protected void tearDown() {
-    try {
-      deleteSet(key, items10);
-      super.tearDown();
-    } catch (Exception e) {
-      e.printStackTrace();
-    }
+  @Override
+  protected void tearDown() throws Exception {
+    deleteSet(key, items10);
+    super.tearDown();
   }
 
   public void testSopInsert_Normal() throws Exception {

--- a/src/test/manual/net/spy/memcached/collection/set/SopInsertWhenKeyNotExist.java
+++ b/src/test/manual/net/spy/memcached/collection/set/SopInsertWhenKeyNotExist.java
@@ -25,12 +25,10 @@ public class SopInsertWhenKeyNotExist extends BaseIntegrationTest {
 
   private String key = "SopInsertWhenKeyNotExist";
 
-  protected void tearDown() {
-    try {
-      mc.delete(key).get();
-      super.tearDown();
-    } catch (Exception e) {
-    }
+  @Override
+  protected void tearDown() throws Exception {
+    mc.delete(key).get();
+    super.tearDown();
   }
 
   /**

--- a/src/test/manual/net/spy/memcached/collection/set/SopOverflowActionTest.java
+++ b/src/test/manual/net/spy/memcached/collection/set/SopOverflowActionTest.java
@@ -31,13 +31,10 @@ public class SopOverflowActionTest extends BaseIntegrationTest {
   private String key = "SopOverflowActionTest";
   private List<String> keyList = new ArrayList<String>();
 
-  protected void setUp() {
+  @Override
+  protected void setUp() throws Exception {
+    super.setUp();
     keyList.add(key);
-    try {
-      super.setUp();
-    } catch (Exception e) {
-      e.printStackTrace();
-    }
   }
 
   public void testSopGet_Maxcount() throws Exception {

--- a/src/test/manual/net/spy/memcached/collection/set/SopServerMessageTest.java
+++ b/src/test/manual/net/spy/memcached/collection/set/SopServerMessageTest.java
@@ -36,11 +36,6 @@ public class SopServerMessageTest extends BaseIntegrationTest {
     mc.asyncSopDelete(key, "bbbb", true);
   }
 
-  @Override
-  protected void tearDown() throws Exception {
-    super.tearDown();
-  }
-
   public void testNotFound() throws Exception {
     CollectionFuture<Set<Object>> future = mc.asyncSopGet(key, 1, false, false);
     assertNull(future.get(1000, TimeUnit.MILLISECONDS));

--- a/src/test/manual/net/spy/memcached/frontcache/LocalCacheManagerTest.java
+++ b/src/test/manual/net/spy/memcached/frontcache/LocalCacheManagerTest.java
@@ -37,15 +37,21 @@ public class LocalCacheManagerTest extends TestCase {
   String[] keys = {"key0", "key1", "key2", "key3", "key4", "key5", "key6",
           "key7", "key8", "key9"};
 
+  @Override
   protected void setUp() throws Exception {
+    super.setUp();
     ConnectionFactoryBuilder cfb = new ConnectionFactoryBuilder();
     cfb.setFrontCacheExpireTime(5);
     cfb.setMaxFrontCacheElements(10);
     client = ArcusClient.createArcusClient("127.0.0.1:2181", "test", cfb);
   }
 
+  @Override
   protected void tearDown() throws Exception {
-    client.shutdown();
+    if (client != null) {
+      client.shutdown();
+    }
+    super.tearDown();
   }
 
   public void testGet() throws Exception {

--- a/src/test/manual/net/spy/memcached/test/MutateWithDefaultTest.java
+++ b/src/test/manual/net/spy/memcached/test/MutateWithDefaultTest.java
@@ -26,17 +26,10 @@ public class MutateWithDefaultTest extends BaseIntegrationTest {
 
   private String key = "MutateWithDefaultTest";
 
+  @Override
   protected void setUp() throws Exception {
     super.setUp();
-    try {
-      mc.delete(key);
-    } catch (Exception e) {
-      e.printStackTrace();
-    }
-  }
-
-  protected void tearDown() throws Exception {
-    super.tearDown();
+    mc.delete(key);
   }
 
   public void testIncr() {


### PR DESCRIPTION
작성된 테스트들이 setUp, tearDown을 오버라이딩하여 사용할 때
부모클래스인 TestCase의 setUp, tearDown을 콜하도록 수정하였습니다.
수정하면서 관련하여 리팩토링할 부분이 있으면 조금씩 수정하였습니다.
함께 수정된 사항은 아래와 같습니다.
- USE_ZK와 같은 설정 관련 변수들의 경우 public으로 선언하여 다른 클래스들이 상속받지 않고 참조 가능하게 수정
- setUp, tearDown 이 exception을 throws 하므로, 내부에서 try catch 안하도록 통일

그 외에 현재 테스트 코드들을 보면 TestCase를 상속하고 함수 이름의 prefix에 test를 붙여 테스트 하는 코드들이 있는 반면 Test 어노테이션을 붙여 테스트 하는 코드들이 있습니다. 이를 하나로 통일하는 작업이 차후에 진행되어야할 것으로 보입니다.