### PR TITLE
CLEANUP: removed unnecessary log warn message in getAllOperations().

### DIFF
--- a/src/main/java/net/spy/memcached/protocol/TCPMemcachedNodeImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/TCPMemcachedNodeImpl.java
@@ -685,18 +685,16 @@ public abstract class TCPMemcachedNodeImpl extends SpyObject
     }
 
     while (hasWriteOp()) {
-    /* large byte operation
-     * may exist write queue & read queue
-     */
+      /* Operation could exist both writeQ and readQ,
+       * if all bytes of the operation have not been written yet.
+       */
       Operation op = removeCurrentWriteOp();
       if (!allOp.contains(op)) {
         allOp.add(op);
-      } else {
-        getLogger().warn("Duplicate operation exist in " + this + " : " + op);
       }
     }
 
-    if (inputQueue.size() > 0) {
+    if (!inputQueue.isEmpty()) {
       inputQueue.drainTo(allOp);
     }
 


### PR DESCRIPTION
operation 은 readQ, writeQ 모두에 존재할 수 있는데, 이 경우는 정상적인 상태로 보여 굳이 warn log message 를 남길 필요가 없다고 판단해 제거하였습니다.