### PR TITLE
FIX: delay move operation and reconnect task when switchover occurs

### DIFF
--- a/src/main/java/net/spy/memcached/MemcachedNode.java
+++ b/src/main/java/net/spy/memcached/MemcachedNode.java
@@ -284,5 +284,7 @@ public interface MemcachedNode {
   void addAllOpToInputQ(BlockingQueue<Operation> allOp);
 
   int moveOperations(final MemcachedNode toNode);
+
+  int getWriteOpCount();
   /* ENABLE_REPLICATION end */
 }

--- a/src/main/java/net/spy/memcached/MemcachedNodeROImpl.java
+++ b/src/main/java/net/spy/memcached/MemcachedNodeROImpl.java
@@ -237,5 +237,10 @@ public class MemcachedNodeROImpl implements MemcachedNode {
   public int moveOperations(final MemcachedNode toNode) {
     throw new UnsupportedOperationException();
   }
+
+  @Override
+  public int getWriteOpCount() {
+    return root.getWriteOpCount();
+  }
   /* ENABLE_REPLICATION end */
 }

--- a/src/main/java/net/spy/memcached/MemcachedReplicaGroup.java
+++ b/src/main/java/net/spy/memcached/MemcachedReplicaGroup.java
@@ -24,6 +24,7 @@ public abstract class MemcachedReplicaGroup extends SpyObject {
   protected MemcachedNode masterNode;
   protected MemcachedNode slaveNode;
   private boolean prevMasterPick;
+  private boolean writable = true;
 
   protected MemcachedReplicaGroup(final String groupName) {
     if (groupName == null)
@@ -87,6 +88,18 @@ public abstract class MemcachedReplicaGroup extends SpyObject {
 
   public static String getGroupNameForNode(final MemcachedNode node) {
     return ((ArcusReplNodeAddress) node.getSocketAddress()).getGroupName();
+  }
+
+  public boolean isWritable() {
+    return writable;
+  }
+
+  public void enableWrite() {
+    this.writable = true;
+  }
+
+  public void disableWrite() {
+    this.writable = false;
   }
 }
 /* ENABLE_REPLICATION end */

--- a/src/test/java/net/spy/memcached/MemcachedNodeROImplTest.java
+++ b/src/test/java/net/spy/memcached/MemcachedNodeROImplTest.java
@@ -29,7 +29,7 @@ public class MemcachedNodeROImplTest extends MockObjectTestCase {
     Set<String> acceptable = new HashSet<String>(Arrays.asList(
             "toString", "getSocketAddress", "getBytesRemainingToWrite",
             "getReconnectCount", "getSelectionOps", "hasReadOp",
-            "hasWriteOp", "isActive"));
+            "hasWriteOp", "isActive", "getWriteOpCount"));
 
     for (Method meth : MemcachedNode.class.getMethods()) {
       if (acceptable.contains(meth.getName())) {

--- a/src/test/java/net/spy/memcached/MockMemcachedNode.java
+++ b/src/test/java/net/spy/memcached/MockMemcachedNode.java
@@ -261,5 +261,10 @@ public class MockMemcachedNode implements MemcachedNode {
     // noop
     return 0;
   }
+
+  @Override
+  public int getWriteOpCount() {
+    return 0;
+  }
   /* ENABLE_REPLICATION end */
 }


### PR DESCRIPTION
아래 이슈에 대한 PR입니다.
https://github.com/naver/arcus-java-client/issues/233

ZK 이벤트에서 switchover를 수신했을 때(MemcachedConnection.updateConnection), 
readQ에 존재하는 이미 반영이 완료된 operation이 신규 master로 이동함에 따라, 
operation이 중복해서 반영이 될 수 있기 때문에, 

updateConnection에서 operation을 이동하지 않고, operation을 read하는 부분에서
readQ에 writeOperation이 더이상 존재하지 않거나, 
switch over를 수신하였을 때 신규 master로 이동할 수 있도록 처리하였습니다. 

또한 중간에 ZK 이벤트로 인한 노드 변경이 일어날 수 있기 때문에, 
각 상황에 맞는 적절한 코드를 추가하였습니다.
