### PR TITLE
FIX: install markupsafe before travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ cache:
 
 before_install:
   - sudo apt-get install -qq build-essential autoconf automake libtool libcppunit-dev python-setuptools python-dev ant
+  - sudo pip install markupsafe
   - bash install-arcus-memcached.sh develop
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,8 @@ script:
 
 notifications:
   email:
-    - junhyun.park@jam2in.com
-    - minkikim89@jam2in.com
-    - alsdn653@jam2in.com
+    if: fork = false OR type = pull_request
+    recipients:
+      - junhyun.park@jam2in.com
+      - minkikim89@jam2in.com
+      - alsdn653@jam2in.com

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ cache:
 
 before_install:
   - sudo apt-get install -qq build-essential autoconf automake libtool libcppunit-dev python-setuptools python-dev ant
-  - sudo pip install markupsafe
   - bash install-arcus-memcached.sh develop
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,5 @@
 language: java
 
-cache:
-  directories:
-  - $HOME/arcus
-  - $HOME/.m2
-
 before_install:
   - sudo apt-get install -qq build-essential autoconf automake libtool libcppunit-dev python-setuptools python-dev ant
   - bash install-arcus-memcached.sh develop

--- a/install-arcus-memcached.sh
+++ b/install-arcus-memcached.sh
@@ -29,7 +29,8 @@ checkBranch() {
 if [ ! -x "$HOME/arcus/bin/memcached" ] || [ ! -x "$HOME/arcus/zookeeper/bin/zkServer.sh" ]
 then
   echo "No arcus installation! running clone and build..."
-  git clone --recursive git://github.com/naver/arcus.git $HOME/arcus
+  git clone --recursive git://github.com/computerphilosopher/arcus.git $HOME/arcus
+  git checkout bspark/markupsafe
   cd $HOME/arcus/scripts && ./build.sh
 
   if [ "$TARGET_SERVER_BR" != "master" ]; then

--- a/install-arcus-memcached.sh
+++ b/install-arcus-memcached.sh
@@ -31,8 +31,7 @@ then
   echo "No arcus installation! running clone and build..."
   git clone --recursive git://github.com/computerphilosopher/arcus.git $HOME/arcus
   cd $HOME/arcus/scripts
-  git checkout bspark/markupsafe
-  ./build.sh
+  git checkout bspark/markupsafe && ./build.sh
 
   if [ "$TARGET_SERVER_BR" != "master" ]; then
     echo "Changing server branch to $TARGET_SERVER_BR"

--- a/install-arcus-memcached.sh
+++ b/install-arcus-memcached.sh
@@ -30,8 +30,9 @@ if [ ! -x "$HOME/arcus/bin/memcached" ] || [ ! -x "$HOME/arcus/zookeeper/bin/zkS
 then
   echo "No arcus installation! running clone and build..."
   git clone --recursive git://github.com/computerphilosopher/arcus.git $HOME/arcus
+  cd $HOME/arcus/scripts
   git checkout bspark/markupsafe
-  cd $HOME/arcus/scripts && ./build.sh
+  ./build.sh
 
   if [ "$TARGET_SERVER_BR" != "master" ]; then
     echo "Changing server branch to $TARGET_SERVER_BR"


### PR DESCRIPTION
포크된 저장소에서 travis 알림이 가지 않게 하는 작업을 하다가 빌드에 실패하는 현상이 관찰됐습니다. 파이썬 모듈 jinja2의 import 실패 에러입니다. 원인은 markupsafe라는 모듈이 없기 때문입니다.

```
Fatal error: Traceback (most recent call last):
  File "/home/travis/arcus/scripts/fabfile.py", line 119, in upload_template_local
    from jinja2 import Environment, FileSystemLoader
  File "/home/travis/arcus/lib/python/site-packages/Jinja2-2.10-py2.7.egg/jinja2/__init__.py", line 33, in <module>
    from jinja2.environment import Environment, Template
  File "/home/travis/arcus/lib/python/site-packages/Jinja2-2.10-py2.7.egg/jinja2/environment.py", line 15, in <module>
    from jinja2 import nodes
  File "/home/travis/arcus/lib/python/site-packages/Jinja2-2.10-py2.7.egg/jinja2/nodes.py", line 19, in <module>
    from jinja2.utils import Markup
  File "/home/travis/arcus/lib/python/site-packages/Jinja2-2.10-py2.7.egg/jinja2/utils.py", line 647, in <module>
    from markupsafe import Markup, escape, soft_unicode
ImportError: No module named markupsafe
Unable to import Jinja2 -- see above.
```
[원본](https://travis-ci.org/github/computerphilosopher/arcus-java-client/builds/676023650)


구글링 결과 jinja2는 markupsafe를 의존성으로 가지고 있다고 합니다. ([링크](https://github.com/rdickert/project-quicksilver/issues/6#issuecomment-20822097))

pip를 통해 해당 모듈을 install 하도록 했더니 빌드 실패 현상이 사라졌습니다. 