### PR TITLE
FIX: reset continuous timeout count to 0 when operation succeeds

### DIFF
--- a/src/main/java/net/spy/memcached/MemcachedConnection.java
+++ b/src/main/java/net/spy/memcached/MemcachedConnection.java
@@ -1235,8 +1235,9 @@ public final class MemcachedConnection extends SpyObject {
       if (node == null) {
         LoggerFactory.getLogger(MemcachedConnection.class).debug("handling node for operation is not set");
       } else {
-        if (isTimeout || !op.isCancelled())
+        if (!op.isCancelled()) {
           node.setContinuousTimeout(isTimeout);
+        }
       }
     } catch (Exception e) {
       LoggerFactory.getLogger(MemcachedConnection.class).error(e.getMessage());


### PR DESCRIPTION
Operation 성공시 MemcachedConnection.opSucceeded 메소드 호출이 이루어져도 노드의 continuous timeout count은 0으로 초기화되지 않는 현상이 있어 수정하였습니다.

