### PR TITLE
CLEANUP: add pool information to MemcachedNode toString

### DIFF
--- a/src/main/java/net/spy/memcached/ArcusClient.java
+++ b/src/main/java/net/spy/memcached/ArcusClient.java
@@ -184,6 +184,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
   private static String VERSION;
   private static final Logger arcusLogger = LoggerFactory.getLogger(ArcusClient.class);
   private static final String ARCUS_CLOUD_ADDR = "127.0.0.1:2181";
+  private static final String DEFAULT_ARCUS_CLIENT_NAME = "ArcusClient";
   private boolean dead;
 
   // final BulkService bulkService;
@@ -232,7 +233,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
   /**
    * @param hostPorts   arcus admin addresses
    * @param serviceCode service code
-   * @param poolSize    Arcus clinet pool size
+   * @param poolSize    Arcus client pool size
    * @param cfb         ConnectionFactoryBuilder
    * @return multiple ArcusClient
    */
@@ -245,7 +246,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
 
   /**
    * @param serviceCode service code
-   * @param poolSize    Arcus clinet pool size
+   * @param poolSize    Arcus client pool size
    * @param cfb         ConnectionFactoryBuilder
    * @return multiple ArcusClient
    */
@@ -260,7 +261,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
    * @param hostPorts   arcus admin addresses
    * @param serviceCode service code
    * @param cfb         ConnectionFactoryBuilder
-   * @param poolSize    Arcus clinet pool size
+   * @param poolSize    Arcus client pool size
    * @param waitTimeFor Connect
    *                    waiting time for connection establishment(milliseconds)
    * @return multiple ArcusClient
@@ -303,12 +304,32 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
    * Create an Arcus client for the given memcached server addresses.
    *
    * @param cf    connection factory to configure connections for this client
+   * @param name  client name
    * @param addrs socket addresses for the memcached servers
    * @return Arcus client
    */
   protected static ArcusClient getInstance(ConnectionFactory cf,
+                                           String name,
                                            List<InetSocketAddress> addrs) throws IOException {
-    return new ArcusClient(cf, addrs);
+    return new ArcusClient(cf, name, addrs);
+  }
+
+  /**
+   * Create an Arcus client for the given memcached server addresses.
+   *
+   * @param cf    connection factory to configure connections for this client
+   * @param name  client name
+   * @param addrs socket addresses for the memcached servers
+   * @throws IOException if connections cannot be established
+   */
+  public ArcusClient(ConnectionFactory cf, String name, List<InetSocketAddress> addrs)
+          throws IOException {
+    super(cf, name, addrs);
+    // bulkService = new BulkService(cf.getBulkServiceLoopLimit(),
+    //         cf.getBulkServiceThreadCount(), cf.getBulkServiceSingleOpTimeout());
+    collectionTranscoder = new CollectionTranscoder();
+    smgetKeyChunkSize = cf.getDefaultMaxSMGetKeyChunkSize();
+    registerMbean();
   }
 
   /**
@@ -318,11 +339,10 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
    * @param addrs socket addresses for the memcached servers
    * @throws IOException if connections cannot be established
    */
