### PR TITLE
DOC: change the description of the max item size

### DIFF
--- a/docs/03-key-value-API.md
+++ b/docs/03-key-value-API.md
@@ -4,7 +4,7 @@ Key-value item은 하나의 key에 대해 하나의 value만을 저장하는 ite
 
 **제약조건**
 - Key의 최대 크기는 250 character이다.
-- Value는 최대 1Mb까지 저장할 수 있다.
+- Cache item의 최대 크기는 1MB이다.
 
 Key-value item에 대해 수행가능한 연산들은 아래와 같다.
 


### PR DESCRIPTION
doc 문서의 Value 설명 부분이 잘못되어
이에 대한 수정을 위한 PR 입니다.

기존 문서 에서 `Value는 최대 1Mb까지 저장할 수 있다.`로 설명된 부분을
`Cache item의 최대 크기는 1MB이다.`로 변경 했습니다.

@jhpark816
확인 요청 드립니다.