### PR TITLE
CLEANUP: add OperationStatus to OperationFuture

### DIFF
--- a/src/main/java/net/spy/memcached/ArcusClient.java
+++ b/src/main/java/net/spy/memcached/ArcusClient.java
@@ -392,7 +392,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
     Operation op = opFact.store(storeType, key, co.getFlags(),
             exp, co.getData(), new OperationCallback() {
               public void receivedStatus(OperationStatus val) {
-                rv.set(val.isSuccess());
+                rv.set(val.isSuccess(), val);
               }
 
               public void complete() {

--- a/src/main/java/net/spy/memcached/MemcachedClient.java
+++ b/src/main/java/net/spy/memcached/MemcachedClient.java
@@ -354,7 +354,7 @@ public class MemcachedClient extends SpyThread
     Operation op = opFact.store(storeType, key, co.getFlags(),
             exp, co.getData(), new OperationCallback() {
               public void receivedStatus(OperationStatus val) {
-                rv.set(val.isSuccess());
+                rv.set(val.isSuccess(), val);
               }
 
               public void complete() {
@@ -381,7 +381,7 @@ public class MemcachedClient extends SpyThread
     Operation op = opFact.cat(catType, cas, key, co.getData(),
         new OperationCallback() {
           public void receivedStatus(OperationStatus val) {
-            rv.set(val.isSuccess());
+            rv.set(val.isSuccess(), val);
           }
 
           public void complete() {
@@ -508,11 +508,11 @@ public class MemcachedClient extends SpyThread
             co.getData(), new OperationCallback() {
               public void receivedStatus(OperationStatus val) {
                 if (val instanceof CASOperationStatus) {
-                  rv.set(((CASOperationStatus) val).getCASResponse());
+                  rv.set(((CASOperationStatus) val).getCASResponse(), val);
                 } else if (val instanceof CancelledOperationStatus) {
-                  rv.set(CASResponse.CANCELED);
+                  rv.set(CASResponse.CANCELED, val);
                 } else {
-                  rv.set(CASResponse.UNDEFINED);
+                  rv.set(CASResponse.UNDEFINED, val);
                 }
               }
 
@@ -870,7 +870,7 @@ public class MemcachedClient extends SpyThread
           private Future<T> val = null;
 
           public void receivedStatus(OperationStatus status) {
-            rv.set(val);
+            rv.set(val, status);
           }
 
           public void gotData(String k, int flags, byte[] data) {
@@ -927,7 +927,7 @@ public class MemcachedClient extends SpyThread
           private CASValue<T> val = null;
 
           public void receivedStatus(OperationStatus status) {
-            rv.set(val);
+            rv.set(val, status);
           }
 
           public void gotData(String k, int flags, long cas, byte[] data) {
@@ -1530,7 +1530,7 @@ public class MemcachedClient extends SpyThread
     Operation op = addOp(key, opFact.mutate(m, key, by, def, exp,
         new OperationCallback() {
           public void receivedStatus(OperationStatus s) {
-            rv.set(new Long(s.isSuccess() ? s.getMessage() : "-1"));
+            rv.set(new Long(s.isSuccess() ? s.getMessage() : "-1"), s);
           }
 
           public void complete() {
@@ -1671,7 +1671,7 @@ public class MemcachedClient extends SpyThread
     DeleteOperation op = opFact.delete(key,
         new OperationCallback() {
           public void receivedStatus(OperationStatus s) {
-            rv.set(s.isSuccess());
+            rv.set(s.isSuccess(), s);
           }
 
           public void complete() {

--- a/src/main/java/net/spy/memcached/internal/GetFuture.java
+++ b/src/main/java/net/spy/memcached/internal/GetFuture.java
@@ -7,6 +7,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
 import net.spy.memcached.ops.Operation;
+import net.spy.memcached.ops.OperationStatus;
 
 /**
  * Future returned for GET operations.
@@ -38,8 +39,12 @@ public class GetFuture<T> implements Future<T> {
     return v == null ? null : v.get();
   }
 
-  public void set(Future<T> d) {
-    rv.set(d);
+  public OperationStatus getStatus() {
+    return rv.getStatus();
+  }
+
+  public void set(Future<T> d, OperationStatus s) {
+    rv.set(d, s);
   }
 
   public void setOperation(Operation to) {

--- a/src/main/java/net/spy/memcached/ops/CASOperationStatus.java
+++ b/src/main/java/net/spy/memcached/ops/CASOperationStatus.java
@@ -9,8 +9,8 @@ public class CASOperationStatus extends OperationStatus {
 
   private final CASResponse casResponse;
 
-  public CASOperationStatus(boolean success, String msg, CASResponse cres) {
-    super(success, msg);
+  public CASOperationStatus(boolean success, String msg, CASResponse cres, StatusCode code) {
+    super(success, msg, code);
     casResponse = cres;
   }
 

--- a/src/main/java/net/spy/memcached/ops/CancelledOperationStatus.java
+++ b/src/main/java/net/spy/memcached/ops/CancelledOperationStatus.java
@@ -6,7 +6,7 @@ package net.spy.memcached.ops;
 public class CancelledOperationStatus extends OperationStatus {
 
   public CancelledOperationStatus() {
-    super(false, "cancelled");
+    super(false, "cancelled", StatusCode.CANCELLED);
   }
 
 }

--- a/src/main/java/net/spy/memcached/ops/OperationStatus.java
+++ b/src/main/java/net/spy/memcached/ops/OperationStatus.java
@@ -7,11 +7,16 @@ public class OperationStatus {
 
   private final boolean isSuccess;
   private final String message;
+  private final StatusCode statusCode;
 
   public OperationStatus(boolean success, String msg) {
-    super();
+    this(success, msg, null);
+  }
+
+  public OperationStatus(boolean success, String msg, StatusCode code) {
     isSuccess = success;
     message = msg;
+    statusCode = code;
   }
 
   /**
@@ -26,6 +31,13 @@ public class OperationStatus {
    */
   public String getMessage() {
     return message;
+  }
+
+  /**
+   * Get the status code associated with the operation status.
+   */
+  public StatusCode getStatusCode() {
+    return statusCode;
   }
 
   @Override

--- a/src/main/java/net/spy/memcached/ops/StatusCode.java
+++ b/src/main/java/net/spy/memcached/ops/StatusCode.java
@@ -1,0 +1,73 @@
+/*
+ * arcus-java-client : Arcus Java client
+ * Copyright 2020 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+// Copyright (C) 2006-2009 Dustin Sallings
+// Copyright (C) 2009-2011 Couchbase, Inc.
+
+package net.spy.memcached.ops;
+
+import net.spy.memcached.compat.log.Logger;
+import net.spy.memcached.compat.log.LoggerFactory;
+
+public enum StatusCode {
+
+  SUCCESS,
+  ERR_NOT_FOUND,
+  ERR_EXISTS,
+  ERR_2BIG,
+  ERR_INVAL,
+  ERR_NOT_STORED,
+  ERR_DELTA_BADVAL,
+  ERR_TYPE_MISMATCH,
+  ERR_UNKNOWN_COMMAND,
+  ERR_NO_MEM,
+  ERR_NOT_SUPPORTED,
+  ERR_ERROR,
+  ERR_SERVER,
+  ERR_CLIENT,
+  CANCELLED,
+  INTERRUPTED,
+  TIMEDOUT,
+  UNDEFINED;
+
+  private static final Logger logger =
+          LoggerFactory.getLogger(StatusCode.class);
+
+  public static StatusCode fromAsciiLine(String line) {
+    if (line.equals("OK") || line.equals("END") ||
+        line.equals("STORED") || line.equals("DELETED")) {
+      return SUCCESS;
+    } else if (line.equals("NOT_STORED")) {
+      return ERR_NOT_STORED;
+    } else if (line.equals("EXISTS")) {
+      return ERR_EXISTS;
+    } else if (line.equals("NOT_FOUND")) {
+      return ERR_NOT_FOUND;
+    } else if (line.equals("TYPE_MISMATCH")) {
+      return ERR_TYPE_MISMATCH;
+    } else if (line.equals("ERROR")) {
+      return ERR_ERROR;
+    } else if (line.equals("SERVER_ERROR")) {
+      return ERR_SERVER;
+    } else if (line.equals("CLIENT_ERROR")) {
+      return ERR_CLIENT;
+    } else {
+      logger.warn("Undefined response message: %s", line);
+      return UNDEFINED;
+    }
+  }
+
+}

--- a/src/main/java/net/spy/memcached/plugin/FrontCacheGetFuture.java
+++ b/src/main/java/net/spy/memcached/plugin/FrontCacheGetFuture.java
@@ -17,11 +17,13 @@
 package net.spy.memcached.plugin;
 
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
 import net.sf.ehcache.Element;
+import net.spy.memcached.internal.GetFuture;
+import net.spy.memcached.ops.OperationStatus;
+import net.spy.memcached.ops.StatusCode;
 
 /**
  * Future returned for GET operations.
@@ -30,11 +32,15 @@ import net.sf.ehcache.Element;
  *
  * @param <T> Type of object returned from the get
  */
-public class FrontCacheGetFuture<T> implements Future<T> {
+public class FrontCacheGetFuture<T> extends GetFuture<T> {
 
+  private static final OperationStatus END =
+          new OperationStatus(true, "END", StatusCode.SUCCESS);
   private final Element element;
 
+
   public FrontCacheGetFuture(Element element) {
+    super(null, 0);
     this.element = element;
   }
 
@@ -46,6 +52,11 @@ public class FrontCacheGetFuture<T> implements Future<T> {
   @Override
   public T get() throws InterruptedException, ExecutionException {
     return getValue();
+  }
+
+  @Override
+  public OperationStatus getStatus() {
+    return END;
   }
 
   @SuppressWarnings("unchecked")

--- a/src/main/java/net/spy/memcached/protocol/GetCallbackWrapper.java
+++ b/src/main/java/net/spy/memcached/protocol/GetCallbackWrapper.java
@@ -5,6 +5,7 @@ package net.spy.memcached.protocol;
 
 import net.spy.memcached.ops.GetOperation;
 import net.spy.memcached.ops.OperationStatus;
+import net.spy.memcached.ops.StatusCode;
 
 /**
  * Wrapper callback for use in optimized gets.
@@ -12,7 +13,7 @@ import net.spy.memcached.ops.OperationStatus;
 public class GetCallbackWrapper implements GetOperation.Callback {
 
   private static final OperationStatus END =
-          new OperationStatus(true, "END");
+          new OperationStatus(true, "END", StatusCode.SUCCESS);
 
   private boolean completed = false;
   private int remainingKeys = 0;

--- a/src/main/java/net/spy/memcached/protocol/ascii/BaseGetOpImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/BaseGetOpImpl.java
@@ -10,13 +10,15 @@ import net.spy.memcached.ops.OperationCallback;
 import net.spy.memcached.ops.OperationState;
 import net.spy.memcached.ops.OperationStatus;
 import net.spy.memcached.ops.OperationType;
+import net.spy.memcached.ops.StatusCode;
 
 /**
  * Base class for get and gets handlers.
  */
 abstract class BaseGetOpImpl extends OperationImpl {
 
-  private static final OperationStatus END = new OperationStatus(true, "END");
+  private static final OperationStatus END =
+          new OperationStatus(true, "END", StatusCode.SUCCESS);
   private static final String RN_STRING = "\r\n";
   private final String cmd;
   private final Collection<String> keys;

--- a/src/main/java/net/spy/memcached/protocol/ascii/BaseStoreOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/BaseStoreOperationImpl.java
@@ -25,6 +25,7 @@ import net.spy.memcached.ops.OperationCallback;
 import net.spy.memcached.ops.OperationState;
 import net.spy.memcached.ops.OperationStatus;
 import net.spy.memcached.ops.OperationType;
+import net.spy.memcached.ops.StatusCode;
 
 /**
  * Base class for ascii store operations (add, set, replace, append, prepend).
@@ -33,7 +34,7 @@ abstract class BaseStoreOperationImpl extends OperationImpl {
 
   private static final int OVERHEAD = 32;
   private static final OperationStatus STORED =
-          new OperationStatus(true, "STORED");
+          new OperationStatus(true, "STORED", StatusCode.SUCCESS);
   protected final String type;
   protected final String key;
   protected final int flags;

--- a/src/main/java/net/spy/memcached/protocol/ascii/CASOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/CASOperationImpl.java
@@ -14,6 +14,7 @@ import net.spy.memcached.ops.OperationState;
 import net.spy.memcached.ops.OperationStatus;
 import net.spy.memcached.ops.OperationType;
 import net.spy.memcached.ops.StoreType;
+import net.spy.memcached.ops.StatusCode;
 
 class CASOperationImpl extends OperationImpl implements CASOperation {
 
@@ -23,11 +24,14 @@ class CASOperationImpl extends OperationImpl implements CASOperation {
   private static final int OVERHEAD = 64;
 
   private static final OperationStatus STORED =
-          new CASOperationStatus(true, "STORED", CASResponse.OK);
+          new CASOperationStatus(true, "STORED",
+                  CASResponse.OK, StatusCode.SUCCESS);
   private static final OperationStatus NOT_FOUND =
-          new CASOperationStatus(false, "NOT_FOUND", CASResponse.NOT_FOUND);
+          new CASOperationStatus(false, "NOT_FOUND",
+                  CASResponse.NOT_FOUND, StatusCode.ERR_NOT_FOUND);
   private static final OperationStatus EXISTS =
-          new CASOperationStatus(false, "EXISTS", CASResponse.EXISTS);
+          new CASOperationStatus(false, "EXISTS",
+                  CASResponse.EXISTS, StatusCode.ERR_EXISTS);
 
   private final String key;
   private final long casValue;

--- a/src/main/java/net/spy/memcached/protocol/ascii/DeleteOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/DeleteOperationImpl.java
@@ -13,6 +13,7 @@ import net.spy.memcached.ops.OperationCallback;
 import net.spy.memcached.ops.OperationState;
 import net.spy.memcached.ops.OperationStatus;
 import net.spy.memcached.ops.OperationType;
+import net.spy.memcached.ops.StatusCode;
 
 /**
  * Operation to delete an item from the cache.
@@ -23,9 +24,9 @@ final class DeleteOperationImpl extends OperationImpl
   private static final int OVERHEAD = 32;
 
   private static final OperationStatus DELETED =
-          new OperationStatus(true, "DELETED");
+          new OperationStatus(true, "DELETED", StatusCode.SUCCESS);
   private static final OperationStatus NOT_FOUND =
-          new OperationStatus(false, "NOT_FOUND");
+          new OperationStatus(false, "NOT_FOUND", StatusCode.ERR_NOT_FOUND);
 
   private final String key;
 

--- a/src/main/java/net/spy/memcached/protocol/ascii/FlushByPrefixOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/FlushByPrefixOperationImpl.java
@@ -24,6 +24,7 @@ import net.spy.memcached.ops.OperationCallback;
 import net.spy.memcached.ops.OperationState;
 import net.spy.memcached.ops.OperationStatus;
 import net.spy.memcached.ops.OperationType;
+import net.spy.memcached.ops.StatusCode;
 
 /**
  * Arcus flush by prefix operation.
@@ -31,8 +32,10 @@ import net.spy.memcached.ops.OperationType;
 final class FlushByPrefixOperationImpl extends OperationImpl implements
         FlushOperation {
 
-  private static final OperationStatus OK = new OperationStatus(true, "OK");
-  private static final OperationStatus NOT_FOUND = new OperationStatus(false, "NOT_FOUND");
+  private static final OperationStatus OK =
+          new OperationStatus(true, "OK", StatusCode.SUCCESS);
+  private static final OperationStatus NOT_FOUND =
+          new OperationStatus(false, "NOT_FOUND", StatusCode.ERR_NOT_FOUND);
 
   private final String prefix;
   private final int delay;

--- a/src/main/java/net/spy/memcached/protocol/ascii/FlushOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/FlushOperationImpl.java
@@ -10,6 +10,7 @@ import net.spy.memcached.ops.OperationCallback;
 import net.spy.memcached.ops.OperationState;
 import net.spy.memcached.ops.OperationStatus;
 import net.spy.memcached.ops.OperationType;
+import net.spy.memcached.ops.StatusCode;
 
 /**
  * Memcached flush_all operation.
@@ -20,7 +21,7 @@ final class FlushOperationImpl extends OperationImpl
   private static final byte[] FLUSH = "flush_all\r\n".getBytes();
 
   private static final OperationStatus OK =
-          new OperationStatus(true, "OK");
+          new OperationStatus(true, "OK", StatusCode.SUCCESS);
 
   private final int delay;
 

--- a/src/main/java/net/spy/memcached/protocol/ascii/MutatorOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/MutatorOperationImpl.java
@@ -30,6 +30,7 @@ import net.spy.memcached.ops.OperationCallback;
 import net.spy.memcached.ops.OperationState;
 import net.spy.memcached.ops.OperationStatus;
 import net.spy.memcached.ops.OperationType;
+import net.spy.memcached.ops.StatusCode;
 
 /**
  * Operation for mutating integers inside of memcached.
@@ -40,9 +41,9 @@ final class MutatorOperationImpl extends OperationImpl
   public static final int OVERHEAD = 32;
 
   private static final OperationStatus NOT_FOUND =
-          new OperationStatus(false, "NOT_FOUND");
+          new OperationStatus(false, "NOT_FOUND", StatusCode.ERR_NOT_FOUND);
   private static final OperationStatus TYPE_MISMATCH =
-          new OperationStatus(false, "TYPE_MISMATCH");
+          new OperationStatus(false, "TYPE_MISMATCH", StatusCode.ERR_TYPE_MISMATCH);
 
   private final Mutator mutator;
   private final String key;

--- a/src/main/java/net/spy/memcached/protocol/ascii/OperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/OperationImpl.java
@@ -28,6 +28,7 @@ import net.spy.memcached.ops.OperationCallback;
 import net.spy.memcached.ops.OperationErrorType;
 import net.spy.memcached.ops.OperationState;
 import net.spy.memcached.ops.OperationStatus;
+import net.spy.memcached.ops.StatusCode;
 import net.spy.memcached.protocol.BaseOperationImpl;
 
 /**
@@ -69,7 +70,7 @@ abstract class OperationImpl extends BaseOperationImpl implements Operation {
       }
     }
     if (rv == null) {
-      rv = new OperationStatus(false, line);
+      rv = new OperationStatus(false, line, StatusCode.fromAsciiLine(line));
     }
     return rv;
   }

--- a/src/main/java/net/spy/memcached/protocol/ascii/StatsOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/StatsOperationImpl.java
@@ -25,6 +25,7 @@ import net.spy.memcached.ops.OperationState;
 import net.spy.memcached.ops.OperationStatus;
 import net.spy.memcached.ops.OperationType;
 import net.spy.memcached.ops.StatsOperation;
+import net.spy.memcached.ops.StatusCode;
 
 /**
  * Operation to retrieve statistics from a memcached server.
@@ -32,7 +33,8 @@ import net.spy.memcached.ops.StatsOperation;
 final class StatsOperationImpl extends OperationImpl
         implements StatsOperation {
 
-  private static final OperationStatus END = new OperationStatus(true, "END");
+  private static final OperationStatus END =
+          new OperationStatus(true, "END", StatusCode.SUCCESS);
 
   private static final byte[] MSG = "stats\r\n".getBytes();
 

--- a/src/main/java/net/spy/memcached/protocol/ascii/VersionOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/VersionOperationImpl.java
@@ -11,6 +11,7 @@ import net.spy.memcached.ops.OperationState;
 import net.spy.memcached.ops.OperationStatus;
 import net.spy.memcached.ops.OperationType;
 import net.spy.memcached.ops.VersionOperation;
+import net.spy.memcached.ops.StatusCode;
 
 /**
  * Operation to request the version of a memcached server.
@@ -30,9 +31,10 @@ final class VersionOperationImpl extends OperationImpl
   public void handleLine(String line) {
     OperationStatus cause;
     if (line.startsWith("VERSION ")) {
-      cause = new OperationStatus(true, line.substring("VERSION ".length()));
+      cause = new OperationStatus(
+              true, line.substring("VERSION ".length()), StatusCode.SUCCESS);
     } else {
-      cause = new OperationStatus(false, line);
+      cause = new OperationStatus(false, line, StatusCode.fromAsciiLine(line));
     }
     getCallback().receivedStatus(cause);
     transitionState(OperationState.COMPLETE);

--- a/src/main/java/net/spy/memcached/protocol/binary/MutatorOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/binary/MutatorOperationImpl.java
@@ -7,6 +7,7 @@ import net.spy.memcached.ops.MutatorOperation;
 import net.spy.memcached.ops.Mutator;
 import net.spy.memcached.ops.OperationCallback;
 import net.spy.memcached.ops.OperationStatus;
+import net.spy.memcached.ops.StatusCode;
 
 class MutatorOperationImpl extends OperationImpl implements
         MutatorOperation {
@@ -54,7 +55,7 @@ class MutatorOperationImpl extends OperationImpl implements
   @Override
   protected void decodePayload(byte[] pl) {
     getCallback().receivedStatus(new OperationStatus(true,
-            String.valueOf(decodeLong(pl, 0))));
+            String.valueOf(decodeLong(pl, 0)), StatusCode.SUCCESS));
   }
 
   public Collection<String> getKeys() {

--- a/src/main/java/net/spy/memcached/protocol/binary/OperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/binary/OperationImpl.java
@@ -12,6 +12,7 @@ import net.spy.memcached.ops.OperationCallback;
 import net.spy.memcached.ops.OperationErrorType;
 import net.spy.memcached.ops.OperationState;
 import net.spy.memcached.ops.OperationStatus;
+import net.spy.memcached.ops.StatusCode;
 import net.spy.memcached.protocol.BaseOperationImpl;
 
 /**
@@ -32,16 +33,20 @@ abstract class OperationImpl extends BaseOperationImpl {
   protected static final int ERR_NOT_STORED = 5;
 
   protected static final OperationStatus NOT_FOUND_STATUS =
-          new CASOperationStatus(false, "Not Found", CASResponse.NOT_FOUND);
+          new CASOperationStatus(false, "Not Found",
+                  CASResponse.NOT_FOUND, StatusCode.ERR_NOT_FOUND);
   protected static final OperationStatus EXISTS_STATUS =
-          new CASOperationStatus(false, "Object exists", CASResponse.EXISTS);
+          new CASOperationStatus(false, "Object exists",
+                  CASResponse.EXISTS, StatusCode.ERR_EXISTS);
   protected static final OperationStatus NOT_STORED_STATUS =
-          new CASOperationStatus(false, "Not Stored", CASResponse.NOT_FOUND);
+          new CASOperationStatus(false, "Not Stored",
+                  CASResponse.NOT_FOUND, StatusCode.ERR_NOT_STORED);
 
   protected static final byte[] EMPTY_BYTES = new byte[0];
 
   protected static final OperationStatus STATUS_OK =
-          new CASOperationStatus(true, "OK", CASResponse.OK);
+          new CASOperationStatus(true, "OK",
+                  CASResponse.OK, StatusCode.SUCCESS);
 
   private static final AtomicInteger seqNumber = new AtomicInteger(0);
 

--- a/src/main/java/net/spy/memcached/protocol/binary/SASLBaseOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/binary/SASLBaseOperationImpl.java
@@ -11,6 +11,7 @@ import javax.security.sasl.SaslException;
 import net.spy.memcached.ops.OperationCallback;
 import net.spy.memcached.ops.OperationState;
 import net.spy.memcached.ops.OperationStatus;
+import net.spy.memcached.ops.StatusCode;
 
 public abstract class SASLBaseOperationImpl extends OperationImpl {
 
@@ -60,10 +61,11 @@ public abstract class SASLBaseOperationImpl extends OperationImpl {
   protected void finishedPayload(byte[] pl) throws IOException {
     if (errorCode == SASL_CONTINUE) {
       getCallback().receivedStatus(new OperationStatus(true,
-              new String(pl)));
+              new String(pl), StatusCode.SUCCESS));
       transitionState(OperationState.COMPLETE);
     } else if (errorCode == 0) {
-      getCallback().receivedStatus(new OperationStatus(true, ""));
+      getCallback().receivedStatus(new OperationStatus(true,
+              "", StatusCode.SUCCESS));
       transitionState(OperationState.COMPLETE);
     } else {
       super.finishedPayload(pl);

--- a/src/main/java/net/spy/memcached/protocol/binary/SASLMechsOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/binary/SASLMechsOperationImpl.java
@@ -3,6 +3,7 @@ package net.spy.memcached.protocol.binary;
 import net.spy.memcached.ops.OperationCallback;
 import net.spy.memcached.ops.OperationStatus;
 import net.spy.memcached.ops.SASLMechsOperation;
+import net.spy.memcached.ops.StatusCode;
 
 class SASLMechsOperationImpl extends OperationImpl implements
         SASLMechsOperation {
@@ -21,7 +22,7 @@ class SASLMechsOperationImpl extends OperationImpl implements
   @Override
   protected void decodePayload(byte[] pl) {
     getCallback().receivedStatus(
-            new OperationStatus(true, new String(pl)));
+            new OperationStatus(true, new String(pl), StatusCode.SUCCESS));
   }
 
 }

--- a/src/main/java/net/spy/memcached/protocol/binary/VersionOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/binary/VersionOperationImpl.java
@@ -2,6 +2,7 @@ package net.spy.memcached.protocol.binary;
 
 import net.spy.memcached.ops.OperationCallback;
 import net.spy.memcached.ops.OperationStatus;
+import net.spy.memcached.ops.StatusCode;
 import net.spy.memcached.ops.VersionOperation;
 
 class VersionOperationImpl extends OperationImpl implements VersionOperation {
@@ -19,7 +20,8 @@ class VersionOperationImpl extends OperationImpl implements VersionOperation {
 
   @Override
   protected void decodePayload(byte[] pl) {
-    getCallback().receivedStatus(new OperationStatus(true, new String(pl)));
+    getCallback().receivedStatus(
+            new OperationStatus(true, new String(pl), StatusCode.SUCCESS));
   }
 
 }


### PR DESCRIPTION
https://github.com/naver/arcus-java-client/issues/226#issuecomment-638697151 이슈 관련 PR 입니다.
이번에 deleteBulk 연산을 release 내용에 넣을 예정이고, 여기서 OperationStatus를 사용할 수 있도록 할 예정이기 때문에 이 PR에서 OperationFuture에 OperationStatus를 추가하는 작업 진행했습니다. 외부 API 자체는 아직 타입을 바꾸지 않았기 때문에 아직 응용에서 OperationStatus를 사용하지는 못하는 상태입니다. 
코드 수정에는 spymemcached 코드를 참고하였습니다.