-  public ArcusClient(ConnectionFactory cf, List<InetSocketAddress> addrs)
+  public ArcusClient(ConnectionFactory cf,
+                     List<InetSocketAddress> addrs)
           throws IOException {
-    super(cf, addrs);
-    // bulkService = new BulkService(cf.getBulkServiceLoopLimit(),
-    //         cf.getBulkServiceThreadCount(), cf.getBulkServiceSingleOpTimeout());
+    super(cf, DEFAULT_ARCUS_CLIENT_NAME, addrs);
     collectionTranscoder = new CollectionTranscoder();
     smgetKeyChunkSize = cf.getDefaultMaxSMGetKeyChunkSize();
     registerMbean();

--- a/src/main/java/net/spy/memcached/BinaryConnectionFactory.java
+++ b/src/main/java/net/spy/memcached/BinaryConnectionFactory.java
@@ -38,10 +38,12 @@ public class BinaryConnectionFactory extends DefaultConnectionFactory {
   }
 
   @Override
-  public MemcachedNode createMemcachedNode(SocketAddress sa,
+  public MemcachedNode createMemcachedNode(String name,
+                                           SocketAddress sa,
                                            SocketChannel c, int bufSize) {
     boolean doAuth = false;
-    return new BinaryMemcachedNodeImpl(sa, c, bufSize,
+    return new BinaryMemcachedNodeImpl(name,
+            sa, c, bufSize,
             createReadOperationQueue(),
             createWriteOperationQueue(),
             createOperationQueue(),

--- a/src/main/java/net/spy/memcached/CacheManager.java
+++ b/src/main/java/net/spy/memcached/CacheManager.java
@@ -485,8 +485,9 @@ public class CacheManager extends SpyThread implements Watcher,
     client = new ArcusClient[poolSize];
     for (int i = 0; i < poolSize; i++) {
       try {
-        client[i] = ArcusClient.getInstance(cfb.build(), socketList);
-        client[i].setName("Memcached IO (" + (i+1) + "-" + poolSize + ") for " + serviceCode);
+        String clientName = "ArcusClient(" + (i+1) + "-" + poolSize + ") for " + serviceCode;
+        client[i] = ArcusClient.getInstance(cfb.build(), clientName, socketList);
+        client[i].setName("Memcached IO for " + serviceCode);
         client[i].setCacheManager(this);
       } catch (IOException e) {
         getLogger().fatal("Arcus Connection has critical problems. contact arcus manager.");

--- a/src/main/java/net/spy/memcached/ConnectionFactory.java
+++ b/src/main/java/net/spy/memcached/ConnectionFactory.java
@@ -39,18 +39,22 @@ public interface ConnectionFactory {
   /**
    * Create a MemcachedConnection for the given SocketAddresses.
    *
+   * @param name  client name
    * @param addrs the addresses of the memcached servers
    * @return a new MemcachedConnection connected to those addresses
    * @throws IOException for problems initializing the memcached connections
    */
-  MemcachedConnection createConnection(List<InetSocketAddress> addrs)
+  MemcachedConnection createConnection(String name, List<InetSocketAddress> addrs)
           throws IOException;
+
 
   /**
    * Create a new memcached node.
    */
-  MemcachedNode createMemcachedNode(SocketAddress sa,
+  MemcachedNode createMemcachedNode(String name,
+                                    SocketAddress sa,
                                     SocketChannel c, int bufSize);
+
 
   /**
    * Create a BlockingQueue for operations for a connection.

--- a/src/main/java/net/spy/memcached/ConnectionFactoryBuilder.java
+++ b/src/main/java/net/spy/memcached/ConnectionFactoryBuilder.java
@@ -437,9 +437,10 @@ public class ConnectionFactoryBuilder {
 
       /* ENABLE_REPLICATION if */
       @Override
-      public MemcachedConnection createConnection(List<InetSocketAddress> addrs)
+      public MemcachedConnection createConnection(String name,
+                                                  List<InetSocketAddress> addrs)
               throws IOException {
-        MemcachedConnection c = super.createConnection(addrs);
+        MemcachedConnection c = super.createConnection(name, addrs);
         c.setArcusReplEnabled(arcusReplEnabled);
         return c;
       }

--- a/src/main/java/net/spy/memcached/DefaultConnectionFactory.java
+++ b/src/main/java/net/spy/memcached/DefaultConnectionFactory.java
@@ -206,12 +206,14 @@ public class DefaultConnectionFactory extends SpyObject
     this(DEFAULT_OP_QUEUE_LEN, DEFAULT_READ_BUFFER_SIZE);
   }
 
-  public MemcachedNode createMemcachedNode(SocketAddress sa,
+  public MemcachedNode createMemcachedNode(String name,
+                                           SocketAddress sa,
                                            SocketChannel c, int bufSize) {
 
     OperationFactory of = getOperationFactory();
     if (of instanceof AsciiOperationFactory) {
-      return new AsciiMemcachedNodeImpl(sa, c, bufSize,
+      return new AsciiMemcachedNodeImpl(name,
+              sa, c, bufSize,
               createReadOperationQueue(),
               createWriteOperationQueue(),
               createOperationQueue(),
@@ -221,7 +223,8 @@ public class DefaultConnectionFactory extends SpyObject
       if (getAuthDescriptor() != null) {
         doAuth = true;
       }
-      return new BinaryMemcachedNodeImpl(sa, c, bufSize,
+      return new BinaryMemcachedNodeImpl(name,
+              sa, c, bufSize,
               createReadOperationQueue(),
               createWriteOperationQueue(),
               createOperationQueue(),
@@ -233,9 +236,10 @@ public class DefaultConnectionFactory extends SpyObject
     }
   }
 
-  public MemcachedConnection createConnection(List<InetSocketAddress> addrs)
+  public MemcachedConnection createConnection(String name,
+                                              List<InetSocketAddress> addrs)
           throws IOException {
-    return new MemcachedConnection(getReadBufSize(), this, addrs,
+    return new MemcachedConnection(name, getReadBufSize(), this, addrs,
             getInitialObservers(), getFailureMode(), getOperationFactory());
   }
 

--- a/src/main/java/net/spy/memcached/MemcachedClient.java
+++ b/src/main/java/net/spy/memcached/MemcachedClient.java
@@ -140,9 +140,22 @@ public class MemcachedClient extends SpyThread
 
   private final byte delimiter;
 
+  private static final String DEFAULT_MEMCACHED_CLIENT_NAME = "MemcachedClient";
+
   private static final int GET_BULK_CHUNK_SIZE = 200;
 
   private final AuthThreadMonitor authMonitor = new AuthThreadMonitor();
+
+  /**
+   * Get a memcache client operating on the specified memcached locations.
+   *
+   * @param name client name
+   * @param ia   the memcached locations
+   * @throws IOException if connections cannot be established
+   */
+  public MemcachedClient(String name, InetSocketAddress... ia) throws IOException {
+    this(new DefaultConnectionFactory(), name, Arrays.asList(ia));
+  }
 
   /**
    * Get a memcache client operating on the specified memcached locations.
@@ -151,7 +164,7 @@ public class MemcachedClient extends SpyThread
    * @throws IOException if connections cannot be established
    */
   public MemcachedClient(InetSocketAddress... ia) throws IOException {
-    this(new DefaultConnectionFactory(), Arrays.asList(ia));
+    this(new DefaultConnectionFactory(), DEFAULT_MEMCACHED_CLIENT_NAME, Arrays.asList(ia));
   }
 
   /**
@@ -162,9 +175,8 @@ public class MemcachedClient extends SpyThread
    */
   public MemcachedClient(List<InetSocketAddress> addrs)
           throws IOException {
-    this(new DefaultConnectionFactory(), addrs);
+    this(new DefaultConnectionFactory(), DEFAULT_MEMCACHED_CLIENT_NAME, addrs);
   }
-
   /**
    * Get a memcache client over the specified memcached locations.
    *
@@ -174,8 +186,24 @@ public class MemcachedClient extends SpyThread
    */
   public MemcachedClient(ConnectionFactory cf, List<InetSocketAddress> addrs)
           throws IOException {
+    this(cf, DEFAULT_MEMCACHED_CLIENT_NAME, addrs);
+  }
+
+  /**
+   * Get a memcache client over the specified memcached locations.
+   *
+   * @param cf    the connection factory to configure connections for this client
+   * @param name  client name
+   * @param addrs the socket addresses
+   * @throws IOException if connections cannot be established
+   */
+  public MemcachedClient(ConnectionFactory cf, String name, List<InetSocketAddress> addrs)
+          throws IOException {
     if (cf == null) {
       throw new NullPointerException("Connection factory required");
+    }
+    if (name == null) {
+      throw new NullPointerException("Client name required");
     }
     if (addrs == null) {
       throw new NullPointerException("Server list required");
@@ -192,7 +220,7 @@ public class MemcachedClient extends SpyThread
     transcoder = cf.getDefaultTranscoder();
     opFact = cf.getOperationFactory();
     assert opFact != null : "Connection factory failed to make op factory";
-    conn = cf.createConnection(addrs);
+    conn = cf.createConnection(name, addrs);
     assert conn != null : "Connection factory failed to make a connection";
     operationTimeout = cf.getOperationTimeout();
     authDescriptor = cf.getAuthDescriptor();

--- a/src/main/java/net/spy/memcached/plugin/FrontCacheMemcachedClient.java
+++ b/src/main/java/net/spy/memcached/plugin/FrontCacheMemcachedClient.java
@@ -43,12 +43,13 @@ public class FrontCacheMemcachedClient extends MemcachedClient {
    * Create the memcached client and the front cache.
    *
    * @param cf    the connection factory to configure connections for this client
+   * @param name  client name
    * @param addrs the socket addresses for the memcached servers
    * @throws IOException if connections cannot be established
    */
   public FrontCacheMemcachedClient(ConnectionFactory cf,
-                                   List<InetSocketAddress> addrs) throws IOException {
-    super(cf, addrs);
+                                   String name, List<InetSocketAddress> addrs) throws IOException {
+    super(cf, name, addrs);
 
     if (cf.getMaxFrontCacheElements() > 0) {
       String cacheName = cf.getFrontCacheName();

--- a/src/main/java/net/spy/memcached/protocol/TCPMemcachedNodeImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/TCPMemcachedNodeImpl.java
@@ -49,6 +49,7 @@ import net.spy.memcached.ops.OperationState;
 public abstract class TCPMemcachedNodeImpl extends SpyObject
         implements MemcachedNode {
 
+  private String nodeName;
   private final SocketAddress socketAddress;
   private final ByteBuffer rbuf;
   private final ByteBuffer wbuf;
@@ -129,7 +130,8 @@ public abstract class TCPMemcachedNodeImpl extends SpyObject
     }
   }
 
-  public TCPMemcachedNodeImpl(SocketAddress sa, SocketChannel c,
+  public TCPMemcachedNodeImpl(String name,
+                              SocketAddress sa, SocketChannel c,
                               int bufSize, BlockingQueue<Operation> rq,
                               BlockingQueue<Operation> wq, BlockingQueue<Operation> iq,
                               long opQueueMaxBlockTime, boolean waitForAuth,
@@ -152,6 +154,7 @@ public abstract class TCPMemcachedNodeImpl extends SpyObject
     socketAddress=sa;
     */
     /* ENABLE_REPLICATION end */
+    nodeName = name + " " + sa;
     setChannel(c);
     rbuf = ByteBuffer.allocate(bufSize);
     wbuf = ByteBuffer.allocate(bufSize);
@@ -467,7 +470,8 @@ public abstract class TCPMemcachedNodeImpl extends SpyObject
     int rsize = readQ.size() + (optimizedOp == null ? 0 : 1);
     int wsize = writeQ.size();
     int isize = inputQueue.size();
-    return "{QA sa=" + getSocketAddress() + ", #Rops=" + rsize
+    return "{QA name=" + nodeName
+            + ", #Rops=" + rsize
             + ", #Wops=" + wsize
             + ", #iq=" + isize
             + ", topRop=" + getCurrentReadOp()

--- a/src/main/java/net/spy/memcached/protocol/ascii/AsciiMemcachedNodeImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/AsciiMemcachedNodeImpl.java
@@ -15,11 +15,12 @@ import net.spy.memcached.protocol.TCPMemcachedNodeImpl;
  * Memcached node for the ASCII protocol.
  */
 public final class AsciiMemcachedNodeImpl extends TCPMemcachedNodeImpl {
-  public AsciiMemcachedNodeImpl(SocketAddress sa, SocketChannel c,
+  public AsciiMemcachedNodeImpl(String name,
+                                SocketAddress sa, SocketChannel c,
                                 int bufSize, BlockingQueue<Operation> rq,
                                 BlockingQueue<Operation> wq, BlockingQueue<Operation> iq,
                                 Long opQueueMaxBlockTimeNs) {
-    super(sa, c, bufSize, rq, wq, iq, opQueueMaxBlockTimeNs,
+    super(name, sa, c, bufSize, rq, wq, iq, opQueueMaxBlockTimeNs,
         false /* ascii never does auth */, true /* ascii protocol */);
   }
 

--- a/src/main/java/net/spy/memcached/protocol/binary/BinaryMemcachedNodeImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/binary/BinaryMemcachedNodeImpl.java
@@ -20,11 +20,12 @@ public class BinaryMemcachedNodeImpl extends TCPMemcachedNodeImpl {
   private final int MAX_SET_OPTIMIZATION_COUNT = 65535;
   private final int MAX_SET_OPTIMIZATION_BYTES = 2 * 1024 * 1024;
 
-  public BinaryMemcachedNodeImpl(SocketAddress sa, SocketChannel c,
+  public BinaryMemcachedNodeImpl(String name,
+                                 SocketAddress sa, SocketChannel c,
                                  int bufSize, BlockingQueue<Operation> rq,
                                  BlockingQueue<Operation> wq, BlockingQueue<Operation> iq,
                                  Long opQueueMaxBlockTimeNs, boolean waitForAuth) {
-    super(sa, c, bufSize, rq, wq, iq, opQueueMaxBlockTimeNs,
+    super(name, sa, c, bufSize, rq, wq, iq, opQueueMaxBlockTimeNs,
             waitForAuth, false /* binary protocol */);
   }
 

--- a/src/test/java/net/spy/memcached/ClientBaseCase.java
+++ b/src/test/java/net/spy/memcached/ClientBaseCase.java
@@ -92,15 +92,16 @@ public abstract class ClientBaseCase extends TestCase {
          */
         @Override
         public MemcachedConnection createConnection(
-                List<InetSocketAddress> addrs) throws IOException {
-          return new MemcachedConnection(getReadBufSize(), this, addrs,
+                String name, List<InetSocketAddress> addrs) throws IOException {
+          return new MemcachedConnection(name, getReadBufSize(), this, addrs,
                   getInitialObservers(), getFailureMode(), getOperationFactory());
         }
 
         @Override
-        public MemcachedNode createMemcachedNode(SocketAddress sa,
+        public MemcachedNode createMemcachedNode(String name,
+                                                 SocketAddress sa,
                                                  SocketChannel c, int bufSize) {
-          return inner.createMemcachedNode(sa, c, bufSize);
+          return inner.createMemcachedNode(name, sa, c, bufSize);
         }
 
         @Override

--- a/src/test/java/net/spy/memcached/ConnectionFactoryBuilderTest.java
+++ b/src/test/java/net/spy/memcached/ConnectionFactoryBuilderTest.java
@@ -90,7 +90,7 @@ public class ConnectionFactoryBuilderTest extends BaseMockCase {
 
     SocketChannel sc = SocketChannel.open();
     try {
-      assertTrue(f.createMemcachedNode(
+      assertTrue(f.createMemcachedNode("factory builder test node",
               InetSocketAddress.createUnresolved("localhost", 11211),
               sc, 1)
               instanceof AsciiMemcachedNodeImpl);
@@ -167,7 +167,7 @@ public class ConnectionFactoryBuilderTest extends BaseMockCase {
 
     SocketChannel sc = SocketChannel.open();
     try {
-      assertTrue(f.createMemcachedNode(
+      assertTrue(f.createMemcachedNode("factory builder test node",
               InetSocketAddress.createUnresolved("localhost", 11211),
               sc, 1)
               instanceof BinaryMemcachedNodeImpl);

--- a/src/test/java/net/spy/memcached/MemcachedClientConstructorTest.java
+++ b/src/test/java/net/spy/memcached/MemcachedClientConstructorTest.java
@@ -141,7 +141,7 @@ public class MemcachedClientConstructorTest extends TestCase {
     try {
       client = new MemcachedClient(new DefaultConnectionFactory() {
         @Override
-        public MemcachedConnection createConnection(
+        public MemcachedConnection createConnection(String name,
                 List<InetSocketAddress> addrs) throws IOException {
           return null;
         }

--- a/src/test/java/net/spy/memcached/MemcachedConnectionTest.java
+++ b/src/test/java/net/spy/memcached/MemcachedConnectionTest.java
@@ -38,7 +38,7 @@ public class MemcachedConnectionTest extends TestCase {
     ConnectionFactory cf = cfb.build();
     List<InetSocketAddress> addrs = new ArrayList<InetSocketAddress>();
 
-    conn = new MemcachedConnection(1024, cf, addrs,
+    conn = new MemcachedConnection("connection test", 1024, cf, addrs,
         cf.getInitialObservers(), cf.getFailureMode(), cf.getOperationFactory());
     locator = (ArcusKetamaNodeLocator) conn.getLocator();
   }

--- a/src/test/java/net/spy/memcached/protocol/TCPMemcachedNodeImplTest.java
+++ b/src/test/java/net/spy/memcached/protocol/TCPMemcachedNodeImplTest.java
@@ -59,12 +59,14 @@ public class TCPMemcachedNodeImplTest extends TestCase {
     final DefaultConnectionFactory factory = new DefaultConnectionFactory(inputQueueSize, 4096);
 
     TCPMemcachedNodeImpl fromNode = (TCPMemcachedNodeImpl) factory.createMemcachedNode(
+        "tcp node impl test node",
         InetSocketAddress.createUnresolved("127.0.0.1", 11211),
         SocketChannel.open(),
         4096
     );
 
     TCPMemcachedNodeImpl toNode = (TCPMemcachedNodeImpl) factory.createMemcachedNode(
+        "tcp node impl test node",
         InetSocketAddress.createUnresolved("127.0.0.2", 11211),
         SocketChannel.open(),
         4096


### PR DESCRIPTION
pool에 대한 정보를 MemcachedNode toString 결과에 추가하였으며,
handleIO에서 connectable 이벤트로 selectionKey 처리할 때 로깅하는 부분을 selectionKey가 아닌 MemcachedNode 정보를 출력하도록 수정하였습니다.