### PR TITLE
ENHANCE: add node information to the cancellation message

### DIFF
--- a/src/main/java/net/spy/memcached/MemcachedConnection.java
+++ b/src/main/java/net/spy/memcached/MemcachedConnection.java
@@ -294,8 +294,8 @@ public final class MemcachedConnection extends SpyObject {
     List<MemcachedNode> removeNodes = new ArrayList<MemcachedNode>();
 
     for (MemcachedNode node : locator.getAll()) {
-      if (addrs.contains((InetSocketAddress) node.getSocketAddress())) {
-        addrs.remove((InetSocketAddress) node.getSocketAddress());
+      if (addrs.contains(node.getSocketAddress())) {
+        addrs.remove(node.getSocketAddress());
       } else {
         removeNodes.add(node);
       }
@@ -749,7 +749,7 @@ public final class MemcachedConnection extends SpyObject {
 
       qa.setupForAuth("due to exception"); // noop if !shouldAuth
       getLogger().warn("Reconnecting due to exception on %s", qa, e);
-      lostConnection(qa, ReconnDelay.DEFAULT, "exception" + e);
+      lostConnection(qa, ReconnDelay.DEFAULT, e.getMessage());
     }
     qa.fixupOps();
   }

--- a/src/main/java/net/spy/memcached/MemcachedNode.java
+++ b/src/main/java/net/spy/memcached/MemcachedNode.java
@@ -131,6 +131,11 @@ public interface MemcachedNode {
   int getSelectionOps();
 
   /**
+   * Get the node name used for reading ip, port and hostname from this node
+   */
+  String getNodeName();
+
+  /**
    * Get the buffer used for reading data from this node.
    */
   ByteBuffer getRbuf();

--- a/src/main/java/net/spy/memcached/MemcachedNodeROImpl.java
+++ b/src/main/java/net/spy/memcached/MemcachedNodeROImpl.java
@@ -43,6 +43,11 @@ public class MemcachedNodeROImpl implements MemcachedNode {
     return root.toString();
   }
 
+  @Override
+  public String getNodeName() {
+    return root.getNodeName();
+  }
+
   public MemcachedNode getMemcachedNode() {
     return root;
   }

--- a/src/main/java/net/spy/memcached/protocol/BaseOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/BaseOperationImpl.java
@@ -86,7 +86,11 @@ public abstract class BaseOperationImpl extends SpyObject {
 
   public final void cancel(String cause) {
     cancelled = true;
-    cancelCause = "Cancelled (" + cause + ")";
+    if (handlingNode != null) {
+      cancelCause = "Cancelled (" + cause + " : (" + handlingNode.getNodeName() + ")" + ")";
+    } else {
+      cancelCause = "Cancelled (" + cause + ")";
+    }
     wasCancelled();
     callback.complete();
   }

--- a/src/main/java/net/spy/memcached/protocol/TCPMemcachedNodeImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/TCPMemcachedNodeImpl.java
@@ -400,6 +400,10 @@ public abstract class TCPMemcachedNodeImpl extends SpyObject
     return rv;
   }
 
+  public final String getNodeName() {
+    return nodeName;
+  }
+
   public final ByteBuffer getRbuf() {
     return rbuf;
   }

--- a/src/test/java/net/spy/memcached/MemcachedNodeROImplTest.java
+++ b/src/test/java/net/spy/memcached/MemcachedNodeROImplTest.java
@@ -28,7 +28,7 @@ public class MemcachedNodeROImplTest extends MockObjectTestCase {
 
     Set<String> acceptable = new HashSet<String>(Arrays.asList(
             "toString", "getSocketAddress", "getBytesRemainingToWrite",
-            "getReconnectCount", "getSelectionOps", "hasReadOp",
+            "getReconnectCount", "getSelectionOps", "getNodeName", "hasReadOp",
             "hasWriteOp", "isActive", "isFirstConnecting"));
 
     for (Method meth : MemcachedNode.class.getMethods()) {

--- a/src/test/java/net/spy/memcached/MockMemcachedNode.java
+++ b/src/test/java/net/spy/memcached/MockMemcachedNode.java
@@ -118,6 +118,11 @@ public class MockMemcachedNode implements MemcachedNode {
     return 0;
   }
 
+  @Override
+  public String getNodeName() {
+    return null;
+  }
+
   public ByteBuffer getRbuf() {
     return null;
   }


### PR DESCRIPTION
#305  에 대한 pr입니다.
#321 의 pr을 close하고 새로 pr하였습니다.


nodename을 이용하여 정보를 보강하도록 했습니다. 수정된 결과로는
- DNS name이 존재할 시 (hostname출력)
   ```
   Cancelled (inactive node: (ArcusClient /127.0.0.1:11211-localhost))
   ```
- DNS name이 존재하지 않을 시 (ip출력)
   ```
   Cancelled (inactive node: (ArcusClient /1.255.51.181:11912-1.255.51.181))
   ```

- hostname을 추가하여 테스트가 깨지는 경우가 몇개 있어서 테스트도 같이 수정하였습니다.

리뷰 요청드립니다.
@hjyun328 