### PR TITLE
ENHANCE: add node information to the cancellation message

### DIFF
--- a/src/main/java/net/spy/memcached/MemcachedConnection.java
+++ b/src/main/java/net/spy/memcached/MemcachedConnection.java
@@ -1081,7 +1081,7 @@ public final class MemcachedConnection extends SpyObject {
       placeIn = primary;
     } else if (failureMode == FailureMode.Cancel) {
       o.setHandlingNode(primary);
-      o.cancel("inactive node");
+      o.cancel("inactive node: (" + primary.getNodeName() + ")");
     } else {
       // Look for another node in sequence that is ready.
       Iterator<MemcachedNode> iter = getNodeSequence(key, o);

--- a/src/main/java/net/spy/memcached/MemcachedNode.java
+++ b/src/main/java/net/spy/memcached/MemcachedNode.java
@@ -131,6 +131,11 @@ public interface MemcachedNode {
   int getSelectionOps();
 
   /**
+   * Get the NodeName used for reading ip, port and hostName from this node
+   */
+  String getNodeName();
+
+  /**
    * Get the buffer used for reading data from this node.
    */
   ByteBuffer getRbuf();

--- a/src/main/java/net/spy/memcached/MemcachedNodeROImpl.java
+++ b/src/main/java/net/spy/memcached/MemcachedNodeROImpl.java
@@ -43,6 +43,11 @@ public class MemcachedNodeROImpl implements MemcachedNode {
     return root.toString();
   }
 
+  @Override
+  public String getNodeName() {
+    return root.getNodeName();
+  }
+
   public MemcachedNode getMemcachedNode() {
     return root;
   }

--- a/src/main/java/net/spy/memcached/protocol/TCPMemcachedNodeImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/TCPMemcachedNodeImpl.java
@@ -18,6 +18,7 @@
 package net.spy.memcached.protocol;
 
 import java.io.IOException;
+import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.nio.ByteBuffer;
 import java.nio.channels.SelectionKey;
@@ -147,7 +148,8 @@ public abstract class TCPMemcachedNodeImpl extends SpyObject
     socketAddress=sa;
     */
     /* ENABLE_REPLICATION end */
-    nodeName = name + " " + sa;
+    String hostName = ((InetSocketAddress) sa).getHostName();
+    nodeName = name + " " + sa + hostName;
     setChannel(c);
     rbuf = ByteBuffer.allocate(bufSize);
     wbuf = ByteBuffer.allocate(bufSize);
@@ -412,6 +414,11 @@ public abstract class TCPMemcachedNodeImpl extends SpyObject
       rv = SelectionKey.OP_CONNECT;
     }
     return rv;
+  }
+
+  @Override
+  public final String getNodeName() {
+    return nodeName;
   }
 
   public final ByteBuffer getRbuf() {

--- a/src/test/java/net/spy/memcached/CancelFailureModeTest.java
+++ b/src/test/java/net/spy/memcached/CancelFailureModeTest.java
@@ -3,7 +3,7 @@ package net.spy.memcached;
 import junit.framework.TestCase;
 
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Future;
+import net.spy.memcached.internal.OperationFuture;
 
 public class CancelFailureModeTest extends TestCase {
   private String serverList= "127.0.0.1:11311";
@@ -29,12 +29,13 @@ public class CancelFailureModeTest extends TestCase {
   }
 
   public void testQueueingToDownServer() throws Exception {
-    Future<Boolean> f = client.add("someKey", 0, "some object");
+    OperationFuture<Boolean> f = client.add("someKey", 0, "some object");
     try {
       boolean b = f.get();
       fail("Should've thrown an exception, returned " + b);
     } catch (ExecutionException e) {
       // probably OK
+      System.out.println(e.getMessage());
     }
     assertTrue(f.isCancelled());
   }

--- a/src/test/java/net/spy/memcached/TimeoutTest.java
+++ b/src/test/java/net/spy/memcached/TimeoutTest.java
@@ -8,7 +8,7 @@ public class TimeoutTest extends TestCase {
   @Override
   protected void setUp() throws Exception {
     super.setUp();
-    client = new MemcachedClient(new DefaultConnectionFactory() {
+    client = new ArcusClient(new DefaultConnectionFactory() {
       @Override
       public long getOperationTimeout() {
         return 1;


### PR DESCRIPTION
#305 에 대한 pr입니다.

- inactive node => inactive node(ip:port)
    - 수정 전
        ```
        Cancelled (inactive node)
        ```
    - 수정 후
       ```
       Cancelled (inactive node(/3.16.158.131:11211, hostName: ec2-3-16-158-131.us-east-2.compute.amazonaws.com))
       ```
- ... Connection reset by peer => ... Connection reset by peer(ip:port)
   - 해당 메세지가 사용되는 곳을 찾지 못하였습니다.  
- 다른 Cancel 메세지도 확인하여 추가
   - 노드 취소로 인한 문제가 발생했을 때 모두 logger에 node에 대한 정보를 포함하여서 넘겨주고 있어서 다른 부분에서는
      추가해야할 곳이 없어보였습니다.

또한 테스트 코드에 콘솔에서 메세지를 확인할 수 있도록 코드를 추가했습니다.