### PR TITLE
CLEANUP: remove fake node

### DIFF
--- a/src/main/java/net/spy/memcached/AddrUtil.java
+++ b/src/main/java/net/spy/memcached/AddrUtil.java
@@ -25,12 +25,12 @@ public final class AddrUtil {
     if (s == null) {
       throw new NullPointerException("Null host list");
     }
-    if (s.trim().equals("")) {
-      throw new IllegalArgumentException("No hosts in list:  ``"
-              + s + "''");
-    }
     ArrayList<InetSocketAddress> addrs =
             new ArrayList<InetSocketAddress>();
+
+    if (s.trim().equals("")) {
+      return addrs;
+    }
 
     for (String hoststuff : s.split("(?:\\s|,)+")) {
       if (hoststuff.equals("")) {

--- a/src/main/java/net/spy/memcached/ArcusClient.java
+++ b/src/main/java/net/spy/memcached/ArcusClient.java
@@ -2260,7 +2260,13 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
       if (!keySet.add(k)) {
         throw new IllegalArgumentException("Duplicate keys exist in key list.");
       }
-      String node = conn.findNodeByKey(k).getSocketAddress().toString();
+      MemcachedNode qa = conn.findNodeByKey(k);
+      String node;
+      if (qa == null) {
+        node = "fake_node";
+      } else {
+        node = qa.getSocketAddress().toString();
+      }
       int cc;
       if (chunkCount.containsKey(node)) {
         cc = chunkCount.get(node);

--- a/src/main/java/net/spy/memcached/MemcachedNode.java
+++ b/src/main/java/net/spy/memcached/MemcachedNode.java
@@ -258,13 +258,6 @@ public interface MemcachedNode {
   int getTimeoutRatioNow();
 
   /**
-   * Is this a fake node?
-   *
-   * @return true or false
-   */
-  boolean isFake();
-
-  /**
    * Shutdown the node
    */
   void shutdown() throws IOException;

--- a/src/main/java/net/spy/memcached/MemcachedNodeROImpl.java
+++ b/src/main/java/net/spy/memcached/MemcachedNodeROImpl.java
@@ -211,10 +211,6 @@ public class MemcachedNodeROImpl implements MemcachedNode {
     throw new UnsupportedOperationException();
   }
 
-  public boolean isFake() {
-    throw new UnsupportedOperationException();
-  }
-
   public void shutdown() throws IOException {
     throw new UnsupportedOperationException();
   }

--- a/src/main/java/net/spy/memcached/protocol/TCPMemcachedNodeImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/TCPMemcachedNodeImpl.java
@@ -18,7 +18,6 @@
 package net.spy.memcached.protocol;
 
 import java.io.IOException;
-import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.nio.ByteBuffer;
 import java.nio.channels.SelectionKey;
@@ -35,7 +34,6 @@ import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 
 import net.spy.memcached.ArcusReplNodeAddress;
-import net.spy.memcached.CacheManager;
 import net.spy.memcached.MemcachedNode;
 import net.spy.memcached.MemcachedReplicaGroup;
 import net.spy.memcached.compat.SpyObject;
@@ -87,16 +85,9 @@ public abstract class TCPMemcachedNodeImpl extends SpyObject
    */
   private volatile long addOpCount;
 
-  // fake node
-  private boolean isFake = false;
-
   /* ENABLE_REPLICATION if */
   private MemcachedReplicaGroup replicaGroup;
   /* ENABLE_REPLICATION end */
-
-  public boolean isFake() {
-    return isFake;
-  }
 
   private void resetTimeoutRatioCount() {
     if (toRatioEnabled) {
@@ -169,13 +160,6 @@ public abstract class TCPMemcachedNodeImpl extends SpyObject
     shouldAuth = waitForAuth;
     isAsciiProtocol = asciiProtocol;
     setupForAuth("init authentication");
-
-    // is this a fake node?
-    if (sa instanceof InetSocketAddress) {
-      InetSocketAddress inetSockAddr = (InetSocketAddress) sa;
-      String ipport = inetSockAddr.getAddress() + ":" + inetSockAddr.getPort();
-      isFake = ("/" + CacheManager.FAKE_SERVER_NODE).equals(ipport);
-    }
   }
 
   public final void copyInputQueue() {
@@ -443,8 +427,7 @@ public abstract class TCPMemcachedNodeImpl extends SpyObject
   }
 
   public final boolean isActive() {
-    return !isFake && reconnectAttempt == 0
-            && getChannel() != null && getChannel().isConnected();
+    return reconnectAttempt == 0 && getChannel() != null && getChannel().isConnected();
   }
 
   public final void reconnecting() {

--- a/src/test/java/net/spy/memcached/AddrUtilTest.java
+++ b/src/test/java/net/spy/memcached/AddrUtilTest.java
@@ -78,26 +78,6 @@ public class AddrUtilTest extends TestCase {
     }
   }
 
-  public void testBrokenList() throws Exception {
-    String s = "";
-    try {
-      List<InetSocketAddress> addrs = AddrUtil.getAddresses(s);
-      fail("Expected failure, got " + addrs);
-    } catch (IllegalArgumentException e) {
-      assertEquals("No hosts in list:  ``''", e.getMessage());
-    }
-  }
-
-  public void testBrokenList2() throws Exception {
-    String s = "   ";
-    try {
-      List<InetSocketAddress> addrs = AddrUtil.getAddresses(s);
-      fail("Expected failure, got " + addrs);
-    } catch (IllegalArgumentException e) {
-      assertEquals("No hosts in list:  ``   ''", e.getMessage());
-    }
-  }
-
   public void testNullList() throws Exception {
     String s = null;
     try {

--- a/src/test/java/net/spy/memcached/ArcusTimeoutTest.java
+++ b/src/test/java/net/spy/memcached/ArcusTimeoutTest.java
@@ -68,7 +68,7 @@ public class ArcusTimeoutTest extends TestCase {
       public FailureMode getFailureMode() {
         return FailureMode.Retry;
       }
-    }, AddrUtil.getAddresses(CacheManager.FAKE_SERVER_NODE));
+    }, AddrUtil.getAddresses("0.0.0.0:23456"));
   }
 
   @After

--- a/src/test/java/net/spy/memcached/MockMemcachedNode.java
+++ b/src/test/java/net/spy/memcached/MockMemcachedNode.java
@@ -226,10 +226,6 @@ public class MockMemcachedNode implements MemcachedNode {
     return -1; // disabled
   }
 
-  public boolean isFake() {
-    return false;
-  }
-
   public void shutdown() throws IOException {
     // noop
   }


### PR DESCRIPTION
기존에 캐시노드가 존재하지 않을 시 fake node를 사용하여 실제 노드가 존재하는 것처럼 동작하도록 하였으나,
이에 대한 처리가 매번 버그를 유발하여 이를 삭제하도록 합니다.