### PR TITLE
FEATURE : add specific TimeoutException message

### DIFF
--- a/docs/10-log-message.md
+++ b/docs/10-log-message.md
@@ -106,14 +106,14 @@ at net.spy.memcached.MemcachedClient.run(MemcachedClient.java:1630)
 timeout시간 내에 사용자가 요청한 결과 값을 반환해 줄 수 없으면 아래 로그를 남기고 TimeoutException을 던진다.
 
 ```java
-net.spy.memcached.internal.CheckedOperationTimeoutException: Timed out waiting for operation. > 300 - failing node: /127.0.0.1:11211 [WRITING] [#iq=13 #Wops=7 #Rops=10 #CT=13]
+net.spy.memcached.internal.CheckedOperationTimeoutException: GET operation timed out (>300 MILLISECONDS ) - failing node: /127.0.0.1:11211 [WRITING] [#iq=13 #Wops=7 #Rops=10 #CT=13]
 ```
 
 로그의 의미는 다음과 같다.
 
 | 메세지 | 설명 |
 | ------ | ---- |
-| Timed out waiting for operation. > 300 MILLISECONDS| Timeout 값이 300ms로 지정되어있고 요청의 결과를 받기까지300ms이상 걸려서 timeout되었다.|
+| GET operation timed out (>300 MILLISECONDS )| Timeout 값이 300ms로 지정되어있고 GET 요청의 결과를 받기까지 300ms 이상 걸려서 timeout되었다.|
 | Failing node: /127.0.0.1:11211 | 해당 요청은 127.0.0.1:11211 에서 수행한다. |
 | [WRITING]	| 해당 요청은 socket write를 위해 대기 중이다. |
 | [READING]	| 해당 요청은 서버로 전달되었고 결과가 돌아오기를 기다리거나, 결과 값을 읽어 들이는 중이다. |

--- a/src/main/java/net/spy/memcached/ArcusClient.java
+++ b/src/main/java/net/spy/memcached/ArcusClient.java
@@ -1071,8 +1071,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
           for (Operation op : ops) {
             MemcachedConnection.opTimedOut(op);
           }
