### PR TITLE
ENHANCE: local caching added to gets and asyncGetsBulk

### DIFF
--- a/src/main/java/net/spy/memcached/MemcachedClient.java
+++ b/src/main/java/net/spy/memcached/MemcachedClient.java
@@ -969,6 +969,9 @@ public class MemcachedClient extends SpyThread
           }
 
           public void complete() {
+            if (localCacheManager != null) {
+                localCacheManager.put(key, val);
+            }
             latch.countDown();
           }
         });
@@ -1302,7 +1305,7 @@ public class MemcachedClient extends SpyThread
         ops.add(op);
       }
     }
-    return new BulkGetFuture<CASValue<T>>(m, ops, latch);
+    return new BulkGetFuture<CASValue<T>>(m, ops, latch, localCacheManager);
   }
 
   /**

--- a/src/main/java/net/spy/memcached/internal/BulkGetFuture.java
+++ b/src/main/java/net/spy/memcached/internal/BulkGetFuture.java
@@ -26,6 +26,7 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
+import net.spy.memcached.CASValue;
 import net.spy.memcached.MemcachedConnection;
 import net.spy.memcached.OperationTimeoutException;
 import net.spy.memcached.compat.log.LoggerFactory;
@@ -157,7 +158,8 @@ public class BulkGetFuture<T> implements BulkFuture<Map<String, T>> {
       if (localCacheManager != null) {
         // iff it is from the remote cache.
         if (!(future instanceof LocalCacheManager.Task)) {
-          localCacheManager.put(key, value);
+          localCacheManager.put(key,
+                  value instanceof CASValue ? ((CASValue<?>) value).getValue() : value);
         }
       }
     }

--- a/src/test/manual/net/spy/memcached/frontcache/LocalCacheManagerTest.java
+++ b/src/test/manual/net/spy/memcached/frontcache/LocalCacheManagerTest.java
@@ -16,9 +16,14 @@
  */
 package net.spy.memcached.frontcache;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Future;
 
+import net.spy.memcached.CASValue;
+import net.spy.memcached.internal.GetFuture;
+import net.spy.memcached.internal.OperationFuture;
 import org.junit.Ignore;
 
 import junit.framework.TestCase;
@@ -95,6 +100,57 @@ public class LocalCacheManagerTest extends TestCase {
     assertNull(cached);
   }
 
