### PR TITLE
CLEANUP: change the return type Future to OperationFuture

### DIFF
--- a/checkstyle-suppressions.xml
+++ b/checkstyle-suppressions.xml
@@ -6,4 +6,5 @@
 
 <suppressions>
     <suppress checks="LineLength" files="OperationType\.java"/>
+    <suppress checks="LineLength" files="ArcusClient.java" />
 </suppressions>

--- a/docs/03-key-value-API.md
+++ b/docs/03-key-value-API.md
@@ -19,9 +19,9 @@ Key-value item에 대해 수행가능한 연산들은 아래와 같다.
 key-value item을 저장하는 API로 set, add, replace를 제공한다.
 
 ```java
-Future<Boolean> set(String key, int exp, Object obj)
-Future<Boolean> add(String key, int exp, Object obj)
-Future<Boolean> replace(String key, int exp, Object obj)
+OperationFuture<Boolean> set(String key, int exp, Object obj)
+OperationFuture<Boolean> add(String key, int exp, Object obj)
+OperationFuture<Boolean> replace(String key, int exp, Object obj)
 ```
 
 - \<key, obj\>의 key-value item을 저장한다.
@@ -31,11 +31,18 @@ Future<Boolean> replace(String key, int exp, Object obj)
   - replace는 해당 key가 있을 경우만, \<key, obj\> item을 교체하여 저장한다.
 - 저장된 key-value item은 exp 초 이후에 삭제된다.
 
+수행 결과는 future 객체를 통해 얻는다.
+
+future.getStatus().getStatusCode()          | 설명
+--------------------------------------------| ---------
+StatusCode.SUCCESS                          | 저장 성공
+StatusCode.ERR_NOT_STORED                   | 저장 실패 (add : 이미 존재하는 key, replace : 주어진 key에 해당하는 item이 없음)
+
 key-vlaue item에 주어진 value를 추가하는 API로 prepend, append를 제공한다.
 
 ```java
-Future<Boolean> prepend(long cas, String key, Object val)
-Future<Boolean> append(long cas, String key, Object val)
+OperationFuture<Boolean> prepend(long cas, String key, Object val)
+OperationFuture<Boolean> append(long cas, String key, Object val)
 ```
 
 - key-value item에서 value 추가 위치는 API에 따라 다르다.
@@ -43,6 +50,14 @@ Future<Boolean> append(long cas, String key, Object val)
   - append는 item의 value 부분에서 가장 뒤쪽에 추가한다.
 - 첫째 인자인 cas는 현재 이용되지 않으므로 임의의 값을 주면 된다.
   초기에 CAS(compare-and-set) 연산으로 수행하기 위한 용도로 필요했던 인자이다.
+
+수행 결과는 future 객체를 통해 얻는다.
+
+future.getStatus().getStatusCode()          | 설명
+--------------------------------------------| ---------
+StatusCode.SUCCESS                          | 저장 성공
+StatusCode.ERR_NOT_STORED                   | 저장 실패 (주어진 key에 해당하는 item이 없음)  
+
 
 한번의 API 호출로 다수의 key-value items을 set하는 bulk API를 제공한다.
 
@@ -80,21 +95,26 @@ StatusCode.ERR_EXISTS           | 동일 key가 이미 존재함
 하나의 key를 가진 cache item에 저장된 value를 조회하는 API를 제공한다.
 
 ```java
-Future<Object> asyncGet(String key)
+GetFuture<Object> asyncGet(String key)
 ```
 
 - 주어진 key에 저장된 value를 반환한다.
 
+수행 결과는 future 객체를 통해 얻는다.
+
+future.get(key).getStatusCode() | 설명
+--------------------------------| ---------
+StatusCode.SUCCESS              | 조회 성공(key에 해당하는 item 존재하지 않아도 성공)
+
 여러 key들의 value들을 한번에 조회하는 bulk API를 제공한다.
 
 ```java
-Future<Map<String,Object>> asyncGetBulk(Collection<String> keys)
-Future<Map<String,Object>> asyncGetBulk(String... keys)
+BulkFuture<Map<String,Object>> asyncGetBulk(Collection<String> keys)
+BulkFuture<Map<String,Object>> asyncGetBulk(String... keys)
 ```
 
 - 다수 key들에 저장된 value를 Map<String, Object> 형태로 반환한다.
 - 다수 key들은 String 유형의 Collection이거나 String 유형의 나열된 key 목록일 수 있다.
-
 
 ## Key-Value Item 값의 증감
 
