### PR TITLE
CLEANUP: ensure compatibility about changing E2BIG

### DIFF
--- a/src/test/java/net/spy/memcached/ProtocolBaseCase.java
+++ b/src/test/java/net/spy/memcached/ProtocolBaseCase.java
@@ -643,7 +643,9 @@ public abstract class ProtocolBaseCase extends ClientBaseCase {
     } catch (ExecutionException e) {
       e.printStackTrace();
       OperationException oe = (OperationException) e.getCause();
-      assertSame(OperationErrorType.CLIENT, oe.getType());
+      // ensure compatibility about changing E2BIG
+      assertTrue(OperationErrorType.CLIENT == oe.getType() ||
+            OperationErrorType.SERVER == oe.getType());
     }
 
     // But I should still be able to do something.


### PR DESCRIPTION
old cache server 와의 호환성 보장을 위해 E2BIG을 CLIENT or SERVER 로 확인하도록 변경하였습니다.