### PR TITLE
ENHANCE: add the TimeoutException message to broadcasting operation

### DIFF
--- a/src/main/java/net/spy/memcached/ArcusClient.java
+++ b/src/main/java/net/spy/memcached/ArcusClient.java
@@ -2086,9 +2086,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
           }
         } else {
           // continuous timeout counter will be reset
-          for (Operation op : ops) {
-            MemcachedConnection.opSucceeded(op);
-          }
+          MemcachedConnection.opsSucceeded(ops);
         }
 
         for (Operation op : ops) {
@@ -2452,9 +2450,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
           }
         } else {
           // continuous timeout counter will be reset
-          for (Operation op : ops) {
-            MemcachedConnection.opSucceeded(op);
-          }
+          MemcachedConnection.opsSucceeded(ops);
         }
 
         for (Operation op : ops) {
@@ -2727,9 +2723,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
           }
         } else {
           // continuous timeout counter will be reset
-          for (Operation op : ops) {
-            MemcachedConnection.opSucceeded(op);
-          }
+          MemcachedConnection.opsSucceeded(ops);
         }
 
         for (Operation op : ops) {
@@ -4209,9 +4203,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
           }
         } else {
           // continuous timeout counter will be reset
-          for (Operation op : ops) {
-            MemcachedConnection.opSucceeded(op);
-          }
+          MemcachedConnection.opsSucceeded(ops);
         }
 
         for (Operation op : ops) {

--- a/src/main/java/net/spy/memcached/MemcachedConnection.java
+++ b/src/main/java/net/spy/memcached/MemcachedConnection.java
@@ -1240,6 +1240,17 @@ public final class MemcachedConnection extends SpyObject {
   }
 
   /**
+   * helper method: reset timeout counter
+   *
+   * @param ops
+   */
+  public static void opsSucceeded(Collection<Operation> ops) {
+    for (Operation op : ops) {
+      MemcachedConnection.setTimeout(op, false);
+    }
+  }
+
+  /**
    * helper method: do some error checking and set timeout boolean
    *
    * @param op

--- a/src/main/java/net/spy/memcached/OperationTimeoutException.java
+++ b/src/main/java/net/spy/memcached/OperationTimeoutException.java
@@ -18,6 +18,7 @@ package net.spy.memcached;
 
 import net.spy.memcached.ops.Operation;
 
+import java.util.Collection;
 import java.util.Collections;
 import java.util.concurrent.TimeUnit;
 
@@ -48,5 +49,12 @@ public class OperationTimeoutException extends RuntimeException {
                                    Operation op) {
     super(TimedOutMessageFactory
             .createTimedoutMessage(duration, units, Collections.singleton(op)));
+  }
+
+  public OperationTimeoutException(long duration,
+                                   TimeUnit units,
+                                   Collection<Operation> ops) {
+    super(TimedOutMessageFactory
+            .createTimedoutMessage(duration, units, ops));
   }
 }

--- a/src/main/java/net/spy/memcached/internal/BulkGetFuture.java
+++ b/src/main/java/net/spy/memcached/internal/BulkGetFuture.java
@@ -138,9 +138,7 @@ public class BulkGetFuture<T> implements BulkFuture<Map<String, T>> {
         MemcachedConnection.opsTimedOut(timedoutOps);
       }
     } else {
-      for (Operation op : ops) {
-        MemcachedConnection.opSucceeded(op);
-      }
+      MemcachedConnection.opsSucceeded(ops);
     }
     for (Operation op : ops) {
       if (op.isCancelled()) {

--- a/src/main/java/net/spy/memcached/internal/BulkOperationFuture.java
+++ b/src/main/java/net/spy/memcached/internal/BulkOperationFuture.java
@@ -67,9 +67,7 @@ public abstract class BulkOperationFuture<T>
       }
     } else {
       // continuous timeout counter will be reset
-      for (Operation op : ops) {
-        MemcachedConnection.opSucceeded(op);
-      }
+      MemcachedConnection.opsSucceeded(ops);
     }
 
     for (Operation op : ops) {

--- a/src/main/java/net/spy/memcached/internal/CollectionGetBulkFuture.java
+++ b/src/main/java/net/spy/memcached/internal/CollectionGetBulkFuture.java
@@ -73,9 +73,7 @@ public class CollectionGetBulkFuture<T> implements Future<T> {
       }
     } else {
       // continuous timeout counter will be reset
-      for (Operation op : ops) {
-        MemcachedConnection.opSucceeded(op);
-      }
+      MemcachedConnection.opsSucceeded(ops);
     }
 
     for (Operation op : ops) {


### PR DESCRIPTION
#326 을 반영한 commit입니다.

broadcasting operation들이 timeout시에 해당 timeoutException 메세지를 남기도록 수정했습니다.

```
- version
Exception in thread "main" net.spy.memcached.OperationTimeoutException: VERSION operation timed out (>700 MILLISECONDS) - failing nodes: /127.0.0.1:11911 [READING] [#Tops=2 #iq=0 #Wops=0 #Rops=1 #CT=1 #TR=-1], /127.0.0.1:11912 [READING] [#Tops=2 #iq=0 #Wops=0 #Rops=1 #CT=1 #TR=-1]

- stats
Exception in thread "main" net.spy.memcached.OperationTimeoutException: STATS operation timed out (>700 MILLISECONDS) - failing nodes: /127.0.0.1:11911[READING] [#Tops=2 #iq=0 #Wops=0 #Rops=1 #CT=1 #TR=-1], /127.0.0.1:11912 [READING] [#Tops=3 #iq=0 #Wops=0 #Rops=2 #CT=1 #TR=-1]
```

또한 ops를 하나하나 foreach로 넘겨주는 코드의 중복이 있어서 해당 내용을
MemcachedConnection에서 복수개의 op를 직접 처리하도록 하였습니다.

해당 내용이 반영되면 후 작업으로 flush의 timeout  동작 및 MemcachedConnection의 opSucceeded에도 복수개의 op를 처리하는 동작을 반영하여서 리팩토링하여 반영할 예정입니다.