### PR TITLE
FIX: Operation command buffer size

### DIFF
--- a/src/main/java/net/spy/memcached/protocol/ascii/BaseStoreOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/BaseStoreOperationImpl.java
@@ -34,7 +34,7 @@ import net.spy.memcached.ops.StatusCode;
  */
 abstract class BaseStoreOperationImpl extends OperationImpl {
 
-  private static final int OVERHEAD = 32;
+  private static final int OVERHEAD = 64;
 
   private static final OperationStatus STORED =
           new OperationStatus(true, "STORED", StatusCode.SUCCESS);

--- a/src/main/java/net/spy/memcached/protocol/ascii/MutatorOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/MutatorOperationImpl.java
@@ -40,7 +40,7 @@ import net.spy.memcached.ops.StatusCode;
 final class MutatorOperationImpl extends OperationImpl
         implements MutatorOperation {
 
-  public static final int OVERHEAD = 32;
+  public static final int OVERHEAD = 64;
 
   private static final OperationStatus NOT_FOUND =
           new OperationStatus(false, "NOT_FOUND", StatusCode.ERR_NOT_FOUND);


### PR DESCRIPTION
MutatorOperation, BaseStoreOperation 이 두 Operation이 BufferOverFlowException 발생할 수 있어 OVERHEAD 사이즈를 32에서 

64로 변경하였습니다.