### PR TITLE
CLEANUP: fixed moveOperation to move operations to writeQ instead of …

### DIFF
--- a/src/main/java/net/spy/memcached/MemcachedNode.java
+++ b/src/main/java/net/spy/memcached/MemcachedNode.java
@@ -274,7 +274,7 @@ public interface MemcachedNode {
 
   MemcachedReplicaGroup getReplicaGroup();
 
-  int addAllOpToInputQ(BlockingQueue<Operation> allOp);
+  int addAllOpToWriteQ(BlockingQueue<Operation> allOp);
 
   int moveOperations(final MemcachedNode toNode);
   /* ENABLE_REPLICATION end */

--- a/src/main/java/net/spy/memcached/MemcachedNodeROImpl.java
+++ b/src/main/java/net/spy/memcached/MemcachedNodeROImpl.java
@@ -228,7 +228,7 @@ public class MemcachedNodeROImpl implements MemcachedNode {
     throw new UnsupportedOperationException();
   }
 
-  public int addAllOpToInputQ(BlockingQueue<Operation> allOp) {
+  public int addAllOpToWriteQ(BlockingQueue<Operation> allOp) {
     throw new UnsupportedOperationException();
   }
 

--- a/src/main/java/net/spy/memcached/protocol/TCPMemcachedNodeImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/TCPMemcachedNodeImpl.java
@@ -685,7 +685,7 @@ public abstract class TCPMemcachedNodeImpl extends SpyObject
     return allOp;
   }
 
-  public int addAllOpToInputQ(BlockingQueue<Operation> allOp) {
+  public int addAllOpToWriteQ(BlockingQueue<Operation> allOp) {
     int movedOpCount = 0;
     for (Operation op : allOp) {
       op.setHandlingNode(this);
@@ -696,7 +696,7 @@ public abstract class TCPMemcachedNodeImpl extends SpyObject
         op.initialize(); // write completed or not yet initialized
         op.resetState(); // reset operation state
       }
-      if (inputQueue.offer(op)) {
+      if (writeQ.offer(op)) {
         op.setMoved(true);
         movedOpCount++;
       } else {
@@ -713,7 +713,7 @@ public abstract class TCPMemcachedNodeImpl extends SpyObject
     int movedOpCount = 0;
 
     if (opCount > 0) {
-      movedOpCount = toNode.addAllOpToInputQ(allOp);
+      movedOpCount = toNode.addAllOpToWriteQ(allOp);
       getLogger().info("Total %d operations have been moved to %s "
               + "and %d operations have been canceled.",
           movedOpCount, toNode, opCount - movedOpCount);

--- a/src/test/java/net/spy/memcached/MockMemcachedNode.java
+++ b/src/test/java/net/spy/memcached/MockMemcachedNode.java
@@ -248,7 +248,7 @@ public class MockMemcachedNode implements MemcachedNode {
   }
 
   @Override
-  public int addAllOpToInputQ(BlockingQueue<Operation> allOp) {
+  public int addAllOpToWriteQ(BlockingQueue<Operation> allOp) {
     // noop
     return 0;
   }

--- a/src/test/java/net/spy/memcached/protocol/TCPMemcachedNodeImplTest.java
+++ b/src/test/java/net/spy/memcached/protocol/TCPMemcachedNodeImplTest.java
@@ -60,10 +60,9 @@ public class TCPMemcachedNodeImplTest extends TestCase {
     final int fromReadOpCount = 5,
               fromWriteOpCount= 5,
               fromInputOpCount = 10,
-              fromAllOpCount = fromReadOpCount + fromWriteOpCount + fromInputOpCount,
-              inputQueueSize = 15;
+              fromAllOpCount = fromReadOpCount + fromWriteOpCount + fromInputOpCount;
 
-    final DefaultConnectionFactory factory = new DefaultConnectionFactory(inputQueueSize, 4096);
+    final DefaultConnectionFactory factory = new DefaultConnectionFactory();
 
     TCPMemcachedNodeImpl fromNode = (TCPMemcachedNodeImpl) factory.createMemcachedNode(
         "tcp node impl test node",
@@ -112,23 +111,19 @@ public class TCPMemcachedNodeImplTest extends TestCase {
     }
 
     // when
-    assertEquals(inputQueueSize, fromNode.moveOperations(toNode));
+    assertEquals(fromAllOpCount, fromNode.moveOperations(toNode));
 
     // then
     assertEquals(0, fromNode.getInputQueueSize());
     assertEquals(0, fromNode.getWriteQueueSize());
     assertEquals(0, fromNode.getReadQueueSize());
-    assertEquals(inputQueueSize, toNode.getInputQueueSize());
-    assertEquals(inputQueueSize, getAddOpCount(toNode));
+    assertEquals(fromAllOpCount, toNode.getWriteQueueSize());
+    assertEquals(fromAllOpCount, getAddOpCount(toNode));
 
     for (int i = 0; i < fromAllOpCount; i++) {
       Operation op = fromOperations.get(i);
-      if (i < inputQueueSize) {
-        assertSame(op.getHandlingNode(), toNode);
-        assertFalse(op.isCancelled());
-      } else {
-        assertTrue(op.isCancelled());
-      }
+      assertSame(op.getHandlingNode(), toNode);
+      assertFalse(op.isCancelled());
     }
   }
   


### PR DESCRIPTION
…inputQ

https://github.com/naver/arcus-java-client/issues/253 이슈에 대한 PR입니다.
moveOperation으로 operation들을 옮길 때 inputQ가 아닌 writeQ로 옮겨 operation 순서를 지킬 수 있도록 수정하였습니다.