### PR TITLE
TEST: fix sleep time for item to be expired

### DIFF
--- a/src/test/manual/net/spy/memcached/emptycollection/InsertBTreeWithAttrAndEFlagTest.java
+++ b/src/test/manual/net/spy/memcached/emptycollection/InsertBTreeWithAttrAndEFlagTest.java
@@ -64,7 +64,7 @@ public class InsertBTreeWithAttrAndEFlagTest extends BaseIntegrationTest {
               collectionAttributes.getMaxCount());
 
       // check expire time
-      Thread.sleep(EXPIRE_TIME_IN_SEC * 2000L);
+      Thread.sleep(EXPIRE_TIME_IN_SEC * 1000L + 1000L);
       Map<Long, Element<Object>> map = mc.asyncBopGet(KEY, BKEY,
               ElementFlagFilter.DO_NOT_FILTER, false, false).get();
       Assert.assertNull(map);
@@ -118,7 +118,7 @@ public class InsertBTreeWithAttrAndEFlagTest extends BaseIntegrationTest {
               collectionAttributes.getMaxCount());
 
       // check expire time
-      Thread.sleep(EXPIRE_TIME_IN_SEC * 2000L);
+      Thread.sleep(EXPIRE_TIME_IN_SEC * 1000L + 1000L);
       Map<Long, Element<Object>> map = mc.asyncBopGet(KEY, BKEY,
               ElementFlagFilter.DO_NOT_FILTER, false, false).get();
       Assert.assertNull(map);

--- a/src/test/manual/net/spy/memcached/emptycollection/InsertListWithAttrTest.java
+++ b/src/test/manual/net/spy/memcached/emptycollection/InsertListWithAttrTest.java
@@ -62,7 +62,7 @@ public class InsertListWithAttrTest extends BaseIntegrationTest {
               collectionAttributes.getMaxCount());
 
       // check expire time
-      Thread.sleep(EXPIRE_TIME_IN_SEC * 2000L);
+      Thread.sleep(EXPIRE_TIME_IN_SEC * 1000L + 1000L);
       List<Object> list = mc.asyncLopGet(KEY, INDEX, false, false).get();
       Assert.assertNull(list);
     } catch (Exception e) {

--- a/src/test/manual/net/spy/memcached/emptycollection/InsertMapWithAttrTest.java
+++ b/src/test/manual/net/spy/memcached/emptycollection/InsertMapWithAttrTest.java
@@ -62,7 +62,7 @@ public class InsertMapWithAttrTest extends BaseIntegrationTest {
               collectionAttributes.getMaxCount());
 
       // check expire time
-      Thread.sleep(EXPIRE_TIME_IN_SEC * 2000L);
+      Thread.sleep(EXPIRE_TIME_IN_SEC * 1000L + 1000L);
       Map<String, Object> map = mc.asyncMopGet(KEY, MKEY, false, false).get();
       Assert.assertNull(map);
     } catch (Exception e) {

--- a/src/test/manual/net/spy/memcached/emptycollection/InsertSetWithAttrTest.java
+++ b/src/test/manual/net/spy/memcached/emptycollection/InsertSetWithAttrTest.java
@@ -60,7 +60,7 @@ public class InsertSetWithAttrTest extends BaseIntegrationTest {
               collectionAttributes.getMaxCount());
 
       // check expire time
-      Thread.sleep(EXPIRE_TIME_IN_SEC * 2000L);
+      Thread.sleep(EXPIRE_TIME_IN_SEC * 1000L + 1000L);
       Set<Object> set = mc.asyncSopGet(KEY, 10, false, false).get();
       Assert.assertNull(set);
     } catch (Exception e) {

--- a/src/test/manual/net/spy/memcached/emptycollection/PipedBulkInsertBTreeWithAttrTest.java
+++ b/src/test/manual/net/spy/memcached/emptycollection/PipedBulkInsertBTreeWithAttrTest.java
@@ -74,7 +74,7 @@ public class PipedBulkInsertBTreeWithAttrTest extends BaseIntegrationTest {
               collectionAttributes.getMaxCount());
 
       // check expire time
-      Thread.sleep(EXPIRE_TIME_IN_SEC * 2000L);
+      Thread.sleep(EXPIRE_TIME_IN_SEC * 1000L + 1000L);
       Map<Long, Element<Object>> map = mc.asyncBopGet(KEY, BKEY,
               ElementFlagFilter.DO_NOT_FILTER, false, false).get();
       Assert.assertNull(map);

--- a/src/test/manual/net/spy/memcached/emptycollection/PipedBulkInsertListWithAttrTest.java
+++ b/src/test/manual/net/spy/memcached/emptycollection/PipedBulkInsertListWithAttrTest.java
@@ -77,7 +77,7 @@ public class PipedBulkInsertListWithAttrTest extends BaseIntegrationTest {
       }
 
       // check expire time
-      Thread.sleep(EXPIRE_TIME_IN_SEC * 2000L);
+      Thread.sleep(EXPIRE_TIME_IN_SEC * 1000L + 1000L);
       List<Object> list = mc.asyncLopGet(KEY, 0, false, false).get();
       Assert.assertNull(list);
     } catch (Exception e) {

--- a/src/test/manual/net/spy/memcached/emptycollection/PipedBulkInsertMapWithAttrTest.java
+++ b/src/test/manual/net/spy/memcached/emptycollection/PipedBulkInsertMapWithAttrTest.java
@@ -68,7 +68,7 @@ public class PipedBulkInsertMapWithAttrTest extends BaseIntegrationTest {
               collectionAttributes.getMaxCount());
 
       // check expire time
-      Thread.sleep(EXPIRE_TIME_IN_SEC * 2000L);
+      Thread.sleep(EXPIRE_TIME_IN_SEC * 1000L + 1000L);
       Map<String, Object> map = mc.asyncMopGet(KEY, MKEY,
               false, false).get();
       Assert.assertNull(map);

--- a/src/test/manual/net/spy/memcached/emptycollection/PipedBulkInsertSetWithAttrTest.java
+++ b/src/test/manual/net/spy/memcached/emptycollection/PipedBulkInsertSetWithAttrTest.java
@@ -77,7 +77,7 @@ public class PipedBulkInsertSetWithAttrTest extends BaseIntegrationTest {
       }
 
       // check expire time
-      Thread.sleep(EXPIRE_TIME_IN_SEC * 2000L);
+      Thread.sleep(EXPIRE_TIME_IN_SEC * 1000L + 1000L);
       List<Object> list = mc.asyncLopGet(KEY, 0, false, false).get();
       Assert.assertNull(list);
     } catch (Exception e) {


### PR DESCRIPTION
expired 테스트에서 아이템이 expired 되기 위해 기다리는 시간을 수정하였습니다.

**변경전**
expire_time_in_sec * 2

**변경후**
expire_time_in_sec + 1초