### PR TITLE
FEATURE: apply warning violation severity in checkstyle

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -269,8 +269,11 @@
                     <encoding>UTF-8</encoding>
                     <consoleOutput>true</consoleOutput>
                     <failsOnError>true</failsOnError>
+                    <violationSeverity>warning</violationSeverity>
                     <linkXRef>false</linkXRef>
+                    <includeResources>true</includeResources>
                     <includeTestSourceDirectory>true</includeTestSourceDirectory>
+                    <includeTestResources>true</includeTestResources>
                 </configuration>
                 <executions>
                     <execution>


### PR DESCRIPTION
mvn install시 checkstyle이 실행이 안되는 문제가 있었습니다.

현재 violation level을 warning으로 설정하였는데,
실제로 검사할 때는 error level 부터 검사를 하여서, violation warning이 발생하여도 mvn install은 성공하게됩니다. 따라서 현재 상태에서 CI와 연동되지 않는 문제가 있습니다.

이전에 rebase 하면서 해당 설정을 누락한 듯 싶습니다.

이에 대해 warning level 까지 검사를 할 수 있도록 수정하였습니다.



