### PR TITLE
FIX: fixed parsing only one result after switchover in pipe operation

### DIFF
--- a/src/main/java/net/spy/memcached/collection/CollectionBulkInsert.java
+++ b/src/main/java/net/spy/memcached/collection/CollectionBulkInsert.java
@@ -50,6 +50,10 @@ public abstract class CollectionBulkInsert<T> extends CollectionObject {
     this.nextOpIndex = i;
   }
 
+  public int getNextOpIndex() {
+    return nextOpIndex;
+  }
+
   public abstract ByteBuffer getAsciiCommand();
 
   public abstract ByteBuffer getBinaryCommand();

--- a/src/main/java/net/spy/memcached/collection/CollectionPipedInsert.java
+++ b/src/main/java/net/spy/memcached/collection/CollectionPipedInsert.java
@@ -50,6 +50,10 @@ public abstract class CollectionPipedInsert<T> extends CollectionObject {
     this.nextOpIndex = i;
   }
 
+  public int getNextOpIndex() {
+    return nextOpIndex;
+  }
+
   public abstract ByteBuffer getAsciiCommand();
 
   public abstract ByteBuffer getBinaryCommand();

--- a/src/main/java/net/spy/memcached/collection/CollectionPipedUpdate.java
+++ b/src/main/java/net/spy/memcached/collection/CollectionPipedUpdate.java
@@ -45,6 +45,10 @@ public abstract class CollectionPipedUpdate<T> extends CollectionObject {
     this.nextOpIndex = i;
   }
 
+  public int getNextOpIndex() {
+    return nextOpIndex;
+  }
+
   public abstract ByteBuffer getAsciiCommand();
 
   public abstract ByteBuffer getBinaryCommand();

--- a/src/main/java/net/spy/memcached/protocol/ascii/CollectionBulkInsertOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/CollectionBulkInsertOperationImpl.java
@@ -100,12 +100,12 @@ public class CollectionBulkInsertOperationImpl extends OperationImpl
     }
     /* ENABLE_REPLICATION end */
 
-    if (insert.getItemCount() == 1) {
+    if (insert.getItemCount() - insert.getNextOpIndex() == 1) {
       OperationStatus status = matchStatus(line, STORED, CREATED_STORED,
               NOT_FOUND, ELEMENT_EXISTS, OVERFLOWED, OUT_OF_RANGE,
               TYPE_MISMATCH, BKEY_MISMATCH);
       if (status.isSuccess()) {
-        cb.receivedStatus(END);
+        cb.receivedStatus((successAll) ? END : FAILED_END);
       } else {
         cb.gotStatus(index, status);
         cb.receivedStatus(FAILED_END);

--- a/src/main/java/net/spy/memcached/protocol/ascii/CollectionPipedInsertOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/CollectionPipedInsertOperationImpl.java
@@ -102,12 +102,12 @@ public class CollectionPipedInsertOperationImpl extends OperationImpl
     }
     /* ENABLE_REPLICATION end */
 
-    if (insert.getItemCount() == 1) {
+    if (insert.getItemCount() - insert.getNextOpIndex() == 1) {
       OperationStatus status = matchStatus(line, STORED, CREATED_STORED,
               NOT_FOUND, ELEMENT_EXISTS, OVERFLOWED, OUT_OF_RANGE,
               TYPE_MISMATCH, BKEY_MISMATCH);
       if (status.isSuccess()) {
-        cb.receivedStatus(END);
+        cb.receivedStatus((successAll) ? END : FAILED_END);
       } else {
         cb.gotStatus(index, status);
         cb.receivedStatus(FAILED_END);

--- a/src/main/java/net/spy/memcached/protocol/ascii/CollectionPipedUpdateOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/CollectionPipedUpdateOperationImpl.java
@@ -98,12 +98,12 @@ public class CollectionPipedUpdateOperationImpl extends OperationImpl implements
     }
     /* ENABLE_REPLICATION end */
 
-    if (update.getItemCount() == 1) {
+    if (update.getItemCount() - update.getNextOpIndex() == 1) {
       OperationStatus status = matchStatus(line, UPDATED, NOT_FOUND,
               NOT_FOUND_ELEMENT, NOTHING_TO_UPDATE, TYPE_MISMATCH,
               BKEY_MISMATCH, EFLAG_MISMATCH, SERVER_ERROR);
       if (status.isSuccess()) {
-        cb.receivedStatus(END);
+        cb.receivedStatus((successAll) ? END : FAILED_END);
       } else {
         cb.gotStatus(index, status);
         cb.receivedStatus(FAILED_END);


### PR DESCRIPTION
#378 을 반영한 pr입니다.

pipedInsert 연산 도중 맨 마지막 key의 연산에서 switchover가 발생할 시에
전송하지 못한 인덱스를 저장하여 변경된 master에게 Insert 연산을 재전송합니다.

pipedInsert 내부 구현에서는 ascii 명령어 생성시 하나의 연산을 전송할때는 "PIPE"를 붙이지 않은 nomal 연산을 전송하므로 마지막 인덱스에서 switchover가 발생하여 재전송을 하면 nomal 연산에 대한 결과값을 보내게 됩니다.

그러므로 기존 코드에서 pipedInsert 수행시 1개의 연산 전송을 할때 뿐만 아니라 switchover가 발생한 후 하나의 연산이 재전송 되었을 때도 nomal 연산을 parsing할 수 있도록 수정하였습니다.