### PR TITLE
CLEANUP: removed readBufferSize argument in MemcachedConnection().

### DIFF
--- a/src/main/java/net/spy/memcached/DefaultConnectionFactory.java
+++ b/src/main/java/net/spy/memcached/DefaultConnectionFactory.java
@@ -239,7 +239,7 @@ public class DefaultConnectionFactory extends SpyObject
   public MemcachedConnection createConnection(String name,
                                               List<InetSocketAddress> addrs)
           throws IOException {
-    return new MemcachedConnection(name, getReadBufSize(), this, addrs,
+    return new MemcachedConnection(name, this, addrs,
             getInitialObservers(), getFailureMode(), getOperationFactory());
   }
 

--- a/src/main/java/net/spy/memcached/MemcachedConnection.java
+++ b/src/main/java/net/spy/memcached/MemcachedConnection.java
@@ -105,14 +105,16 @@ public final class MemcachedConnection extends SpyObject {
   /**
    * Construct a memcached connection.
    *
-   * @param name    the name of memcached connection
-   * @param bufSize the size of the buffer used for reading from the server
-   * @param f       the factory that will provide an operation queue
-   * @param a       the addresses of the servers to connect to
+   * @param name      the name of memcached connection
+   * @param f         the factory that will provide an operation queue
+   * @param a         the addresses of the servers to connect to
+   * @param obs       the observers that see the first connection established.
+   * @param fm        the failure mode for the underlying connection :
+   *                  Cancel(default), Redistribute, Retry.
+   * @param opfactory the operation factory.
    * @throws IOException if a connection attempt fails early
    */
-  public MemcachedConnection(String name,
-                             int bufSize, ConnectionFactory f,
+  public MemcachedConnection(String name, ConnectionFactory f,
                              List<InetSocketAddress> a, Collection<ConnectionObserver> obs,
                              FailureMode fm, OperationFactory opfactory)
           throws IOException {
@@ -540,7 +542,6 @@ public final class MemcachedConnection extends SpyObject {
                                     SocketAddress sa) throws IOException {
     SocketChannel ch = SocketChannel.open();
     ch.configureBlocking(false);
-    // bufSize : 16384 (default value)
     MemcachedNode qa = f.createMemcachedNode(name, sa, ch, f.getReadBufSize());
     if (timeoutRatioThreshold > 0) {
       qa.enableTimeoutRatio();

--- a/src/test/java/net/spy/memcached/ClientBaseCase.java
+++ b/src/test/java/net/spy/memcached/ClientBaseCase.java
@@ -93,7 +93,7 @@ public abstract class ClientBaseCase extends TestCase {
         @Override
         public MemcachedConnection createConnection(
                 String name, List<InetSocketAddress> addrs) throws IOException {
-          return new MemcachedConnection(name, getReadBufSize(), this, addrs,
+          return new MemcachedConnection(name, this, addrs,
                   getInitialObservers(), getFailureMode(), getOperationFactory());
         }
 

--- a/src/test/java/net/spy/memcached/MemcachedConnectionTest.java
+++ b/src/test/java/net/spy/memcached/MemcachedConnectionTest.java
@@ -34,11 +34,11 @@ public class MemcachedConnectionTest extends TestCase {
   @Override
   protected void setUp() throws Exception {
     super.setUp();
-    ConnectionFactoryBuilder cfb = new ConnectionFactoryBuilder();
+    ConnectionFactoryBuilder cfb = new ConnectionFactoryBuilder().setReadBufferSize(1024);
     ConnectionFactory cf = cfb.build();
     List<InetSocketAddress> addrs = new ArrayList<InetSocketAddress>();
 
-    conn = new MemcachedConnection("connection test", 1024, cf, addrs,
+    conn = new MemcachedConnection("connection test", cf, addrs,
         cf.getInitialObservers(), cf.getFailureMode(), cf.getOperationFactory());
     locator = (ArcusKetamaNodeLocator) conn.getLocator();
   }


### PR DESCRIPTION
MemcachedConnection() 로 전달한 bufSize 를 사용하지 않고 f.getReadBufSize() 를 통해 bufSize 를 얻고 있으므로 제거하였습니다.