### PR TITLE
CLEANUP: don't occur switchover in sop exist operation.

### DIFF
--- a/src/main/java/net/spy/memcached/collection/SetPipedExist.java
+++ b/src/main/java/net/spy/memcached/collection/SetPipedExist.java
@@ -36,16 +36,6 @@ public class SetPipedExist<T> extends CollectionObject {
   private final Transcoder<T> tc;
   private int itemCount;
 
-  protected int nextOpIndex = 0;
-
-  /**
-   * set next index of operation
-   * that will be processed after when operation moved by switchover
-   */
-  public void setNextOpIndex(int i) {
-    this.nextOpIndex = i;
-  }
-
   public List<T> getValues() {
     return this.values;
   }
@@ -84,7 +74,7 @@ public class SetPipedExist<T> extends CollectionObject {
 
     // create ascii operation string
     int eSize = encodedList.size();
-    for (int i = this.nextOpIndex; i < eSize; i++) {
+    for (int i = 0; i < eSize; i++) {
       byte[] each = encodedList.get(i);
 
       setArguments(bb, COMMAND, key, each.length,

--- a/src/main/java/net/spy/memcached/protocol/ascii/CollectionPipedExistOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/CollectionPipedExistOperationImpl.java
@@ -114,9 +114,6 @@ public class CollectionPipedExistOperationImpl extends OperationImpl implements
         successAll = false;
       }
       cb.gotStatus(index, status);
-      /* ENABLE_REPLICATION if */
-      this.setPipedExist.setNextOpIndex(index);
-      /* ENABLE_REPLICATION end */
       index++;
     }
   }


### PR DESCRIPTION
sop exist 는 read operation 으로 switchover 가 발생하지 않으므로 이에 대한 처리 코드를 제거하였습니다.

@minkikim89 리뷰 요청드립니다.