### PR TITLE
FEATURE: support zookeeper dynamic reconfiguration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -85,7 +85,7 @@
         <dependency>
             <groupId>org.apache.zookeeper</groupId>
             <artifactId>zookeeper</artifactId>
-            <version>3.4.14</version>
+            <version>3.5.7</version>
             <exclusions>
                 <exclusion>
                     <groupId>log4j</groupId>

--- a/src/main/java/net/spy/memcached/CacheMonitor.java
+++ b/src/main/java/net/spy/memcached/CacheMonitor.java
@@ -151,6 +151,16 @@ public class CacheMonitor extends SpyObject implements Watcher,
   }
 
   /**
+   * Set cache monitor is dead.
+   */
+  public void setDead() {
+    if (!dead) {
+      getLogger().info("Set CacheMonitor is dead. " + getInfo());
+      dead = true;
+    }
+  }
+
+  /**
    * Check if the cache monitor is dead.
    */
   public boolean isDead() {

--- a/src/main/java/net/spy/memcached/ConfigMonitor.java
+++ b/src/main/java/net/spy/memcached/ConfigMonitor.java
@@ -1,0 +1,180 @@
+/*
+ * arcus-java-client : Arcus Java client
+ * Copyright 2020 JaM2in Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.spy.memcached;
+
+import java.io.IOException;
+
+import net.spy.memcached.compat.SpyObject;
+
+import org.apache.zookeeper.AsyncCallback.DataCallback;
+import org.apache.zookeeper.WatchedEvent;
+import org.apache.zookeeper.Watcher;
+import org.apache.zookeeper.ZooDefs;
+import org.apache.zookeeper.ZooKeeper;
+import org.apache.zookeeper.data.Stat;
+import org.apache.zookeeper.server.util.ConfigUtils;
+
+/**
+ * ConfigMonitor monitors the changes of the zk server ensemble list
+ * in the ZooKeeper node(/zookeeper/config).
+ */
+public class ConfigMonitor extends SpyObject implements Watcher,
+        DataCallback {
+
+  private final ZooKeeper zk;
+
+  private Long configVersion;
+
+  private String prevConfigString;
+
+  private volatile boolean dead;
+
+  private final ConfigMonitorListener listener;
+
+  /**
+   * Constructor
+   *
+   * @param zk          ZooKeeper connection
+   * @param listener    Callback listener
+   */
+  public ConfigMonitor(ZooKeeper zk, ConfigMonitorListener listener) {
+    this.zk = zk;
+    this.listener = listener;
+
+    getLogger().info("Initializing the ConfigMonitor.");
+
+    // Get the config from the Arcus admin synchronously.
+    // Returning list would be processed in processResult().
+    syncGetConfig();
+  }
+
+  /**
+   * Other classes use the ConfigMonitor by implementing this method
+   */
+  public interface ConfigMonitorListener {
+    /**
+     * The connect string of zk admin has changed.
+     */
+    void setZkConnectString(String zkConnectString);
+
+    /**
+     * The ZooKeeper session is no longer valid.
+     */
+    void closing();
+  }
+
+  /**
+   * Processes every events from the ZooKeeper.
+   */
+  public void process(WatchedEvent event) {
+    synchronized (this) {
+      if (event.getType() != Event.EventType.None &&
+          event.getPath() != null && event.getPath().equals(ZooDefs.CONFIG_NODE)) {
+        syncGetConfig();
+      }
+    }
+  }
+
+  /**
+   * A callback function to process the result of getConfig(watch=true).
+   */
+  public void processResult(int rc, String path, Object ctx,
+                            byte[] data, Stat stat) {
+    if (path != null && path.equals(ZooDefs.CONFIG_NODE)) {
+      // similar to config -c
+      String configData = new String(data);
+      String[] config = ConfigUtils.getClientConfigStr(configData).split(" ");
+      long version;
+
+      try {
+        version = Long.parseLong(config[0], 16);
+      } catch (NumberFormatException e) {
+        getLogger().warn("NuberFormatException trying parsing version.");
+        return;
+      }
+
+      if (this.configVersion == null) {
+        this.configVersion = version;
+        prevConfigString = configData;
+      } else if (version > this.configVersion) {
+        getLogger().warn("Admin config has been changed : "
+                + "From=" + prevConfigString + ", "
+                + "To=" + configData + ", "
+                + "[addminSessionId=0x"
+                + Long.toHexString(zk.getSessionId()) + "]");
+
+        String hostList = config[1];
+        listener.setZkConnectString(hostList);
+        try {
+          zk.updateServerList(hostList);
+        } catch (IOException e) {
+          getLogger().warn("IOException trying to updateServerList. retry later");
+        }
+        this.configVersion = version;
+        prevConfigString = configData;
+      } else {
+        getLogger().warn("Unexpected version. configVersion = "
+                + this.configVersion + ", version = " + version);
+      }
+    }
+  }
+
+  private void syncGetConfig() {
+    if (getLogger().isDebugEnabled()) {
+      getLogger().debug("Set a new watch on " + ZooDefs.CONFIG_NODE);
+    }
+
+    zk.sync(ZooDefs.CONFIG_NODE, null, null);
+    zk.getConfig(this, this, null);
+  }
+
+  /**
+   * Shutdown the ConfigMonitor.
+   */
+  public void shutdown() {
+    if (!dead) {
+      getLogger().info("Shutting down the ConfigMonitor. " + getInfo());
+      dead = true;
+      listener.closing();
+    }
+  }
+
+  /**
+   * Set config monitor is dead.
+   */
+  public void setDead() {
+    if (!dead) {
+      getLogger().info("Set ConfigMonitor is dead. " + getInfo());
+      dead = true;
+    }
+  }
+
+  /**
+   * Check if the config monitor is dead.
+   */
+  public boolean isDead() {
+    return dead;
+  }
+
+  private String getInfo() {
+    String zkSessionId = null;
+    if (zk != null) {
+      zkSessionId = "0x" + Long.toHexString(zk.getSessionId());
+    }
+    return "[adminSessionId=" + zkSessionId + "]";
+  }
+}


### PR DESCRIPTION
ZooKeeper dynamic reconfiguration 기능 지원을 위한 PR 입니다.

zookeeper library version을 3.4.14 에서 3.5.7로 업그레이드 했습니다.

zookeeper initialize 시점에 /zookeeper/config znode와 data를 조회하고
configMonitor class 생성을 enable/disable 합니다.
조회한 configuration data는 필요한 정보들을 parsing 하고 현재 version과 비교하여,
변경이 필요한 경우만 ZK server list를 업데이트 하도록 했습니다.

@hjyun328 @jhpark816 
확인 요청 드립니다.