### PR TITLE
FIX : on the bulk operation only the timed out operation set the time…

### DIFF
--- a/src/main/java/net/spy/memcached/ArcusClient.java
+++ b/src/main/java/net/spy/memcached/ArcusClient.java
@@ -23,6 +23,7 @@ import java.net.InetSocketAddress;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Enumeration;
 import java.util.HashMap;
@@ -1068,16 +1069,19 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
           throws InterruptedException, TimeoutException, ExecutionException {
 
         if (!latch.await(duration, units)) {
+          Collection<Operation> timedoutOps = new HashSet<Operation>();
           for (Operation op : ops) {
-            MemcachedConnection.opTimedOut(op);
+            if (op.getState() != OperationState.COMPLETE) {
+              timedoutOps.add(op);
+            }
           }
-          throw new CheckedOperationTimeoutException(duration, units, ops);
-        } else {
-          // continuous timeout counter will be reset
-          for (Operation op : ops) {
-            MemcachedConnection.opSucceeded(op);
+          if (timedoutOps.size() > 0) {
+            MemcachedConnection.opTimedOut(timedoutOps.iterator().next());
+            throw new CheckedOperationTimeoutException(duration, units, timedoutOps);
           }
         }
+        // continuous timeout counter will be reset only once in pipe
+        MemcachedConnection.opSucceeded(ops.iterator().next());
 
         for (Operation op : ops) {
           if (op != null && op.hasErrored()) {
@@ -2068,10 +2072,18 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
 
         if (!blatch.await(duration, units)) {
           // whenever timeout occurs, continuous timeout counter will increase by 1.
+          Collection<Operation> timedoutOps = new HashSet<Operation>();
           for (Operation op : ops) {
-            MemcachedConnection.opTimedOut(op);
+            if (op.getState() != OperationState.COMPLETE) {
+              MemcachedConnection.opTimedOut(op);
+              timedoutOps.add(op);
+            } else {
+              MemcachedConnection.opSucceeded(op);
+            }
           }
-          throw new CheckedOperationTimeoutException(duration, units, ops);
+          if (timedoutOps.size() > 0) {
+            throw new CheckedOperationTimeoutException(duration, units, timedoutOps);
+          }
         } else {
           // continuous timeout counter will be reset
           for (Operation op : ops) {
@@ -2426,10 +2438,18 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
           throws InterruptedException, TimeoutException, ExecutionException {
 
         if (!blatch.await(duration, units)) {
+          Collection<Operation> timedoutOps = new HashSet<Operation>();
           for (Operation op : ops) {
-            MemcachedConnection.opTimedOut(op);
+            if (op.getState() != OperationState.COMPLETE) {
+              timedoutOps.add(op);
+            } else {
+              MemcachedConnection.opSucceeded(op);
+            }
           }
-          throw new CheckedOperationTimeoutException(duration, units, ops);
+          if (timedoutOps.size() > 0) {
+            MemcachedConnection.opsTimedOut(timedoutOps);
+            throw new CheckedOperationTimeoutException(duration, units, timedoutOps);
+          }
         } else {
           // continuous timeout counter will be reset
           for (Operation op : ops) {
@@ -2693,10 +2713,18 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
           throws InterruptedException, TimeoutException, ExecutionException {
 
         if (!blatch.await(duration, units)) {
+          Collection<Operation> timedoutOps = new HashSet<Operation>();
           for (Operation op : ops) {
-            MemcachedConnection.opTimedOut(op);
+            if (op.getState() != OperationState.COMPLETE) {
+              timedoutOps.add(op);
+            } else {
+              MemcachedConnection.opSucceeded(op);
+            }
           }
-          throw new CheckedOperationTimeoutException(duration, units, ops);
+          if (timedoutOps.size() > 0) {
+            MemcachedConnection.opsTimedOut(timedoutOps);
+            throw new CheckedOperationTimeoutException(duration, units, timedoutOps);
+          }
         } else {
           // continuous timeout counter will be reset
           for (Operation op : ops) {
@@ -3915,16 +3943,19 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
           throws InterruptedException, TimeoutException, ExecutionException {
 
         if (!latch.await(duration, units)) {
+          Collection<Operation> timedoutOps = new HashSet<Operation>();
           for (Operation op : ops) {
-            MemcachedConnection.opTimedOut(op);
+            if (op.getState() != OperationState.COMPLETE) {
+              timedoutOps.add(op);
+            }
           }
-          throw new CheckedOperationTimeoutException(duration, units, ops);
-        } else {
-          // continuous timeout counter will be reset
-          for (Operation op : ops) {
-            MemcachedConnection.opSucceeded(op);
+          if (timedoutOps.size() > 0) {
+            MemcachedConnection.opTimedOut(timedoutOps.iterator().next());
+            throw new CheckedOperationTimeoutException(duration, units, timedoutOps);
           }
         }
+        // continuous timeout counter will be reset only once in pipe
+        MemcachedConnection.opSucceeded(ops.iterator().next());
 
         for (Operation op : ops) {
           if (op != null && op.hasErrored()) {
@@ -4164,10 +4195,18 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
                                                         TimeUnit units)
           throws InterruptedException, TimeoutException, ExecutionException {
         if (!latch.await(duration, units)) {
+          Collection<Operation> timedoutOps = new HashSet<Operation>();
           for (Operation op : ops) {
-            MemcachedConnection.opTimedOut(op);
+            if (op.getState() != OperationState.COMPLETE) {
+              timedoutOps.add(op);
+            } else {
+              MemcachedConnection.opSucceeded(op);
+            }
           }
-          throw new CheckedOperationTimeoutException(duration, units, ops);
+          if (timedoutOps.size() > 0) {
+            MemcachedConnection.opsTimedOut(timedoutOps);
+            throw new CheckedOperationTimeoutException(duration, units, timedoutOps);
+          }
         } else {
           // continuous timeout counter will be reset
           for (Operation op : ops) {

--- a/src/main/java/net/spy/memcached/MemcachedConnection.java
+++ b/src/main/java/net/spy/memcached/MemcachedConnection.java
@@ -1206,6 +1206,31 @@ public final class MemcachedConnection extends SpyObject {
   }
 
   /**
+   * helper method: increase timeout count on a distinct attached node to this op
+   *
+   * @param ops
+   */
+  public static void opsTimedOut(Collection<Operation> ops) {
+    Collection<String> timedoutNodes = new HashSet<String>();
+    for (Operation op : ops) {
+      try {
+        MemcachedNode node = op.getHandlingNode();
+        if (node == null) {
+          continue;
+        }
+
+        String key = node.getSocketAddress().toString();
+        if (!timedoutNodes.contains(key)) {
+          timedoutNodes.add(key);
+          node.setContinuousTimeout(true);
+        }
+      } catch (Exception e) {
+        LoggerFactory.getLogger(MemcachedConnection.class).error(e.getMessage());
+      }
+    }
+  }
+
+  /**
    * helper method: reset timeout counter
    *
    * @param op


### PR DESCRIPTION
bulk 연산의 time out 발생시 모든 operation에 대해 timed out 처리하던 일부 Future에 대해서
timeout 발생된 operation에만 timedout 처리하도록 변경하였습니다.