### PR TITLE
ENHANCE: using stringbuilder in CachaManager.getAddressListString

### DIFF
--- a/src/main/java/net/spy/memcached/CacheManager.java
+++ b/src/main/java/net/spy/memcached/CacheManager.java
@@ -333,16 +333,16 @@ public class CacheManager extends SpyThread implements Watcher,
   }
 
   private String getAddressListString(List<String> children) {
-    String addrs = "";
+    StringBuilder addrs = new StringBuilder();
     for (int i = 0; i < children.size(); i++) {
       String[] temp = children.get(i).split("-");
       if (i != 0) {
-        addrs = addrs + "," + temp[0];
+        addrs.append(",").append(temp[0]);
       } else {
-        addrs = temp[0];
+        addrs.append(temp[0]);
       }
     }
-    return addrs;
+    return addrs.toString();
   }
 
   /**


### PR DESCRIPTION
CacheManager에서 address string 연결시, String 객체를 계속해서 생성하는 문제가 있어 StringBuilder를 사용하여 최적화하였습니다.