### PR TITLE
FIX: skipping reconnect request that already reconnected

### DIFF
--- a/src/main/java/net/spy/memcached/MemcachedConnection.java
+++ b/src/main/java/net/spy/memcached/MemcachedConnection.java
@@ -1012,6 +1012,11 @@ public final class MemcachedConnection extends SpyObject {
       final MemcachedNode qa = i.next();
       i.remove();
       try {
+        if (qa.getChannel() != null) {
+          getLogger().info("Skipping reconnect request that already reconnected to %s", qa);
+          continue;
+        }
+
         if (!seen.containsKey(qa)) {
           seen.put(qa, Boolean.TRUE);
           getLogger().info("Reconnecting %s", qa);


### PR DESCRIPTION
같은 node에 대해 연속해서 reconnect 요청이 될 경우,
handleIO의 reconnect 처리 타이밍에 따라 이미 연결이 완료된 node에 대해
기존 연결을 해제하지 않고 새로운 연결을 생성하는 동작이 수행되는 문제가 있었습니다.
이러한 동작은 fd leak을 발생시키게 되며, 반복될 때 마다 fd가 증가하는 문제를 발생시키므로
reconnect 처리 동작에서 node의 channel이 null일 경우만 연결을 생성하도록 변경 했습니다.

@jhpark816 
확인 요청 드립니다.