### PR TITLE
FIX: add null check in attachment removal of selection key

### DIFF
--- a/src/main/java/net/spy/memcached/ArcusKetamaNodeLocator.java
+++ b/src/main/java/net/spy/memcached/ArcusKetamaNodeLocator.java
@@ -18,6 +18,7 @@
 package net.spy.memcached;
 
 import java.io.IOException;
+import java.nio.channels.SelectionKey;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -160,7 +161,10 @@ public class ArcusKetamaNodeLocator extends SpyObject implements NodeLocator {
         updateHash(node, true);
 
         try {
-          node.getSk().attach(null);
+          SelectionKey sk = node.getSk();
+          if (sk != null) {
+            sk.attach(null);
+          }
           node.shutdown();
         } catch (IOException e) {
           getLogger().error(

--- a/src/main/java/net/spy/memcached/ArcusReplKetamaNodeLocator.java
+++ b/src/main/java/net/spy/memcached/ArcusReplKetamaNodeLocator.java
@@ -19,6 +19,7 @@
 package net.spy.memcached;
 
 import java.io.IOException;
+import java.nio.channels.SelectionKey;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -204,7 +205,10 @@ public class ArcusReplKetamaNodeLocator extends SpyObject implements NodeLocator
         mrg.deleteMemcachedNode(node);
 
         try {
-          node.getSk().attach(null);
+          SelectionKey sk = node.getSk();
+          if (sk != null) {
+            sk.attach(null);
+          }
           node.shutdown();
         } catch (IOException e) {
           getLogger().error("Failed to shutdown the node : " + node.toString());


### PR DESCRIPTION
연결에 실패하여 selector에 selection key가 등록되지 않은 노드가 hashring에 제거되는 경우 null pointer exception이 발생될 수 있어 수정하였습니다.