### PR TITLE
FEATURE: requeue the version dependent operation until a version of the node is received

### DIFF
--- a/src/main/java/net/spy/memcached/ops/Operation.java
+++ b/src/main/java/net/spy/memcached/ops/Operation.java
@@ -108,4 +108,6 @@ public interface Operation {
   boolean isReadOperation();
 
   APIType getAPIType();
+
+  boolean isVersionDependent();
 }

--- a/src/main/java/net/spy/memcached/protocol/BaseOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/BaseOperationImpl.java
@@ -22,6 +22,8 @@ import java.nio.ByteBuffer;
 import net.spy.memcached.MemcachedNode;
 import net.spy.memcached.compat.SpyObject;
 import net.spy.memcached.ops.APIType;
+import net.spy.memcached.ops.BTreeGetBulkOperation;
+import net.spy.memcached.ops.BTreeSortMergeGetOperation;
 import net.spy.memcached.ops.CancelledOperationStatus;
 import net.spy.memcached.ops.OperationCallback;
 import net.spy.memcached.ops.OperationErrorType;
@@ -232,5 +234,10 @@ public abstract class BaseOperationImpl extends SpyObject {
 
   public void setAPIType(APIType type) {
     this.apiType = type;
+  }
+
+  public boolean isVersionDependent() {
+    return this instanceof BTreeGetBulkOperation
+        || this instanceof BTreeSortMergeGetOperation;
   }
 }


### PR DESCRIPTION
version dependent한 operation을 writing할 때 node의 버전을 수신하지 않은 상태라면, 해당 operation을 writeQ에서 제거하고 inputQ로 다시 삽입하도록 수정하였습니다.