### PR TITLE
ENHANCE: do not rearrange list when removing addresses of changed rep…

### DIFF
--- a/src/main/java/net/spy/memcached/MemcachedConnection.java
+++ b/src/main/java/net/spy/memcached/MemcachedConnection.java
@@ -352,14 +352,15 @@ public final class MemcachedConnection extends SpyObject {
     return changedGroupSet;
   }
 
-  private void removeAddrsOfUnchangedGroups(List<InetSocketAddress> addrs,
-                                            Set<String> changedGroups) {
-    for (Iterator<InetSocketAddress> iter = addrs.iterator(); iter.hasNext();) {
-      ArcusReplNodeAddress replAddr = (ArcusReplNodeAddress) iter.next();
-      if (!changedGroups.contains(replAddr.getGroupName())) {
-        iter.remove();
+  private List<InetSocketAddress> findAddrsOfChangedGroups(List<InetSocketAddress> addrs,
+                                                           Set<String> changedGroups) {
+    List<InetSocketAddress> changedGroupAddrs = new ArrayList<InetSocketAddress>();
+    for (InetSocketAddress addr : addrs) {
+      if (changedGroups.contains(((ArcusReplNodeAddress) addr).getGroupName())) {
+        changedGroupAddrs.add(addr);
       }
     }
+    return changedGroupAddrs;
   }
 
   private void updateReplConnections(List<InetSocketAddress> addrs) throws IOException {
@@ -380,10 +381,10 @@ public final class MemcachedConnection extends SpyObject {
      * and update the state of groups based on them.
      */
     Set<String> changedGroups = findChangedGroups(addrs);
-    removeAddrsOfUnchangedGroups(addrs, changedGroups);
+    List<InetSocketAddress> changedGroupAddrs  = findAddrsOfChangedGroups(addrs, changedGroups);
 
     Map<String, List<ArcusReplNodeAddress>> newAllGroups =
-            ArcusReplNodeAddress.makeGroupAddrsList(addrs);
+            ArcusReplNodeAddress.makeGroupAddrsList(changedGroupAddrs);
     Map<String, MemcachedReplicaGroup> oldAllGroups =
             ((ArcusReplKetamaNodeLocator) locator).getAllGroups();
 


### PR DESCRIPTION
변경된 복제 그룹에 해당되는 address를 가져올 때 ArrayList의 iterator.remove를 사용하면 List의 rearrange 작업으로 성능을 떨어뜨려 이를 최적화하였습니다.

LinkedList를 변경하는 것도 방법이지만, 메소드 변수의 상태를 변경(element remove)하는 코드는, 코드의 동작을 예측하기가 힘들어 아예 새로운 객체를 리턴하여 변경된 복제 그룹에 해당되는 주소를 사용할 수 있도록 하였습니다.