### PR TITLE
FEATURE: support mgets command

### DIFF
--- a/docs/03-key-value-API.md
+++ b/docs/03-key-value-API.md
@@ -106,14 +106,38 @@ future.get(key).getStatusCode() | 설명
 --------------------------------| ---------
 StatusCode.SUCCESS              | 조회 성공(key에 해당하는 item 존재하지 않아도 성공)
 
-여러 key들의 value들을 한번에 조회하는 bulk API를 제공한다.
+여러 key들의 value를 한번에 조회하는 bulk API를 제공한다.
 
 ```java
-BulkFuture<Map<String,Object>> asyncGetBulk(Collection<String> keys)
-BulkFuture<Map<String,Object>> asyncGetBulk(String... keys)
+BulkFuture<Map<String, Object>> asyncGetBulk(Collection<String> keys)
+BulkFuture<Map<String, Object>> asyncGetBulk(String... keys)
 ```
 
 - 다수 key들에 저장된 value를 Map<String, Object> 형태로 반환한다.
+- 다수 key들은 String 유형의 Collection이거나 String 유형의 나열된 key 목록일 수 있다.
+
+하나의 key를 가진 cache item에 저장된 CASValue를 조회하는 API를 제공한다.
+
+```java
+GetFuture<CASValue<Object>> asyncGets(String key)
+```
+
+- 주어진 key에 저장된 CASValue(cas, value)를 반환한다.
+
+수행 결과는 future 객체를 통해 얻는다.
+
+future.get(key).getStatusCode() | 설명
+--------------------------------| ---------
+StatusCode.SUCCESS              | 조회 성공(key에 해당하는 item 존재하지 않아도 성공)
+
+여러 key들의 CASValue를 한번에 조회하는 bulk API를 제공한다.
+
+```java
+BulkFuture<Map<String, CASValue<Object>>> asyncGetsBulk(Collection<String> keys)
+BulkFuture<Map<String, CASValue<Object>>> asyncGetsBulk(String... keys)
+```
+
+- 다수 key들에 저장된 CASValue를 Map<String, CASValue<Object>> 형태로 반환한다.
 - 다수 key들은 String 유형의 Collection이거나 String 유형의 나열된 key 목록일 수 있다.
 
 ## Key-Value Item 값의 증감

--- a/src/main/java/net/spy/memcached/ArcusClientPool.java
+++ b/src/main/java/net/spy/memcached/ArcusClientPool.java
@@ -210,6 +210,29 @@ public class ArcusClientPool implements ArcusClientIF {
     return this.getClient().asyncGetBulk(keys);
   }
 