+  public void testGets() throws Exception {
+    List<String> valueList = new ArrayList<String>();
+    for (String k : keys) {
+      String value = k + "_value";
+      client.set(k, 2, value).get();
+      valueList.add(value);
+    }
+
+    OperationFuture<CASValue<Object>> f = client.asyncGets(keys[0]);
+    GetFuture<Object> future = client.asyncGet(keys[0]);
+
+    Object noResult = f.get();
+    Object result = future.get();
+
+    Transcoder<Object> tc = null;
+    Object cached = client.getLocalCacheManager().get(keys[0], tc);
+
+    assertNotSame("the same result", noResult, cached);
+    assertSame("not the same result", result, cached);
+
+    // after 3 seconds : remote expired, locally cached
+    Thread.sleep(3000);
+
+    // but we have locally cached results.
+    // Gets save value without CAS in local cache
+    // so you can find only value
+    f = client.asyncGets(keys[0]);
+    future = client.asyncGet(keys[0]);
+
+    noResult = f.get();
+    result = future.get();
+
+    cached = client.getLocalCacheManager().get(keys[0], tc);
+    assertNotSame("the same result", noResult, cached);
+    assertEquals("not the same result", result, cached);
+
+    // after another 3 seconds : both remote and local expired
+    Thread.sleep(3000);
+
+    f = client.asyncGets(keys[0]);
+    future = client.asyncGet(keys[0]);
+    noResult = f.get();
+    result = future.get();
+
+    cached = client.getLocalCacheManager().get(keys[0], tc);
+
+    assertNull(noResult);
+    assertNull(result);
+    assertNull(cached);
+  }
+
   public void testGetBulk() throws Exception {
     for (String k : keys) {
       client.set(k, 2, k + "_value").get();
@@ -131,6 +187,51 @@ public class LocalCacheManagerTest extends TestCase {
 
     result = client.getBulk(keys);
     assertNotNull(result);
+    assertTrue(0 == result.size());
+  }
+
+  public void testGetsBulk() throws Exception {
+    for (String k : keys) {
+      client.set(k, 2, k + "_value").get();
+    }
+
+    // read-through.
+    Map<String, CASValue<Object>> noResult = client.getsBulk(keys);
+
+    // expecting that the keys are locally cached.
+    LocalCacheManager lcm = client.getLocalCacheManager();
+    for (String k : keys) {
+      Transcoder<Object> tc = null;
+      Object got = lcm.get(k, tc);
+      assertNotNull(got);
+    }
+
+    // after 3 seconds, all keys should be expired.
+    Thread.sleep(3000);
+
+    // but we have locally cached results.
+    // GetsBulk save value without CAS in local cache
+    // so you can find only value
+    Map<String, Object> result = client.getBulk(keys);
+    noResult = client.getsBulk(keys);
+
+    assertTrue(keys.length == result.size());
+    assertTrue(0 == noResult.size());
+
+    // then after additional 3 seconds, locally cached results should be
+    // expired.
+    Thread.sleep(3000);
+
+    for (String k : keys) {
+      Transcoder<Object> tc = null;
+      Object got = lcm.get(k, tc);
+      assertNull(got);
+    }
+
+    result = client.getBulk(keys);
+    noResult = client.getsBulk(keys);
+
+    assertTrue(0 == result.size());
     assertTrue(0 == result.size());
   }
 
@@ -231,6 +332,56 @@ public class LocalCacheManagerTest extends TestCase {
     result = f.get();
     assertNotNull(result);
     assertTrue(keySet2.length == result.size());
+  }
+
+  public void testAsyncGetsBulk() throws Exception {
+    for (String k : keys) {
+      client.set(k, 2, k + "_value").get();
+    }
+
+    // read-through.
+    BulkFuture<Map<String, CASValue<Object>>> f = client.asyncGetsBulk(keys);
+    f.get();
+
+    // expecting that the keys are locally cached.
+    LocalCacheManager lcm = client.getLocalCacheManager();
+    for (String k : keys) {
+      Transcoder<Object> tc = null;
+      Object got = lcm.get(k, tc);
+      assertNotNull(got);
+    }
+
+    // after 3 seconds, all keys should be expired.
+    Thread.sleep(3000);
+
+    // but we have locally cached results.
+    // asyncGetsBulk save value without CAS in local cache
+    // so you can find only value
+    f = client.asyncGetsBulk(keys);
+    BulkFuture<Map<String, Object>> future = client.asyncGetBulk(keys);
+    Map<String, Object> result = future.get();
+    Map<String, CASValue<Object>> noResult = f.get();
+
+    assertEquals(noResult.size(), 0);
+    assertTrue(keys.length == result.size());
+
+    // then after additional 3 seconds, locally cached results should be
+    // expired.
+    Thread.sleep(3000);
+
+    for (String k : keys) {
+      Transcoder<Object> tc = null;
+      Object got = lcm.get(k, tc);
+      assertNull(got);
+    }
+
+    f = client.asyncGetsBulk(keys);
+    future = client.asyncGetBulk(keys);
+    result = future.get();
+    noResult = f.get();
+
+    assertTrue(0 == result.size());
+    assertTrue(0 == noResult.size());
   }
 
 }


### PR DESCRIPTION
#330 에 관한 pr입니다.

- gets, asyncGetsBulk에 local caching을 위해 CAS Value중 value 값만을 저장하도록 변경
- gets() -> get(), asyncGetsBulk() -> asyncGetBulk()시에 value 값만 반환되는 것을 확인 하도록
  테스트 코드 추가
  - assumeTrue()로 인해 setup단계에서 바로 true로 끝나버려 테스트 코드 부분이 실행되지 않아
     해당부분을 제거했습니다.