### PR TITLE
CLEANUP: do not cancel the operations if it is first connecting

### DIFF
--- a/src/main/java/net/spy/memcached/MemcachedClient.java
+++ b/src/main/java/net/spy/memcached/MemcachedClient.java
@@ -1127,7 +1127,7 @@ public class MemcachedClient extends SpyThread
       // FIXME.  Support FailureMode.  See MemcachedConnection.addOperation.
       if (primaryNode == null) {
         node = null;
-      } else if (primaryNode.isActive()) {
+      } else if (primaryNode.isActive() || primaryNode.isFirstConnecting()) {
         node = primaryNode;
       } else {
         Iterator<MemcachedNode> iter = conn.getNodeSequence(key);

--- a/src/main/java/net/spy/memcached/MemcachedConnection.java
+++ b/src/main/java/net/spy/memcached/MemcachedConnection.java
@@ -1077,7 +1077,8 @@ public final class MemcachedConnection extends SpyObject {
     MemcachedNode primary = getPrimaryNode(key, o);
     if (primary == null) {
       o.cancel("no node");
-    } else if (primary.isActive() || failureMode == FailureMode.Retry) {
+    } else if (primary.isActive() || primary.isFirstConnecting() ||
+               failureMode == FailureMode.Retry) {
       placeIn = primary;
     } else if (failureMode == FailureMode.Cancel) {
       o.setHandlingNode(primary);
@@ -1249,7 +1250,8 @@ public final class MemcachedConnection extends SpyObject {
     // FIXME.  Support other FailureMode's.  See MemcachedConnection.addOperation.
     if (primary == null) {
       return null;
-    } else if (primary.isActive() || failureMode == FailureMode.Retry) {
+    } else if (primary.isActive() || primary.isFirstConnecting() ||
+               failureMode == FailureMode.Retry) {
       placeIn = primary;
     } else {
       Iterator<MemcachedNode> iter = getNodeSequence(key);

--- a/src/main/java/net/spy/memcached/MemcachedNode.java
+++ b/src/main/java/net/spy/memcached/MemcachedNode.java
@@ -152,6 +152,11 @@ public interface MemcachedNode {
   boolean isActive();
 
   /**
+   * True if it is the first connecting attempt.
+   */
+  boolean isFirstConnecting();
+
+  /**
    * Notify this node that it will be reconnecting.
    */
   void reconnecting();

--- a/src/main/java/net/spy/memcached/MemcachedNodeROImpl.java
+++ b/src/main/java/net/spy/memcached/MemcachedNodeROImpl.java
@@ -123,6 +123,10 @@ public class MemcachedNodeROImpl implements MemcachedNode {
     return root.isActive();
   }
 
+  public boolean isFirstConnecting() {
+    return root.isFirstConnecting();
+  }
+
   public void reconnecting() {
     throw new UnsupportedOperationException();
   }

--- a/src/main/java/net/spy/memcached/protocol/TCPMemcachedNodeImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/TCPMemcachedNodeImpl.java
@@ -58,6 +58,7 @@ public abstract class TCPMemcachedNodeImpl extends SpyObject
   // This has been declared volatile so it can be used as an availability
   // indicator.
   private volatile int reconnectAttempt = 1;
+  private boolean isFirstConnecting = true;
   private SocketChannel channel;
   private int toWrite = 0;
   protected Operation optimizedOp = null;
@@ -430,14 +431,20 @@ public abstract class TCPMemcachedNodeImpl extends SpyObject
     return reconnectAttempt == 0 && getChannel() != null && getChannel().isConnected();
   }
 
+  public final boolean isFirstConnecting() {
+    return isFirstConnecting;
+  }
+
   public final void reconnecting() {
     reconnectAttempt++;
+    isFirstConnecting = false;
     continuousTimeout.set(0);
     resetTimeoutRatioCount();
   }
 
   public final void connected() {
     reconnectAttempt = 0;
+    isFirstConnecting = false;
     continuousTimeout.set(0);
     resetTimeoutRatioCount();
   }

--- a/src/test/java/net/spy/memcached/MemcachedNodeROImplTest.java
+++ b/src/test/java/net/spy/memcached/MemcachedNodeROImplTest.java
@@ -29,7 +29,7 @@ public class MemcachedNodeROImplTest extends MockObjectTestCase {
     Set<String> acceptable = new HashSet<String>(Arrays.asList(
             "toString", "getSocketAddress", "getBytesRemainingToWrite",
             "getReconnectCount", "getSelectionOps", "hasReadOp",
-            "hasWriteOp", "isActive"));
+            "hasWriteOp", "isActive", "isFirstConnecting"));
 
     for (Method meth : MemcachedNode.class.getMethods()) {
       if (acceptable.contains(meth.getName())) {

--- a/src/test/java/net/spy/memcached/MockMemcachedNode.java
+++ b/src/test/java/net/spy/memcached/MockMemcachedNode.java
@@ -130,6 +130,10 @@ public class MockMemcachedNode implements MemcachedNode {
     return false;
   }
 
+  public boolean isFirstConnecting() {
+    return false;
+  }
+
   public void reconnecting() {
     // noop
   }


### PR DESCRIPTION
https://github.com/naver/arcus-java-client/issues/304 에 대한 PR입니다.
new connection이 생성되면 바로 해시링에 참여하고, 이러한 첫번째 접속 시도일 때는
connected 상태가 아니어도 connection에 연산이 삽입되도록 하였습니다.
만약 connected 상태가 되기전에 큐가 가득차게 된다면 queue overflow exception이 발생할 수 있습니다.