+  public <T> BulkFuture<Map<String, CASValue<T>>> asyncGetsBulk(Collection<String> keys,
+                                                                Iterator<Transcoder<T>> tcs) {
+    return this.getClient().asyncGetsBulk(keys, tcs);
+  }
+
+  public <T> BulkFuture<Map<String, CASValue<T>>> asyncGetsBulk(Collection<String> keys,
+                                                                Transcoder<T> tc) {
+    return this.getClient().asyncGetsBulk(keys, tc);
+  }
+
+  public BulkFuture<Map<String, CASValue<Object>>> asyncGetsBulk(Collection<String> keys) {
+    return this.getClient().asyncGetsBulk(keys);
+  }
+
+  public <T> BulkFuture<Map<String, CASValue<T>>> asyncGetsBulk(Transcoder<T> tc,
+                                                                String... keys) {
+    return this.getClient().asyncGetsBulk(tc, keys);
+  }
+
+  public BulkFuture<Map<String, CASValue<Object>>> asyncGetsBulk(String... keys) {
+    return this.getClient().asyncGetsBulk(keys);
+  }
+
   public <T> Map<String, T> getBulk(Collection<String> keys, Transcoder<T> tc)
           throws OperationTimeoutException {
     return this.getClient().getBulk(keys, tc);
@@ -228,6 +251,26 @@ public class ArcusClientPool implements ArcusClientIF {
   public Map<String, Object> getBulk(String... keys)
           throws OperationTimeoutException {
     return this.getClient().getBulk(keys);
+  }
+
+  public <T> Map<String, CASValue<T>> getsBulk(Collection<String> keys, Transcoder<T> tc)
+          throws OperationTimeoutException {
+    return this.getClient().getsBulk(keys, tc);
+  }
+
+  public Map<String, CASValue<Object>> getsBulk(Collection<String> keys)
+          throws OperationTimeoutException {
+    return this.getClient().getsBulk(keys);
+  }
+
+  public <T> Map<String, CASValue<T>> getsBulk(Transcoder<T> tc, String... keys)
+          throws OperationTimeoutException {
+    return this.getClient().getsBulk(tc, keys);
+  }
+
+  public Map<String, CASValue<Object>> getsBulk(String... keys)
+          throws OperationTimeoutException {
+    return this.getClient().getsBulk(keys);
   }
 
   public Map<SocketAddress, String> getVersions() {

--- a/src/main/java/net/spy/memcached/MemcachedClientIF.java
+++ b/src/main/java/net/spy/memcached/MemcachedClientIF.java
@@ -105,6 +105,19 @@ public interface MemcachedClientIF {
 
   BulkFuture<Map<String, Object>> asyncGetBulk(String... keys);
 
+  <T> BulkFuture<Map<String, CASValue<T>>> asyncGetsBulk(Collection<String> keys,
+                                                         Iterator<Transcoder<T>> tcs);
+
+  <T> BulkFuture<Map<String, CASValue<T>>> asyncGetsBulk(Collection<String> keys,
+                                                         Transcoder<T> tc);
+
+  BulkFuture<Map<String, CASValue<Object>>> asyncGetsBulk(Collection<String> keys);
+
+  <T> BulkFuture<Map<String, CASValue<T>>> asyncGetsBulk(Transcoder<T> tc,
+                                                         String... keys);
+
+  BulkFuture<Map<String, CASValue<Object>>> asyncGetsBulk(String... keys);
+
   <T> Map<String, T> getBulk(Collection<String> keys, Transcoder<T> tc)
           throws OperationTimeoutException;
 
@@ -115,6 +128,18 @@ public interface MemcachedClientIF {
           throws OperationTimeoutException;
 
   Map<String, Object> getBulk(String... keys)
+          throws OperationTimeoutException;
+
+  <T> Map<String, CASValue<T>> getsBulk(Collection<String> keys, Transcoder<T> tc)
+          throws OperationTimeoutException;
+
+  Map<String, CASValue<Object>> getsBulk(Collection<String> keys)
+          throws OperationTimeoutException;
+
+  <T> Map<String, CASValue<T>> getsBulk(Transcoder<T> tc, String... keys)
+          throws OperationTimeoutException;
+
+  Map<String, CASValue<Object>> getsBulk(String... keys)
           throws OperationTimeoutException;
 
   Map<SocketAddress, String> getVersions();

--- a/src/main/java/net/spy/memcached/MemcachedNode.java
+++ b/src/main/java/net/spy/memcached/MemcachedNode.java
@@ -217,6 +217,11 @@ public interface MemcachedNode {
   boolean enabledMGetOp();
 
   /**
+   * Check the enable MGets operation.
+   */
+  boolean enabledMGetsOp();
+
+  /**
    * Check the enable SpaceSeparate operation.
    */
   boolean enabledSpaceSeparate();

--- a/src/main/java/net/spy/memcached/MemcachedNodeROImpl.java
+++ b/src/main/java/net/spy/memcached/MemcachedNodeROImpl.java
@@ -168,6 +168,10 @@ public class MemcachedNodeROImpl implements MemcachedNode {
     throw new UnsupportedOperationException();
   }
 
+  public boolean enabledMGetsOp() {
+    throw new UnsupportedOperationException();
+  }
+
   public boolean enabledSpaceSeparate() {
     throw new UnsupportedOperationException();
   }

--- a/src/main/java/net/spy/memcached/OperationFactory.java
+++ b/src/main/java/net/spy/memcached/OperationFactory.java
@@ -143,6 +143,15 @@ public interface OperationFactory {
   GetOperation get(Collection<String> keys, GetOperation.Callback cb);
 
   /**
+   * Create a gets operation.
+   *
+   * @param keys the collection of keys to get
+   * @param cb   the callback that will contain the results
+   * @return a new GetsOperation
+   */
+  GetsOperation gets(Collection<String> keys, GetsOperation.Callback cb);
+
+  /**
    * Create a mget operation.
    *
    * @param keys the collection of keys to get
@@ -150,6 +159,15 @@ public interface OperationFactory {
    * @return a new GetOperation
    */
   GetOperation mget(Collection<String> keys, GetOperation.Callback cb);
+
+  /**
+   * Create a mgets operation.
+   *
+   * @param keys the collection of keys to get
+   * @param cb   the callback that will contain the results
+   * @return a new GetOperation
+   */
+  GetsOperation mgets(Collection<String> keys, GetsOperation.Callback cb);
 
   /**
    * Create a mutator operation.

--- a/src/main/java/net/spy/memcached/ops/APIType.java
+++ b/src/main/java/net/spy/memcached/ops/APIType.java
@@ -24,7 +24,8 @@ public enum APIType {
   CAS(OperationType.WRITE),
   INCR(OperationType.WRITE), DECR(OperationType.WRITE),
   DELETE(OperationType.WRITE),
-  GET(OperationType.READ), GETS(OperationType.READ), MGET(OperationType.READ),
+  GET(OperationType.READ), GETS(OperationType.READ),
+  MGET(OperationType.READ), MGETS(OperationType.READ),
 
   // List API Type
   LOP_CREATE(OperationType.WRITE),

--- a/src/main/java/net/spy/memcached/ops/BaseOperationFactory.java
+++ b/src/main/java/net/spy/memcached/ops/BaseOperationFactory.java
@@ -44,12 +44,16 @@ public abstract class BaseOperationFactory implements OperationFactory {
     Collection<Operation> rv = new ArrayList<Operation>(
             op.getKeys().size());
     if (op instanceof GetOperation) {
-      rv.addAll(cloneGet(op));
-    } else if (op instanceof GetsOperation) {
-      GetsOperation.Callback callback =
-              (GetsOperation.Callback) op.getCallback();
+      GetOperation.Callback getCb = new MultiGetOperationCallback(
+              op.getCallback(), op.getKeys().size());
       for (String k : op.getKeys()) {
-        rv.add(gets(k, callback));
+        rv.add(get(k, getCb));
+      }
+    } else if (op instanceof GetsOperation) {
+      GetsOperation.Callback getsCb = new MultiGetsOperationCallback(
+              op.getCallback(), op.getKeys().size());
+      for (String k : op.getKeys()) {
+        rv.add(gets(k, getsCb));
       }
     } else if (op instanceof CASOperation) {
       CASOperation cop = (CASOperation) op;
@@ -98,11 +102,6 @@ public abstract class BaseOperationFactory implements OperationFactory {
     } else {
       assert false : "Unhandled operation type: " + op.getClass();
     }
-
     return rv;
   }
-
-  protected abstract Collection<? extends Operation> cloneGet(
-          KeyedOperation op);
-
 }

--- a/src/main/java/net/spy/memcached/protocol/ascii/AsciiOperationFactory.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/AsciiOperationFactory.java
@@ -16,7 +16,6 @@
  */
 package net.spy.memcached.protocol.ascii;
 
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -70,12 +69,9 @@ import net.spy.memcached.ops.FlushOperation;
 import net.spy.memcached.ops.GetAttrOperation;
 import net.spy.memcached.ops.GetOperation;
 import net.spy.memcached.ops.GetsOperation;
-import net.spy.memcached.ops.KeyedOperation;
-import net.spy.memcached.ops.MultiGetOperationCallback;
 import net.spy.memcached.ops.Mutator;
 import net.spy.memcached.ops.MutatorOperation;
 import net.spy.memcached.ops.NoopOperation;
-import net.spy.memcached.ops.Operation;
 import net.spy.memcached.ops.OperationCallback;
 import net.spy.memcached.ops.SASLAuthOperation;
 import net.spy.memcached.ops.SASLMechsOperation;
@@ -111,8 +107,16 @@ public class AsciiOperationFactory extends BaseOperationFactory {
     return new GetsOperationImpl(key, cb);
   }
 
+  public GetsOperation gets(Collection<String> keys, GetsOperation.Callback cb) {
+    return new GetsOperationImpl(keys, cb);
+  }
+
   public GetOperation mget(Collection<String> keys, GetOperation.Callback cb) {
     return new MGetOperationImpl(keys, cb);
+  }
+
+  public GetsOperation mgets(Collection<String> keys, GetsOperation.Callback cb) {
+    return new MGetsOperationImpl(keys, cb);
   }
 
   public MutatorOperation mutate(Mutator m, String key, int by,
@@ -146,17 +150,6 @@ public class AsciiOperationFactory extends BaseOperationFactory {
                                     long casId,
                                     String key, byte[] data, OperationCallback cb) {
     return new ConcatenationOperationImpl(catType, key, data, cb);
-  }
-
-  @Override
-  protected Collection<? extends Operation> cloneGet(KeyedOperation op) {
-    Collection<Operation> rv = new ArrayList<Operation>();
-    GetOperation.Callback callback = new MultiGetOperationCallback(
-            op.getCallback(), op.getKeys().size());
-    for (String k : op.getKeys()) {
-      rv.add(get(k, callback));
-    }
-    return rv;
   }
 
   public SASLMechsOperation saslMechs(OperationCallback cb) {

--- a/src/main/java/net/spy/memcached/protocol/ascii/BaseGetOpImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/BaseGetOpImpl.java
@@ -150,7 +150,7 @@ abstract class BaseGetOpImpl extends OperationImpl {
       commandBuilder.append(keysString);
       commandBuilder.append(RN_STRING);
     } else {
-      assert cmd.equals("mget") : "Unknown Command " + cmd;
+      assert (cmd.equals("mget") || cmd.equals("mgets")) : "Unknown Command " + cmd;
 
       int lenKeys = keysString.getBytes().length;
       int numKeys = keys.size();

--- a/src/main/java/net/spy/memcached/protocol/ascii/GetsOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/GetsOperationImpl.java
@@ -1,6 +1,8 @@
 package net.spy.memcached.protocol.ascii;
 
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
 
 import net.spy.memcached.ops.APIType;
 import net.spy.memcached.ops.GetsOperation;
@@ -14,6 +16,11 @@ class GetsOperationImpl extends BaseGetOpImpl implements GetsOperation {
 
   public GetsOperationImpl(String key, GetsOperation.Callback cb) {
     super(CMD, cb, Collections.singleton(key));
+    setAPIType(APIType.GETS);
+  }
+
+  public GetsOperationImpl(Collection<String> keys, GetsOperation.Callback cb) {
+    super(CMD, cb, new HashSet<String>(keys));
     setAPIType(APIType.GETS);
   }
 

--- a/src/main/java/net/spy/memcached/protocol/ascii/MGetsOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/MGetsOperationImpl.java
@@ -1,0 +1,21 @@
+package net.spy.memcached.protocol.ascii;
+
+import net.spy.memcached.ops.APIType;
+import net.spy.memcached.ops.GetsOperation;
+
+import java.util.Collection;
+import java.util.HashSet;
+
+/**
+ * Operation for retrieving data.
+ */
+public class MGetsOperationImpl extends BaseGetOpImpl implements GetsOperation {
+
+  private static final String CMD = "mgets";
+
+  public MGetsOperationImpl(Collection<String> k, Callback c) {
+    super(CMD, c, new HashSet<String>(k));
+    setAPIType(APIType.MGETS);
+  }
+
+}

--- a/src/main/java/net/spy/memcached/protocol/binary/BinaryOperationFactory.java
+++ b/src/main/java/net/spy/memcached/protocol/binary/BinaryOperationFactory.java
@@ -16,7 +16,6 @@
  */
 package net.spy.memcached.protocol.binary;
 
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -71,13 +70,9 @@ import net.spy.memcached.ops.GetAttrOperation;
 import net.spy.memcached.ops.GetOperation;
 import net.spy.memcached.ops.GetOperation.Callback;
 import net.spy.memcached.ops.GetsOperation;
-import net.spy.memcached.ops.KeyedOperation;
-import net.spy.memcached.ops.MultiGetOperationCallback;
-import net.spy.memcached.ops.MultiGetsOperationCallback;
 import net.spy.memcached.ops.Mutator;
 import net.spy.memcached.ops.MutatorOperation;
 import net.spy.memcached.ops.NoopOperation;
-import net.spy.memcached.ops.Operation;
 import net.spy.memcached.ops.OperationCallback;
 import net.spy.memcached.ops.SASLAuthOperation;
 import net.spy.memcached.ops.SASLMechsOperation;
@@ -114,9 +109,19 @@ public class BinaryOperationFactory extends BaseOperationFactory {
     return new GetOperationImpl(key, cb);
   }
 
+  public GetsOperation gets(Collection<String> keys, GetsOperation.Callback callback) {
+    throw new RuntimeException(
+            "gets is not supported in binary protocol yet.");
+  }
+
   public GetOperation mget(Collection<String> keys, GetOperation.Callback cb) {
     throw new RuntimeException(
             "mget is not supported in binary protocol yet.");
+  }
+
+  public GetsOperation mgets(Collection<String> keys, GetsOperation.Callback cb) {
+    throw new RuntimeException(
+            "mgets is not supported in binary protocol yet.");
   }
 
   public MutatorOperation mutate(Mutator m, String key, int by,
@@ -151,24 +156,6 @@ public class BinaryOperationFactory extends BaseOperationFactory {
   public ConcatenationOperation cat(ConcatenationType catType, long casId,
                                     String key, byte[] data, OperationCallback cb) {
     return new ConcatenationOperationImpl(catType, key, data, casId, cb);
-  }
-
-  @Override
-  protected Collection<? extends Operation> cloneGet(KeyedOperation op) {
-    Collection<Operation> rv = new ArrayList<Operation>();
-    GetOperation.Callback getCb = null;
-    GetsOperation.Callback getsCb = null;
-    if (op.getCallback() instanceof GetOperation.Callback) {
-      getCb = new MultiGetOperationCallback(
-              op.getCallback(), op.getKeys().size());
-    } else {
-      getsCb = new MultiGetsOperationCallback(
-              op.getCallback(), op.getKeys().size());
-    }
-    for (String k : op.getKeys()) {
-      rv.add(getCb == null ? gets(k, getsCb) : get(k, getCb));
-    }
-    return rv;
   }
 
   public SASLAuthOperation saslAuth(String[] mech, String serverName,

--- a/src/test/java/net/spy/memcached/BinaryClientTest.java
+++ b/src/test/java/net/spy/memcached/BinaryClientTest.java
@@ -32,6 +32,31 @@ public class BinaryClientTest extends ProtocolBaseCase {
     assertTrue(true);
   }
 
+  @Override
+  public void testGetsBulk() throws Exception {
+    assertTrue(true);
+  }
+
+  @Override
+  public void testGetsBulkVararg() throws Exception {
+    assertTrue(true);
+  }
+
+  @Override
+  public void testGetsBulkVarargWithTranscoder() throws Exception {
+    assertTrue(true);
+  }
+
+  @Override
+  public void testAsyncGetsBulkVarargWithTranscoder() throws Exception {
+    assertTrue(true);
+  }
+
+  @Override
+  public void testAsyncGetsBulkWithTranscoderIterator() throws Exception {
+    assertTrue(true);
+  }
+
   public void testCASAppendFail() throws Exception {
     final String key = "append.key";
     assertTrue(client.set(key, 5, "test").get());

--- a/src/test/java/net/spy/memcached/MockMemcachedNode.java
+++ b/src/test/java/net/spy/memcached/MockMemcachedNode.java
@@ -183,6 +183,11 @@ public class MockMemcachedNode implements MemcachedNode {
     return false;
   }
 
+  @Override
+  public boolean enabledMGetsOp() {
+    return false;
+  }
+
   public boolean enabledSpaceSeparate() {
     return false;
   }

--- a/src/test/java/net/spy/memcached/protocol/binary/OperationFactoryTest.java
+++ b/src/test/java/net/spy/memcached/protocol/binary/OperationFactoryTest.java
@@ -10,4 +10,13 @@ public class OperationFactoryTest extends OperationFactoryTestBase {
     return new BinaryOperationFactory();
   }
 
+  @Override
+  public void testMultipleGetsOperationCloning() {
+    assertTrue(true);
+  }
+
+  @Override
+  public void testMultipleGetsOperationFanout() {
+    assertTrue(true);
+  }
 }


### PR DESCRIPTION
mgets 지원 

issue : #320 

mgets 지원을 위하여 APITYPE에 MGETS를 추가하였으며, 노드 초기화시 해당 노드가 mgets를 지원할 수 있는지
enabeldMgets를 추가하여 지원하지 않을시엔 gets를 사용하도록 했습니다.

- asyncGetsBulk, getsBulk API 추가
- 테스트 코드 추가 
- doc : key-value 조회 부분에 기존에 포함되지 않았던 asyncGets와 개발된 asyncGetsBulk를 추가 

asyncGetBulk와 asyncGetsBulk가 중복되는 부분이 있어서 중복코드를 제거하기 위해 리팩토링을 진행했지만,
오히려 더 복잡하게 코드가 변하게 되어 간결성 유지를 위해 크게 중복된 부분만 메서드로 통합하였습니다.
리팩토링 필요한 부분은 리뷰를 통해 의견받고 더 진행 하도록 하겠습니다.