### PR TITLE
FIX: add override code for isDone function to some bulk code

### DIFF
--- a/src/main/java/net/spy/memcached/ArcusClient.java
+++ b/src/main/java/net/spy/memcached/ArcusClient.java
@@ -1146,6 +1146,15 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
         return new CollectionOperationStatus(true, "END",
                 CollectionResponse.END);
       }
+
+      @Override
+      public boolean isDone() {
+        boolean rv = true;
+        for (Operation op : ops) {
+          rv &= op.getState() == OperationState.COMPLETE;
+        }
+        return rv || isCancelled();
+      }
     };
   }
 
@@ -4072,6 +4081,15 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
         return new CollectionOperationStatus(true, "END",
                 CollectionResponse.END);
       }
+
+      @Override
+      public boolean isDone() {
+        boolean rv = true;
+        for (Operation op : ops) {
+          rv &= op.getState() == OperationState.COMPLETE;
+        }
+        return rv || isCancelled();
+      }
     };
   }
 
@@ -4313,6 +4331,15 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
       @Override
       public CollectionOperationStatus getOperationStatus() {
         return null;
+      }
+
+      @Override
+      public boolean isDone() {
+        boolean rv = true;
+        for (Operation op : ops) {
+          rv &= op.getState() == OperationState.COMPLETE;
+        }
+        return rv || isCancelled();
       }
     };
   }


### PR DESCRIPTION
일부 bulk 연산에 isDone 함수가 override 되어있지 않아 추가하였습니다.
현재 상태에서 해당 연산들에 대해 isDone 함수를 호출 할 시 assert 문에 걸려서
exception이 발생합니다.