@@ -103,23 +123,29 @@ key-value item에서 value 부분의 값을 증가시키거나 감소시키는 �
 
 
 ```java
-Future<Long> asyncIncr(String key, int by)
-Future<Long> asyncDecr(String key, int by)
+OperationFuture<Long> asyncIncr(String key, int by)
+OperationFuture<Long> asyncDecr(String key, int by)
 ```
 
 - key에 저장된 정수형 데이터의 값을 by 만큼 증가/감소시킨다.
   key가 cache에 존재하지 않으면 증감연산은 수행되지 않는다.
 - 반환되는 값은 증감 후의 값이다. 
 
-
 ```java
-Future<Long> asyncIncr(String key, int by, long def, int exp)
-Future<Long> asyncDecr(String key, int by, long def, int exp)
+OperationFuture<Long> asyncIncr(String key, int by, long def, int exp)
+OperationFuture<Long> asyncDecr(String key, int by, long def, int exp)
 ```
 
 - key에 저장된 정수형 데이터의 값을 by 만큼 증가/감소시킨다.
   key가 cache에 존재하지 않으면 \<key, def\> item을 추가하며, exp 초 이후에 삭제된다.
 - 반환되는 값은 증감 후의 값이다.
+
+수행 결과는 future 객체를 통해 얻는다.
+
+future.getStatus().getStatusCode()          | 설명
+--------------------------------------------| ---------
+StatusCode.SUCCESS                          | 증감 성공
+StatusCode.ERR_NOT_FOUND                    | 증감 실패 (Key miss, 주어진 key에 해당하는 item이 없음)
 
 
 ## Key-Value Item 삭제
@@ -128,10 +154,17 @@ Future<Long> asyncDecr(String key, int by, long def, int exp)
 여러 key들의 item들을 한번에 삭제하는 bulk API를 제공한다.
 
 ```java
-Future<Boolean> delete(String key)
+OperationFuture<Boolean> delete(String key)
 ```
 
 - 주어진 key를 가진 item을 cache에서 삭제한다.
