### PR TITLE
CLEANUP: refactor asyncSetBulk, asyncDeleteBulk

### DIFF
--- a/src/main/java/net/spy/memcached/internal/BulkOperationFuture.java
+++ b/src/main/java/net/spy/memcached/internal/BulkOperationFuture.java
@@ -1,0 +1,85 @@
+package net.spy.memcached.internal;
+
+import net.spy.memcached.MemcachedConnection;
+import net.spy.memcached.ops.CollectionOperationStatus;
+import net.spy.memcached.ops.Operation;
+import net.spy.memcached.ops.OperationState;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.TimeUnit;
+
+public abstract class BulkOperationFuture
+        extends OperationFuture<Map<String, CollectionOperationStatus>> {
+  protected final Map<String, CollectionOperationStatus> failedResult =
+          new HashMap<String, CollectionOperationStatus>();
+  protected final ConcurrentLinkedQueue<Operation> ops = new ConcurrentLinkedQueue<Operation>();
+
+  public BulkOperationFuture(Collection<String> keys, CountDownLatch l, long timeout) {
+    super(l, timeout);
+
+    for (String key : keys) {
+      ops.add(createOp(key));
+    }
+  }
+
+  @Override
+  public boolean cancel(boolean ign) {
+    boolean rv = false;
+    for (Operation op : ops) {
+      op.cancel("by application.");
+      rv |= op.getState() == OperationState.WRITE_QUEUED;
+    }
+    return rv;
+  }
+
+  @Override
+  public boolean isCancelled() {
+    for (Operation op : ops) {
+      if (op.isCancelled())
+        return true;
+    }
+    return false;
+  }
+
+  @Override
+  public Map<String, CollectionOperationStatus> get(long duration,
+                                                    TimeUnit units) throws InterruptedException,
+          TimeoutException, ExecutionException {
+    if (!latch.await(duration, units)) {
+      for (Operation op : ops) {
+        if (op.getState() != OperationState.COMPLETE) {
+          MemcachedConnection.opTimedOut(op);
+        } else {
+          MemcachedConnection.opSucceeded(op);
+        }
+      }
+      throw new CheckedOperationTimeoutException(
+              "Timed out waiting for bulk operation >" + duration + " " + units, ops);
+    } else {
+      // continuous timeout counter will be reset
+      for (Operation op : ops) {
+        MemcachedConnection.opSucceeded(op);
+      }
+    }
+
+    for (Operation op : ops) {
+      if (op != null && op.hasErrored()) {
+        throw new ExecutionException(op.getException());
+      }
+
+      if (op != null && op.isCancelled()) {
+        throw new ExecutionException(new RuntimeException(op.getCancelCause()));
+      }
+    }
+
+    return failedResult;
+  }
+
+  public abstract Operation createOp(String key);
+}

--- a/src/main/java/net/spy/memcached/internal/OperationFuture.java
+++ b/src/main/java/net/spy/memcached/internal/OperationFuture.java
@@ -36,7 +36,7 @@ import net.spy.memcached.ops.OperationState;
  */
 public class OperationFuture<T> implements Future<T> {
 
-  private final CountDownLatch latch;
+  protected final CountDownLatch latch;
   private final AtomicReference<T> objRef;
   private final long timeout;
   private Operation op;

--- a/src/test/manual/net/spy/memcached/bulkoperation/BulkDeleteTest.java
+++ b/src/test/manual/net/spy/memcached/bulkoperation/BulkDeleteTest.java
@@ -51,12 +51,6 @@ public class BulkDeleteTest extends BaseIntegrationTest {
     } catch (Exception e) {
       assertEquals("Key list is empty.", e.getMessage());
     }
-    try {
-      String[] keys = new String[1];
-      mc.asyncDeleteBulk(keys);
-    } catch (Exception e) {
-      assertEquals("Key list is empty.", e.getMessage());
-    }
   }
 
   public void testInsertAndDelete() {


### PR DESCRIPTION
https://github.com/naver/arcus-java-client/issues/229 이슈에 대한 PR입니다.
기존 bulkService 코드는 사용하는 쪽만 주석으로 해두고 코드는 그대로 둔 상태입니다.

코드를 bopInsertBulk 기준으로 수정하고 보니 기존 bulkService와 동작이 달라지는 부분들이 생기네요.
1. DEFAULT_LOOP_LIMIT와 같은 연산양 조절 기능이 사라짐
2. singleOpTimeout에 따른 일부 연산 timeout 처리 기능이 사라짐

