### PR TITLE
FIX: do not offer the operation to input queue with zero remaining ca…

### DIFF
--- a/src/main/java/net/spy/memcached/MemcachedConnection.java
+++ b/src/main/java/net/spy/memcached/MemcachedConnection.java
@@ -454,12 +454,14 @@ public final class MemcachedConnection extends SpyObject {
      */
     if (group.getMasterNode() != null && group.getSlaveNode() != null) {
       if (((ArcusReplNodeAddress) node.getSocketAddress()).isMaster()) {
-        node.moveOperations(group.getSlaveNode());
-        addedQueue.offer(group.getSlaveNode());
+        if (node.moveOperations(group.getSlaveNode()) > 0) {
+          addedQueue.offer(group.getSlaveNode());
+        }
         ((ArcusReplKetamaNodeLocator) locator).switchoverReplGroup(group);
       } else {
-        node.moveOperations(group.getMasterNode());
-        addedQueue.offer(group.getMasterNode());
+        if (node.moveOperations(group.getMasterNode()) > 0) {
+          addedQueue.offer(group.getMasterNode());
+        }
       }
       queueReconnect(node, ReconnDelay.IMMEDIATE,
           "Discarded all pending reading state operation to move operations.");

--- a/src/main/java/net/spy/memcached/MemcachedNode.java
+++ b/src/main/java/net/spy/memcached/MemcachedNode.java
@@ -274,7 +274,7 @@ public interface MemcachedNode {
 
   MemcachedReplicaGroup getReplicaGroup();
 
-  void addAllOpToInputQ(BlockingQueue<Operation> allOp);
+  int addAllOpToInputQ(BlockingQueue<Operation> allOp);
 
   int moveOperations(final MemcachedNode toNode);
   /* ENABLE_REPLICATION end */

--- a/src/main/java/net/spy/memcached/MemcachedNodeROImpl.java
+++ b/src/main/java/net/spy/memcached/MemcachedNodeROImpl.java
@@ -228,7 +228,7 @@ public class MemcachedNodeROImpl implements MemcachedNode {
     throw new UnsupportedOperationException();
   }
 
-  public void addAllOpToInputQ(BlockingQueue<Operation> allOp) {
+  public int addAllOpToInputQ(BlockingQueue<Operation> allOp) {
     throw new UnsupportedOperationException();
   }
 

--- a/src/test/java/net/spy/memcached/MockMemcachedNode.java
+++ b/src/test/java/net/spy/memcached/MockMemcachedNode.java
@@ -248,8 +248,9 @@ public class MockMemcachedNode implements MemcachedNode {
   }
 
   @Override
-  public void addAllOpToInputQ(BlockingQueue<Operation> allOp) {
+  public int addAllOpToInputQ(BlockingQueue<Operation> allOp) {
     // noop
+    return 0;
   }
 
   @Override


### PR DESCRIPTION
move operation시 target node의 inputQueue의 remaining capacity가 0임에도 불구하고, cancel된 operation을 offer하는 버그를 수정하였습니다.

또한 move operation의 리턴 값을, 실제 이동된 operation의 count를 리턴할 수 있도록 수정하였습니다.