### PR TITLE
 ENHANCE: reflected only the changed groups in hash ring

### DIFF
--- a/src/main/java/net/spy/memcached/ArcusReplNodeAddress.java
+++ b/src/main/java/net/spy/memcached/ArcusReplNodeAddress.java
@@ -150,7 +150,7 @@ public class ArcusReplNodeAddress extends InetSocketAddress {
         entry.setValue(new ArrayList<ArcusReplNodeAddress>());
       } else if (!newGroupNodes.get(0).master) {
         /* This case can occur during the switchover or failover.
-         * 1) In the switchover, it occurs after below the first phase. 
+         * 1) In the switchover, it occurs after below the first phase.
          * - the old master is changed to the new slave node.
          * - the old slave is changed to the new master node.
          * 2) In the failover, it occurs after below the first phase.


### PR DESCRIPTION
replication switchover response read 와 다른 group에 의한 cache list update가
동시에 발생 할 경우, switchover를 여러번 반복 수행하는 문제가 발생할 수 있습니다.

이유는 switchover response read 로 group switchover 를 수행 했지만,
아직 node는 cache list update를 하지 않은 상태에서
다른 group cache list update에 의해 old cache list를 read하게 되면서
또 다시 switchover가 발생 했다고 판단하고 또 다시 switchover를 수행하게 됩니다.

위 상황에 대한 해결을 위해 CacheManager가 cache list를 read하면
replication cluster일 경우 이전 cache list와 비교하여
변경된 group만 cache list를 반영하도록 수정 했습니다.

@minkikim89 @hjyun328 
확인 요청 드립니다.