### PR TITLE
fix: remove unnecessary API

### DIFF
--- a/src/main/java/net/spy/memcached/collection/CollectionAttributes.java
+++ b/src/main/java/net/spy/memcached/collection/CollectionAttributes.java
@@ -203,10 +203,6 @@ public class CollectionAttributes extends Attributes {
     return minBkey;
   }
 
-  public void setMinBkey(Long minBkey) {
-    this.minBkey = minBkey;
-  }
-
   public byte[] getMinBkeyByBytes() {
     return minBkeyByBytes;
   }


### PR DESCRIPTION
CollectionAttributes 클래스에 MinBkey를 설정하는 set API가 불필요하게 있어 
사용자에게 노출 될 수 있기 때문에 제거 하였습니다.