### PR TITLE
FEATURE: apply checkstyle to test sources

### DIFF
--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -202,13 +202,6 @@
         <!-- https://checkstyle.sourceforge.io/config_misc.html -->
         <!--
         <module name="ArrayTypeStyle"/>
-        -->
-        <module name="AvoidEscapedUnicodeCharacters">
-            <property name="allowEscapesForControlCharacters" value="true"/>
-            <property name="allowByTailComment" value="true"/>
-            <property name="allowNonPrintableEscapes" value="true"/>
-        </module>
-        <!--
         <module name="CommentsIndentation">
             <property name="tokens" value="SINGLE_LINE_COMMENT, BLOCK_COMMENT_BEGIN"/>
         </module>

--- a/src/test/java/net/spy/memcached/ProtocolBaseCase.java
+++ b/src/test/java/net/spy/memcached/ProtocolBaseCase.java
@@ -164,7 +164,7 @@ public abstract class ProtocolBaseCase extends ClientBaseCase {
     String key = "this-is-my-key";
     assertSame("Expected error CASing with no existing value.",
             CASResponse.NOT_FOUND,
-            client.cas(key, 9223372036854775807l, "bad value"));
+            client.cas(key, 9223372036854775807L, "bad value"));
   }
 
   public void testExtendedUTF8Key() throws Exception {


### PR DESCRIPTION
client에 적용된 checkstyle이 `src/main/**.java` 코드에만 반영되는 문제가 있네요.
테스트 `src/test/**.java` 코드에도 checkstyle을 적용할 수 있도록 수정하였습니다.

이와 함께 테스트 코드에서 기존 모듈의 violation error가 발생되는 곳이 있어 코드 수정하였습니다.

