### PR TITLE
CLEANUP: return immutable collection of node and groups

### DIFF
--- a/src/main/java/net/spy/memcached/ArcusKetamaNodeLocator.java
+++ b/src/main/java/net/spy/memcached/ArcusKetamaNodeLocator.java
@@ -75,7 +75,11 @@ public class ArcusKetamaNodeLocator extends SpyObject implements NodeLocator {
   }
 
   public Collection<MemcachedNode> getAll() {
-    return allNodes;
+    return Collections.unmodifiableCollection(allNodes);
+  }
+
+  public SortedMap<Long, SortedSet<MemcachedNode>> getKetamaNodes() {
+    return Collections.unmodifiableSortedMap(ketamaNodes);
   }
 
   public MemcachedNode getPrimary(final String k) {
@@ -210,14 +214,6 @@ public class ArcusKetamaNodeLocator extends SpyObject implements NodeLocator {
     if (remove) {
       config.removeNode(node);
     }
-  }
-
-  public SortedMap<Long, SortedSet<MemcachedNode>> getKetamaNodes() {
-    return Collections.unmodifiableSortedMap(ketamaNodes);
-  }
-
-  public Collection<MemcachedNode> getAllNodes() {
-    return Collections.unmodifiableCollection(allNodes);
   }
 
   class KetamaIterator implements Iterator<MemcachedNode> {

--- a/src/main/java/net/spy/memcached/ArcusKetamaNodeLocator.java
+++ b/src/main/java/net/spy/memcached/ArcusKetamaNodeLocator.java
@@ -101,13 +101,11 @@ public class ArcusKetamaNodeLocator extends SpyObject implements NodeLocator {
           if (nodeHash == null) {
             hash = ketamaNodes.firstKey();
           } else {
-            hash = nodeHash.longValue();
+            hash = nodeHash;
           }
         }
         rv = ketamaNodes.get(hash).first();
       }
-    } catch (RuntimeException e) {
-      throw e;
     } finally {
       lock.unlock();
     }
@@ -139,8 +137,6 @@ public class ArcusKetamaNodeLocator extends SpyObject implements NodeLocator {
       for (MemcachedNode n : allNodes) {
         an.add(new MemcachedNodeROImpl(n));
       }
-    } catch (RuntimeException e) {
-      throw e;
     } finally {
       lock.unlock();
     }
@@ -172,8 +168,6 @@ public class ArcusKetamaNodeLocator extends SpyObject implements NodeLocator {
           node.setSk(null);
         }
       }
-    } catch (RuntimeException e) {
-      throw e;
     } finally {
       lock.unlock();
     }

--- a/src/main/java/net/spy/memcached/ArcusReplKetamaNodeLocator.java
+++ b/src/main/java/net/spy/memcached/ArcusReplKetamaNodeLocator.java
@@ -138,15 +138,13 @@ public class ArcusReplKetamaNodeLocator extends SpyObject implements NodeLocator
           if (nodeHash == null) {
             hash = ketamaGroups.firstKey();
           } else {
-            hash = nodeHash.longValue();
+            hash = nodeHash;
           }
         }
         rg = ketamaGroups.get(hash).first();
         // return a node (master / slave) for the replica pick request.
         rv = rg.getNodeForReplicaPick(pick);
       }
-    } catch (RuntimeException e) {
-      throw e;
     } finally {
       lock.unlock();
     }
@@ -188,8 +186,6 @@ public class ArcusReplKetamaNodeLocator extends SpyObject implements NodeLocator
       for (MemcachedNode n : allNodes) {
         an.add(new MemcachedNodeROImpl(n));
       }
-    } catch (RuntimeException e) {
-      throw e;
     } finally {
       lock.unlock();
     }
@@ -262,8 +258,6 @@ public class ArcusReplKetamaNodeLocator extends SpyObject implements NodeLocator
         allGroups.remove(group.getGroupName());
         updateHash(group, true);
       }
-    } catch (RuntimeException e) {
-      throw e;
     } finally {
       lock.unlock();
     }

--- a/src/main/java/net/spy/memcached/ArcusReplKetamaNodeLocator.java
+++ b/src/main/java/net/spy/memcached/ArcusReplKetamaNodeLocator.java
@@ -21,6 +21,7 @@ package net.spy.memcached;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -97,11 +98,11 @@ public class ArcusReplKetamaNodeLocator extends SpyObject implements NodeLocator
   }
 
   public Collection<MemcachedNode> getAll() {
-    return allNodes;
+    return Collections.unmodifiableCollection(allNodes);
   }
 
   public Map<String, MemcachedReplicaGroup> getAllGroups() {
-    return allGroups;
+    return Collections.unmodifiableMap(allGroups);
   }
 
   public Collection<MemcachedNode> getMasterNodes() {

--- a/src/test/java/net/spy/memcached/MemcachedConnectionTest.java
+++ b/src/test/java/net/spy/memcached/MemcachedConnectionTest.java
@@ -66,19 +66,19 @@ public class MemcachedConnectionTest extends TestCase {
     conn.handleNodesChangeQueue();
 
     // then
-    assertTrue(1 == locator.getAllNodes().size());
+    assertTrue(1 == locator.getAll().size());
 
     // 2nd test (nodes=3)
     conn.handleNodesChangeQueue();
 
     // then
-    assertTrue(3 == locator.getAllNodes().size());
+    assertTrue(3 == locator.getAll().size());
 
     // 3rd test (nodes=1)
     conn.handleNodesChangeQueue();
 
     // then
-    assertTrue(1 == locator.getAllNodes().size());
+    assertTrue(1 == locator.getAll().size());
   }
 
   public void testNodesChangeQueue_empty() throws Exception {
@@ -89,7 +89,7 @@ public class MemcachedConnectionTest extends TestCase {
     conn.handleNodesChangeQueue();
 
     // then
-    assertTrue(0 == locator.getAllNodes().size());
+    assertTrue(0 == locator.getAll().size());
   }
 
   public void testNodesChangeQueue_invalid_addr() {
@@ -116,7 +116,7 @@ public class MemcachedConnectionTest extends TestCase {
     conn.handleNodesChangeQueue();
 
     // then
-    assertTrue(2 == locator.getAllNodes().size());
+    assertTrue(2 == locator.getAll().size());
   }
 
   public void testNodesChangeQueue_twice() throws Exception {
@@ -128,7 +128,7 @@ public class MemcachedConnectionTest extends TestCase {
     conn.handleNodesChangeQueue();
 
     // then
-    assertTrue(1 == locator.getAllNodes().size());
+    assertTrue(1 == locator.getAll().size());
   }
 
   public void testAddOperations() throws Exception {


### PR DESCRIPTION
KetamaLocator의 node, group collection의 reference를 그대로 리턴하게 되어, 바깥에서 collection을 수정할 위험이 있어 이러한 collection 들을 immutable 속성으로 변경하여 리턴하도록 수정하였습니다. 

참고로 immutable collection은 element 변경(remove, put, ...)시 UnsupportedOperationException 발생됩니다. (get은 element를 변경하지 않으므로 그대로 동작)

