### PR TITLE
FEATURE: add maven plugin of checkstyle

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -260,6 +260,27 @@
                 </executions>
             </plugin>
             -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-checkstyle-plugin</artifactId>
+                <version>3.1.1</version>
+                <configuration>
+                    <configLocation>checkstyle.xml</configLocation>
+                    <encoding>UTF-8</encoding>
+                    <consoleOutput>true</consoleOutput>
+                    <failsOnError>true</failsOnError>
+                    <linkXRef>false</linkXRef>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>validate</id>
+                        <phase>validate</phase>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
         <extensions>
             <extension>


### PR DESCRIPTION
checkstyle PR( https://github.com/naver/arcus-java-client/commit/afc6a912354743b8dc6d984bb1c980f7c96664c4 )을 rebase하다가 실수로 pom.xml 파일을 누락하였습니다.

이전 PR에 pom.xml 파일이 없어 checkstyle이 동작을 하지 않을 것이며 CI와도 연동이 되지 않을 것입니다.

이를 위해 pom.xml 파일에 대해 PR 올립니다.
