### PR TITLE
CLEANUP : refactored the cache list update functions of replication cluster

### DIFF
--- a/src/main/java/net/spy/memcached/MemcachedReplicaGroup.java
+++ b/src/main/java/net/spy/memcached/MemcachedReplicaGroup.java
@@ -1,6 +1,7 @@
 /*
  * arcus-java-client : Arcus Java client
  * Copyright 2010-2014 NAVER Corp.
+ * Copyright 2014-2021 JaM2in Co., Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -56,10 +57,10 @@ public abstract class MemcachedReplicaGroup extends SpyObject {
     return slaveNode;
   }
 
-  public MemcachedNode getNodeForReplicaPick(ReplicaPick priority) {
+  public MemcachedNode getNodeByReplicaPick(ReplicaPick pick) {
     MemcachedNode node = null;
 
-    switch (priority) {
+    switch (pick) {
       case MASTER:
         node = masterNode;
         break;
@@ -76,7 +77,7 @@ public abstract class MemcachedReplicaGroup extends SpyObject {
         } else {
           node = masterNode;
         }
-        prevMasterPick = prevMasterPick ? false : true;
+        prevMasterPick = !prevMasterPick;
         break;
       default: // This case never exist.
         break;
@@ -86,7 +87,7 @@ public abstract class MemcachedReplicaGroup extends SpyObject {
 
   public abstract boolean changeRole();
 
-  public static String getGroupNameForNode(final MemcachedNode node) {
+  public static String getGroupNameFromNode(final MemcachedNode node) {
     return ((ArcusReplNodeAddress) node.getSocketAddress()).getGroupName();
   }
 }

--- a/src/main/java/net/spy/memcached/MemcachedReplicaGroupImpl.java
+++ b/src/main/java/net/spy/memcached/MemcachedReplicaGroupImpl.java
@@ -1,6 +1,7 @@
 /*
  * arcus-java-client : Arcus Java client
  * Copyright 2010-2014 NAVER Corp.
+ * Copyright 2014-2021 JaM2in Co., Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,7 +21,7 @@ package net.spy.memcached;
 public class MemcachedReplicaGroupImpl extends MemcachedReplicaGroup {
 
   public MemcachedReplicaGroupImpl(final MemcachedNode node) {
-    super(getGroupNameForNode(node));
+    super(getGroupNameFromNode(node));
 
     // Cannot make MemcachedReplicaGoup instance without group name and master/slave node
     if (node == null) {
@@ -35,7 +36,7 @@ public class MemcachedReplicaGroupImpl extends MemcachedReplicaGroup {
       return false;
     }
 
-    if (this.group.equals(getGroupNameForNode(node))) {
+    if (this.group.equals(getGroupNameFromNode(node))) {
       if (((ArcusReplNodeAddress) node.getSocketAddress()).isMaster()) {
         this.masterNode = node;
       } else {
@@ -44,9 +45,8 @@ public class MemcachedReplicaGroupImpl extends MemcachedReplicaGroup {
 
       node.setReplicaGroup(this);
       return true;
-    } else {
-      return false;
     }
+    return false;
   }
 
   public boolean deleteMemcachedNode(final MemcachedNode node) {
@@ -54,16 +54,15 @@ public class MemcachedReplicaGroupImpl extends MemcachedReplicaGroup {
       return false;
     }
 
-    if (this.group.equals(getGroupNameForNode(node))) {
+    if (this.group.equals(getGroupNameFromNode(node))) {
       if (((ArcusReplNodeAddress) node.getSocketAddress()).isMaster()) {
         this.masterNode = null;
       } else {
         this.slaveNode = null;
       }
       return true;
-    } else {
-      return false;
     }
+    return false;
   }
 
   public boolean changeRole() {

--- a/src/main/java/net/spy/memcached/ReplicaPick.java
+++ b/src/main/java/net/spy/memcached/ReplicaPick.java
@@ -1,6 +1,7 @@
 /*
  * arcus-java-client : Arcus Java client
  * Copyright 2010-2014 NAVER Corp.
+ * Copyright 2014-2021 JaM2in Co., Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/spy/memcached/util/ArcusReplKetamaNodeLocatorConfiguration.java
+++ b/src/main/java/net/spy/memcached/util/ArcusReplKetamaNodeLocatorConfiguration.java
@@ -23,6 +23,10 @@ import net.spy.memcached.MemcachedReplicaGroup;
 
 import java.util.Comparator;
 
+/**
+ * This configuration class is aware that InetSocketAddress is really ArcusReplNodeAddress.
+ * Its getKeyForNode uses the group name, instead of the socket address.
+ */
 public class ArcusReplKetamaNodeLocatorConfiguration implements
         KetamaNodeLocatorConfiguration {
 


### PR DESCRIPTION
replication 동작중 cache list update로 node의 변경이 일어나는 부분들을 수정하였습니다.
 기존의 로직들 중 긴 부분은 모듈화하였고,  메소드명 변경 및  간단화 작업을 진행했습니다.

이후 작업으로는
1. cache list update 설계안 적용
2. "SWITCHOVER" or "REPL_SLAVE" 메세지 수신에 따른 동작 리팩토링
3. 메세지 수신에 따른 switchover 수행입니다.