+
+수행 결과는 future 객체를 통해 얻는다.
+
+future.getStatus().getStatusCode()          | 설명
+--------------------------------------------| ---------
+StatusCode.SUCCESS                          | 삭제 성공
+StatusCode.ERR_NOT_FOUND                    | 삭제 실패 (Key miss, 주어진 key에 해당하는 item이 없음)
  
 ```java
 Future<Map<String, OperationStatus>> asyncDeleteBulk(List<String> key)
@@ -143,6 +176,6 @@ Future<Map<String, OperationStatus>> asyncDeleteBulk(String... key)
 
 delete 실패한 키와 실패 원인은 future 객체를 통해 Map 형태로 조회할 수 있다.
 
-future.get(key).getStatusCode() | 설명
---------------------------------| ---------
-StatusCode.ERR_NOT_FOUND        | Key miss (주어진 key에 해당하는 item이 없음)
+future.get().get(key).getStatusCode() | 설명
+--------------------------------------| ---------
+StatusCode.ERR_NOT_FOUND              | 삭제 실패 (Key miss, 주어진 key에 해당하는 item이 없음)

--- a/src/main/java/net/spy/memcached/ArcusClient.java
+++ b/src/main/java/net/spy/memcached/ArcusClient.java
@@ -400,7 +400,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
     }
   }
 
-  Future<Boolean> asyncStore(StoreType storeType, String key, int exp, CachedData co) {
+  OperationFuture<Boolean> asyncStore(StoreType storeType, String key, int exp, CachedData co) {
     final CountDownLatch latch = new CountDownLatch(1);
     final OperationFuture<Boolean> rv = new OperationFuture<Boolean>(latch,
             operationTimeout);

--- a/src/main/java/net/spy/memcached/ArcusClientPool.java
+++ b/src/main/java/net/spy/memcached/ArcusClientPool.java
@@ -44,6 +44,7 @@ import net.spy.memcached.internal.CollectionFuture;
 import net.spy.memcached.internal.CollectionGetBulkFuture;
 import net.spy.memcached.internal.OperationFuture;
 import net.spy.memcached.internal.SMGetFuture;
+import net.spy.memcached.internal.GetFuture;
 import net.spy.memcached.ops.CollectionOperationStatus;
 import net.spy.memcached.ops.OperationStatus;
 import net.spy.memcached.ops.StoreType;
@@ -89,30 +90,30 @@ public class ArcusClientPool implements ArcusClientIF {
     }
   }
 
-  public Future<Boolean> append(long cas, String key, Object val) {
+  public OperationFuture<Boolean> append(long cas, String key, Object val) {
     return this.getClient().append(cas, key, val);
   }
 
-  public <T> Future<Boolean> append(long cas, String key, T val,
-                                    Transcoder<T> tc) {
+  public <T> OperationFuture<Boolean> append(long cas, String key, T val,
+                                             Transcoder<T> tc) {
     return this.getClient().append(cas, key, val, tc);
   }
 
-  public Future<Boolean> prepend(long cas, String key, Object val) {
+  public OperationFuture<Boolean> prepend(long cas, String key, Object val) {
     return this.getClient().prepend(cas, key, val);
   }
 
-  public <T> Future<Boolean> prepend(long cas, String key, T val,
-                                     Transcoder<T> tc) {
+  public <T> OperationFuture<Boolean> prepend(long cas, String key, T val,
+                                              Transcoder<T> tc) {
     return this.getClient().prepend(cas, key, val, tc);
   }
 
-  public <T> Future<CASResponse> asyncCAS(String key, long casId, T value,
-                                          Transcoder<T> tc) {
+  public <T> OperationFuture<CASResponse> asyncCAS(String key, long casId, T value,
+                                                   Transcoder<T> tc) {
     return this.getClient().asyncCAS(key, casId, value, tc);
   }
 
-  public Future<CASResponse> asyncCAS(String key, long casId, Object value) {
+  public OperationFuture<CASResponse> asyncCAS(String key, long casId, Object value) {
 
     return this.getClient().asyncCAS(key, casId, value);
   }
@@ -127,44 +128,44 @@ public class ArcusClientPool implements ArcusClientIF {
     return this.getClient().cas(key, casId, value);
   }
 
-  public <T> Future<Boolean> add(String key, int exp, T o, Transcoder<T> tc) {
+  public <T> OperationFuture<Boolean> add(String key, int exp, T o, Transcoder<T> tc) {
     return this.getClient().add(key, exp, o, tc);
   }
 
-  public Future<Boolean> add(String key, int exp, Object o) {
+  public OperationFuture<Boolean> add(String key, int exp, Object o) {
     return this.getClient().add(key, exp, o);
   }
 
-  public <T> Future<Boolean> set(String key, int exp, T o, Transcoder<T> tc) {
+  public <T> OperationFuture<Boolean> set(String key, int exp, T o, Transcoder<T> tc) {
     return this.getClient().set(key, exp, o, tc);
   }
 
-  public Future<Boolean> set(String key, int exp, Object o) {
+  public OperationFuture<Boolean> set(String key, int exp, Object o) {
     return this.getClient().set(key, exp, o);
   }
 
-  public <T> Future<Boolean> replace(String key, int exp, T o,
-                                     Transcoder<T> tc) {
+  public <T> OperationFuture<Boolean> replace(String key, int exp, T o,
+                                              Transcoder<T> tc) {
     return this.getClient().replace(key, exp, o, tc);
   }
 
-  public Future<Boolean> replace(String key, int exp, Object o) {
+  public OperationFuture<Boolean> replace(String key, int exp, Object o) {
     return this.getClient().replace(key, exp, o);
   }
 
-  public <T> Future<T> asyncGet(String key, Transcoder<T> tc) {
+  public <T> GetFuture<T> asyncGet(String key, Transcoder<T> tc) {
     return this.getClient().asyncGet(key, tc);
   }
 
-  public Future<Object> asyncGet(String key) {
+  public GetFuture<Object> asyncGet(String key) {
     return this.getClient().asyncGet(key);
   }
 
-  public <T> Future<CASValue<T>> asyncGets(String key, Transcoder<T> tc) {
+  public <T> OperationFuture<CASValue<T>> asyncGets(String key, Transcoder<T> tc) {
     return this.getClient().asyncGets(key, tc);
   }
 
-  public Future<CASValue<Object>> asyncGets(String key) {
+  public OperationFuture<CASValue<Object>> asyncGets(String key) {
     return this.getClient().asyncGets(key);
   }
 
@@ -269,23 +270,23 @@ public class ArcusClientPool implements ArcusClientIF {
     return this.getClient().decr(key, by, def, exp);
   }
 
-  public Future<Long> asyncIncr(String key, int by) {
+  public OperationFuture<Long> asyncIncr(String key, int by) {
     return this.getClient().asyncIncr(key, by);
   }
 
-  public Future<Long> asyncIncr(String key, int by, long def, int exp) {
+  public OperationFuture<Long> asyncIncr(String key, int by, long def, int exp) {
     return this.getClient().asyncIncr(key, by, def, exp);
   }
 
-  public Future<Long> asyncDecr(String key, int by) {
+  public OperationFuture<Long> asyncDecr(String key, int by) {
     return this.getClient().asyncDecr(key, by);
   }
 
-  public Future<Long> asyncDecr(String key, int by, long def, int exp) {
+  public OperationFuture<Long> asyncDecr(String key, int by, long def, int exp) {
     return this.getClient().asyncDecr(key, by, def, exp);
   }
 
-  public Future<Boolean> delete(String key) {
+  public OperationFuture<Boolean> delete(String key) {
     return this.getClient().delete(key);
   }
 

--- a/src/main/java/net/spy/memcached/MemcachedClient.java
+++ b/src/main/java/net/spy/memcached/MemcachedClient.java
@@ -376,8 +376,8 @@ public class MemcachedClient extends SpyThread
     return conn.broadcastOperation(of, nodes);
   }
 
-  private <T> Future<Boolean> asyncStore(StoreType storeType, String key,
-                                         int exp, T value, Transcoder<T> tc) {
+  private <T> OperationFuture<Boolean> asyncStore(StoreType storeType, String key,
+                                                  int exp, T value, Transcoder<T> tc) {
     CachedData co = tc.encode(value);
     final CountDownLatch latch = new CountDownLatch(1);
     final OperationFuture<Boolean> rv = new OperationFuture<Boolean>(latch,
@@ -397,12 +397,12 @@ public class MemcachedClient extends SpyThread
     return rv;
   }
 
-  private Future<Boolean> asyncStore(StoreType storeType,
-                                     String key, int exp, Object value) {
+  private OperationFuture<Boolean> asyncStore(StoreType storeType,
+                                              String key, int exp, Object value) {
     return asyncStore(storeType, key, exp, value, transcoder);
   }
 
-  private <T> Future<Boolean> asyncCat(
+  private <T> OperationFuture<Boolean> asyncCat(
           ConcatenationType catType, long cas, String key,
           T value, Transcoder<T> tc) {
     CachedData co = tc.encode(value);
@@ -438,7 +438,7 @@ public class MemcachedClient extends SpyThread
    * @throws IllegalStateException in the rare circumstance where queue
    *                               is too full to accept any more requests
    */
-  public Future<Boolean> append(long cas, String key, Object val) {
+  public OperationFuture<Boolean> append(long cas, String key, Object val) {
     return append(cas, key, val, transcoder);
   }
 
@@ -457,8 +457,8 @@ public class MemcachedClient extends SpyThread
    * @throws IllegalStateException in the rare circumstance where queue
    *                               is too full to accept any more requests
    */
-  public <T> Future<Boolean> append(long cas, String key, T val,
-                                    Transcoder<T> tc) {
+  public <T> OperationFuture<Boolean> append(long cas, String key, T val,
+                                             Transcoder<T> tc) {
     return asyncCat(ConcatenationType.append, cas, key, val, tc);
   }
 
@@ -475,7 +475,7 @@ public class MemcachedClient extends SpyThread
    * @throws IllegalStateException in the rare circumstance where queue
    *                               is too full to accept any more requests
    */
-  public Future<Boolean> prepend(long cas, String key, Object val) {
+  public OperationFuture<Boolean> prepend(long cas, String key, Object val) {
     return prepend(cas, key, val, transcoder);
   }
 
@@ -494,8 +494,8 @@ public class MemcachedClient extends SpyThread
    * @throws IllegalStateException in the rare circumstance where queue
    *                               is too full to accept any more requests
    */
-  public <T> Future<Boolean> prepend(long cas, String key, T val,
-                                     Transcoder<T> tc) {
+  public <T> OperationFuture<Boolean> prepend(long cas, String key, T val,
+                                              Transcoder<T> tc) {
     return asyncCat(ConcatenationType.prepend, cas, key, val, tc);
   }
 
@@ -511,8 +511,8 @@ public class MemcachedClient extends SpyThread
    * @throws IllegalStateException in the rare circumstance where queue
    *                               is too full to accept any more requests
    */
-  public <T> Future<CASResponse> asyncCAS(String key, long casId, T value,
-                                          Transcoder<T> tc) {
+  public <T> OperationFuture<CASResponse> asyncCAS(String key, long casId, T value,
+                                                   Transcoder<T> tc) {
     return asyncCAS(key, casId, 0, value, tc);
   }
 
@@ -529,8 +529,8 @@ public class MemcachedClient extends SpyThread
    * @throws IllegalStateException in the rare circumstance where queue
    *                               is too full to accept any more requests
    */
-  public <T> Future<CASResponse> asyncCAS(String key, long casId, int exp, T value,
-                                          Transcoder<T> tc) {
+  public <T> OperationFuture<CASResponse> asyncCAS(String key, long casId, int exp, T value,
+                                                   Transcoder<T> tc) {
     CachedData co = tc.encode(value);
     final CountDownLatch latch = new CountDownLatch(1);
     final OperationFuture<CASResponse> rv = new OperationFuture<CASResponse>(
@@ -566,7 +566,7 @@ public class MemcachedClient extends SpyThread
    * @throws IllegalStateException in the rare circumstance where queue
    *                               is too full to accept any more requests
    */
-  public Future<CASResponse> asyncCAS(String key, long casId, Object value) {
+  public OperationFuture<CASResponse> asyncCAS(String key, long casId, Object value) {
     return asyncCAS(key, casId, value, transcoder);
   }
 
@@ -581,8 +581,8 @@ public class MemcachedClient extends SpyThread
    * @throws IllegalStateException in the rare circumstance where queue is too
    *                               full to accept any more requests
    */
-  public Future<CASResponse> asyncCAS(String key, long casId,
-                                      int exp, Object value) {
+  public OperationFuture<CASResponse> asyncCAS(String key, long casId,
+                                               int exp, Object value) {
     return asyncCAS(key, casId, exp, value, transcoder);
   }
 
@@ -698,7 +698,7 @@ public class MemcachedClient extends SpyThread
    * @throws IllegalStateException in the rare circumstance where queue
    *                               is too full to accept any more requests
    */
-  public <T> Future<Boolean> add(String key, int exp, T o, Transcoder<T> tc) {
+  public <T> OperationFuture<Boolean> add(String key, int exp, T o, Transcoder<T> tc) {
     return asyncStore(StoreType.add, key, exp, o, tc);
   }
 
@@ -733,7 +733,7 @@ public class MemcachedClient extends SpyThread
    * @throws IllegalStateException in the rare circumstance where queue
    *                               is too full to accept any more requests
    */
-  public Future<Boolean> add(String key, int exp, Object o) {
+  public OperationFuture<Boolean> add(String key, int exp, Object o) {
     return asyncStore(StoreType.add, key, exp, o, transcoder);
   }
 
@@ -769,7 +769,7 @@ public class MemcachedClient extends SpyThread
    * @throws IllegalStateException in the rare circumstance where queue
    *                               is too full to accept any more requests
    */
-  public <T> Future<Boolean> set(String key, int exp, T o, Transcoder<T> tc) {
+  public <T> OperationFuture<Boolean> set(String key, int exp, T o, Transcoder<T> tc) {
     return asyncStore(StoreType.set, key, exp, o, tc);
   }
 
@@ -804,7 +804,7 @@ public class MemcachedClient extends SpyThread
    * @throws IllegalStateException in the rare circumstance where queue
    *                               is too full to accept any more requests
    */
-  public Future<Boolean> set(String key, int exp, Object o) {
+  public OperationFuture<Boolean> set(String key, int exp, Object o) {
     return asyncStore(StoreType.set, key, exp, o, transcoder);
   }
 
@@ -841,7 +841,7 @@ public class MemcachedClient extends SpyThread
    * @throws IllegalStateException in the rare circumstance where queue
    *                               is too full to accept any more requests
    */
-  public <T> Future<Boolean> replace(String key, int exp, T o,
+  public <T> OperationFuture<Boolean> replace(String key, int exp, T o,
                                      Transcoder<T> tc) {
     return asyncStore(StoreType.replace, key, exp, o, tc);
   }
@@ -877,7 +877,7 @@ public class MemcachedClient extends SpyThread
    * @throws IllegalStateException in the rare circumstance where queue
    *                               is too full to accept any more requests
    */
-  public Future<Boolean> replace(String key, int exp, Object o) {
+  public OperationFuture<Boolean> replace(String key, int exp, Object o) {
     return asyncStore(StoreType.replace, key, exp, o, transcoder);
   }
 
@@ -891,7 +891,7 @@ public class MemcachedClient extends SpyThread
    * @throws IllegalStateException in the rare circumstance where queue
    *                               is too full to accept any more requests
    */
-  public <T> Future<T> asyncGet(final String key, final Transcoder<T> tc) {
+  public <T> GetFuture<T> asyncGet(final String key, final Transcoder<T> tc) {
 
     final CountDownLatch latch = new CountDownLatch(1);
     final GetFuture<T> rv = new GetFuture<T>(latch, operationTimeout);
@@ -932,7 +932,7 @@ public class MemcachedClient extends SpyThread
    * @throws IllegalStateException in the rare circumstance where queue
    *                               is too full to accept any more requests
    */
-  public Future<Object> asyncGet(final String key) {
+  public GetFuture<Object> asyncGet(final String key) {
     return asyncGet(key, transcoder);
   }
 
@@ -946,8 +946,8 @@ public class MemcachedClient extends SpyThread
    * @throws IllegalStateException in the rare circumstance where queue
    *                               is too full to accept any more requests
    */
-  public <T> Future<CASValue<T>> asyncGets(final String key,
-                                           final Transcoder<T> tc) {
+  public <T> OperationFuture<CASValue<T>> asyncGets(final String key,
+                                                    final Transcoder<T> tc) {
 
     final CountDownLatch latch = new CountDownLatch(1);
     final OperationFuture<CASValue<T>> rv =
@@ -986,7 +986,7 @@ public class MemcachedClient extends SpyThread
    * @throws IllegalStateException in the rare circumstance where queue
    *                               is too full to accept any more requests
    */
-  public Future<CASValue<Object>> asyncGets(final String key) {
+  public OperationFuture<CASValue<Object>> asyncGets(final String key) {
     return asyncGets(key, transcoder);
   }
 
@@ -1432,7 +1432,7 @@ public class MemcachedClient extends SpyThread
         // XXX:  Potential abstraction leak.
         // The handling of incr/decr in the binary protocol
         // Allows us to avoid string processing.
-        rv.set(new Long(s.isSuccess() ? s.getMessage() : "-1"));
+        rv.set(Long.parseLong(s.isSuccess() ? s.getMessage() : "-1"));
       }
 
       public void complete() {
@@ -1560,7 +1560,7 @@ public class MemcachedClient extends SpyThread
     return rv;
   }
 
-  private Future<Long> asyncMutate(Mutator m, String key, int by, long def,
+  private OperationFuture<Long> asyncMutate(Mutator m, String key, int by, long def,
                                    int exp) {
     final CountDownLatch latch = new CountDownLatch(1);
     final OperationFuture<Long> rv = new OperationFuture<Long>(
@@ -1568,7 +1568,7 @@ public class MemcachedClient extends SpyThread
     Operation op = addOp(key, opFact.mutate(m, key, by, def, exp,
         new OperationCallback() {
           public void receivedStatus(OperationStatus s) {
-            rv.set(new Long(s.isSuccess() ? s.getMessage() : "-1"), s);
+            rv.set(Long.parseLong(s.isSuccess() ? s.getMessage() : "-1"), s);
           }
 
           public void complete() {
@@ -1589,7 +1589,7 @@ public class MemcachedClient extends SpyThread
    * @throws IllegalStateException in the rare circumstance where queue
    *                               is too full to accept any more requests
    */
-  public Future<Long> asyncIncr(String key, int by) {
+  public OperationFuture<Long> asyncIncr(String key, int by) {
     return asyncMutate(Mutator.incr, key, by, -1, 0);
   }
 
@@ -1605,7 +1605,7 @@ public class MemcachedClient extends SpyThread
    * @throws IllegalStateException in the rare circumstance where queue
    *                               is too full to accept any more requests
    */
-  public Future<Long> asyncIncr(String key, int by, long def, int exp) {
+  public OperationFuture<Long> asyncIncr(String key, int by, long def, int exp) {
     return asyncMutate(Mutator.incr, key, by, def, exp);
   }
 
@@ -1619,7 +1619,7 @@ public class MemcachedClient extends SpyThread
    * @throws IllegalStateException in the rare circumstance where queue
    *                               is too full to accept any more requests
    */
-  public Future<Long> asyncDecr(String key, int by) {
+  public OperationFuture<Long> asyncDecr(String key, int by) {
     return asyncMutate(Mutator.decr, key, by, -1, 0);
   }
 
@@ -1635,7 +1635,7 @@ public class MemcachedClient extends SpyThread
    * @throws IllegalStateException in the rare circumstance where queue
    *                               is too full to accept any more requests
    */
-  public Future<Long> asyncDecr(String key, int by, long def, int exp) {
+  public OperationFuture<Long> asyncDecr(String key, int by, long def, int exp) {
     return asyncMutate(Mutator.decr, key, by, def, exp);
   }
 
@@ -1690,7 +1690,7 @@ public class MemcachedClient extends SpyThread
    * @deprecated Hold values are no longer honored.
    */
   @Deprecated
-  public Future<Boolean> delete(String key, int hold) {
+  public OperationFuture<Boolean> delete(String key, int hold) {
     return delete(key);
   }
 
@@ -1702,7 +1702,7 @@ public class MemcachedClient extends SpyThread
    * @throws IllegalStateException in the rare circumstance where queue
    *                               is too full to accept any more requests
    */
-  public Future<Boolean> delete(String key) {
+  public OperationFuture<Boolean> delete(String key) {
     final CountDownLatch latch = new CountDownLatch(1);
     final OperationFuture<Boolean> rv = new OperationFuture<Boolean>(latch,
             operationTimeout);

--- a/src/main/java/net/spy/memcached/plugin/FrontCacheMemcachedClient.java
+++ b/src/main/java/net/spy/memcached/plugin/FrontCacheMemcachedClient.java
@@ -19,11 +19,12 @@ package net.spy.memcached.plugin;
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.util.List;
-import java.util.concurrent.Future;
 
 import net.sf.ehcache.Element;
 import net.spy.memcached.ConnectionFactory;
 import net.spy.memcached.MemcachedClient;
+import net.spy.memcached.internal.GetFuture;
+import net.spy.memcached.internal.OperationFuture;
 import net.spy.memcached.transcoders.Transcoder;
 
 /**
@@ -74,7 +75,7 @@ public class FrontCacheMemcachedClient extends MemcachedClient {
    * @return a future that will hold the value of the key
    */
   @Override
-  public <T> Future<T> asyncGet(final String key, final Transcoder<T> tc) {
+  public <T> GetFuture<T> asyncGet(final String key, final Transcoder<T> tc) {
     Element frontElement = null;
 
     if (localCacheManager != null) {
@@ -96,7 +97,7 @@ public class FrontCacheMemcachedClient extends MemcachedClient {
    * @return a future that will hold success/error status of the operation
    */
   @Override
-  public Future<Boolean> delete(String key) {
+  public OperationFuture<Boolean> delete(String key) {
     if (localCacheManager != null) {
       localCacheManager.delete(key);
     }

--- a/src/main/java/net/spy/memcached/protocol/ascii/MutatorOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/MutatorOperationImpl.java
@@ -79,7 +79,7 @@ final class MutatorOperationImpl extends OperationImpl
     OperationStatus status = null;
     try {
       Long.valueOf(line);
-      getCallback().receivedStatus(new OperationStatus(true, line));
+      getCallback().receivedStatus(new OperationStatus(true, line, StatusCode.SUCCESS));
     } catch (NumberFormatException e) {
       status = matchStatus(line, NOT_FOUND, TYPE_MISMATCH);
       getCallback().receivedStatus(status);

--- a/src/test/manual/net/spy/memcached/ops/OperationStatusTest.java
+++ b/src/test/manual/net/spy/memcached/ops/OperationStatusTest.java
@@ -1,0 +1,122 @@
+package net.spy.memcached.ops;
+
+import net.spy.memcached.collection.BaseIntegrationTest;
+import net.spy.memcached.internal.OperationFuture;
+
+public class OperationStatusTest extends BaseIntegrationTest {
+  private static final int EXP = 100;
+
+  @Override
+  protected void setUp() throws Exception {
+    super.setUp();
+    mc.flush();
+  }
+
+  public void testStore_success() throws Exception{
+    //given
+    String value = "value1";
+    String replaceValue = "value2";
+    String appendValue = "plus";
+
+    //when
+    OperationFuture<Boolean> addOperationFuture = mc.add("abc", EXP, value);
+    OperationFuture<Boolean> setOperationFuture = mc.set("abc", EXP, value);
+    OperationFuture<Boolean> replaceOperationFuture = mc.replace("abc", EXP, replaceValue);
+    OperationFuture<Boolean> prependOperationFuture = mc.prepend(10, "abc", appendValue);
+    OperationFuture<Boolean> appendOperationFuture = mc.append(10, "abc", appendValue);
+
+    mc.add("bcc",EXP, value);
+    mc.add("cbd",EXP,"2222");
+    mc.add("efg",EXP,"3333");
+
+    //then
+    assertEquals(StatusCode.SUCCESS, addOperationFuture.getStatus().getStatusCode());
+    assertEquals(StatusCode.SUCCESS, setOperationFuture.getStatus().getStatusCode());
+    assertEquals(StatusCode.SUCCESS, replaceOperationFuture.getStatus().getStatusCode());
+    assertEquals(StatusCode.SUCCESS, prependOperationFuture.getStatus().getStatusCode());
+    assertEquals(StatusCode.SUCCESS, appendOperationFuture.getStatus().getStatusCode());
+  }
+
+  public void testStore_fail() throws Exception{
+    //given
+    String value = "value1";
+    String replaceValue = "value2";
+    String appendValue = "plus";
+
+    //when
+    mc.add("abc", EXP, value);
+
+    // add already stored key
+    OperationFuture<Boolean> addOperationFuture = mc.add("abc", EXP, replaceValue);
+    // replace using non-exist key
+    OperationFuture<Boolean> replaceOperationFuture = mc.replace("bc", EXP, replaceValue);
+    // prepend using non-exist key
+    OperationFuture<Boolean> prependOperationFuture = mc.prepend(102, "cda", appendValue);
+    // append using non-exist key
+    OperationFuture<Boolean> appendOperationFuture = mc.append(102, "efg", appendValue);
+
+    //then
+    assertEquals(StatusCode.ERR_NOT_STORED, addOperationFuture.getStatus().getStatusCode());
+    assertEquals(StatusCode.ERR_NOT_STORED, replaceOperationFuture.getStatus().getStatusCode());
+    assertEquals(StatusCode.ERR_NOT_STORED, prependOperationFuture.getStatus().getStatusCode());
+    assertEquals(StatusCode.ERR_NOT_STORED, appendOperationFuture.getStatus().getStatusCode());
+  }
+
+  public void testIncrAndDecr_success() throws Exception {
+    //given
+    String key = "key";
+    String value = "65";
+    int value2 = 61;
+    mc.set(key, EXP, value);
+
+    //when
+    OperationFuture<Long> incrOperationFuture = mc.asyncIncr(key, value2);
+    OperationFuture<Long> decrOperationFuture = mc.asyncDecr(key, value2);
+
+    //then
+    assertEquals(StatusCode.SUCCESS, incrOperationFuture.getStatus().getStatusCode());
+    assertEquals(StatusCode.SUCCESS, decrOperationFuture.getStatus().getStatusCode());
+  }
+
+  public void testIncrAndDecr_fail() throws Exception {
+    //given
+    int value = 1;
+    int value2 = 2;
+
+    mc.set("abc", EXP, value);
+
+    //when
+    OperationFuture<Long> incrOperationFuture = mc.asyncIncr("bc", value2);
+    OperationFuture<Long> decrOperationFuture = mc.asyncDecr("bc", value2);
+
+    //then
+    assertEquals(StatusCode.ERR_NOT_FOUND, incrOperationFuture.getStatus().getStatusCode());
+    assertEquals(StatusCode.ERR_NOT_FOUND, decrOperationFuture.getStatus().getStatusCode());
+  }
+
+  public void testDelete_success() throws Exception {
+    //given
+    String value = "example";
+
+    mc.add("abc", EXP, value);
+
+    //when
+    OperationFuture<Boolean> deleteOperationFuture = mc.delete("abc");
+
+    //then
+    assertEquals(StatusCode.SUCCESS, deleteOperationFuture.getStatus().getStatusCode());
+  }
+
+  public void testDelete_fail() throws Exception {
+    //given
+    String value = "example";
+
+    mc.add("abc", EXP, value);
+
+    //when
+    OperationFuture<Boolean> deleteOperationFuture = mc.delete("bc");
+
+    //then
+    assertEquals(StatusCode.ERR_NOT_FOUND, deleteOperationFuture.getStatus().getStatusCode());
+  }
+}


### PR DESCRIPTION
#226 에 대한 pr입니다.

[Key-Value Item 연산](https://github.com/naver/arcus-java-client/blob/master/docs/arcus-java-client-user-guide.md) API 목록을 참고하여 key-value 연산들의 반환 타입인 Future을 OperationFuture로 변경하였습니다.
인터페이스를 제외한 구현클래스의 반환타입을 모두 변경하였습니다.
인터페이스의 반환타입을 변경하지 않은 이유는 Mock을 이용한 테스트에 오류가 발생하여 테스트가 실패하는 문제가 발생했기 때문입니다.
해당 문제를 해결하기 위하여 spymemcached를 참고하였고, spymemcached에서도 OperationFuture의 반환 타입은 구현 클래스에서만 적용이 되어 있었습니다.

아래는 참고한 spymemcached의 내용 중 일부입니다.
- MemcachedClientIF
```java
Future<Boolean> set(String key, int exp, Object o);

Future<Boolean> set(String key, int exp, Object o);
```
- MemcachedClient
```java
@Override
 public OperationFuture<Boolean> set(String key, int exp, Object o) {
   return asyncStore(StoreType.set, key, exp, o, transcoder);
 }

@Override
 public OperationFuture<Boolean> replace(String key, int exp, Object o) {
   return asyncStore(StoreType.replace, key, exp, o, transcoder);
 }
```