### PR TITLE
CLEANUP: remove the authentication failure log when OperationExceptio…

### DIFF
--- a/src/main/java/net/spy/memcached/MemcachedConnection.java
+++ b/src/main/java/net/spy/memcached/MemcachedConnection.java
@@ -789,22 +789,21 @@ public final class MemcachedConnection extends SpyObject {
     } catch (ClosedChannelException e) {
       // Note, not all channel closes end up here
       if (!shutDown) {
-        getLogger().info("Closed channel and not shutting down.  "
+        getLogger().warn("Closed channel and not shutting down.  "
                 + "Queueing reconnect on %s", qa, e);
         lostConnection(qa, ReconnDelay.DEFAULT, "closed channel");
       }
     } catch (ConnectException e) {
       // Failures to establish a connection should attempt a reconnect
       // without signaling the observers.
-      getLogger().info("Reconnecting due to failure to connect to %s",
+      getLogger().warn("Reconnecting due to failure to connect to %s",
               qa, e);
       queueReconnect(qa, ReconnDelay.DEFAULT, "failure to connect");
     } catch (OperationException e) {
-      qa.setupForAuth("authentication failure"); // noop if !shouldAuth
-      getLogger().info("Reconnection due to exception " +
-              "handling a memcached operation on %s.  " +
-              "This may be due to an authentication failure.", qa, e);
-      lostConnection(qa, ReconnDelay.IMMEDIATE, "authentication failure");
+      qa.setupForAuth("operation exception"); // noop if !shouldAuth
+      getLogger().warn("Reconnection due to exception " +
+              "handling a memcached exception on %s.", qa, e);
+      lostConnection(qa, ReconnDelay.IMMEDIATE, "operation exception");
     } catch (Exception e) {
       // Any particular error processing an item should simply
       // cause us to reconnect to the server.
@@ -813,7 +812,7 @@ public final class MemcachedConnection extends SpyObject {
       // restarting, which lead here with IOException
 
       qa.setupForAuth("due to exception"); // noop if !shouldAuth
-      getLogger().info("Reconnecting due to exception on %s", qa, e);
+      getLogger().warn("Reconnecting due to exception on %s", qa, e);
       lostConnection(qa, ReconnDelay.DEFAULT, "exception" + e);
     }
     qa.fixupOps();


### PR DESCRIPTION
예전 이슈를 보니 아래와 같이 로그가 발생합니다.
```
2018-05-02 22:01:44.192 ERROR net.spy.memcached.protocol.ascii.MGetOperationImpl: Error: ERROR by net.spy.memcached.protocol.ascii.MGetOperationImpl@2526a06b
2018-05-02 22:01:44.192 INFO net.spy.memcached.MemcachedConnection: Reconnection due to exception handling a memcached operation on {QA sa=/xxxxxxxxxxx(ip 삭제), #Rops=1, #Wops=0, #iq=0, topRop=net.spy.memcached.protocol.ascii.MGetOperationImpl@2526a06b, topWop=null, toWrite=0, interested=1}. This may be due to an authentication failure. 
2018-05-02 22:01:44.192 WARN net.spy.memcached.ArcusClient: Unsuccessful get: {OperationStatus success=false: cancelled} OperationException: GENERAL
```

이미 정확히 어떤 연산에서 어떤 오류가 나오는지 error 레벨에서 잘 출력되고 있기 때문에 추가적인 로깅 내용을 추가할 필요없이 혼돈을 줄 수 있는 authentication failure 로깅만 지우면 될 것 같습니다.