### PR TITLE
FEATURE : support expanded replication group

### DIFF
--- a/src/main/java/net/spy/memcached/MemcachedReplicaGroup.java
+++ b/src/main/java/net/spy/memcached/MemcachedReplicaGroup.java
@@ -95,6 +95,15 @@ public abstract class MemcachedReplicaGroup extends SpyObject {
     }
   }
 
+  public void setMasterCandidateByAddr(ArcusReplNodeAddress address) {
+    for (MemcachedNode node : this.getSlaveNodes()) {
+      if (address.isSameAddress((ArcusReplNodeAddress) node.getSocketAddress())) {
+        this.setMasterCandidate(node);
+        break;
+      }
+    }
+  }
+
   public MemcachedNode getNodeByReplicaPick(ReplicaPick pick) {
     MemcachedNode node = null;
 

--- a/src/main/java/net/spy/memcached/MemcachedReplicaGroupImpl.java
+++ b/src/main/java/net/spy/memcached/MemcachedReplicaGroupImpl.java
@@ -40,7 +40,7 @@ public class MemcachedReplicaGroupImpl extends MemcachedReplicaGroup {
       if (((ArcusReplNodeAddress) node.getSocketAddress()).isMaster()) {
         this.masterNode = node;
       } else {
-        this.slaveNode = node;
+        this.slaveNodes.add(node);
       }
 
       node.setReplicaGroup(this);
@@ -58,7 +58,7 @@ public class MemcachedReplicaGroupImpl extends MemcachedReplicaGroup {
       if (((ArcusReplNodeAddress) node.getSocketAddress()).isMaster()) {
         this.masterNode = null;
       } else {
-        this.slaveNode = null;
+        this.slaveNodes.remove(node);
       }
       return true;
     }
@@ -69,16 +69,17 @@ public class MemcachedReplicaGroupImpl extends MemcachedReplicaGroup {
         /* role change */
     MemcachedNode tmpNode = this.masterNode;
 
-    this.masterNode = this.slaveNode;
+    this.masterNode = this.masterCandidate;
     if (this.masterNode != null) { // previous slave node
       ((ArcusReplNodeAddress) this.masterNode.getSocketAddress()).setMaster(true);
+      this.slaveNodes.remove(this.masterNode);
+      this.setMasterCandidate(null);
     }
 
-    this.slaveNode = tmpNode;
-    if (this.slaveNode != null) { // previous master node
-      ((ArcusReplNodeAddress) this.slaveNode.getSocketAddress()).setMaster(false);
+    if (tmpNode != null) { // previous master node
+      ((ArcusReplNodeAddress) tmpNode.getSocketAddress()).setMaster(false);
+      this.slaveNodes.add(tmpNode);
     }
-
     return true;
   }
 }

--- a/src/main/java/net/spy/memcached/MemcachedReplicaGroupROImpl.java
+++ b/src/main/java/net/spy/memcached/MemcachedReplicaGroupROImpl.java
@@ -21,7 +21,9 @@ public class MemcachedReplicaGroupROImpl extends MemcachedReplicaGroup {
   public MemcachedReplicaGroupROImpl(final MemcachedReplicaGroup group) {
     super(group.getGroupName());
     this.masterNode = new MemcachedNodeROImpl(group.getMasterNode());
-    this.slaveNode = new MemcachedNodeROImpl(group.getSlaveNode());
+    for (MemcachedNode slaveNode : group.getSlaveNodes()) {
+      slaveNodes.add(new MemcachedNodeROImpl(slaveNode));
+    }
   }
 
   @Override

--- a/src/main/java/net/spy/memcached/protocol/BaseOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/BaseOperationImpl.java
@@ -125,6 +125,17 @@ public abstract class BaseOperationImpl extends SpyObject {
   }
 
   protected final void receivedMoveOperations(String cause) {
+    // switchover message e.g.
+    // one slave node case : "SWITCHOVER", "REPL_SLAVE",
+    // two or more than slave nodes case : "SWITCHOVER <ip:port>", "REPL_SLAVE <ip:port>"
+    String[] messages = cause.split(" ");
+    if (messages.length < 1 || messages.length > 2) {
+      getLogger().error("response message error: %s by %s from %s", cause, this, handlingNode);
+      transitionState(OperationState.COMPLETE);
+      return;
+    } else if (messages.length == 2) {
+      handlingNode.getReplicaGroup().setMasterCandidateByAddr(messages[1]);
+    }
     getLogger().info("%s message received by %s operation from %s", cause, this, handlingNode);
     transitionState(OperationState.MOVING);
   }


### PR DESCRIPTION
replication 삼중화 지원을 위한 pr입니다.

주요 변경점
- slaveNode -> slaveNodes , slaveNode 여러개 지원
  - slaveNode의 갯수는 MAX_REPL_SLAVE_SIZE로 수정
- cache list의 변경, switchover, failover시 slaveNodes를 대응하기 위한 변경
  -  cache list 변경시 이전 group 구성 정보를 통해 변경점을 확인시, node의 address와 실제 node의 index를 확인하기 위한 메소드가 추가되었습니다.
  -  switchover 및 failover 동작을 위해 changeRole시 기존 slaveNodes의 index가 필요합니다. 
     - 기존의 "SWITCHOVER" 및 "FAILOVER" 응답 수신시에는 oldSlaves의 0번 노드를 사용합니다.
     -  확장된 응답 메시지 "SWITCHOVER[master ip:port]\r\n", "REPL_SLAVE[master ip:port]\r\n" 수신시에는 parsing된 address를 이용해 index를 찾습니다.
