### PR TITLE
CLEANUP: change the return type Future to OperationFuture

### DIFF
--- a/src/main/java/net/spy/memcached/ArcusClient.java
+++ b/src/main/java/net/spy/memcached/ArcusClient.java
@@ -262,7 +262,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
    * @param serviceCode service code
    * @param cfb         ConnectionFactoryBuilder
    * @param poolSize    Arcus client pool size
-   * @param waitTimeFor Connect
+   * @param waitTimeForConnect Connect
    *                    waiting time for connection establishment(milliseconds)
    * @return multiple ArcusClient
    */
@@ -400,7 +400,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
     }
   }
 
-  Future<Boolean> asyncStore(StoreType storeType, String key, int exp, CachedData co) {
+  OperationFuture<Boolean> asyncStore(StoreType storeType, String key, int exp, CachedData co) {
     final CountDownLatch latch = new CountDownLatch(1);
     final OperationFuture<Boolean> rv = new OperationFuture<Boolean>(latch,
             operationTimeout);
@@ -1209,7 +1209,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
 
   @Deprecated
   @Override
-  public <T> Future<Map<String, CollectionOperationStatus>> asyncSetBulk(final List<String> key,
+  public <T> OperationFuture<Map<String, CollectionOperationStatus>> asyncSetBulk(final List<String> key,
                                                                          final int exp, final T o,
                                                                          Transcoder<T> tc) {
     if (key == null) {
@@ -1246,14 +1246,14 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
 
   @Deprecated
   @Override
-  public Future<Map<String, CollectionOperationStatus>> asyncSetBulk(List<String> key,
+  public OperationFuture<Map<String, CollectionOperationStatus>> asyncSetBulk(List<String> key,
                                                                      int exp, Object o) {
     return asyncSetBulk(key, exp, o, transcoder);
   }
 
   @Deprecated
   @Override
-  public <T> Future<Map<String, CollectionOperationStatus>> asyncSetBulk(final Map<String, T> o,
+  public <T> OperationFuture<Map<String, CollectionOperationStatus>> asyncSetBulk(final Map<String, T> o,
                                                                          final int exp,
                                                                          Transcoder<T> tc) {
     if (o == null) {
@@ -1290,14 +1290,14 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
 
   @Deprecated
   @Override
-  public Future<Map<String, CollectionOperationStatus>> asyncSetBulk(Map<String, Object> o,
+  public OperationFuture<Map<String, CollectionOperationStatus>> asyncSetBulk(Map<String, Object> o,
                                                                      int exp) {
     return asyncSetBulk(o, exp, transcoder);
   }
 
 
   @Override
-  public <T> Future<Map<String, OperationStatus>> asyncStoreBulk(final StoreType type,
+  public <T> OperationFuture<Map<String, OperationStatus>> asyncStoreBulk(final StoreType type,
                                                                  final List<String> key,
                                                                  final int exp, final T o,
                                                                  Transcoder<T> tc) {
@@ -1333,14 +1333,14 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
   }
 
   @Override
-  public Future<Map<String, OperationStatus>> asyncStoreBulk(StoreType type,
+  public OperationFuture<Map<String, OperationStatus>> asyncStoreBulk(StoreType type,
                                                              List<String> key,
                                                              int exp, Object o) {
     return asyncStoreBulk(type, key, exp, o, transcoder);
   }
 
   @Override
-  public <T> Future<Map<String, OperationStatus>> asyncStoreBulk(final StoreType type,
+  public <T> OperationFuture<Map<String, OperationStatus>> asyncStoreBulk(final StoreType type,
                                                                  final Map<String, T> o,
                                                                  final int exp,
                                                                  Transcoder<T> tc) {
@@ -1375,14 +1375,14 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
   }
 
   @Override
-  public Future<Map<String, OperationStatus>> asyncStoreBulk(StoreType type,
+  public OperationFuture<Map<String, OperationStatus>> asyncStoreBulk(StoreType type,
                                                              Map<String, Object> o,
                                                              int exp) {
     return asyncStoreBulk(type, o, exp, transcoder);
   }
 
   @Override
-  public Future<Map<String, OperationStatus>> asyncDeleteBulk(List<String> key) {
+  public OperationFuture<Map<String, OperationStatus>> asyncDeleteBulk(List<String> key) {
     if (key == null) {
       throw new IllegalArgumentException("Key list is null.");
     } else if (key.isEmpty()) {
@@ -1412,7 +1412,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
   }
 
   @Override
-  public Future<Map<String, OperationStatus>> asyncDeleteBulk(String... key) {
+  public OperationFuture<Map<String, OperationStatus>> asyncDeleteBulk(String... key) {
     if (key == null) {
       throw new IllegalArgumentException("Key list is null.");
     }

--- a/src/main/java/net/spy/memcached/ArcusClientIF.java
+++ b/src/main/java/net/spy/memcached/ArcusClientIF.java
@@ -189,7 +189,7 @@ public interface ArcusClientIF {
    * @param tc   the transcoder to serialize and unserialize the value
    * @return a future that will hold the list of failed
    */
-  public abstract <T> Future<Map<String, OperationStatus>> asyncStoreBulk(
+  public abstract <T> OperationFuture<Map<String, OperationStatus>> asyncStoreBulk(
           StoreType type, List<String> key, int exp, T o, Transcoder<T> tc);
 
   /**
@@ -201,7 +201,7 @@ public interface ArcusClientIF {
    * @param o    the object to store on each keys
    * @return a future that will hold the list of failed
    */
-  public abstract Future<Map<String, OperationStatus>> asyncStoreBulk(
+  public abstract OperationFuture<Map<String, OperationStatus>> asyncStoreBulk(
           StoreType type, List<String> key, int exp, Object o);
 
   /**
@@ -214,7 +214,7 @@ public interface ArcusClientIF {
    * @param tc   the transcoder to serialize and unserialize the value
    * @return a future that will hold the list of failed
    */
-  public abstract <T> Future<Map<String, OperationStatus>> asyncStoreBulk(
+  public abstract <T> OperationFuture<Map<String, OperationStatus>> asyncStoreBulk(
           StoreType type, Map<String, T> o, int exp, Transcoder<T> tc);
 
   /**
@@ -225,7 +225,7 @@ public interface ArcusClientIF {
    * @param exp  the expiration of this object
    * @return a future that will hold the list of failed
    */
-  public abstract Future<Map<String, OperationStatus>> asyncStoreBulk(
+  public abstract OperationFuture<Map<String, OperationStatus>> asyncStoreBulk(
           StoreType type, Map<String, Object> o, int exp);
 
   /**
@@ -247,7 +247,7 @@ public interface ArcusClientIF {
    * @return a future that will hold the list of failed
    *
    */
-  public abstract Future<Map<String, OperationStatus>> asyncDeleteBulk(
+  public abstract OperationFuture<Map<String, OperationStatus>> asyncDeleteBulk(
           List<String> key);
 
   /**
@@ -257,7 +257,7 @@ public interface ArcusClientIF {
    * @return a future that will hold the list of failed
    *
    */
-  public abstract Future<Map<String, OperationStatus>> asyncDeleteBulk(
+  public abstract OperationFuture<Map<String, OperationStatus>> asyncDeleteBulk(
           String... key);
 
 

--- a/src/main/java/net/spy/memcached/ArcusClientPool.java
+++ b/src/main/java/net/spy/memcached/ArcusClientPool.java
@@ -89,20 +89,20 @@ public class ArcusClientPool implements ArcusClientIF {
     }
   }
 
-  public Future<Boolean> append(long cas, String key, Object val) {
+  public OperationFuture<Boolean> append(long cas, String key, Object val) {
     return this.getClient().append(cas, key, val);
   }
 
-  public <T> Future<Boolean> append(long cas, String key, T val,
+  public <T> OperationFuture<Boolean> append(long cas, String key, T val,
                                     Transcoder<T> tc) {
     return this.getClient().append(cas, key, val, tc);
   }
 
-  public Future<Boolean> prepend(long cas, String key, Object val) {
+  public OperationFuture<Boolean> prepend(long cas, String key, Object val) {
     return this.getClient().prepend(cas, key, val);
   }
 
-  public <T> Future<Boolean> prepend(long cas, String key, T val,
+  public <T> OperationFuture<Boolean> prepend(long cas, String key, T val,
                                      Transcoder<T> tc) {
     return this.getClient().prepend(cas, key, val, tc);
   }
@@ -127,28 +127,28 @@ public class ArcusClientPool implements ArcusClientIF {
     return this.getClient().cas(key, casId, value);
   }
 
-  public <T> Future<Boolean> add(String key, int exp, T o, Transcoder<T> tc) {
+  public <T> OperationFuture<Boolean> add(String key, int exp, T o, Transcoder<T> tc) {
     return this.getClient().add(key, exp, o, tc);
   }
 
-  public Future<Boolean> add(String key, int exp, Object o) {
+  public OperationFuture<Boolean> add(String key, int exp, Object o) {
     return this.getClient().add(key, exp, o);
   }
 
-  public <T> Future<Boolean> set(String key, int exp, T o, Transcoder<T> tc) {
+  public <T> OperationFuture<Boolean> set(String key, int exp, T o, Transcoder<T> tc) {
     return this.getClient().set(key, exp, o, tc);
   }
 
-  public Future<Boolean> set(String key, int exp, Object o) {
+  public OperationFuture<Boolean> set(String key, int exp, Object o) {
     return this.getClient().set(key, exp, o);
   }
 
-  public <T> Future<Boolean> replace(String key, int exp, T o,
+  public <T> OperationFuture<Boolean> replace(String key, int exp, T o,
                                      Transcoder<T> tc) {
     return this.getClient().replace(key, exp, o, tc);
   }
 
-  public Future<Boolean> replace(String key, int exp, Object o) {
+  public OperationFuture<Boolean> replace(String key, int exp, Object o) {
     return this.getClient().replace(key, exp, o);
   }
 
@@ -269,23 +269,23 @@ public class ArcusClientPool implements ArcusClientIF {
     return this.getClient().decr(key, by, def, exp);
   }
 
-  public Future<Long> asyncIncr(String key, int by) {
+  public OperationFuture<Long> asyncIncr(String key, int by) {
     return this.getClient().asyncIncr(key, by);
   }
 
-  public Future<Long> asyncIncr(String key, int by, long def, int exp) {
+  public OperationFuture<Long> asyncIncr(String key, int by, long def, int exp) {
     return this.getClient().asyncIncr(key, by, def, exp);
   }
 
-  public Future<Long> asyncDecr(String key, int by) {
+  public OperationFuture<Long> asyncDecr(String key, int by) {
     return this.getClient().asyncDecr(key, by);
   }
 
-  public Future<Long> asyncDecr(String key, int by, long def, int exp) {
+  public OperationFuture<Long> asyncDecr(String key, int by, long def, int exp) {
     return this.getClient().asyncDecr(key, by, def, exp);
   }
 
-  public Future<Boolean> delete(String key) {
+  public OperationFuture<Boolean> delete(String key) {
     return this.getClient().delete(key);
   }
 
@@ -336,65 +336,65 @@ public class ArcusClientPool implements ArcusClientIF {
 
   @Deprecated
   @Override
-  public <T> Future<Map<String, CollectionOperationStatus>> asyncSetBulk(
+  public <T> OperationFuture<Map<String, CollectionOperationStatus>> asyncSetBulk(
           List<String> key, int exp, T o, Transcoder<T> tc) {
     return this.getClient().asyncSetBulk(key, exp, o, tc);
   }
 
   @Deprecated
   @Override
-  public Future<Map<String, CollectionOperationStatus>> asyncSetBulk(
+  public OperationFuture<Map<String, CollectionOperationStatus>> asyncSetBulk(
           List<String> key, int exp, Object o) {
     return this.getClient().asyncSetBulk(key, exp, o);
   }
 
   @Deprecated
   @Override
-  public <T> Future<Map<String, CollectionOperationStatus>> asyncSetBulk(
+  public <T> OperationFuture<Map<String, CollectionOperationStatus>> asyncSetBulk(
           Map<String, T> o, int exp, Transcoder<T> tc) {
     return this.getClient().asyncSetBulk(o, exp, tc);
   }
 
   @Deprecated
   @Override
-  public Future<Map<String, CollectionOperationStatus>> asyncSetBulk(
+  public OperationFuture<Map<String, CollectionOperationStatus>> asyncSetBulk(
           Map<String, Object> o, int exp) {
     return this.getClient().asyncSetBulk(o, exp);
   }
 
 
   @Override
-  public <T> Future<Map<String, OperationStatus>> asyncStoreBulk(
+  public <T> OperationFuture<Map<String, OperationStatus>> asyncStoreBulk(
           StoreType type, List<String> key, int exp, T o, Transcoder<T> tc) {
     return this.getClient().asyncStoreBulk(type, key, exp, o, tc);
   }
 
   @Override
-  public Future<Map<String, OperationStatus>> asyncStoreBulk(
+  public OperationFuture<Map<String, OperationStatus>> asyncStoreBulk(
           StoreType type, List<String> key, int exp, Object o) {
     return this.getClient().asyncStoreBulk(type, key, exp, o);
   }
 
   @Override
-  public <T> Future<Map<String, OperationStatus>> asyncStoreBulk(
+  public <T> OperationFuture<Map<String, OperationStatus>> asyncStoreBulk(
           StoreType type, Map<String, T> o, int exp, Transcoder<T> tc) {
     return this.getClient().asyncStoreBulk(type, o, exp, tc);
   }
 
   @Override
-  public Future<Map<String, OperationStatus>> asyncStoreBulk(
+  public OperationFuture<Map<String, OperationStatus>> asyncStoreBulk(
           StoreType type, Map<String, Object> o, int exp) {
     return this.getClient().asyncStoreBulk(type, o, exp);
   }
 
   @Override
-  public Future<Map<String, OperationStatus>> asyncDeleteBulk(
+  public OperationFuture<Map<String, OperationStatus>> asyncDeleteBulk(
           List<String> key) {
     return this.getClient().asyncDeleteBulk(key);
   }
 
   @Override
-  public Future<Map<String, OperationStatus>> asyncDeleteBulk(
+  public OperationFuture<Map<String, OperationStatus>> asyncDeleteBulk(
           String... key) {
     return this.getClient().asyncDeleteBulk(key);
   }

--- a/src/main/java/net/spy/memcached/MemcachedClient.java
+++ b/src/main/java/net/spy/memcached/MemcachedClient.java
@@ -347,7 +347,7 @@ public class MemcachedClient extends SpyThread
    * (internal use) Add a raw operation to a numbered connection.
    * This method is exposed for testing.
    *
-   * @param which server number
+   * @param key server number
    * @param op    the operation to perform
    * @return the Operation
    */
@@ -376,7 +376,7 @@ public class MemcachedClient extends SpyThread
     return conn.broadcastOperation(of, nodes);
   }
 
-  private <T> Future<Boolean> asyncStore(StoreType storeType, String key,
+  private <T> OperationFuture<Boolean> asyncStore(StoreType storeType, String key,
                                          int exp, T value, Transcoder<T> tc) {
     CachedData co = tc.encode(value);
     final CountDownLatch latch = new CountDownLatch(1);
@@ -402,7 +402,7 @@ public class MemcachedClient extends SpyThread
     return asyncStore(storeType, key, exp, value, transcoder);
   }
 
-  private <T> Future<Boolean> asyncCat(
+  private <T> OperationFuture<Boolean> asyncCat(
           ConcatenationType catType, long cas, String key,
           T value, Transcoder<T> tc) {
     CachedData co = tc.encode(value);
@@ -438,7 +438,7 @@ public class MemcachedClient extends SpyThread
    * @throws IllegalStateException in the rare circumstance where queue
    *                               is too full to accept any more requests
    */
-  public Future<Boolean> append(long cas, String key, Object val) {
+  public OperationFuture<Boolean> append(long cas, String key, Object val) {
     return append(cas, key, val, transcoder);
   }
 
@@ -457,7 +457,7 @@ public class MemcachedClient extends SpyThread
    * @throws IllegalStateException in the rare circumstance where queue
    *                               is too full to accept any more requests
    */
-  public <T> Future<Boolean> append(long cas, String key, T val,
+  public <T> OperationFuture<Boolean> append(long cas, String key, T val,
                                     Transcoder<T> tc) {
     return asyncCat(ConcatenationType.append, cas, key, val, tc);
   }
@@ -475,7 +475,7 @@ public class MemcachedClient extends SpyThread
    * @throws IllegalStateException in the rare circumstance where queue
    *                               is too full to accept any more requests
    */
-  public Future<Boolean> prepend(long cas, String key, Object val) {
+  public OperationFuture<Boolean> prepend(long cas, String key, Object val) {
     return prepend(cas, key, val, transcoder);
   }
 
@@ -494,7 +494,7 @@ public class MemcachedClient extends SpyThread
    * @throws IllegalStateException in the rare circumstance where queue
    *                               is too full to accept any more requests
    */
-  public <T> Future<Boolean> prepend(long cas, String key, T val,
+  public <T> OperationFuture<Boolean> prepend(long cas, String key, T val,
                                      Transcoder<T> tc) {
     return asyncCat(ConcatenationType.prepend, cas, key, val, tc);
   }
@@ -698,7 +698,7 @@ public class MemcachedClient extends SpyThread
    * @throws IllegalStateException in the rare circumstance where queue
    *                               is too full to accept any more requests
    */
-  public <T> Future<Boolean> add(String key, int exp, T o, Transcoder<T> tc) {
+  public <T> OperationFuture<Boolean> add(String key, int exp, T o, Transcoder<T> tc) {
     return asyncStore(StoreType.add, key, exp, o, tc);
   }
 
@@ -733,7 +733,7 @@ public class MemcachedClient extends SpyThread
    * @throws IllegalStateException in the rare circumstance where queue
    *                               is too full to accept any more requests
    */
-  public Future<Boolean> add(String key, int exp, Object o) {
+  public OperationFuture<Boolean> add(String key, int exp, Object o) {
     return asyncStore(StoreType.add, key, exp, o, transcoder);
   }
 
@@ -769,7 +769,7 @@ public class MemcachedClient extends SpyThread
    * @throws IllegalStateException in the rare circumstance where queue
    *                               is too full to accept any more requests
    */
-  public <T> Future<Boolean> set(String key, int exp, T o, Transcoder<T> tc) {
+  public <T> OperationFuture<Boolean> set(String key, int exp, T o, Transcoder<T> tc) {
     return asyncStore(StoreType.set, key, exp, o, tc);
   }
 
@@ -804,7 +804,7 @@ public class MemcachedClient extends SpyThread
    * @throws IllegalStateException in the rare circumstance where queue
    *                               is too full to accept any more requests
    */
-  public Future<Boolean> set(String key, int exp, Object o) {
+  public OperationFuture<Boolean> set(String key, int exp, Object o) {
     return asyncStore(StoreType.set, key, exp, o, transcoder);
   }
 
@@ -841,7 +841,7 @@ public class MemcachedClient extends SpyThread
    * @throws IllegalStateException in the rare circumstance where queue
    *                               is too full to accept any more requests
    */
-  public <T> Future<Boolean> replace(String key, int exp, T o,
+  public <T> OperationFuture<Boolean> replace(String key, int exp, T o,
                                      Transcoder<T> tc) {
     return asyncStore(StoreType.replace, key, exp, o, tc);
   }
@@ -877,7 +877,7 @@ public class MemcachedClient extends SpyThread
    * @throws IllegalStateException in the rare circumstance where queue
    *                               is too full to accept any more requests
    */
-  public Future<Boolean> replace(String key, int exp, Object o) {
+  public OperationFuture<Boolean> replace(String key, int exp, Object o) {
     return asyncStore(StoreType.replace, key, exp, o, transcoder);
   }
 
@@ -946,7 +946,7 @@ public class MemcachedClient extends SpyThread
    * @throws IllegalStateException in the rare circumstance where queue
    *                               is too full to accept any more requests
    */
-  public <T> Future<CASValue<T>> asyncGets(final String key,
+  public <T> OperationFuture<CASValue<T>> asyncGets(final String key,
                                            final Transcoder<T> tc) {
 
     final CountDownLatch latch = new CountDownLatch(1);
@@ -986,7 +986,7 @@ public class MemcachedClient extends SpyThread
    * @throws IllegalStateException in the rare circumstance where queue
    *                               is too full to accept any more requests
    */
-  public Future<CASValue<Object>> asyncGets(final String key) {
+  public OperationFuture<CASValue<Object>> asyncGets(final String key) {
     return asyncGets(key, transcoder);
   }
 
@@ -1560,7 +1560,7 @@ public class MemcachedClient extends SpyThread
     return rv;
   }
 
-  private Future<Long> asyncMutate(Mutator m, String key, int by, long def,
+  private OperationFuture<Long> asyncMutate(Mutator m, String key, int by, long def,
                                    int exp) {
     final CountDownLatch latch = new CountDownLatch(1);
     final OperationFuture<Long> rv = new OperationFuture<Long>(
@@ -1589,7 +1589,7 @@ public class MemcachedClient extends SpyThread
    * @throws IllegalStateException in the rare circumstance where queue
    *                               is too full to accept any more requests
    */
-  public Future<Long> asyncIncr(String key, int by) {
+  public OperationFuture<Long> asyncIncr(String key, int by) {
     return asyncMutate(Mutator.incr, key, by, -1, 0);
   }
 
@@ -1605,7 +1605,7 @@ public class MemcachedClient extends SpyThread
    * @throws IllegalStateException in the rare circumstance where queue
    *                               is too full to accept any more requests
    */
-  public Future<Long> asyncIncr(String key, int by, long def, int exp) {
+  public OperationFuture<Long> asyncIncr(String key, int by, long def, int exp) {
     return asyncMutate(Mutator.incr, key, by, def, exp);
   }
 
@@ -1619,7 +1619,7 @@ public class MemcachedClient extends SpyThread
    * @throws IllegalStateException in the rare circumstance where queue
    *                               is too full to accept any more requests
    */
-  public Future<Long> asyncDecr(String key, int by) {
+  public OperationFuture<Long> asyncDecr(String key, int by) {
     return asyncMutate(Mutator.decr, key, by, -1, 0);
   }
 
@@ -1635,7 +1635,7 @@ public class MemcachedClient extends SpyThread
    * @throws IllegalStateException in the rare circumstance where queue
    *                               is too full to accept any more requests
    */
-  public Future<Long> asyncDecr(String key, int by, long def, int exp) {
+  public OperationFuture<Long> asyncDecr(String key, int by, long def, int exp) {
     return asyncMutate(Mutator.decr, key, by, def, exp);
   }
 
@@ -1690,7 +1690,7 @@ public class MemcachedClient extends SpyThread
    * @deprecated Hold values are no longer honored.
    */
   @Deprecated
-  public Future<Boolean> delete(String key, int hold) {
+  public OperationFuture<Boolean> delete(String key, int hold) {
     return delete(key);
   }
 
@@ -1702,7 +1702,7 @@ public class MemcachedClient extends SpyThread
    * @throws IllegalStateException in the rare circumstance where queue
    *                               is too full to accept any more requests
    */
-  public Future<Boolean> delete(String key) {
+  public OperationFuture<Boolean> delete(String key) {
     final CountDownLatch latch = new CountDownLatch(1);
     final OperationFuture<Boolean> rv = new OperationFuture<Boolean>(latch,
             operationTimeout);

--- a/src/main/java/net/spy/memcached/MemcachedClientIF.java
+++ b/src/main/java/net/spy/memcached/MemcachedClientIF.java
@@ -9,6 +9,7 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
 import net.spy.memcached.internal.BulkFuture;
+import net.spy.memcached.internal.OperationFuture;
 import net.spy.memcached.transcoders.Transcoder;
 
 /**
@@ -28,14 +29,14 @@ public interface MemcachedClientIF {
 
   NodeLocator getNodeLocator();
 
-  Future<Boolean> append(long cas, String key, Object val);
+  OperationFuture<Boolean> append(long cas, String key, Object val);
 
-  <T> Future<Boolean> append(long cas, String key, T val,
+  <T> OperationFuture<Boolean> append(long cas, String key, T val,
                              Transcoder<T> tc);
 
-  Future<Boolean> prepend(long cas, String key, Object val);
+  OperationFuture<Boolean> prepend(long cas, String key, Object val);
 
-  <T> Future<Boolean> prepend(long cas, String key, T val,
+  <T> OperationFuture<Boolean> prepend(long cas, String key, T val,
                               Transcoder<T> tc);
 
   <T> Future<CASResponse> asyncCAS(String key, long casId, T value,
@@ -60,27 +61,27 @@ public interface MemcachedClientIF {
   CASResponse cas(String key, long casId, Object value)
           throws OperationTimeoutException;
 
-  <T> Future<Boolean> add(String key, int exp, T o, Transcoder<T> tc);
+  <T> OperationFuture<Boolean> add(String key, int exp, T o, Transcoder<T> tc);
 
-  Future<Boolean> add(String key, int exp, Object o);
+  OperationFuture<Boolean> add(String key, int exp, Object o);
 
-  <T> Future<Boolean> set(String key, int exp, T o, Transcoder<T> tc);
+  <T> OperationFuture<Boolean> set(String key, int exp, T o, Transcoder<T> tc);
 
-  Future<Boolean> set(String key, int exp, Object o);
+  OperationFuture<Boolean> set(String key, int exp, Object o);
 
-  <T> Future<Boolean> replace(String key, int exp, T o,
+  <T> OperationFuture<Boolean> replace(String key, int exp, T o,
                               Transcoder<T> tc);
 
-  Future<Boolean> replace(String key, int exp, Object o);
+  OperationFuture<Boolean> replace(String key, int exp, Object o);
 
   <T> Future<T> asyncGet(String key, Transcoder<T> tc);
 
   Future<Object> asyncGet(String key);
 
-  <T> Future<CASValue<T>> asyncGets(String key,
+  <T> OperationFuture<CASValue<T>> asyncGets(String key,
                                     Transcoder<T> tc);
 
-  Future<CASValue<Object>> asyncGets(String key);
+  OperationFuture<CASValue<Object>> asyncGets(String key);
 
   <T> CASValue<T> gets(String key, Transcoder<T> tc)
           throws OperationTimeoutException;
@@ -133,13 +134,13 @@ public interface MemcachedClientIF {
   long decr(String key, int by, long def, int exp)
           throws OperationTimeoutException;
 
-  Future<Long> asyncIncr(String key, int by);
+  OperationFuture<Long> asyncIncr(String key, int by);
 
-  Future<Long> asyncIncr(String key, int by, long def, int exp);
+  OperationFuture<Long> asyncIncr(String key, int by, long def, int exp);
 
-  Future<Long> asyncDecr(String key, int by);
+  OperationFuture<Long> asyncDecr(String key, int by);
 
-  Future<Long> asyncDecr(String key, int by, long def, int exp);
+  OperationFuture<Long> asyncDecr(String key, int by, long def, int exp);
 
   long incr(String key, int by, long def)
           throws OperationTimeoutException;
@@ -147,7 +148,7 @@ public interface MemcachedClientIF {
   long decr(String key, int by, long def)
           throws OperationTimeoutException;
 
-  Future<Boolean> delete(String key);
+  OperationFuture<Boolean> delete(String key);
 
   Future<Boolean> flush(int delay);
 

--- a/src/main/java/net/spy/memcached/plugin/FrontCacheMemcachedClient.java
+++ b/src/main/java/net/spy/memcached/plugin/FrontCacheMemcachedClient.java
@@ -24,6 +24,7 @@ import java.util.concurrent.Future;
 import net.sf.ehcache.Element;
 import net.spy.memcached.ConnectionFactory;
 import net.spy.memcached.MemcachedClient;
+import net.spy.memcached.internal.OperationFuture;
 import net.spy.memcached.transcoders.Transcoder;
 
 /**
@@ -96,7 +97,7 @@ public class FrontCacheMemcachedClient extends MemcachedClient {
    * @return a future that will hold success/error status of the operation
    */
   @Override
-  public Future<Boolean> delete(String key) {
+  public OperationFuture<Boolean> delete(String key) {
     if (localCacheManager != null) {
       localCacheManager.delete(key);
     }


### PR DESCRIPTION
#226에 대한 pr입니다.

[Key-Value Item 연산](https://github.com/naver/arcus-java-client/blob/master/docs/arcus-java-client-user-guide.md) API 목록을 참고하여 key-value 연산들의 반환 타입인 Future을 OperationFuture로 변경하였습니다.
인터페이스를 제외한 구현클래스의 반환타입을 모두 변경하였습니다.
인터페이스의 반환타입을 변경하지 않은 이유는 Mock을 이용한 테스트에 오류가 발생하여 테스트가 실패하는 문제가 발생했기 때문입니다.
해당 문제를 해결하기 위하여 spymemcached를 참고하였고, spymemcached에서도 OperationFuture의 반환 타입은 구현 클래스에서만 적용이 되어 있었습니다.

아래는 참고한 spymemcached의 내용 중 일부입니다.

```java
Future<Boolean> set(String key, int exp, Object o);

Future<Boolean> set(String key, int exp, Object o);
```

```java
@Override
 public OperationFuture<Boolean> set(String key, int exp, Object o) {
   return asyncStore(StoreType.set, key, exp, o, transcoder);
 }

@Override
 public OperationFuture<Boolean> replace(String key, int exp, Object o) {
   return asyncStore(StoreType.replace, key, exp, o, transcoder);
 }
```