### PR TITLE
FIX: fixed bkey validation and converting to unsinged long

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -101,6 +101,11 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>20.0</version>
+        </dependency>
 
         <!-- TEST -->
         <dependency>

--- a/src/main/java/net/spy/memcached/ArcusClient.java
+++ b/src/main/java/net/spy/memcached/ArcusClient.java
@@ -2800,16 +2800,19 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
   public CollectionFuture<Boolean> asyncBopUpdate(String key,
                                                   byte[] bkey, ElementFlagUpdate eFlagUpdate,
                                                   Object value) {
+    BTreeUtil.validateBkey(bkey);
     BTreeUpdate<Object> collectionUpdate = new BTreeUpdate<Object>(value, eFlagUpdate, false);
     return asyncCollectionUpdate(key, BTreeUtil.toHex(bkey), collectionUpdate,
             collectionTranscoder);
   }
+
 
   @Override
   public <T> CollectionFuture<Boolean> asyncBopUpdate(String key,
                                                       byte[] bkey,
                                                       ElementFlagUpdate eFlagUpdate, T value,
                                                       Transcoder<T> tc) {
+    BTreeUtil.validateBkey(bkey);
     BTreeUpdate<T> collectionUpdate = new BTreeUpdate<T>(value, eFlagUpdate, false);
     return asyncCollectionUpdate(key, BTreeUtil.toHex(bkey), collectionUpdate, tc);
   }
