### PR TITLE
FIX: add missing SWITCHOVER, REPL_SLAVE response handling

### DIFF
--- a/src/main/java/net/spy/memcached/protocol/ascii/MutatorOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/MutatorOperationImpl.java
@@ -71,6 +71,7 @@ final class MutatorOperationImpl extends OperationImpl
     /* ENABLE_REPLICATION if */
     if (line.equals("SWITCHOVER") || line.equals("REPL_SLAVE")) {
       receivedMoveOperations(line);
+      return;
     }
     /* ENABLE_REPLICATION end */
 

--- a/src/main/java/net/spy/memcached/protocol/ascii/SetAttrOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/SetAttrOperationImpl.java
@@ -72,6 +72,7 @@ class SetAttrOperationImpl extends OperationImpl
     /* ENABLE_REPLICATION if */
     if (line.equals("SWITCHOVER") || line.equals("REPL_SLAVE")) {
       receivedMoveOperations(line);
+      return;
     }
     /* ENABLE_REPLICATION end */
     getCallback().receivedStatus(


### PR DESCRIPTION
Write type의 operation 중 replication SWITCHOVER / REPL_SLAVE
응답에 대한 return 처리가 빠져있는 operation이 있어 추가 했습니다.
return 처리가 되지 않을 경우 위 응답에 대해 아래와 같은 로그를 출력하게 됩니다.
`[Memcached IO] - Unhandled state: {OperationStatus success=false:  REPL_SLAVE}`

Write type의 replication response 처리는 https://github.com/naver/arcus-java-client/commit/8c4776c071094dd3b510a07d2c0368e6ea7af58c commit에서 일괄적으로 추가되었는데,
두 operation만 빠진 것 같습니다.

@hjyun328 @minkikim89 @jhpark816 
확인 요청 드립니다.