### PR TITLE
FIX: disable email notification in forked repo except PR

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,8 @@ script:
 
 notifications:
   email:
-    - junhyun.park@jam2in.com
-    - minkikim89@jam2in.com
-    - alsdn653@jam2in.com
+    if: fork = false OR type = pull_reqest
+    recipients:
+      - junhyun.park@jam2in.com
+      - minkikim89@jam2in.com
+      - alsdn653@jam2in.com


### PR DESCRIPTION
forked 저장소의 빌드는 PR을 제외하고 이메일 알림이 가지 않도록 했습니다.