-          throw new CheckedOperationTimeoutException(
-                  "Timed out waiting for operation >" + duration + " " + units, ops);
+          throw new CheckedOperationTimeoutException(duration, units, ops);
         } else {
           // continuous timeout counter will be reset
           for (Operation op : ops) {
@@ -2072,8 +2071,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
           for (Operation op : ops) {
             MemcachedConnection.opTimedOut(op);
           }
-          throw new CheckedOperationTimeoutException(
-                  "Timed out waiting for operation. >" + duration + " " + units, ops);
+          throw new CheckedOperationTimeoutException(duration, units, ops);
         } else {
           // continuous timeout counter will be reset
           for (Operation op : ops) {
@@ -2431,8 +2429,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
           for (Operation op : ops) {
             MemcachedConnection.opTimedOut(op);
           }
-          throw new CheckedOperationTimeoutException(
-                  "Timed out waiting for operation >" + duration + " " + units, ops);
+          throw new CheckedOperationTimeoutException(duration, units, ops);
         } else {
           // continuous timeout counter will be reset
           for (Operation op : ops) {
@@ -2699,8 +2696,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
           for (Operation op : ops) {
             MemcachedConnection.opTimedOut(op);
           }
-          throw new CheckedOperationTimeoutException(
-                  "Timed out waiting for operation >" + duration + " " + units, ops);
+          throw new CheckedOperationTimeoutException(duration, units, ops);
         } else {
           // continuous timeout counter will be reset
           for (Operation op : ops) {
@@ -3922,8 +3918,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
           for (Operation op : ops) {
             MemcachedConnection.opTimedOut(op);
           }
-          throw new CheckedOperationTimeoutException(
-                  "Timed out waiting for operation >" + duration + " " + units, ops);
+          throw new CheckedOperationTimeoutException(duration, units, ops);
         } else {
           // continuous timeout counter will be reset
           for (Operation op : ops) {
@@ -4168,13 +4163,11 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
       public Map<String, CollectionOperationStatus> get(long duration,
                                                         TimeUnit units)
           throws InterruptedException, TimeoutException, ExecutionException {
-
         if (!latch.await(duration, units)) {
           for (Operation op : ops) {
             MemcachedConnection.opTimedOut(op);
           }
-          throw new CheckedOperationTimeoutException(
-                  "Timed out waiting for bulk operation >" + duration + " " + units, ops);
+          throw new CheckedOperationTimeoutException(duration, units, ops);
         } else {
           // continuous timeout counter will be reset
           for (Operation op : ops) {

--- a/src/main/java/net/spy/memcached/OperationTimeoutException.java
+++ b/src/main/java/net/spy/memcached/OperationTimeoutException.java
@@ -16,6 +16,11 @@
  */
 package net.spy.memcached;
 
+import net.spy.memcached.ops.Operation;
+
+import java.util.Collections;
+import java.util.concurrent.TimeUnit;
+
 /**
  * Thrown by {@link MemcachedClient} when any internal operations timeout.
  *
@@ -30,8 +35,18 @@ public class OperationTimeoutException extends RuntimeException {
     super(message);
   }
 
+  public OperationTimeoutException(Throwable cause) {
+    super(cause);
+  }
+
   public OperationTimeoutException(String message, Throwable cause) {
     super(message, cause);
   }
 
+  public OperationTimeoutException(long duration,
+                                   TimeUnit units,
+                                   Operation op) {
+    super(TimedOutMessageFactory
+            .createTimedoutMessage(duration, units, Collections.singleton(op)));
+  }
 }

--- a/src/main/java/net/spy/memcached/TimedOutMessageFactory.java
+++ b/src/main/java/net/spy/memcached/TimedOutMessageFactory.java
@@ -1,0 +1,73 @@
+package net.spy.memcached;
+
+import net.spy.memcached.ops.Operation;
+import net.spy.memcached.ops.GetOperation;
+import net.spy.memcached.ops.StoreOperation;
+import net.spy.memcached.ops.DeleteOperation;
+
+import java.util.Collection;
+import java.util.concurrent.TimeUnit;
+
+public final class TimedOutMessageFactory {
+
+  private TimedOutMessageFactory() {
+  }
+
+  public static String createTimedoutMessage(long duration,
+                                             TimeUnit units,
+                                             Collection<Operation> ops) {
+    StringBuilder rv = new StringBuilder();
+    Operation firstOp = ops.iterator().next();
+    if (isBulkOperation(firstOp, ops)) {
+      rv.append("bulk ");
+    } else if (firstOp.isPipeOperation()) {
+      rv.append("pipe ");
+    }
+    rv.append(firstOp.getAPIType())
+      .append(" operation timed out (>").append(duration)
+      .append(" ").append(units).append(")");
+    return createMessage(rv.toString(), ops);
+  }
+
+  /**
+   * check bulk operation or not
+   * @param op operation
+   * @param ops number of operation (used in GetOpeartion, StoreOperationImpl, DeleteOperationImpl)
+   */
+  private static boolean isBulkOperation(Operation op, Collection<Operation> ops) {
+    if (op instanceof GetOperation) {
+      GetOperation gop = (GetOperation) op;
+      return gop.getKeys().size() > 1;
+    } else if (op instanceof StoreOperation) {
+      return ops.size() > 1;
+    } else if (op instanceof DeleteOperation) {
+      return ops.size() > 1;
+    }
+    return op.isBulkOperation();
+  }
+
+  public static String createMessage(String message,
+                                     Collection<Operation> ops) {
+    StringBuilder rv = new StringBuilder(message);
+    rv.append(" - failing node");
+    rv.append(ops.size() == 1 ? ": " : "s: ");
+    boolean first = true;
+    for (Operation op : ops) {
+      if (first) {
+        first = false;
+      } else {
+        rv.append(", ");
+      }
+      MemcachedNode node = op == null ? null : op.getHandlingNode();
+      rv.append(node == null ? "<unknown>" : node.getSocketAddress());
+      if (op != null) {
+        rv.append(" [").append(op.getState()).append("]");
+      }
+      if (node != null) {
+        rv.append(" [").append(node.getStatus()).append("]");
+      }
+    }
+    return rv.toString();
+  }
+
+}

--- a/src/main/java/net/spy/memcached/internal/BulkOperationFuture.java
+++ b/src/main/java/net/spy/memcached/internal/BulkOperationFuture.java
@@ -49,7 +49,7 @@ public abstract class BulkOperationFuture<T>
 
   @Override
   public Map<String, T> get(long duration,
-                                                    TimeUnit units) throws InterruptedException,
+                            TimeUnit units) throws InterruptedException,
           TimeoutException, ExecutionException {
     if (!latch.await(duration, units)) {
       for (Operation op : ops) {
@@ -59,8 +59,7 @@ public abstract class BulkOperationFuture<T>
           MemcachedConnection.opSucceeded(op);
         }
       }
-      throw new CheckedOperationTimeoutException(
-              "Timed out waiting for bulk operation >" + duration + " " + units, ops);
+      throw new CheckedOperationTimeoutException(duration, units, ops);
     } else {
       // continuous timeout counter will be reset
       for (Operation op : ops) {

--- a/src/main/java/net/spy/memcached/internal/CollectionFuture.java
+++ b/src/main/java/net/spy/memcached/internal/CollectionFuture.java
@@ -24,6 +24,7 @@ import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicReference;
 
 import net.spy.memcached.MemcachedConnection;
+import net.spy.memcached.OperationTimeoutException;
 import net.spy.memcached.ops.CollectionOperationStatus;
 import net.spy.memcached.ops.Operation;
 import net.spy.memcached.ops.OperationState;
@@ -67,8 +68,7 @@ public class CollectionFuture<T> implements Future<T> {
     try {
       return get(timeout, TimeUnit.MILLISECONDS);
     } catch (TimeoutException e) {
-      throw new RuntimeException(
-              "Timed out waiting for operation. >" + timeout + " " + TimeUnit.MILLISECONDS, e);
+      throw new OperationTimeoutException(e);
     }
   }
 
@@ -77,8 +77,7 @@ public class CollectionFuture<T> implements Future<T> {
     if (!latch.await(duration, units)) {
       // whenever timeout occurs, continuous timeout counter will increase by 1.
       MemcachedConnection.opTimedOut(op);
-      throw new CheckedOperationTimeoutException(
-              "Timed out waiting for operation. >" + duration + " " + units, op);
+      throw new CheckedOperationTimeoutException(duration, units, op);
     } else {
       // continuous timeout counter will be reset
       MemcachedConnection.opSucceeded(op);

--- a/src/main/java/net/spy/memcached/internal/CollectionGetBulkFuture.java
+++ b/src/main/java/net/spy/memcached/internal/CollectionGetBulkFuture.java
@@ -24,6 +24,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
 import net.spy.memcached.MemcachedConnection;
+import net.spy.memcached.OperationTimeoutException;
 import net.spy.memcached.ops.CollectionOperationStatus;
 import net.spy.memcached.ops.Operation;
 import net.spy.memcached.ops.OperationState;
@@ -49,7 +50,7 @@ public class CollectionGetBulkFuture<T> implements Future<T> {
     try {
       return get(timeout, TimeUnit.MILLISECONDS);
     } catch (TimeoutException e) {
-      throw new RuntimeException("Timed out waiting for smget operation", e);
+      throw new OperationTimeoutException(e);
     }
   }
 
@@ -60,8 +61,7 @@ public class CollectionGetBulkFuture<T> implements Future<T> {
       for (Operation op : ops) {
         MemcachedConnection.opTimedOut(op);
       }
-      throw new CheckedOperationTimeoutException(
-          "Timed out waiting for b+tree get bulk operation", ops);
+      throw new CheckedOperationTimeoutException(duration, units, ops);
     } else {
       for (Operation op : ops) {
         MemcachedConnection.opSucceeded(op);

--- a/src/main/java/net/spy/memcached/internal/OperationFuture.java
+++ b/src/main/java/net/spy/memcached/internal/OperationFuture.java
@@ -24,6 +24,7 @@ import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicReference;
 
 import net.spy.memcached.MemcachedConnection;
+import net.spy.memcached.OperationTimeoutException;
 import net.spy.memcached.compat.SpyObject;
 import net.spy.memcached.ops.Operation;
 import net.spy.memcached.ops.OperationState;
@@ -70,8 +71,7 @@ public class OperationFuture<T> extends SpyObject implements Future<T> {
     try {
       return get(timeout, TimeUnit.MILLISECONDS);
     } catch (TimeoutException e) {
-      throw new RuntimeException(
-              "Timed out waiting for operation. >" + timeout + " " + TimeUnit.MILLISECONDS, e);
+      throw new OperationTimeoutException(e);
     }
   }
 
@@ -80,8 +80,7 @@ public class OperationFuture<T> extends SpyObject implements Future<T> {
     if (!latch.await(duration, units)) {
       // whenever timeout occurs, continuous timeout counter will increase by 1.
       MemcachedConnection.opTimedOut(op);
-      throw new CheckedOperationTimeoutException(
-              "Timed out waiting for operation. >" + duration + " " + units, op);
+      throw new CheckedOperationTimeoutException(duration, units, op);
     } else {
       // continuous timeout counter will be reset
       MemcachedConnection.opSucceeded(op);

--- a/src/main/java/net/spy/memcached/internal/SMGetFuture.java
+++ b/src/main/java/net/spy/memcached/internal/SMGetFuture.java
@@ -24,6 +24,7 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
+import net.spy.memcached.OperationTimeoutException;
 import net.spy.memcached.collection.SMGetTrimKey;
 import net.spy.memcached.ops.CollectionOperationStatus;
 import net.spy.memcached.ops.Operation;
@@ -44,7 +45,7 @@ public abstract class SMGetFuture<T> implements Future<T> {
     try {
       return get(timeout, TimeUnit.MILLISECONDS);
     } catch (TimeoutException e) {
-      throw new RuntimeException("Timed out waiting for smget operation", e);
+      throw new OperationTimeoutException(e);
     }
   }
 

--- a/src/main/java/net/spy/memcached/ops/Operation.java
+++ b/src/main/java/net/spy/memcached/ops/Operation.java
@@ -107,5 +107,9 @@ public interface Operation {
 
   boolean isReadOperation();
 
+  boolean isBulkOperation();
+
+  boolean isPipeOperation();
+
   APIType getAPIType();
 }

--- a/src/main/java/net/spy/memcached/protocol/BaseOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/BaseOperationImpl.java
@@ -21,14 +21,14 @@ import java.nio.ByteBuffer;
 
 import net.spy.memcached.MemcachedNode;
 import net.spy.memcached.compat.SpyObject;
-import net.spy.memcached.ops.APIType;
 import net.spy.memcached.ops.CancelledOperationStatus;
-import net.spy.memcached.ops.OperationCallback;
-import net.spy.memcached.ops.OperationErrorType;
 import net.spy.memcached.ops.OperationException;
 import net.spy.memcached.ops.OperationState;
 import net.spy.memcached.ops.OperationStatus;
+import net.spy.memcached.ops.OperationCallback;
 import net.spy.memcached.ops.OperationType;
+import net.spy.memcached.ops.OperationErrorType;
+import net.spy.memcached.ops.APIType;
 
 /**
  * Base class for protocol-specific operation implementations.
@@ -233,4 +233,8 @@ public abstract class BaseOperationImpl extends SpyObject {
   public void setAPIType(APIType type) {
     this.apiType = type;
   }
+
+  public abstract boolean isBulkOperation();
+
+  public abstract boolean isPipeOperation();
 }

--- a/src/main/java/net/spy/memcached/protocol/ascii/BTreeFindPositionOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/BTreeFindPositionOperationImpl.java
@@ -137,4 +137,13 @@ public class BTreeFindPositionOperationImpl extends OperationImpl implements
     return Collections.singleton(key);
   }
 
+  @Override
+  public boolean isBulkOperation() {
+    return false;
+  }
+
+  @Override
+  public boolean isPipeOperation() {
+    return false;
+  }
 }

--- a/src/main/java/net/spy/memcached/protocol/ascii/BTreeFindPositionWithGetOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/BTreeFindPositionWithGetOperationImpl.java
@@ -260,4 +260,14 @@ public class BTreeFindPositionWithGetOperationImpl extends OperationImpl impleme
   public Collection<String> getKeys() {
     return Collections.singleton(key);
   }
+
+  @Override
+  public boolean isBulkOperation() {
+    return false;
+  }
+
+  @Override
+  public boolean isPipeOperation() {
+    return false;
+  }
 }

--- a/src/main/java/net/spy/memcached/protocol/ascii/BTreeGetBulkOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/BTreeGetBulkOperationImpl.java
@@ -250,4 +250,14 @@ public class BTreeGetBulkOperationImpl extends OperationImpl implements
   public Collection<String> getKeys() {
     return getBulk.getKeyList();
   }
+
+  @Override
+  public boolean isBulkOperation() {
+    return true;
+  }
+
+  @Override
+  public boolean isPipeOperation() {
+    return false;
+  }
 }

--- a/src/main/java/net/spy/memcached/protocol/ascii/BTreeGetByPositionOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/BTreeGetByPositionOperationImpl.java
@@ -270,4 +270,13 @@ public class BTreeGetByPositionOperationImpl extends OperationImpl implements
     return Collections.singleton(key);
   }
 
+  @Override
+  public boolean isBulkOperation() {
+    return false;
+  }
+
+  @Override
+  public boolean isPipeOperation() {
+    return false;
+  }
 }

--- a/src/main/java/net/spy/memcached/protocol/ascii/BTreeInsertAndGetOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/BTreeInsertAndGetOperationImpl.java
@@ -312,4 +312,13 @@ public class BTreeInsertAndGetOperationImpl extends OperationImpl implements
     return Collections.singleton(key);
   }
 
+  @Override
+  public boolean isBulkOperation() {
+    return false;
+  }
+
+  @Override
+  public boolean isPipeOperation() {
+    return false;
+  }
 }

--- a/src/main/java/net/spy/memcached/protocol/ascii/BTreeSortMergeGetOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/BTreeSortMergeGetOperationImpl.java
@@ -436,4 +436,14 @@ public class BTreeSortMergeGetOperationImpl extends OperationImpl implements
     MISSED_KEYS,
     TRIMMED_KEYS,
   }
+
+  @Override
+  public boolean isBulkOperation() {
+    return true;
+  }
+
+  @Override
+  public boolean isPipeOperation() {
+    return false;
+  }
 }

--- a/src/main/java/net/spy/memcached/protocol/ascii/BTreeSortMergeGetOperationOldImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/BTreeSortMergeGetOperationOldImpl.java
@@ -316,4 +316,14 @@ public class BTreeSortMergeGetOperationOldImpl extends OperationImpl implements
   public Collection<String> getKeys() {
     return smGet.getKeyList();
   }
+
+  @Override
+  public boolean isBulkOperation() {
+    return true;
+  }
+
+  @Override
+  public boolean isPipeOperation() {
+    return false;
+  }
 }

--- a/src/main/java/net/spy/memcached/protocol/ascii/BaseGetOpImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/BaseGetOpImpl.java
@@ -198,4 +198,14 @@ abstract class BaseGetOpImpl extends OperationImpl {
     getCallback().receivedStatus(CANCELLED);
   }
 
+  @Override
+  public boolean isBulkOperation() {
+    return false;
+  }
+
+  @Override
+  public boolean isPipeOperation() {
+    return false;
+  }
+
 }

--- a/src/main/java/net/spy/memcached/protocol/ascii/BaseStoreOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/BaseStoreOperationImpl.java
@@ -112,4 +112,14 @@ abstract class BaseStoreOperationImpl extends OperationImpl {
   public byte[] getData() {
     return data;
   }
+
+  @Override
+  public boolean isBulkOperation() {
+    return false;
+  }
+
+  @Override
+  public boolean isPipeOperation() {
+    return false;
+  }
 }

--- a/src/main/java/net/spy/memcached/protocol/ascii/CASOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/CASOperationImpl.java
@@ -109,4 +109,13 @@ class CASOperationImpl extends OperationImpl implements CASOperation {
     return StoreType.set;
   }
 
+  @Override
+  public boolean isBulkOperation() {
+    return false;
+  }
+
+  @Override
+  public boolean isPipeOperation() {
+    return false;
+  }
 }

--- a/src/main/java/net/spy/memcached/protocol/ascii/CollectionBulkInsertOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/CollectionBulkInsertOperationImpl.java
@@ -172,4 +172,13 @@ public class CollectionBulkInsertOperationImpl extends OperationImpl
     return insert;
   }
 
+  @Override
+  public boolean isBulkOperation() {
+    return true;
+  }
+
+  @Override
+  public boolean isPipeOperation() {
+    return false;
+  }
 }

--- a/src/main/java/net/spy/memcached/protocol/ascii/CollectionCountOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/CollectionCountOperationImpl.java
@@ -115,4 +115,14 @@ public class CollectionCountOperationImpl extends OperationImpl implements
   public Collection<String> getKeys() {
     return Collections.singleton(key);
   }
+
+  @Override
+  public boolean isBulkOperation() {
+    return false;
+  }
+
+  @Override
+  public boolean isPipeOperation() {
+    return false;
+  }
 }

--- a/src/main/java/net/spy/memcached/protocol/ascii/CollectionCreateOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/CollectionCreateOperationImpl.java
@@ -117,4 +117,14 @@ public class CollectionCreateOperationImpl extends OperationImpl
   public CollectionCreate getCreate() {
     return collectionCreate;
   }
+
+  @Override
+  public boolean isBulkOperation() {
+    return false;
+  }
+
+  @Override
+  public boolean isPipeOperation() {
+    return false;
+  }
 }

--- a/src/main/java/net/spy/memcached/protocol/ascii/CollectionDeleteOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/CollectionDeleteOperationImpl.java
@@ -143,4 +143,13 @@ public class CollectionDeleteOperationImpl extends OperationImpl
     return collectionDelete;
   }
 
+  @Override
+  public boolean isBulkOperation() {
+    return false;
+  }
+
+  @Override
+  public boolean isPipeOperation() {
+    return false;
+  }
 }

--- a/src/main/java/net/spy/memcached/protocol/ascii/CollectionExistOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/CollectionExistOperationImpl.java
@@ -122,4 +122,14 @@ public class CollectionExistOperationImpl extends OperationImpl
   public CollectionExist getExist() {
     return collectionExist;
   }
+
+  @Override
+  public boolean isBulkOperation() {
+    return false;
+  }
+
+  @Override
+  public boolean isPipeOperation() {
+    return false;
+  }
 }

--- a/src/main/java/net/spy/memcached/protocol/ascii/CollectionGetOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/CollectionGetOperationImpl.java
@@ -290,4 +290,13 @@ public class CollectionGetOperationImpl extends OperationImpl
     return collectionGet;
   }
 
+  @Override
+  public boolean isBulkOperation() {
+    return false;
+  }
+
+  @Override
+  public boolean isPipeOperation() {
+    return false;
+  }
 }

--- a/src/main/java/net/spy/memcached/protocol/ascii/CollectionInsertOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/CollectionInsertOperationImpl.java
@@ -153,4 +153,13 @@ public class CollectionInsertOperationImpl extends OperationImpl
     return data;
   }
 
+  @Override
+  public boolean isBulkOperation() {
+    return false;
+  }
+
+  @Override
+  public boolean isPipeOperation() {
+    return false;
+  }
 }

--- a/src/main/java/net/spy/memcached/protocol/ascii/CollectionMutateOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/CollectionMutateOperationImpl.java
@@ -134,4 +134,13 @@ public class CollectionMutateOperationImpl extends OperationImpl implements
     return subkey;
   }
 
+  @Override
+  public boolean isBulkOperation() {
+    return false;
+  }
+
+  @Override
+  public boolean isPipeOperation() {
+    return false;
+  }
 }

--- a/src/main/java/net/spy/memcached/protocol/ascii/CollectionPipedExistOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/CollectionPipedExistOperationImpl.java
@@ -144,4 +144,14 @@ public class CollectionPipedExistOperationImpl extends OperationImpl implements
   public SetPipedExist<?> getExist() {
     return setPipedExist;
   }
+
+  @Override
+  public boolean isBulkOperation() {
+    return false;
+  }
+
+  @Override
+  public boolean isPipeOperation() {
+    return true;
+  }
 }

--- a/src/main/java/net/spy/memcached/protocol/ascii/CollectionPipedInsertOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/CollectionPipedInsertOperationImpl.java
@@ -173,4 +173,13 @@ public class CollectionPipedInsertOperationImpl extends OperationImpl
     return insert;
   }
 
+  @Override
+  public boolean isBulkOperation() {
+    return false;
+  }
+
+  @Override
+  public boolean isPipeOperation() {
+    return true;
+  }
 }

--- a/src/main/java/net/spy/memcached/protocol/ascii/CollectionPipedUpdateOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/CollectionPipedUpdateOperationImpl.java
@@ -171,4 +171,13 @@ public class CollectionPipedUpdateOperationImpl extends OperationImpl implements
     return update;
   }
 
+  @Override
+  public boolean isBulkOperation() {
+    return false;
+  }
+
+  @Override
+  public boolean isPipeOperation() {
+    return true;
+  }
 }

--- a/src/main/java/net/spy/memcached/protocol/ascii/CollectionUpdateOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/CollectionUpdateOperationImpl.java
@@ -161,4 +161,13 @@ public class CollectionUpdateOperationImpl extends OperationImpl implements
     return data;
   }
 
+  @Override
+  public boolean isBulkOperation() {
+    return false;
+  }
+
+  @Override
+  public boolean isPipeOperation() {
+    return false;
+  }
 }

--- a/src/main/java/net/spy/memcached/protocol/ascii/DeleteOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/DeleteOperationImpl.java
@@ -63,4 +63,13 @@ final class DeleteOperationImpl extends OperationImpl
     return Collections.singleton(key);
   }
 
+  @Override
+  public boolean isBulkOperation() {
+    return false;
+  }
+
+  @Override
+  public boolean isPipeOperation() {
+    return false;
+  }
 }

--- a/src/main/java/net/spy/memcached/protocol/ascii/FlushByPrefixOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/FlushByPrefixOperationImpl.java
@@ -82,4 +82,14 @@ final class FlushByPrefixOperationImpl extends OperationImpl implements
     bb.flip();
     setBuffer(bb);
   }
+
+  @Override
+  public boolean isBulkOperation() {
+    return false;
+  }
+
+  @Override
+  public boolean isPipeOperation() {
+    return false;
+  }
 }

--- a/src/main/java/net/spy/memcached/protocol/ascii/FlushOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/FlushOperationImpl.java
@@ -57,4 +57,14 @@ final class FlushOperationImpl extends OperationImpl
     }
     setBuffer(b);
   }
+
+  @Override
+  public boolean isBulkOperation() {
+    return false;
+  }
+
+  @Override
+  public boolean isPipeOperation() {
+    return false;
+  }
 }

--- a/src/main/java/net/spy/memcached/protocol/ascii/GetAttrOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/GetAttrOperationImpl.java
@@ -104,4 +104,13 @@ class GetAttrOperationImpl extends OperationImpl implements GetAttrOperation {
     return Collections.singleton(key);
   }
 
+  @Override
+  public boolean isBulkOperation() {
+    return false;
+  }
+
+  @Override
+  public boolean isPipeOperation() {
+    return false;
+  }
 }

--- a/src/main/java/net/spy/memcached/protocol/ascii/MGetOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/MGetOperationImpl.java
@@ -18,4 +18,13 @@ public class MGetOperationImpl extends BaseGetOpImpl implements GetOperation {
     setAPIType(APIType.MGET);
   }
 
+  @Override
+  public boolean isBulkOperation() {
+    return true;
+  }
+
+  @Override
+  public boolean isPipeOperation() {
+    return false;
+  }
 }

--- a/src/main/java/net/spy/memcached/protocol/ascii/MutatorOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/MutatorOperationImpl.java
@@ -126,4 +126,13 @@ final class MutatorOperationImpl extends OperationImpl
     return mutator;
   }
 
+  @Override
+  public boolean isBulkOperation() {
+    return false;
+  }
+
+  @Override
+  public boolean isPipeOperation() {
+    return false;
+  }
 }

--- a/src/main/java/net/spy/memcached/protocol/ascii/SetAttrOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/SetAttrOperationImpl.java
@@ -110,4 +110,13 @@ class SetAttrOperationImpl extends OperationImpl
     return attrs;
   }
 
+  @Override
+  public boolean isBulkOperation() {
+    return false;
+  }
+
+  @Override
+  public boolean isPipeOperation() {
+    return false;
+  }
 }

--- a/src/main/java/net/spy/memcached/protocol/ascii/StatsOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/StatsOperationImpl.java
@@ -75,4 +75,13 @@ final class StatsOperationImpl extends OperationImpl
     cb.receivedStatus(CANCELLED);
   }
 
+  @Override
+  public boolean isBulkOperation() {
+    return false;
+  }
+
+  @Override
+  public boolean isPipeOperation() {
+    return false;
+  }
 }

--- a/src/main/java/net/spy/memcached/protocol/ascii/VersionOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/VersionOperationImpl.java
@@ -45,4 +45,13 @@ final class VersionOperationImpl extends OperationImpl
     setBuffer(ByteBuffer.wrap(REQUEST));
   }
 
+  @Override
+  public boolean isBulkOperation() {
+    return false;
+  }
+
+  @Override
+  public boolean isPipeOperation() {
+    return false;
+  }
 }

--- a/src/main/java/net/spy/memcached/protocol/binary/ConcatenationOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/binary/ConcatenationOperationImpl.java
@@ -81,4 +81,13 @@ class ConcatenationOperationImpl extends OperationImpl
     return catType;
   }
 
+  @Override
+  public boolean isBulkOperation() {
+    return false;
+  }
+
+  @Override
+  public boolean isPipeOperation() {
+    return false;
+  }
 }

--- a/src/main/java/net/spy/memcached/protocol/binary/DeleteOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/binary/DeleteOperationImpl.java
@@ -39,4 +39,13 @@ class DeleteOperationImpl extends OperationImpl implements
     return Collections.singleton(key);
   }
 
+  @Override
+  public boolean isBulkOperation() {
+    return false;
+  }
+
+  @Override
+  public boolean isPipeOperation() {
+    return false;
+  }
 }

--- a/src/main/java/net/spy/memcached/protocol/binary/FlushOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/binary/FlushOperationImpl.java
@@ -22,4 +22,13 @@ class FlushOperationImpl extends OperationImpl implements FlushOperation {
     prepareBuffer("", 0, EMPTY_BYTES, delay);
   }
 
+  @Override
+  public boolean isBulkOperation() {
+    return false;
+  }
+
+  @Override
+  public boolean isPipeOperation() {
+    return false;
+  }
 }

--- a/src/main/java/net/spy/memcached/protocol/binary/GetOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/binary/GetOperationImpl.java
@@ -59,4 +59,13 @@ class GetOperationImpl extends OperationImpl
     return Collections.singleton(key);
   }
 
+  @Override
+  public boolean isBulkOperation() {
+    return false;
+  }
+
+  @Override
+  public boolean isPipeOperation() {
+    return false;
+  }
 }

--- a/src/main/java/net/spy/memcached/protocol/binary/MultiGetOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/binary/MultiGetOperationImpl.java
@@ -113,4 +113,13 @@ class MultiGetOperationImpl extends OperationImpl implements GetOperation {
     return keys.values();
   }
 
+  @Override
+  public boolean isBulkOperation() {
+    return true;
+  }
+
+  @Override
+  public boolean isPipeOperation() {
+    return false;
+  }
 }

--- a/src/main/java/net/spy/memcached/protocol/binary/MutatorOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/binary/MutatorOperationImpl.java
@@ -78,4 +78,13 @@ class MutatorOperationImpl extends OperationImpl implements
     return mutator;
   }
 
+  @Override
+  public boolean isBulkOperation() {
+    return false;
+  }
+
+  @Override
+  public boolean isPipeOperation() {
+    return false;
+  }
 }

--- a/src/main/java/net/spy/memcached/protocol/binary/NoopOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/binary/NoopOperationImpl.java
@@ -19,4 +19,13 @@ class NoopOperationImpl extends OperationImpl implements NoopOperation {
     prepareBuffer("", 0, EMPTY_BYTES);
   }
 
+  @Override
+  public boolean isBulkOperation() {
+    return false;
+  }
+
+  @Override
+  public boolean isPipeOperation() {
+    return false;
+  }
 }

--- a/src/main/java/net/spy/memcached/protocol/binary/OptimizedSetImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/binary/OptimizedSetImpl.java
@@ -174,4 +174,13 @@ public class OptimizedSetImpl extends OperationImpl implements Operation {
 
   }
 
+  @Override
+  public boolean isBulkOperation() {
+    return false;
+  }
+
+  @Override
+  public boolean isPipeOperation() {
+    return false;
+  }
 }

--- a/src/main/java/net/spy/memcached/protocol/binary/SASLBaseOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/binary/SASLBaseOperationImpl.java
@@ -72,4 +72,14 @@ public abstract class SASLBaseOperationImpl extends OperationImpl {
     }
   }
 
+  @Override
+  public boolean isBulkOperation() {
+    return false;
+  }
+
+  @Override
+  public boolean isPipeOperation() {
+    return false;
+  }
+
 }

--- a/src/main/java/net/spy/memcached/protocol/binary/SASLMechsOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/binary/SASLMechsOperationImpl.java
@@ -25,4 +25,13 @@ class SASLMechsOperationImpl extends OperationImpl implements
             new OperationStatus(true, new String(pl), StatusCode.SUCCESS));
   }
 
+  @Override
+  public boolean isBulkOperation() {
+    return false;
+  }
+
+  @Override
+  public boolean isPipeOperation() {
+    return false;
+  }
 }

--- a/src/main/java/net/spy/memcached/protocol/binary/StatsOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/binary/StatsOperationImpl.java
@@ -38,4 +38,13 @@ public class StatsOperationImpl extends OperationImpl
     resetInput();
   }
 
+  @Override
+  public boolean isBulkOperation() {
+    return false;
+  }
+
+  @Override
+  public boolean isPipeOperation() {
+    return false;
+  }
 }

--- a/src/main/java/net/spy/memcached/protocol/binary/StoreOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/binary/StoreOperationImpl.java
@@ -106,4 +106,13 @@ class StoreOperationImpl extends OperationImpl
     return storeType;
   }
 
+  @Override
+  public boolean isBulkOperation() {
+    return false;
+  }
+
+  @Override
+  public boolean isPipeOperation() {
+    return false;
+  }
 }

--- a/src/main/java/net/spy/memcached/protocol/binary/VersionOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/binary/VersionOperationImpl.java
@@ -24,4 +24,13 @@ class VersionOperationImpl extends OperationImpl implements VersionOperation {
             new OperationStatus(true, new String(pl), StatusCode.SUCCESS));
   }
 
+  @Override
+  public boolean isBulkOperation() {
+    return false;
+  }
+
+  @Override
+  public boolean isPipeOperation() {
+    return false;
+  }
 }

--- a/src/test/java/net/spy/memcached/ArcusTimeoutMessageTest.java
+++ b/src/test/java/net/spy/memcached/ArcusTimeoutMessageTest.java
@@ -1,0 +1,657 @@
+/*
+ * arcus-java-client : Arcus Java client
+ * Copyright 2010-2016 JaM2in Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.spy.memcached;
+
+import junit.framework.TestCase;
+import net.spy.memcached.collection.CollectionAttributes;
+import net.spy.memcached.collection.Element;
+import net.spy.memcached.collection.ElementFlagUpdate;
+import net.spy.memcached.collection.SMGetElement;
+import net.spy.memcached.collection.ElementFlagFilter;
+import net.spy.memcached.collection.SMGetMode;
+import net.spy.memcached.internal.BulkFuture;
+import net.spy.memcached.internal.CollectionFuture;
+import net.spy.memcached.internal.GetFuture;
+import net.spy.memcached.internal.OperationFuture;
+import net.spy.memcached.internal.SMGetFuture;
+import net.spy.memcached.ops.APIType;
+import net.spy.memcached.ops.CollectionOperationStatus;
+import net.spy.memcached.ops.OperationStatus;
+import net.spy.memcached.ops.StoreType;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.internal.runners.JUnit4ClassRunner;
+import org.junit.runner.RunWith;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Arrays;
+import java.util.TreeMap;
+import java.util.List;
+import java.util.ArrayList;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+@RunWith(JUnit4ClassRunner.class)
+public class ArcusTimeoutMessageTest extends TestCase {
+  private ArcusClient mc = null;
+
+  @Before
+  @Override
+  public void setUp() throws Exception {
+    super.setUp();
+    initClient();
+  }
+
+  private void initClient() throws IOException {
+    List<InetSocketAddress> addresses = AddrUtil.getAddresses("0.0.0.0:23456");
+    addresses.add(AddrUtil.getAddresses("0.0.0.0:23457").get(0));
+    mc = new ArcusClient(new DefaultConnectionFactory() {
+      @Override
+      public long getOperationTimeout() {
+        return 1;
+      }
+
+      @Override
+      public FailureMode getFailureMode() {
+        return FailureMode.Retry;
+      }
+    }, addresses);
+  }
+
+  @After
+  @Override
+  public void tearDown() throws Exception {
+    // override teardown to avoid the flush phase
+    if (mc != null) {
+      mc.shutdown();
+    }
+    super.tearDown();
+  }
+
+
+  @Test
+  public void getWithoutBulkMessage() {
+    String key = "KEY";
+
+    GetFuture<Object> f = mc.asyncGet(key);
+
+    try {
+      f.get(1L, TimeUnit.MILLISECONDS);
+    } catch (InterruptedException e) {
+      e.printStackTrace();
+    } catch (TimeoutException e) {
+      String[] messages = e.getMessage().split(" ");
+      Assert.assertEquals(APIType.GET.toString(), messages[0]);
+    } catch (ExecutionException e) {
+      e.printStackTrace();
+    }
+  }
+
+  @Test
+  public void getBulkWithBulkMessage() {
+    String key = "KEY";
+    int keySize = 300;
+
+    String[] keys = new String[keySize];
+    for (int i = 0; i < keys.length; i++) {
+      keys[i] = key + i;
+    }
+
+    BulkFuture<Map<String, Object>> f = mc.asyncGetBulk(Arrays.asList(keys));
+
+    try {
+      f.get(1L, TimeUnit.MILLISECONDS);
+    } catch (InterruptedException e) {
+      e.printStackTrace();
+    } catch (TimeoutException e) {
+      String[] messages = e.getMessage().split(" ");
+      assertEquals("bulk", messages[0]);
+    } catch (ExecutionException e) {
+      e.printStackTrace();
+    }
+  }
+
+  @Test
+  public void getBulkWithoutBulkMessage() {
+    String key = "KEY";
+    int keySize = 1;
+
+    String[] keys = new String[keySize];
+    for (int i = 0; i < keys.length; i++) {
+      keys[i] = key + i;
+    }
+
+    BulkFuture<Map<String, Object>> f = mc.asyncGetBulk(Arrays.asList(keys));
+
+    try {
+      f.get(1L, TimeUnit.MILLISECONDS);
+    } catch (InterruptedException e) {
+      e.printStackTrace();
+    } catch (TimeoutException e) {
+      String[] messages = e.getMessage().split(" ");
+      assertEquals(APIType.GET.toString(), messages[0]);
+    } catch (ExecutionException e) {
+      e.printStackTrace();
+    }
+  }
+
+  @Test
+  public void storeWithoutBulkMessage() {
+    String key = "KEY";
+    int keySize = 100;
+    String value = "value";
+
+    OperationFuture<Boolean> f
+            = mc.asyncStore(StoreType.add, key, 10, new CachedData(30, value.getBytes(), 300));
+
+    try {
+      f.get(1L, TimeUnit.MILLISECONDS);
+    } catch (InterruptedException e) {
+      e.printStackTrace();
+    } catch (TimeoutException e) {
+      String[] messages = e.getMessage().split(" ");
+      assertEquals(APIType.ADD.toString(), messages[0]);
+    } catch (ExecutionException e) {
+      e.printStackTrace();
+    }
+  }
+
+  @Test
+  public void setBulkWithBulkMessage() {
+    String key = "KEY";
+    int keySize = 100;
+    String value = "value";
+
+    Map<String, Object> map = new HashMap<String, Object>();
+
+    for (int i = 0; i < keySize; i++) {
+      map.put(key + i, i);
+    }
+
+    Future<Map<String, CollectionOperationStatus>> f = mc.asyncSetBulk(map, 30);
+
+    try {
+      f.get(1L, TimeUnit.MILLISECONDS);
+    } catch (InterruptedException e) {
+      e.printStackTrace();
+    } catch (TimeoutException e) {
+      String[] messages = e.getMessage().split(" ");
+      assertEquals("bulk", messages[0]);
+    } catch (ExecutionException e) {
+      e.printStackTrace();
+    }
+  }
+
+  @Test
+  public void setBulkWithoutBulkMessage() {
+    String key = "KEY";
+    int keySize = 1;
+    String value = "value";
+
+    Map<String, Object> map = new HashMap<String, Object>();
+
+    for (int i = 0; i < keySize; i++) {
+      map.put(key + i, i);
+    }
+
+    Future<Map<String, CollectionOperationStatus>> f = mc.asyncSetBulk(map, 30);
+
+    try {
+      f.get(1L, TimeUnit.MILLISECONDS);
+    } catch (InterruptedException e) {
+      e.printStackTrace();
+    } catch (TimeoutException e) {
+      String[] messages = e.getMessage().split(" ");
+      assertEquals(APIType.SET.toString(), messages[0]);
+    } catch (ExecutionException e) {
+      e.printStackTrace();
+    }
+  }
+
+  @Test
+  public void deleteBulkWithBulkMessage() {
+    String key = "KEY";
+    int keySize = 100;
+
+    String[] keys = new String[keySize];
+    for (int i = 0; i < keys.length; i++) {
+      keys[i] = key + i;
+    }
+
+    Future<Map<String, OperationStatus>> f = mc.asyncDeleteBulk(Arrays.asList(keys));
+
+    try {
+      f.get(1L, TimeUnit.MILLISECONDS);
+    } catch (InterruptedException e) {
+      e.printStackTrace();
+    } catch (TimeoutException e) {
+      String[] messages = e.getMessage().split(" ");
+      assertEquals("bulk", messages[0]);
+    } catch (ExecutionException e) {
+      e.printStackTrace();
+    }
+  }
+
+  @Test
+  public void deleteBulkWithoutBulkMessage() {
+    String key = "KEY";
+    int keySize = 1;
+
+    String[] keys = new String[keySize];
+    for (int i = 0; i < keys.length; i++) {
+      keys[i] = key + i;
+    }
+
+    Future<Map<String, OperationStatus>> f = mc.asyncDeleteBulk(Arrays.asList(keys));
+
+    try {
+      f.get(1L, TimeUnit.MILLISECONDS);
+    } catch (InterruptedException e) {
+      e.printStackTrace();
+    } catch (TimeoutException e) {
+      String[] messages = e.getMessage().split(" ");
+      assertEquals(APIType.DELETE.toString(), messages[0]);
+    } catch (ExecutionException e) {
+      e.printStackTrace();
+    }
+  }
+
+  @Test
+  public void sopPipedInsertBulkWithPipeMessage() {
+    String key = "key";
+    int valueCount = mc.getMaxPipedItemCount();
+    Object[] valueList = new Object[valueCount];
+    for (int i = 0; i < valueList.length; i++) {
+      valueList[i] = "value" + i;
+    }
+
+    Future<Map<Integer, CollectionOperationStatus>> f = mc.asyncSopPipedInsertBulk(
+            key, Arrays.asList(valueList), new CollectionAttributes());
+
+    try {
+      f.get(1L, TimeUnit.MILLISECONDS);
+    } catch (InterruptedException e) {
+      e.printStackTrace();
+    } catch (TimeoutException e) {
+      String[] messages = e.getMessage().split(" ");
+      assertEquals("pipe", messages[0]);
+    } catch (ExecutionException e) {
+      e.printStackTrace();
+    }
+  }
+
+  @Test
+  public void sopPipedExistBulkWithPipeMessage() {
+    String key = "key";
+    int valueCount = mc.getMaxPipedItemCount();
+    Object[] valueList = new Object[valueCount];
+    for (int i = 0; i < valueList.length; i++) {
+      valueList[i] = "value" + i;
+    }
+
+    CollectionFuture<Map<Object, Boolean>> f
+            = mc.asyncSopPipedExistBulk(key, Arrays.asList(valueList));
+
+    try {
+      f.get(1L, TimeUnit.MILLISECONDS);
+    } catch (InterruptedException e) {
+      e.printStackTrace();
+    } catch (TimeoutException e) {
+      String[] messages = e.getMessage().split(" ");
+      assertEquals("pipe", messages[0]);
+    } catch (ExecutionException e) {
+      e.printStackTrace();
+    }
+  }
+
+  @Test
+  public void sopInsertBulkWithBulkMessage() {
+    String key = "key";
+    String value = "MyValue";
+    int keySize = 100;
+    String[] keys = new String[keySize];
+    for (int i = 0; i < keys.length; i++) {
+      keys[i] = key + i;
+    }
+
+    Future<Map<String, CollectionOperationStatus>> f = mc.asyncSopInsertBulk(
+            Arrays.asList(keys), value, new CollectionAttributes());
+
+    try {
+      f.get(1L, TimeUnit.MILLISECONDS);
+    } catch (InterruptedException e) {
+      e.printStackTrace();
+    } catch (TimeoutException e) {
+      String[] messages = e.getMessage().split(" ");
+      assertEquals("bulk", messages[0]);
+    } catch (ExecutionException e) {
+      e.printStackTrace();
+    }
+  }
+
+  @Test
+  public void lopPipedInsertBulkWithPipeMessage() {
+    String key = "key";
+    int valueCount = 500;
+    Object[] valueList = new Object[valueCount];
+    for (int i = 0; i < valueList.length; i++) {
+      valueList[i] = "MyValue";
+    }
+
+    // SET
+    Future<Map<Integer, CollectionOperationStatus>> f = mc.asyncLopPipedInsertBulk(
+            key, 0, Arrays.asList(valueList), new CollectionAttributes());
+    try {
+      f.get(1L, TimeUnit.MILLISECONDS);
+    } catch (InterruptedException e) {
+      e.printStackTrace();
+    } catch (TimeoutException e) {
+      String[] messages = e.getMessage().split(" ");
+      assertEquals("pipe", messages[0]);
+    } catch (ExecutionException e) {
+      e.printStackTrace();
+    }
+  }
+
+  @Test
+  public void lopInsertBulkWithBulkMessage() {
+    String value = "MyValue";
+    int keySize = 250000;
+
+    String[] keys = new String[keySize];
+    for (int i = 0; i < keys.length; i++) {
+      keys[i] = "MyLopKey" + i;
+    }
+
+    Future<Map<String, CollectionOperationStatus>> f = mc.asyncLopInsertBulk(
+            Arrays.asList(keys), 0, value, new CollectionAttributes());
+    try {
+      f.get(1L, TimeUnit.MILLISECONDS);
+    } catch (InterruptedException e) {
+      e.printStackTrace();
+    } catch (TimeoutException e) {
+      String[] messages = e.getMessage().split(" ");
+      assertEquals("bulk", messages[0]);
+    } catch (ExecutionException e) {
+      e.printStackTrace();
+    }
+  }
+
+  @Test
+  public void bopPipedInsertBulkWithPipeMessage() {
+    String key = "MyBopKey";
+    String value = "MyValue";
+
+    int bkeySize = mc.getMaxPipedItemCount();
+    Map<Long, Object> bkeys = new TreeMap<Long, Object>();
+    for (int i = 0; i < bkeySize; i++) {
+      bkeys.put((long) i, value);
+    }
+
+    Future<Map<Integer, CollectionOperationStatus>> f = mc.asyncBopPipedInsertBulk(
+            key, bkeys, new CollectionAttributes());
+    try {
+      f.get(1L, TimeUnit.MILLISECONDS);
+    } catch (InterruptedException e) {
+      e.printStackTrace();
+    } catch (TimeoutException e) {
+      String[] messages = e.getMessage().split(" ");
+      assertEquals("pipe", messages[0]);
+    } catch (ExecutionException e) {
+      e.printStackTrace();
+    }
+  }
+
+  @Test
+  public void bopPipedUpdateBulkWithPipeMessage() {
+    String key = "MyBopKey";
+
+    List<Element<Object>> updateElements = new ArrayList<Element<Object>>();
+    for (int i = 0; i < mc.getMaxPipedItemCount(); i++) {
+      updateElements.add(new Element<Object>(i, "updated" + i,
+              new ElementFlagUpdate(new byte[]{1, 1, 1, 1})));
+    }
+
+    Future<Map<Integer, CollectionOperationStatus>> f
+            = mc.asyncBopPipedUpdateBulk(key, updateElements);
+    try {
+      f.get(1L, TimeUnit.MILLISECONDS);
+    } catch (InterruptedException e) {
+      e.printStackTrace();
+    } catch (TimeoutException e) {
+      String[] messages = e.getMessage().split(" ");
+      assertEquals("pipe", messages[0]);
+    } catch (ExecutionException e) {
+      e.printStackTrace();
+    }
+  }
+
+  @Test
+  public void bopInsertBulkWithBulkMessage() {
+    String value = "MyValue";
+    long bkey = Long.MAX_VALUE;
+
+    int keySize = 10000;
+    String[] keys = new String[keySize];
+    for (int i = 0; i < keys.length; i++) {
+      String key = "MyBopKey" + i;
+      keys[i] = key;
+    }
+
+    Future<Map<String, CollectionOperationStatus>> f = mc.asyncBopInsertBulk(
+            Arrays.asList(keys), bkey, new byte[]{0, 0, 1, 1}, value, new CollectionAttributes());
+    try {
+      f.get(1L, TimeUnit.MILLISECONDS);
+    } catch (InterruptedException e) {
+      e.printStackTrace();
+    } catch (TimeoutException e) {
+      String[] messages = e.getMessage().split(" ");
+      assertEquals("bulk", messages[0]);
+    } catch (ExecutionException e) {
+      e.printStackTrace();
+    }
+  }
+
+  @Test
+  public void oldSMGetWithBulkMessage() {
+    String key = "MyBopKey";
+    List<String> keyList = new ArrayList<String>();
+    for (int i = 0; i < 1000; i++) {
+      keyList.add(key + i);
+    }
+
+    SMGetFuture<List<SMGetElement<Object>>> f = mc.asyncBopSortMergeGet(
+            keyList, 0, 1000, ElementFlagFilter.DO_NOT_FILTER, 0, 500);
+    try {
+      f.get(1L, TimeUnit.MILLISECONDS);
+    } catch (InterruptedException e) {
+      e.printStackTrace();
+    } catch (TimeoutException e) {
+      String[] messages = e.getMessage().split(" ");
+      assertEquals("bulk", messages[0]);
+    } catch (ExecutionException e) {
+      e.printStackTrace();
+    }
+  }
+
+  @Test
+  public void smGetTimeoutWithBulkMessage() {
+    String key = "MyBopKey";
+    List<String> keyList = new ArrayList<String>();
+    for (int i = 0; i < 1000; i++) {
+      keyList.add(key + i);
+    }
+
+    SMGetMode smgetMode = SMGetMode.UNIQUE;
+
+    SMGetFuture<List<SMGetElement<Object>>> f = mc.asyncBopSortMergeGet(
+            keyList, 0, 1000, ElementFlagFilter.DO_NOT_FILTER, 500, smgetMode);
+    try {
+      f.get(1L, TimeUnit.MILLISECONDS);
+    } catch (InterruptedException e) {
+      e.printStackTrace();
+    } catch (TimeoutException e) {
+      String[] messages = e.getMessage().split(" ");
+      assertEquals("bulk", messages[0]);
+    } catch (ExecutionException e) {
+      e.printStackTrace();
+    }
+  }
+
+  @Test
+  public void byteArrayBKeyOldSMGetWithBulkMessage() {
+    String key = "MyBopKey";
+    ArrayList<String> keyList;
+    keyList = new ArrayList<String>();
+    for (int i = 0; i < 1000; i++) {
+      keyList.add(key + i);
+    }
+
+    byte[] from = new byte[]{(byte) 0};
+    byte[] to = new byte[]{(byte) 1000};
+
+    SMGetFuture<List<SMGetElement<Object>>> f = mc.asyncBopSortMergeGet(
+            keyList, from, to, ElementFlagFilter.DO_NOT_FILTER, 0, 500);
+    try {
+      f.get(1L, TimeUnit.MILLISECONDS);
+    } catch (InterruptedException e) {
+      e.printStackTrace();
+    } catch (TimeoutException e) {
+      String[] messages = e.getMessage().split(" ");
+      assertEquals("bulk", messages[0]);
+    } catch (ExecutionException e) {
+      e.printStackTrace();
+    }
+  }
+
+  @Test
+  public void byteArrayBKeySMGetWithBulkMessage() {
+    String key = "MyBopKey";
+    List<String> keyList = new ArrayList<String>();
+    for (int i = 0; i < 1000; i++) {
+      keyList.add(key + i);
+    }
+
+    byte[] from = new byte[]{(byte) 0};
+    byte[] to = new byte[]{(byte) 1000};
+
+    SMGetMode smgetMode = SMGetMode.UNIQUE;
+
+    SMGetFuture<List<SMGetElement<Object>>> f = mc.asyncBopSortMergeGet(
+            keyList, from, to, ElementFlagFilter.DO_NOT_FILTER, 500, smgetMode);
+    try {
+      f.get(1L, TimeUnit.MILLISECONDS);
+    } catch (InterruptedException e) {
+      e.printStackTrace();
+    } catch (TimeoutException e) {
+      String[] messages = e.getMessage().split(" ");
+      assertEquals("bulk", messages[0]);
+    } catch (ExecutionException e) {
+      e.printStackTrace();
+    }
+  }
+
+  @Test
+  public void mopPipedInsertBulkWithPipeMessage() {
+    String key = "MyMopKey";
+    String value = "MyValue";
+
+    int elementSize = mc.getMaxPipedItemCount();
+    Map<String, Object> elements = new TreeMap<String, Object>();
+    for (int i = 0; i < elementSize; i++) {
+      elements.put(String.valueOf(i), value);
+    }
+
+    Future<Map<Integer, CollectionOperationStatus>> f = mc.asyncMopPipedInsertBulk(
+            key, elements, new CollectionAttributes());
+    try {
+      f.get(1L, TimeUnit.MILLISECONDS);
+    } catch (InterruptedException e) {
+      e.printStackTrace();
+    } catch (TimeoutException e) {
+      String[] messages = e.getMessage().split(" ");
+      assertEquals("pipe", messages[0]);
+    } catch (ExecutionException e) {
+      e.printStackTrace();
+    }
+    f.cancel(true);
+  }
+
+  @Test
+  public void mopPipedUpdateBulkWithBulkMessage() {
+    String mkey = "MyMopKey";
+    String value = "MyValue";
+    int keySize = 250000;
+
+    String[] keys = new String[keySize];
+    for (int i = 0; i < keys.length; i++) {
+      keys[i] = "MyMopKey" + i;
+    }
+
+    Map<String, Object> updated = new HashMap<String, Object>();
+    for (int i = 0; i < keys.length; i++) {
+      updated.put(keys[i], value + i);
+    }
+
+    CollectionFuture<Map<Integer, CollectionOperationStatus>> f =
+            mc.asyncMopPipedUpdateBulk(mkey, updated);
+    try {
+      f.get(1L, TimeUnit.MILLISECONDS);
+    } catch (InterruptedException e) {
+      e.printStackTrace();
+    } catch (TimeoutException e) {
+      String[] messages = e.getMessage().split(" ");
+      assertEquals("pipe", messages[0]);
+    } catch (ExecutionException e) {
+      e.printStackTrace();
+    }
+    f.cancel(true);
+  }
+
+  @Test
+  public void mopInsertBulkWithBulkMessage() {
+    String mkey = "MyMopKey";
+    String value = "MyValue";
+    int keySize = 250000;
+
+    String[] keys = new String[keySize];
+    for (int i = 0; i < keys.length; i++) {
+      keys[i] = "MyMopKey" + i;
+    }
+
+    Future<Map<String, CollectionOperationStatus>> f = mc.asyncMopInsertBulk(
+            Arrays.asList(keys), mkey, value, new CollectionAttributes());
+    try {
+      f.get(1L, TimeUnit.MILLISECONDS);
+    } catch (InterruptedException e) {
+      e.printStackTrace();
+    } catch (TimeoutException e) {
+      String[] messages = e.getMessage().split(" ");
+      assertEquals("bulk", messages[0]);
+    } catch (ExecutionException e) {
+      e.printStackTrace();
+    }
+    f.cancel(true);
+  }
+}

--- a/src/test/java/net/spy/memcached/ArcusTimeoutTest.java
+++ b/src/test/java/net/spy/memcached/ArcusTimeoutTest.java
@@ -335,6 +335,7 @@ public class ArcusTimeoutTest extends TestCase {
     future.cancel(true);
   }
 
+  @Test(expected = TimeoutException.class)
   public void testMopInsertBulkTimeout()
           throws InterruptedException, ExecutionException, TimeoutException {
     String mkey = "MyMopKey";

--- a/src/test/java/net/spy/memcached/AsciiClientTest.java
+++ b/src/test/java/net/spy/memcached/AsciiClientTest.java
@@ -31,6 +31,16 @@ public class AsciiClientTest extends ProtocolBaseCase {
       public void initialize() {
         setBuffer(ByteBuffer.wrap("garbage\r\n".getBytes()));
       }
+
+      @Override
+      public boolean isBulkOperation() {
+        return false;
+      }
+
+      @Override
+      public boolean isPipeOperation() {
+        return false;
+      }
     });
   }
 

--- a/src/test/java/net/spy/memcached/internal/CheckedOperationTimeoutExceptionTest.java
+++ b/src/test/java/net/spy/memcached/internal/CheckedOperationTimeoutExceptionTest.java
@@ -81,5 +81,14 @@ public class CheckedOperationTimeoutExceptionTest extends TestCase {
       throw new RuntimeException("Not implemented");
     }
 
+    @Override
+    public boolean isBulkOperation() {
+      return false;
+    }
+
+    @Override
+    public boolean isPipeOperation() {
+      return false;
+    }
   }
 }

--- a/src/test/java/net/spy/memcached/protocol/ascii/BaseOpTest.java
+++ b/src/test/java/net/spy/memcached/protocol/ascii/BaseOpTest.java
@@ -134,5 +134,14 @@ public class BaseOpTest extends BaseMockCase {
       setBuffer(ByteBuffer.allocate(0));
     }
 
+    @Override
+    public boolean isBulkOperation() {
+      return false;
+    }
+
+    @Override
+    public boolean isPipeOperation() {
+      return false;
+    }
   }
 }


### PR DESCRIPTION
#306 에 관한 pr입니다.

- <timeout, unit> 정보 (필수)
  - 포함 
- 메소드 API 정보 (option)
  - 포함
- op 정보도 보강하면 좋을 듯. (option)
  - 미포함(논의가 필요합니다.)

아래는 수정 후 timeoutTest를 통해 발생한 exception message입니다.

기존 exception message
```shell
Operation timed out. - failing node: /1.255.51.181:11911 [READING] [#Tops=2 #iq=0 #Wops=0 #Rops=1 #CT=1 #TR=-1]
```
변경 후 exception message
```shell
Operation timed out. >1 MILLISECONDS from net.spy.memcached.internal.BulkGetFuture.get - failing node: /1.255.51.181:11911 [WRITE_QUEUED] [#Tops=2 #iq=0 #Wops=2 #Rops=0 #CT=0 #TR=-1]
```

operation의 관련 정보는 어떤것이 더 추가 되면 좋을지 논의도 필요할 것 같습니다.