### PR TITLE
FIX: incorrect deleteion of replication nodeSet

### DIFF
--- a/src/main/java/net/spy/memcached/ArcusReplKetamaNodeLocator.java
+++ b/src/main/java/net/spy/memcached/ArcusReplKetamaNodeLocator.java
@@ -317,7 +317,7 @@ public class ArcusReplKetamaNodeLocator extends SpyObject implements NodeLocator
 
         SortedSet<MemcachedReplicaGroup> nodeSet = ketamaGroups.get(k);
         if (remove) {
-          nodeSet.remove(ketamaGroups);
+          nodeSet.remove(group);
           if (nodeSet.size() == 0) {
             ketamaGroups.remove(k);
           }


### PR DESCRIPTION
예전에 hash collision 관련 수정하면서 버그가 있었네요.
remove 시에 잘못된 객체를 사용하여 복제 모드에서 group 이 삭제되면 exception이 발생하는 버그가 있습니다.