### PR TITLE
CLEANUP: change kv bulkAPI status type from CollectionOperationStatus…

### DIFF
--- a/docs/03-key-value-API.md
+++ b/docs/03-key-value-API.md
@@ -48,18 +48,21 @@ Future<Boolean> append(long cas, String key, Object val)
   초기에 CAS(compare-and-set) 연산으로 수행하기 위한 용도로 필요했던 인자이다.
 
 
-그리고, 한번의 API 호출로 다수의 key-value items을 set하는 bulk API를 제공한다.
+그리고, 한번의 API 호출로 다수의 key-value items을 저장하는 bulk API를 제공한다.
 
 ```java
-Future<Map<String, CollectionOperationStatus>> asyncSetBulk(List<String> key, int exp, Object obj)
-Future<Map<String, CollectionOperationStatus>> asyncSetBulk(Map<String, Object> map, int exp)
+Future<Map<String, OperationStatus>> asyncStoreBulk(StoreType type, List<String> key, int exp, Object obj)
+Future<Map<String, OperationStatus>> asyncStoreBulk(StoreType type, Map<String, Object> map, int exp)
 ```
 
-- 다수의 key-value item을 한번에 set한다.
-- 전자는 key list의 모든 key에 대해 동일한 obj로 set 연산을 한번에 수행하며, 
-  후자는 map에 있는 모든 \<key, obj\>에 대해 set 연산을 한번에 수행한다.
+- 다수의 key-value item을 한번에 저장한다.
+- 전자는 key list의 모든 key에 대해 동일한 obj로 저장 연산을 한번에 수행하며,
+  후자는 map에 있는 모든 \<key, obj\>에 대해 저장 연산을 한번에 수행한다.
 - 저장된 key-value item들은 모두 exp 초 이후에 삭제된다.
-
+- StoreType은 연산의 저장 유형을 지정한다. 아래의 유형이 있다.
+  - StoreType.set
+  - StoreType.add
+  - StoreType.replace
 
 expiration은 key가 현재 시간부터 expire 될 때까지의 시간(초 단위)을 입력한다.
 시간이 30일을 초과하는 경우 expire 될 unix time을 입력한다.
