### PR TITLE
Use matchStatus method in handleLine method of VersionOperationImpl class to keep source code consistent.

### DIFF
--- a/src/main/java/net/spy/memcached/protocol/ascii/VersionOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/VersionOperationImpl.java
@@ -29,14 +29,12 @@ final class VersionOperationImpl extends OperationImpl
 
   @Override
   public void handleLine(String line) {
-    OperationStatus cause;
-    if (line.startsWith("VERSION ")) {
-      cause = new OperationStatus(
-              true, line.substring("VERSION ".length()), StatusCode.SUCCESS);
-    } else {
-      cause = new OperationStatus(false, line, StatusCode.fromAsciiLine(line));
-    }
-    getCallback().receivedStatus(cause);
+    String version = line.startsWith("VERSION ") ? line.substring("VERSION ".length()) : line;
+
+    getCallback().receivedStatus(matchStatus(version,
+            new OperationStatus(true,
+                    version,
+                    StatusCode.SUCCESS)));
     transitionState(OperationState.COMPLETE);
   }
 


### PR DESCRIPTION
#338
VersionOperationImpl 클래스의 handleLine 메소드에서 matchStatus 메소드를 사용하도록 변경했습니다.