### PR TITLE
FIX: do not create connection pool array if node address is empty

### DIFF
--- a/src/main/java/net/spy/memcached/CacheManager.java
+++ b/src/main/java/net/spy/memcached/CacheManager.java
@@ -372,7 +372,9 @@ public class CacheManager extends SpyThread implements Watcher,
     String addrs = getAddressListString(children);
 
     if (client == null) {
-      createArcusClient(addrs);
+      if (!addrs.isEmpty()) {
+        createArcusClient(addrs);
+      }
       return;
     }
 

--- a/src/main/java/net/spy/memcached/CacheManager.java
+++ b/src/main/java/net/spy/memcached/CacheManager.java
@@ -1,6 +1,7 @@
 /*
  * arcus-java-client : Arcus Java client
  * Copyright 2010-2014 NAVER Corp.
+ * Copyright 2014-2021 JaM2in Co., Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,14 +16,6 @@
  * limitations under the License.
  */
 package net.spy.memcached;
-
-/**
- * A program to use CacheMonitor to start and
- * stop memcached node based on a znode. The program watches the
- * specified znode and saves the znode that corresponds to the
- * memcached server in the remote machine. It also changes the
- * previous ketama node
- */
 
 import java.io.IOException;
 import java.net.InetAddress;
@@ -45,6 +38,13 @@ import org.apache.zookeeper.Watcher;
 import org.apache.zookeeper.ZooKeeper;
 import org.apache.zookeeper.ZooDefs.Ids;
 
+/**
+ * A program to use CacheMonitor to start and
+ * stop memcached node based on a znode. The program watches the
+ * specified znode and saves the znode that corresponds to the
+ * memcached server in the remote machine. It also changes the
+ * previous ketama node
+ */
 public class CacheManager extends SpyThread implements Watcher,
         CacheMonitor.CacheMonitorListener {
   private static final String ARCUS_BASE_CACHE_LIST_ZPATH = "/arcus/cache_list/";
@@ -142,28 +142,33 @@ public class CacheManager extends SpyThread implements Watcher,
          * that bring delay of 5 seconds (as well as dns and host file lookup).
          * So, ZK_CONNECT_TIMEOUT is set as much like ZK session timeout.
          */
-        if (zkInitLatch.await(ZK_CONNECT_TIMEOUT, TimeUnit.MILLISECONDS) == false) {
+        if (!zkInitLatch.await(ZK_CONNECT_TIMEOUT, TimeUnit.MILLISECONDS)) {
           getLogger().fatal("Connecting to Arcus admin(%s) timed out : %d miliseconds",
                   zkConnectString, ZK_CONNECT_TIMEOUT);
           throw new AdminConnectTimeoutException(zkConnectString);
         }
 
-        do {
-          /* ENABLE_REPLICATION if */
-          if (zk.exists(ARCUS_REPL_CACHE_LIST_ZPATH + serviceCode, false) != null) {
-            arcusReplEnabled = true;
-            cfb.internalArcusReplEnabled(true);
-            getLogger().info("Connected to Arcus repl cluster (serviceCode=%s)", serviceCode);
-            break;
-          }
-          /* ENABLE_REPLICATION end */
+        /* ENABLE_REPLICATION if */
+        if (zk.exists(ARCUS_REPL_CACHE_LIST_ZPATH + serviceCode, false) != null) {
+          arcusReplEnabled = true;
+          cfb.internalArcusReplEnabled(true);
+          getLogger().info("Connected to Arcus repl cluster (serviceCode=%s)", serviceCode);
+        } else {
+        /* ENABLE_REPLICATION end */
           if (zk.exists(ARCUS_BASE_CACHE_LIST_ZPATH + serviceCode, false) != null) {
             getLogger().info("Connected to Arcus cluster (seriveCode=%s)", serviceCode);
           } else {
             getLogger().fatal("Service code not found. (%s)", serviceCode);
             throw new NotExistsServiceCodeException(serviceCode);
           }
-        } while (false);
+        }
+
+        if (client == null &&
+            zk.getChildren(getCacheListZPath() + serviceCode, null).isEmpty()) {
+          getLogger().fatal("Memcached nodes not found. (zpath=%s, serviceCode=%s)",
+              getCacheListZPath(), serviceCode);
+          throw new NotExistsMemcachedNodeException(serviceCode);
+        }
 
         String path = getClientInfo();
         if (path.isEmpty()) {
@@ -420,7 +425,7 @@ public class CacheManager extends SpyThread implements Watcher,
 
     cfb.setInitialObservers(Collections.singleton(observer));
 
-    int _awaitTime = 0;
+    int _awaitTime;
     if (waitTimeForConnect == 0) {
       _awaitTime = 50 * addrCount * poolSize;
     } else {
@@ -435,7 +440,7 @@ public class CacheManager extends SpyThread implements Watcher,
         client[i].setName("Memcached IO for " + serviceCode);
         client[i].setCacheManager(this);
       } catch (IOException e) {
-        getLogger().fatal("Arcus Connection has critical problems. contact arcus manager.");
+        getLogger().fatal("Arcus Connection has critical problems. contact arcus manager.", e);
       }
     }
     try {
@@ -446,7 +451,7 @@ public class CacheManager extends SpyThread implements Watcher,
       }
       // Success signal for initial connections to Zookeeper and Memcached.
     } catch (InterruptedException e) {
-      getLogger().fatal("Arcus Connection has critical problems. contact arcus manager.");
+      getLogger().fatal("Arcus Connection has critical problems. contact arcus manager.", e);
     }
     this.clientInitLatch.countDown();
 

--- a/src/main/java/net/spy/memcached/NotExistsMemcachedNodeException.java
+++ b/src/main/java/net/spy/memcached/NotExistsMemcachedNodeException.java
@@ -1,0 +1,27 @@
+/*
+ * arcus-java-client : Arcus Java client
+ * Copyright 2021 JaM2in Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.spy.memcached;
+
+public class NotExistsMemcachedNodeException extends RuntimeException {
+
+  private static final long serialVersionUID = -1461409015284668292L;
+
+  public NotExistsMemcachedNodeException(String message) {
+    super(message);
+  }
+
+}


### PR DESCRIPTION
이슈 발생 상황은 아래와 같습니다.

1) ZooKeeper에 특정 service code의 cache_list znode가 존재하지 않음
2) arcus-java-client 시작
3) CacheManager.commandCacheListChange 호출 (children 파라미터는 empty)
4) CacheManager.createArcusClient("") 호출
4) ArcusClient[poolSize] array 생성
5) 주소가 없으므로 Exception이 throw 됨. (IllegalArgumentException: You must have at least one server to connect to)
6) 특정 service code에서 127.0.0.1:11211 주소를 가진 캐시 서버가 실행됨
7) CacheManager.commandCacheListChange 호출 (children 파라미터는 ["127.0.0.1:11211"])
8) ArcusClient[poolSize] array는 이미 생성됐으므로, CacheManager.createArcusClient("127.0.0.1:11211")을 호출하지 않고 ac.getMemcachedConnection() 을 호출
9) ArcusClient[poolSize] array의 element들은 전부 null 값이므로 NullPointerException 발생
10) ArcusClient를 생성한 쪽은 무한 대기 발생 (캐시 서버와 연결 성공이 되지 않으면, latch의 countDown()은 영원히 실행이 안됨)

ZK의 watcher로부터 비어있는 address를 받을 경우, 4)번의 array 생성을 막는다면 다음 ZK 이벤트가 발생될 때 createArcusClient 메소드를 호출하여 캐시 서버와 연결 시도를 할 수 있도록 수정하였습니다.