@@ -2953,6 +2956,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
   public CollectionFuture<Boolean> asyncBopInsert(String key, byte[] bkey,
                                                   byte[] eFlag, Object value,
                                                   CollectionAttributes attributesForCreate) {
+    BTreeUtil.validateBkey(bkey);
     BTreeInsert<Object> bTreeInsert = new BTreeInsert<Object>(value,
             eFlag, (attributesForCreate != null), null, attributesForCreate);
     return asyncCollectionInsert(key, BTreeUtil.toHex(bkey), bTreeInsert,
@@ -2964,6 +2968,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
                                                       byte[] bkey, byte[] eFlag, T value,
                                                       CollectionAttributes attributesForCreate,
                                                       Transcoder<T> tc) {
+    BTreeUtil.validateBkey(bkey);
     BTreeInsert<T> bTreeInsert = new BTreeInsert<T>(value, eFlag,
             (attributesForCreate != null), null, attributesForCreate);
     return asyncCollectionInsert(key, BTreeUtil.toHex(bkey), bTreeInsert, tc);
@@ -2973,6 +2978,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
   public CollectionFuture<Map<ByteArrayBKey, Element<Object>>> asyncBopGet(
           String key, byte[] bkey, ElementFlagFilter eFlagFilter,
           boolean withDelete, boolean dropIfEmpty) {
+    BTreeUtil.validateBkey(bkey);
     BTreeGet get = new BTreeGet(bkey, bkey, 0, 1, withDelete, dropIfEmpty, eFlagFilter);
     return asyncBopExtendedGet(key, get, false, collectionTranscoder);
   }
@@ -2981,6 +2987,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
   public <T> CollectionFuture<Map<ByteArrayBKey, Element<T>>> asyncBopGet(
           String key, byte[] bkey, ElementFlagFilter eFlagFilter,
           boolean withDelete, boolean dropIfEmpty, Transcoder<T> tc) {
+    BTreeUtil.validateBkey(bkey);
     BTreeGet get = new BTreeGet(bkey, bkey, 0, 1, withDelete, dropIfEmpty, eFlagFilter);
     return asyncBopExtendedGet(key, get, false, tc);
   }
@@ -2989,6 +2996,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
   public CollectionFuture<Map<ByteArrayBKey, Element<Object>>> asyncBopGet(
       String key, byte[] from, byte[] to, ElementFlagFilter eFlagFilter,
       int offset, int count, boolean withDelete, boolean dropIfEmpty) {
+    BTreeUtil.validateBkey(from, to);
     BTreeGet get = new BTreeGet(from, to, offset, count, withDelete, dropIfEmpty, eFlagFilter);
     boolean reverse = BTreeUtil.compareByteArraysInLexOrder(from, to) > 0;
     return asyncBopExtendedGet(key, get, reverse, collectionTranscoder);
@@ -2999,6 +3007,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
           String key, byte[] from, byte[] to, ElementFlagFilter eFlagFilter, int offset,
           int count, boolean withDelete, boolean dropIfEmpty,
           Transcoder<T> tc) {
+    BTreeUtil.validateBkey(from, to);
     BTreeGet get = new BTreeGet(from, to, offset, count, withDelete, dropIfEmpty, eFlagFilter);
     boolean reverse = BTreeUtil.compareByteArraysInLexOrder(from, to) > 0;
     return asyncBopExtendedGet(key, get, reverse, tc);
@@ -3210,22 +3219,22 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
   }
 
   @Override
-  public CollectionFuture<Integer> asyncBopFindPosition(String key, long longBKey,
+  public CollectionFuture<Integer> asyncBopFindPosition(String key, long bkey,
                                                         BTreeOrder order) {
     if (order == null) {
       throw new IllegalArgumentException("BTreeOrder must not be null.");
     }
-    BTreeFindPosition get = new BTreeFindPosition(longBKey, order);
+    BTreeFindPosition get = new BTreeFindPosition(bkey, order);
     return asyncBopFindPosition(key, get);
   }
 
   @Override
-  public CollectionFuture<Integer> asyncBopFindPosition(String key, byte[] byteArrayBKey,
+  public CollectionFuture<Integer> asyncBopFindPosition(String key, byte[] bkey,
                                                         BTreeOrder order) {
     if (order == null) {
       throw new IllegalArgumentException("BTreeOrder must not be null.");
     }
-    BTreeFindPosition get = new BTreeFindPosition(byteArrayBKey, order);
+    BTreeFindPosition get = new BTreeFindPosition(bkey, order);
     return asyncBopFindPosition(key, get);
   }
 
@@ -3310,29 +3319,31 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
 
   @Override
   public CollectionFuture<Map<Integer, Element<Object>>> asyncBopFindPositionWithGet(
-          String key, long longBKey, BTreeOrder order, int count) {
-    BTreeFindPositionWithGet get = new BTreeFindPositionWithGet(longBKey, order, count);
+          String key, long bkey, BTreeOrder order, int count) {
+    BTreeFindPositionWithGet get = new BTreeFindPositionWithGet(bkey, order, count);
     return asyncBopFindPositionWithGet(key, get, collectionTranscoder);
   }
 
   @Override
   public <T> CollectionFuture<Map<Integer, Element<T>>> asyncBopFindPositionWithGet(
-          String key, long longBKey, BTreeOrder order, int count, Transcoder<T> tc) {
-    BTreeFindPositionWithGet get = new BTreeFindPositionWithGet(longBKey, order, count);
+          String key, long bkey, BTreeOrder order, int count, Transcoder<T> tc) {
+    BTreeFindPositionWithGet get = new BTreeFindPositionWithGet(bkey, order, count);
     return asyncBopFindPositionWithGet(key, get, tc);
   }
 
   @Override
   public CollectionFuture<Map<Integer, Element<Object>>> asyncBopFindPositionWithGet(
-          String key, byte[] byteArrayBKey, BTreeOrder order, int count) {
-    BTreeFindPositionWithGet get = new BTreeFindPositionWithGet(byteArrayBKey, order, count);
+          String key, byte[] bkey, BTreeOrder order, int count) {
+    BTreeUtil.validateBkey(bkey);
+    BTreeFindPositionWithGet get = new BTreeFindPositionWithGet(bkey, order, count);
     return asyncBopFindPositionWithGet(key, get, collectionTranscoder);
   }
 
   @Override
   public <T> CollectionFuture<Map<Integer, Element<T>>> asyncBopFindPositionWithGet(
-          String key, byte[] byteArrayBKey, BTreeOrder order, int count, Transcoder<T> tc) {
-    BTreeFindPositionWithGet get = new BTreeFindPositionWithGet(byteArrayBKey, order, count);
+          String key, byte[] bkey, BTreeOrder order, int count, Transcoder<T> tc) {
+    BTreeUtil.validateBkey(bkey);
+    BTreeFindPositionWithGet get = new BTreeFindPositionWithGet(bkey, order, count);
     return asyncBopFindPositionWithGet(key, get, tc);
   }
 
@@ -3454,6 +3465,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
   public BTreeStoreAndGetFuture<Boolean, Object> asyncBopInsertAndGetTrimmed(
           String key, byte[] bkey, byte[] eFlag, Object value,
           CollectionAttributes attributesForCreate) {
+    BTreeUtil.validateBkey(bkey);
     BTreeInsertAndGet<Object> insertAndGet = new BTreeInsertAndGet<Object>(
             BTreeInsertAndGet.Command.INSERT, bkey, eFlag, value, attributesForCreate);
     return asyncBTreeInsertAndGet(key, insertAndGet, collectionTranscoder);
@@ -3463,6 +3475,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
   public <E> BTreeStoreAndGetFuture<Boolean, E> asyncBopInsertAndGetTrimmed(
           String key, byte[] bkey, byte[] eFlag, E value,
           CollectionAttributes attributesForCreate, Transcoder<E> transcoder) {
+    BTreeUtil.validateBkey(bkey);
     BTreeInsertAndGet<E> insertAndGet = new BTreeInsertAndGet<E>(
             BTreeInsertAndGet.Command.INSERT, bkey, eFlag, value, attributesForCreate);
     return asyncBTreeInsertAndGet(key, insertAndGet, transcoder);
@@ -3490,6 +3503,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
   public BTreeStoreAndGetFuture<Boolean, Object> asyncBopUpsertAndGetTrimmed(
           String key, byte[] bkey, byte[] eFlag, Object value,
           CollectionAttributes attributesForCreate) {
+    BTreeUtil.validateBkey(bkey);
     BTreeInsertAndGet<Object> insertAndGet = new BTreeInsertAndGet<Object>(
             BTreeInsertAndGet.Command.UPSERT, bkey, eFlag, value, attributesForCreate);
     return asyncBTreeInsertAndGet(key, insertAndGet, collectionTranscoder);
@@ -3499,6 +3513,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
   public <E> BTreeStoreAndGetFuture<Boolean, E> asyncBopUpsertAndGetTrimmed(
           String key, byte[] bkey, byte[] eFlag, E value,
           CollectionAttributes attributesForCreate, Transcoder<E> transcoder) {
+    BTreeUtil.validateBkey(bkey);
     BTreeInsertAndGet<E> insertAndGet = new BTreeInsertAndGet<E>(
             BTreeInsertAndGet.Command.UPSERT, bkey, eFlag, value, attributesForCreate);
     return asyncBTreeInsertAndGet(key, insertAndGet, transcoder);
@@ -3607,6 +3622,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
                                                   byte[] from, byte[] to,
                                                   ElementFlagFilter eFlagFilter, int count,
                                                   boolean dropIfEmpty) {
+    BTreeUtil.validateBkey(from, to);
     BTreeDelete delete = new BTreeDelete(from, to, count, false, dropIfEmpty, eFlagFilter);
     return asyncCollectionDelete(key, delete);
   }
@@ -3615,6 +3631,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
   public CollectionFuture<Boolean> asyncBopDelete(String key,
                                                   byte[] bkey, ElementFlagFilter eFlagFilter,
                                                   boolean dropIfEmpty) {
+    BTreeUtil.validateBkey(bkey);
     BTreeDelete delete = new BTreeDelete(bkey, false, dropIfEmpty, eFlagFilter);
     return asyncCollectionDelete(key, delete);
   }
@@ -3623,6 +3640,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
   public CollectionFuture<Boolean> asyncBopUpsert(String key,
                                                   byte[] bkey, byte[] elementFlag, Object value,
                                                   CollectionAttributes attributesForCreate) {
+    BTreeUtil.validateBkey(bkey);
     BTreeUpsert<Object> bTreeUpsert = new BTreeUpsert<Object>(value, elementFlag,
             (attributesForCreate != null), null, attributesForCreate);
     return asyncCollectionInsert(key, BTreeUtil.toHex(bkey), bTreeUpsert,
@@ -3634,6 +3652,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
                                                       byte[] bkey, byte[] elementFlag, T value,
                                                       CollectionAttributes attributesForCreate,
                                                       Transcoder<T> tc) {
+    BTreeUtil.validateBkey(bkey);
     BTreeUpsert<T> bTreeUpsert = new BTreeUpsert<T>(value, elementFlag,
             (attributesForCreate != null), null, attributesForCreate);
     return asyncCollectionInsert(key, BTreeUtil.toHex(bkey), bTreeUpsert,
@@ -3644,6 +3663,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
   public CollectionFuture<Integer> asyncBopGetItemCount(String key,
                                                         byte[] from, byte[] to,
                                                         ElementFlagFilter eFlagFilter) {
+    BTreeUtil.validateBkey(from, to);
     CollectionCount collectionCount = new BTreeCount(from, to, eFlagFilter);
     return asyncCollectionCount(key, collectionCount);
   }
@@ -3781,6 +3801,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
   public SMGetFuture<List<SMGetElement<Object>>> asyncBopSortMergeGet(
           List<String> keyList, byte[] from, byte[] to,
           ElementFlagFilter eFlagFilter, int offset, int count) {
+    BTreeUtil.validateBkey(from, to);
     if (keyList == null || keyList.isEmpty()) {
       throw new IllegalArgumentException("Key list is empty.");
     }
@@ -3813,6 +3834,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
   public SMGetFuture<List<SMGetElement<Object>>> asyncBopSortMergeGet(
           List<String> keyList, byte[] from, byte[] to, ElementFlagFilter eFlagFilter,
           int count, SMGetMode smgetMode) {
+    BTreeUtil.validateBkey(from, to);
     if (keyList == null || keyList.isEmpty()) {
       throw new IllegalArgumentException("Key list is empty.");
     }
@@ -4006,6 +4028,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
           List<String> keyList, byte[] bkey, byte[] eFlag, Object value,
           CollectionAttributes attributesForCreate) {
 
+    BTreeUtil.validateBkey(bkey);
     return asyncBopInsertBulk(keyList, bkey, eFlag, value,
             attributesForCreate, collectionTranscoder);
   }
@@ -4015,6 +4038,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
           List<String> keyList, byte[] bkey, byte[] eFlag, T value,
           CollectionAttributes attributesForCreate, Transcoder<T> tc) {
 
+    BTreeUtil.validateBkey(bkey);
     Map<String, List<String>> arrangedKey = groupingKeys(keyList, NON_PIPED_BULK_INSERT_CHUNK_SIZE);
     List<CollectionBulkInsert<T>> insertList = new ArrayList<CollectionBulkInsert<T>>(
             arrangedKey.size());
@@ -4268,6 +4292,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
           List<String> keyList, byte[] from, byte[] to,
           ElementFlagFilter eFlagFilter, int offset, int count,
           Transcoder<T> tc) {
+    BTreeUtil.validateBkey(from, to);
     if (keyList == null) {
       throw new IllegalArgumentException("Key list is null.");
     }
@@ -4409,59 +4434,63 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
   }
 
   @Override
-  public CollectionFuture<Long> asyncBopIncr(String key, long subkey,
+  public CollectionFuture<Long> asyncBopIncr(String key, long bkey,
                                              int by) {
     CollectionMutate collectionMutate = new BTreeMutate(Mutator.incr, by);
     return asyncCollectionMutate(key, String.valueOf(subkey), collectionMutate);
   }
 
   @Override
-  public CollectionFuture<Long> asyncBopIncr(String key, byte[] subkey,
+  public CollectionFuture<Long> asyncBopIncr(String key, byte[] bkey,
                                              int by) {
+    BTreeUtil.validateBkey(bkey);
     CollectionMutate collectionMutate = new BTreeMutate(Mutator.incr, by);
-    return asyncCollectionMutate(key, BTreeUtil.toHex(subkey), collectionMutate);
+    return asyncCollectionMutate(key, BTreeUtil.toHex(bkey), collectionMutate);
   }
 
   @Override
-  public CollectionFuture<Long> asyncBopIncr(String key, long subkey,
+  public CollectionFuture<Long> asyncBopIncr(String key, long bkey,
                                              int by, long initial, byte[] eFlag) {
     CollectionMutate collectionMutate = new BTreeMutate(Mutator.incr, by, initial, eFlag);
     return asyncCollectionMutate(key, String.valueOf(subkey), collectionMutate);
   }
 
   @Override
-  public CollectionFuture<Long> asyncBopIncr(String key, byte[] subkey,
+  public CollectionFuture<Long> asyncBopIncr(String key, byte[] bkey,
                                              int by, long initial, byte[] eFlag) {
+    BTreeUtil.validateBkey(bkey);
     CollectionMutate collectionMutate = new BTreeMutate(Mutator.incr, by, initial, eFlag);
-    return asyncCollectionMutate(key, BTreeUtil.toHex(subkey), collectionMutate);
+    return asyncCollectionMutate(key, BTreeUtil.toHex(bkey), collectionMutate);
   }
 
   @Override
-  public CollectionFuture<Long> asyncBopDecr(String key, long subkey,
+  public CollectionFuture<Long> asyncBopDecr(String key, long bkey,
                                              int by) {
     CollectionMutate collectionMutate = new BTreeMutate(Mutator.decr, by);
     return asyncCollectionMutate(key, String.valueOf(subkey), collectionMutate);
   }
 
   @Override
-  public CollectionFuture<Long> asyncBopDecr(String key, byte[] subkey,
+  public CollectionFuture<Long> asyncBopDecr(String key, byte[] bkey,
                                              int by) {
+    BTreeUtil.validateBkey(bkey);
     CollectionMutate collectionMutate = new BTreeMutate(Mutator.decr, by);
-    return asyncCollectionMutate(key, BTreeUtil.toHex(subkey), collectionMutate);
+    return asyncCollectionMutate(key, BTreeUtil.toHex(bkey), collectionMutate);
   }
 
   @Override
-  public CollectionFuture<Long> asyncBopDecr(String key, long subkey,
+  public CollectionFuture<Long> asyncBopDecr(String key, long bkey,
                                              int by, long initial, byte[] eFlag) {
     CollectionMutate collectionMutate = new BTreeMutate(Mutator.decr, by, initial, eFlag);
     return asyncCollectionMutate(key, String.valueOf(subkey), collectionMutate);
   }
 
   @Override
-  public CollectionFuture<Long> asyncBopDecr(String key, byte[] subkey,
+  public CollectionFuture<Long> asyncBopDecr(String key, byte[] bkey,
                                              int by, long initial, byte[] eFlag) {
+    BTreeUtil.validateBkey(bkey);
     CollectionMutate collectionMutate = new BTreeMutate(Mutator.decr, by, initial, eFlag);
-    return asyncCollectionMutate(key, BTreeUtil.toHex(subkey), collectionMutate);
+    return asyncCollectionMutate(key, BTreeUtil.toHex(bkey), collectionMutate);
   }
 
   /**

--- a/src/main/java/net/spy/memcached/ArcusClient.java
+++ b/src/main/java/net/spy/memcached/ArcusClient.java
@@ -1811,7 +1811,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
                                                   CollectionAttributes attributesForCreate) {
     BTreeInsert<Object> bTreeInsert = new BTreeInsert<Object>(value,
             eFlag, (attributesForCreate != null), null, attributesForCreate);
-    return asyncCollectionInsert(key, String.valueOf(bkey), bTreeInsert, collectionTranscoder);
+    return asyncCollectionInsert(key, BTreeUtil.convertBkey(bkey), bTreeInsert, collectionTranscoder);
   }
 
   @Override
@@ -1848,7 +1848,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
                                                       Transcoder<T> tc) {
     BTreeInsert<T> bTreeInsert = new BTreeInsert<T>(value, eFlag,
             (attributesForCreate != null), null, attributesForCreate);
-    return asyncCollectionInsert(key, String.valueOf(bkey), bTreeInsert, tc);
+    return asyncCollectionInsert(key, BTreeUtil.convertBkey(bkey), bTreeInsert, tc);
   }
 
   @Override
@@ -2764,7 +2764,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
     BTreeUpsert<Object> bTreeUpsert = new BTreeUpsert<Object>(value,
             elementFlag, (attributesForCreate != null), null, attributesForCreate);
 
-    return asyncCollectionInsert(key, String.valueOf(bkey), bTreeUpsert,
+    return asyncCollectionInsert(key, BTreeUtil.convertBkey(bkey), bTreeUpsert,
             collectionTranscoder);
   }
 
@@ -2777,14 +2777,14 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
     BTreeUpsert<T> bTreeUpsert = new BTreeUpsert<T>(value, elementFlag,
             (attributesForCreate != null), null, attributesForCreate);
 
-    return asyncCollectionInsert(key, String.valueOf(bkey), bTreeUpsert, tc);
+    return asyncCollectionInsert(key, BTreeUtil.convertBkey(bkey), bTreeUpsert, tc);
   }
 
   @Override
   public CollectionFuture<Boolean> asyncBopUpdate(String key, long bkey,
                                                   ElementFlagUpdate eFlagUpdate, Object value) {
     BTreeUpdate<Object> collectionUpdate = new BTreeUpdate<Object>(value, eFlagUpdate, false);
-    return asyncCollectionUpdate(key, String.valueOf(bkey), collectionUpdate,
+    return asyncCollectionUpdate(key, BTreeUtil.convertBkey(bkey), collectionUpdate,
             collectionTranscoder);
   }
 
@@ -2793,7 +2793,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
                                                       ElementFlagUpdate eFlagUpdate, T value,
                                                       Transcoder<T> tc) {
     BTreeUpdate<T> collectionUpdate = new BTreeUpdate<T>(value, eFlagUpdate, false);
-    return asyncCollectionUpdate(key, String.valueOf(bkey), collectionUpdate, tc);
+    return asyncCollectionUpdate(key, BTreeUtil.convertBkey(bkey), collectionUpdate, tc);
   }
 
   @Override
@@ -4437,7 +4437,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
   public CollectionFuture<Long> asyncBopIncr(String key, long bkey,
                                              int by) {
     CollectionMutate collectionMutate = new BTreeMutate(Mutator.incr, by);
-    return asyncCollectionMutate(key, String.valueOf(subkey), collectionMutate);
+    return asyncCollectionMutate(key, BTreeUtil.convertBkey(bkey), collectionMutate);
   }
 
   @Override
@@ -4452,7 +4452,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
   public CollectionFuture<Long> asyncBopIncr(String key, long bkey,
                                              int by, long initial, byte[] eFlag) {
     CollectionMutate collectionMutate = new BTreeMutate(Mutator.incr, by, initial, eFlag);
-    return asyncCollectionMutate(key, String.valueOf(subkey), collectionMutate);
+    return asyncCollectionMutate(key, BTreeUtil.convertBkey(bkey), collectionMutate);
   }
 
   @Override
@@ -4467,7 +4467,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
   public CollectionFuture<Long> asyncBopDecr(String key, long bkey,
                                              int by) {
     CollectionMutate collectionMutate = new BTreeMutate(Mutator.decr, by);
-    return asyncCollectionMutate(key, String.valueOf(subkey), collectionMutate);
+    return asyncCollectionMutate(key, BTreeUtil.convertBkey(bkey), collectionMutate);
   }
 
   @Override
@@ -4482,7 +4482,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
   public CollectionFuture<Long> asyncBopDecr(String key, long bkey,
                                              int by, long initial, byte[] eFlag) {
     CollectionMutate collectionMutate = new BTreeMutate(Mutator.decr, by, initial, eFlag);
-    return asyncCollectionMutate(key, String.valueOf(subkey), collectionMutate);
+    return asyncCollectionMutate(key, BTreeUtil.convertBkey(bkey), collectionMutate);
   }
 
   @Override

--- a/src/main/java/net/spy/memcached/collection/BKeyObject.java
+++ b/src/main/java/net/spy/memcached/collection/BKeyObject.java
@@ -92,7 +92,7 @@ public class BKeyObject {
 
   public String getBKeyAsString() {
     if (BKeyType.LONG == type) {
-      return String.valueOf(longBKey);
+      return BTreeUtil.convertBkey(longBKey);
     } else if (BKeyType.BYTEARRAY == type) {
       return BTreeUtil.toHex(byteArrayBKey.getBytes());
     } else {

--- a/src/main/java/net/spy/memcached/collection/BTreeCount.java
+++ b/src/main/java/net/spy/memcached/collection/BTreeCount.java
@@ -27,7 +27,7 @@ public class BTreeCount extends CollectionCount {
   protected final ElementFlagFilter elementFlagFilter;
 
   public BTreeCount(long from, long to, ElementFlagFilter elementFlagFilter) {
-    this.range = String.valueOf(from) + ".." + String.valueOf(to);
+    this.range = BTreeUtil.convertBkey(from) + ".." + BTreeUtil.convertBkey(to);
     this.elementFlagFilter = elementFlagFilter;
   }
 
@@ -37,13 +37,11 @@ public class BTreeCount extends CollectionCount {
   }
 
   public BTreeCount(long from, long to, ElementMultiFlagsFilter elementMultiFlagsFilter) {
-    this.range = String.valueOf(from) + ".." + String.valueOf(to);
-    this.elementFlagFilter = (ElementFlagFilter) elementMultiFlagsFilter;
+    this(from, to, (ElementFlagFilter) elementMultiFlagsFilter);
   }
 
   public BTreeCount(byte[] from, byte[] to, ElementMultiFlagsFilter elementMultiFlagsFilter) {
-    this.range = BTreeUtil.toHex(from) + ".." + BTreeUtil.toHex(to);
-    this.elementFlagFilter = (ElementFlagFilter) elementMultiFlagsFilter;
+    this(from, to, (ElementFlagFilter) elementMultiFlagsFilter);
   }
 
   public String stringify() {

--- a/src/main/java/net/spy/memcached/collection/BTreeDelete.java
+++ b/src/main/java/net/spy/memcached/collection/BTreeDelete.java
@@ -26,7 +26,7 @@ public class BTreeDelete extends CollectionDelete {
   protected ElementFlagFilter elementFlagFilter;
 
   public BTreeDelete(long bkey, boolean noreply) {
-    this.range = String.valueOf(bkey);
+    this.range = BTreeUtil.convertBkey(bkey);
     this.noreply = noreply;
   }
 
@@ -38,12 +38,12 @@ public class BTreeDelete extends CollectionDelete {
   }
 
   public BTreeDelete(long from, long to, boolean noreply) {
-    this.range = String.valueOf(from) + ".." + String.valueOf(to);
+    this.range = BTreeUtil.convertBkey(from) + ".." + BTreeUtil.convertBkey(to);
     this.noreply = noreply;
   }
 
   public BTreeDelete(long from, long to, int count, boolean noreply) {
-    this.range = String.valueOf(from) + ".." + String.valueOf(to);
+    this.range = BTreeUtil.convertBkey(from) + ".." + BTreeUtil.convertBkey(to);
     this.count = count;
     this.noreply = noreply;
   }

--- a/src/main/java/net/spy/memcached/collection/BTreeGet.java
+++ b/src/main/java/net/spy/memcached/collection/BTreeGet.java
@@ -29,7 +29,7 @@ public class BTreeGet extends CollectionGet {
 
   public BTreeGet(long bkey, boolean delete) {
     this.headerCount = 2;
-    this.range = String.valueOf(bkey);
+    this.range = BTreeUtil.convertBkey(bkey);
     this.delete = delete;
   }
 
@@ -42,7 +42,7 @@ public class BTreeGet extends CollectionGet {
 
   public BTreeGet(long from, long to, int offset, int count, boolean delete) {
     this.headerCount = 2;
-    this.range = String.valueOf(from) + ".." + String.valueOf(to);
+    this.range = BTreeUtil.convertBkey(from) + ".." + BTreeUtil.convertBkey(to);
     this.offset = offset;
     this.count = count;
     this.delete = delete;

--- a/src/main/java/net/spy/memcached/collection/BTreeGetBulkImpl.java
+++ b/src/main/java/net/spy/memcached/collection/BTreeGetBulkImpl.java
@@ -62,7 +62,7 @@ public abstract class BTreeGetBulkImpl<T> implements BTreeGetBulk<T> {
                              ElementFlagFilter eFlagFilter, int offset, int count) {
 
     this.keyList = keyList;
-    this.range = String.valueOf(from) + ((to > -1) ? ".." + String.valueOf(to) : "");
+    this.range = BTreeUtil.convertBkey(from) + ((to > -1) ? ".." + BTreeUtil.convertBkey(to) : "");
     this.eFlagFilter = eFlagFilter;
     this.offset = offset;
     this.count = count;

--- a/src/main/java/net/spy/memcached/collection/BTreeGetByPosition.java
+++ b/src/main/java/net/spy/memcached/collection/BTreeGetByPosition.java
@@ -54,7 +54,7 @@ public class BTreeGetByPosition extends CollectionGet {
   public BTreeGetByPosition(BTreeOrder order, int posFrom, int posTo) {
     this.headerCount = 2;
     this.order = order;
-    this.range = String.valueOf(posFrom) + ".." + String.valueOf(posTo);
+    this.range = BTreeUtil.convertBkey(posFrom) + ".." + BTreeUtil.convertBkey(posTo);
     this.posFrom = posFrom;
     this.posTo = posTo;
   }

--- a/src/main/java/net/spy/memcached/collection/BTreeSMGetWithLongTypeBkey.java
+++ b/src/main/java/net/spy/memcached/collection/BTreeSMGetWithLongTypeBkey.java
@@ -55,8 +55,8 @@ public class BTreeSMGetWithLongTypeBkey<T> implements BTreeSMGet<T> {
                                     ElementFlagFilter eFlagFilter, int count, SMGetMode smgetMode) {
     this.keyList = keyList;
 
-    this.range = String.valueOf(from)
-            + ((to > -1) ? ".." + String.valueOf(to) : "");
+    this.range = BTreeUtil.convertBkey(from)
+            + ((to > -1) ? ".." + BTreeUtil.convertBkey(to) : "");
 
     this.eFlagFilter = eFlagFilter;
     this.count = count;

--- a/src/main/java/net/spy/memcached/collection/BTreeSMGetWithLongTypeBkeyOld.java
+++ b/src/main/java/net/spy/memcached/collection/BTreeSMGetWithLongTypeBkeyOld.java
@@ -54,8 +54,8 @@ public class BTreeSMGetWithLongTypeBkeyOld<T> implements BTreeSMGet<T> {
                                        ElementFlagFilter eFlagFilter, int offset, int count) {
     this.keyList = keyList;
 
-    this.range = String.valueOf(from)
-            + ((to > -1) ? ".." + String.valueOf(to) : "");
+    this.range = BTreeUtil.convertBkey(from)
+            + ((to > -1) ? ".." + BTreeUtil.convertBkey(to) : "");
 
     this.eFlagFilter = eFlagFilter;
     this.offset = offset;

--- a/src/main/java/net/spy/memcached/collection/CollectionBulkInsert.java
+++ b/src/main/java/net/spy/memcached/collection/CollectionBulkInsert.java
@@ -79,7 +79,7 @@ public abstract class CollectionBulkInsert<T> extends CollectionObject {
         }
       }
       this.keyList = keyList;
-      this.bkey = String.valueOf(bkey);
+      this.bkey = BTreeUtil.convertBkey(bkey);
       this.eflag = BTreeUtil.toHex(eflag);
       this.value = value;
       this.attribute = attr;

--- a/src/main/java/net/spy/memcached/util/BTreeUtil.java
+++ b/src/main/java/net/spy/memcached/util/BTreeUtil.java
@@ -17,6 +17,8 @@
 package net.spy.memcached.util;
 
 
+import com.google.common.primitives.UnsignedLong;
+
 public final class BTreeUtil {
 
   private static final String HEXES = "0123456789ABCDEF";
@@ -89,5 +91,12 @@ public final class BTreeUtil {
   public static void validateBkey(byte[] from, byte[] to) {
     validateBkey(from);
     validateBkey(to);
+  }
+
+  public static String convertBkey(long bkey) {
+    if (bkey < 0) {
+      return UnsignedLong.fromLongBits(bkey).toString();
+    }
+    return String.valueOf(bkey);
   }
 }

--- a/src/main/java/net/spy/memcached/util/BTreeUtil.java
+++ b/src/main/java/net/spy/memcached/util/BTreeUtil.java
@@ -79,4 +79,15 @@ public final class BTreeUtil {
     }
     return array1.length - array2.length;
   }
+
+  public static void validateBkey(byte[] bkey) {
+    if (bkey.length > 31) {
+      throw new IllegalArgumentException("bkey size exceeded 31");
+    }
+  }
+
+  public static void validateBkey(byte[] from, byte[] to) {
+    validateBkey(from);
+    validateBkey(to);
+  }
 }

--- a/src/test/java/net/spy/memcached/util/BTreeUtilTest.java
+++ b/src/test/java/net/spy/memcached/util/BTreeUtilTest.java
@@ -16,9 +16,12 @@
  */
 package net.spy.memcached.util;
 
+import net.spy.memcached.compat.BaseMockCase;
+import org.junit.function.ThrowingRunnable;
+
 import java.util.Arrays;
 
-import net.spy.memcached.compat.BaseMockCase;
+import static org.junit.Assert.assertThrows;
 
 public class BTreeUtilTest extends BaseMockCase {
 
@@ -76,5 +79,14 @@ public class BTreeUtilTest extends BaseMockCase {
 
     assertEquals(-1, BTreeUtil.compareByteArraysInLexOrder(array1, array2));
     assertEquals(1, BTreeUtil.compareByteArraysInLexOrder(array2, array1));
+  }
+
+  public void testInValidSizeBkey() {
+    assertThrows(IllegalArgumentException.class, new ThrowingRunnable() {
+      @Override
+      public void run() throws Throwable {
+        BTreeUtil.validateBkey(new byte[32]);
+      }
+    });
   }
 }

--- a/src/test/java/net/spy/memcached/util/BTreeUtilTest.java
+++ b/src/test/java/net/spy/memcached/util/BTreeUtilTest.java
@@ -89,4 +89,11 @@ public class BTreeUtilTest extends BaseMockCase {
       }
     });
   }
+
+  public void testConvertUnsignedLongToString() {
+    assertEquals("9223372036854775807", BTreeUtil.convertBkey(Long.MAX_VALUE));
+    assertEquals("9223372036854775808", BTreeUtil.convertBkey(Long.MIN_VALUE));
+    assertEquals("1", BTreeUtil.convertBkey(1));
+    assertEquals("18446744073709551615", BTreeUtil.convertBkey(-1));
+  }
 }


### PR DESCRIPTION
#335 이슈에 관련 pr입니다.

hexadecimal을 지원하는 byte array의 사이즈가 31을 초과할 경우에는 문서상에 `IllegalArgumentException`를 던지게 되있지만, 현재는 client에서 validation이 되지않아 추가하는 코드를 넣었습니다.

또한 long type의 bkey를 사용할 때에도 현재는 `String.valueof()`를 사용하여서 signed long 형태로 bkey가 변환되어, unsinged long 형태로 변환될 수 있도록 변경하였습니다.

두 부분에 대해 따로 commit하여 올려두었습니다.