@@ -67,6 +70,13 @@ expiration은 key가 현재 시간부터 expire 될 때까지의 시간(초 단�
 
 - 0: key가 expire 되지 않도록 설정한다. 하지만 Arcus cache server의 메모리가 부족한 경우 LRU에 의해 언제든지 삭제될 수 있다.
 - -1: key를 sticky item으로 만든다. Sticky item은 expire 되지 않으며 LRU에 의해 삭제되지도 않는다.
+
+저장에 실패한 키와 실패 원인은 future 객체를 통해 Map 형태로 조회할 수 있다.
+
+future.get(key).getStatusCode() | 설명
+--------------------------------| ---------
+StatusCode.ERR_NOT_FOUND        | Key miss (주어진 key에 해당하는 item이 없음)
+StatusCode.ERR_EXISTS           | 동일 key가 이미 존재함
 
 
 ### Key-Value Item 조회
@@ -128,8 +138,8 @@ Future<Boolean> delete(String key)
 - 주어진 key를 가진 item을 cache에서 삭제한다.
  
 ```java
-Future<Map<String, CollectionOperationStatus>> asyncDeleteBulk(List<String> key)
-Future<Map<String, CollectionOperationStatus>> asyncDeleteBulk(String... key)
+Future<Map<String, OperationStatus>> asyncDeleteBulk(List<String> key)
+Future<Map<String, OperationStatus>> asyncDeleteBulk(String... key)
 ```
 
 - 다수의 key-value item을 한번에 delete한다.
@@ -137,6 +147,6 @@ Future<Map<String, CollectionOperationStatus>> asyncDeleteBulk(String... key)
 
 delete 실패한 키와 실패 원인은 future 객체를 통해 Map 형태로 조회할 수 있다.
 
-future.get(key).getResponse() | 설명
-------------------------------| ---------
-CollectionResponse.NOT_FOUND  | Key miss (주어진 key에 해당하는 item이 없음)
+future.get(key).getStatusCode() | 설명
+--------------------------------| ---------
+StatusCode.ERR_NOT_FOUND        | Key miss (주어진 key에 해당하는 item이 없음)

--- a/src/main/java/net/spy/memcached/ArcusClientIF.java
+++ b/src/main/java/net/spy/memcached/ArcusClientIF.java
@@ -38,6 +38,8 @@ import net.spy.memcached.internal.CollectionGetBulkFuture;
 import net.spy.memcached.internal.OperationFuture;
 import net.spy.memcached.internal.SMGetFuture;
 import net.spy.memcached.ops.CollectionOperationStatus;
+import net.spy.memcached.ops.OperationStatus;
+import net.spy.memcached.ops.StoreType;
 import net.spy.memcached.transcoders.Transcoder;
 
 /**
@@ -117,6 +119,7 @@ public interface ArcusClientIF {
    * @param tc  the transcoder to serialize and unserialize the value
    * @return a future that will hold the list of failed
    */
+  @Deprecated
   public abstract <T> Future<Map<String, CollectionOperationStatus>> asyncSetBulk(
           List<String> key, int exp, T o, Transcoder<T> tc);
 
@@ -128,6 +131,7 @@ public interface ArcusClientIF {
    * @param o   the object to store on each keys
    * @return a future that will hold the list of failed
    */
+  @Deprecated
   public abstract Future<Map<String, CollectionOperationStatus>> asyncSetBulk(
           List<String> key, int exp, Object o);
 
@@ -139,6 +143,7 @@ public interface ArcusClientIF {
    * @param tc  the transcoder to serialize and unserialize the value
    * @return a future that will hold the list of failed
    */
+  @Deprecated
   public abstract <T> Future<Map<String, CollectionOperationStatus>> asyncSetBulk(
           Map<String, T> o, int exp, Transcoder<T> tc);
 
@@ -149,8 +154,77 @@ public interface ArcusClientIF {
    * @param exp the expiration of this object
    * @return a future that will hold the list of failed
    */
+  @Deprecated
   public abstract Future<Map<String, CollectionOperationStatus>> asyncSetBulk(
           Map<String, Object> o, int exp);
+
+
+  /**
+   * Store an object in the cache on each key.
+   *
+   * <h2>Basic usage</h2>
+   * <pre>{@code
+   *  ArcusClient c = getClientFromPool();
+   *
+   *  List<String> keys = new ArrayList();
+   *  keys.add("KEY1");
+   *  keys.add("KEY2");
+   *
+   *  // The object to store
+   *  Object value = "VALUE";
+   *
+   *  // Get customized transcoder
+   *  Transcoder myTranscoder = getTranscoder();
+   *
+   *  // Store a value (async) on each keys for one hour using multiple memcached client.
+   *  c.asyncStoreBulk(StoreType.set, keys, 3600, value, transcoder);
+   *  }</pre>
+   *
+   * @param <T>
+   * @param type the type of store operation to perform.
+   * @param key  the key list which this object should be added
+   * @param exp  the expiration of this object
+   * @param o    the object to store on each keys
+   * @param tc   the transcoder to serialize and unserialize the value
+   * @return a future that will hold the list of failed
+   */
+  public abstract <T> Future<Map<String, OperationStatus>> asyncStoreBulk(
+          StoreType type, List<String> key, int exp, T o, Transcoder<T> tc);
+
+  /**
+   * Store an object in the cache on each key using specified memcached client
+   *
+   * @param type the type of store operation to perform.
+   * @param key  the key list which this object should be added
+   * @param exp  the expiration of this object
+   * @param o    the object to store on each keys
+   * @return a future that will hold the list of failed
+   */
+  public abstract Future<Map<String, OperationStatus>> asyncStoreBulk(
+          StoreType type, List<String> key, int exp, Object o);
+
+  /**
+   * Store an object in the cache on each key using specified memcached client
+   *
+   * @param type the type of store operation to perform.
+   * @param o    the map that has keys and values to store
+   * @param exp  the expiration of this object
+   * @param tc   the transcoder to serialize and unserialize the value
+   * @return a future that will hold the list of failed
+   */
+  public abstract <T> Future<Map<String, OperationStatus>> asyncStoreBulk(
+          StoreType type, Map<String, T> o, int exp, Transcoder<T> tc);
+
+  /**
+   * Store an object in the cache on each key using specified memcached client
+   *
+   * @param type the type of store operation to perform.
+   * @param o    the map that has keys and values to store
+   * @param exp  the expiration of this object
+   * @return a future that will hold the list of failed
+   */
+  public abstract Future<Map<String, OperationStatus>> asyncStoreBulk(
+          StoreType type, Map<String, Object> o, int exp);
 
   /**
    * Delete an object in the cache on each key.
@@ -171,7 +245,7 @@ public interface ArcusClientIF {
    * @return a future that will hold the list of failed
    *
    */
-  public abstract Future<Map<String, CollectionOperationStatus>> asyncDeleteBulk(
+  public abstract Future<Map<String, OperationStatus>> asyncDeleteBulk(
           List<String> key);
 
   /**
@@ -181,7 +255,7 @@ public interface ArcusClientIF {
    * @return a future that will hold the list of failed
    *
    */
-  public abstract Future<Map<String, CollectionOperationStatus>> asyncDeleteBulk(
+  public abstract Future<Map<String, OperationStatus>> asyncDeleteBulk(
           String... key);
 
 

--- a/src/main/java/net/spy/memcached/ArcusClientPool.java
+++ b/src/main/java/net/spy/memcached/ArcusClientPool.java
@@ -45,6 +45,8 @@ import net.spy.memcached.internal.CollectionGetBulkFuture;
 import net.spy.memcached.internal.OperationFuture;
 import net.spy.memcached.internal.SMGetFuture;
 import net.spy.memcached.ops.CollectionOperationStatus;
+import net.spy.memcached.ops.OperationStatus;
+import net.spy.memcached.ops.StoreType;
 import net.spy.memcached.transcoders.Transcoder;
 
 /**
@@ -332,38 +334,67 @@ public class ArcusClientPool implements ArcusClientIF {
     return this.getClient().asyncSopExist(key, value);
   }
 
+  @Deprecated
   @Override
   public <T> Future<Map<String, CollectionOperationStatus>> asyncSetBulk(
           List<String> key, int exp, T o, Transcoder<T> tc) {
     return this.getClient().asyncSetBulk(key, exp, o, tc);
   }
 
+  @Deprecated
   @Override
   public Future<Map<String, CollectionOperationStatus>> asyncSetBulk(
           List<String> key, int exp, Object o) {
     return this.getClient().asyncSetBulk(key, exp, o);
   }
 
+  @Deprecated
   @Override
   public <T> Future<Map<String, CollectionOperationStatus>> asyncSetBulk(
           Map<String, T> o, int exp, Transcoder<T> tc) {
     return this.getClient().asyncSetBulk(o, exp, tc);
   }
 
+  @Deprecated
   @Override
   public Future<Map<String, CollectionOperationStatus>> asyncSetBulk(
           Map<String, Object> o, int exp) {
     return this.getClient().asyncSetBulk(o, exp);
   }
 
+
   @Override
-  public Future<Map<String, CollectionOperationStatus>> asyncDeleteBulk(
+  public <T> Future<Map<String, OperationStatus>> asyncStoreBulk(
+          StoreType type, List<String> key, int exp, T o, Transcoder<T> tc) {
+    return this.getClient().asyncStoreBulk(type, key, exp, o, tc);
+  }
+
+  @Override
+  public Future<Map<String, OperationStatus>> asyncStoreBulk(
+          StoreType type, List<String> key, int exp, Object o) {
+    return this.getClient().asyncStoreBulk(type, key, exp, o);
+  }
+
+  @Override
+  public <T> Future<Map<String, OperationStatus>> asyncStoreBulk(
+          StoreType type, Map<String, T> o, int exp, Transcoder<T> tc) {
+    return this.getClient().asyncStoreBulk(type, o, exp, tc);
+  }
+
+  @Override
+  public Future<Map<String, OperationStatus>> asyncStoreBulk(
+          StoreType type, Map<String, Object> o, int exp) {
+    return this.getClient().asyncStoreBulk(type, o, exp);
+  }
+
+  @Override
+  public Future<Map<String, OperationStatus>> asyncDeleteBulk(
           List<String> key) {
     return this.getClient().asyncDeleteBulk(key);
   }
 
   @Override
-  public Future<Map<String, CollectionOperationStatus>> asyncDeleteBulk(
+  public Future<Map<String, OperationStatus>> asyncDeleteBulk(
           String... key) {
     return this.getClient().asyncDeleteBulk(key);
   }

--- a/src/main/java/net/spy/memcached/internal/BulkOperationFuture.java
+++ b/src/main/java/net/spy/memcached/internal/BulkOperationFuture.java
@@ -1,7 +1,6 @@
 package net.spy.memcached.internal;
 
 import net.spy.memcached.MemcachedConnection;
-import net.spy.memcached.ops.CollectionOperationStatus;
 import net.spy.memcached.ops.Operation;
 import net.spy.memcached.ops.OperationState;
 
@@ -14,10 +13,10 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.TimeUnit;
 
-public abstract class BulkOperationFuture
-        extends OperationFuture<Map<String, CollectionOperationStatus>> {
-  protected final Map<String, CollectionOperationStatus> failedResult =
-          new HashMap<String, CollectionOperationStatus>();
+public abstract class BulkOperationFuture<T>
+        extends OperationFuture<Map<String, T>> {
+  protected final Map<String, T> failedResult =
+          new HashMap<String, T>();
   protected final ConcurrentLinkedQueue<Operation> ops = new ConcurrentLinkedQueue<Operation>();
 
   public BulkOperationFuture(Collection<String> keys, CountDownLatch l, long timeout) {
@@ -48,7 +47,7 @@ public abstract class BulkOperationFuture
   }
 
   @Override
-  public Map<String, CollectionOperationStatus> get(long duration,
+  public Map<String, T> get(long duration,
                                                     TimeUnit units) throws InterruptedException,
           TimeoutException, ExecutionException {
     if (!latch.await(duration, units)) {

--- a/src/main/java/net/spy/memcached/protocol/ascii/BaseStoreOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/BaseStoreOperationImpl.java
@@ -33,8 +33,14 @@ import net.spy.memcached.ops.StatusCode;
 abstract class BaseStoreOperationImpl extends OperationImpl {
 
   private static final int OVERHEAD = 32;
+
   private static final OperationStatus STORED =
           new OperationStatus(true, "STORED", StatusCode.SUCCESS);
+  private static final OperationStatus NOT_FOUND =
+          new OperationStatus(false, "NOT_FOUND", StatusCode.ERR_NOT_FOUND);
+  private static final OperationStatus EXISTS =
+          new OperationStatus(false, "EXISTS", StatusCode.ERR_EXISTS);
+
   protected final String type;
   protected final String key;
   protected final int flags;
@@ -62,7 +68,7 @@ abstract class BaseStoreOperationImpl extends OperationImpl {
       return;
     }
     /* ENABLE_REPLICATION end */
-    getCallback().receivedStatus(matchStatus(line, STORED));
+    getCallback().receivedStatus(matchStatus(line, STORED, NOT_FOUND, EXISTS));
     transitionState(OperationState.COMPLETE);
   }
 

--- a/src/test/java/net/spy/memcached/ArcusTimeoutTest.java
+++ b/src/test/java/net/spy/memcached/ArcusTimeoutTest.java
@@ -25,6 +25,7 @@ import net.spy.memcached.internal.CollectionFuture;
 import net.spy.memcached.internal.OperationFuture;
 import net.spy.memcached.internal.SMGetFuture;
 import net.spy.memcached.ops.CollectionOperationStatus;
+import net.spy.memcached.ops.OperationStatus;
 
 import org.junit.After;
 import org.junit.Before;
@@ -132,7 +133,7 @@ public class ArcusTimeoutTest extends TestCase {
       keys[i] = "MyKey" + i;
     }
 
-    Future<Map<String, CollectionOperationStatus>> future = mc.asyncDeleteBulk(keys);
+    Future<Map<String, OperationStatus>> future = mc.asyncDeleteBulk(keys);
     future.get(1L, TimeUnit.MILLISECONDS);
   }
 
@@ -146,7 +147,7 @@ public class ArcusTimeoutTest extends TestCase {
       keys[i] = "MyKey" + i;
     }
 
-    Future<Map<String, CollectionOperationStatus>> future = mc.asyncDeleteBulk(keys);
+    Future<Map<String, OperationStatus>> future = mc.asyncDeleteBulk(keys);
     future.get(1L, TimeUnit.MILLISECONDS);
   }
 

--- a/src/test/manual/net/spy/memcached/bulkoperation/BulkDeleteTest.java
+++ b/src/test/manual/net/spy/memcached/bulkoperation/BulkDeleteTest.java
@@ -18,8 +18,8 @@ package net.spy.memcached.bulkoperation;
 
 import junit.framework.Assert;
 import net.spy.memcached.collection.BaseIntegrationTest;
-import net.spy.memcached.collection.CollectionResponse;
-import net.spy.memcached.ops.CollectionOperationStatus;
+import net.spy.memcached.ops.OperationStatus;
+import net.spy.memcached.ops.StatusCode;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -72,10 +72,10 @@ public class BulkDeleteTest extends BaseIntegrationTest {
         }
 
         // Bulk delete
-        Future<Map<String, CollectionOperationStatus>> future = mc.
+        Future<Map<String, OperationStatus>> future = mc.
                 asyncDeleteBulk(Arrays.asList(keys));
 
-        Map<String, CollectionOperationStatus> errorList;
+        Map<String, OperationStatus> errorList;
         try {
           errorList = future.get(20000L, TimeUnit.MILLISECONDS);
           Assert.assertTrue("Error list is not empty.",
@@ -123,18 +123,18 @@ public class BulkDeleteTest extends BaseIntegrationTest {
         }
 
         // Bulk delete
-        Future<Map<String, CollectionOperationStatus>> future = mc.
+        Future<Map<String, OperationStatus>> future = mc.
                 asyncDeleteBulk(Arrays.asList(keys));
 
-        Map<String, CollectionOperationStatus> errorList;
+        Map<String, OperationStatus> errorList;
         try {
           errorList = future.get(20000L, TimeUnit.MILLISECONDS);
           Assert.assertEquals("Error count is less than input.",
                   keys.length/2, errorList.size());
-          for (Map.Entry<String, CollectionOperationStatus> error :
+          for (Map.Entry<String, OperationStatus> error :
                   errorList.entrySet()) {
-            Assert.assertEquals(error.getValue().getResponse(),
-                    CollectionResponse.NOT_FOUND);
+            Assert.assertEquals(error.getValue().getStatusCode(),
+                    StatusCode.ERR_NOT_FOUND);
           }
         } catch (TimeoutException e) {
           future.cancel(true);


### PR DESCRIPTION
… to OperationStatus

bulkAPI 리턴 타입을 CollectionOperationStatus에서 OperationStatus로 변경하였습니다.
asyncSetBulk의 경우 이 API를 deprecated 시키고, asyncStoreBulk API를 추가하였습니다.