### PR TITLE
FIX: change the order of moveOperation and ChangeRole on switchover

### DIFF
--- a/src/main/java/net/spy/memcached/MemcachedConnection.java
+++ b/src/main/java/net/spy/memcached/MemcachedConnection.java
@@ -555,16 +555,10 @@ public final class MemcachedConnection extends SpyObject {
      */
     if (group.getMasterNode() != null && group.getMasterCandidate() != null) {
       if (((ArcusReplNodeAddress) node.getSocketAddress()).isMaster()) {
-        MemcachedNode masterCandidateNode = group.getMasterCandidate();
-        if (node.moveOperations(masterCandidateNode) > 0) {
-          addedQueue.offer(masterCandidateNode);
-        }
         ((ArcusReplKetamaNodeLocator) locator).switchoverReplGroup(group);
-      } else {
-        if (node.moveOperations(group.getMasterNode()) > 0) {
-          addedQueue.offer(group.getMasterNode());
-        }
       }
+      node.moveOperations(group.getMasterNode());
+      addedQueue.offer(group.getMasterNode());
       queueReconnect(node, ReconnDelay.IMMEDIATE,
           "Discarded all pending reading state operation to move operations.");
     } else {


### PR DESCRIPTION
#402 관련 pr입니다.

ZK가 아닌, Old Master 서버로부터 "SWITCHOVER" 메세지를 받아 swichover시 기존의 코드에서는
moveOperation이 이루어진뒤에 role을 변경하게 되어 있어, role을 변경하기전 oldMaster가 Operation을 받게 된다면
남아 있는 Operation은 move되지 않게 됩니다.

그래서 순서를 조정하여 role을 먼저 변경하고 moveOperation이 이루어 지도록 수정했습니다.

~~또한 masterCandidate가 없을 경우 이전 swichover에서 설정해둔 masterCandidate를 활용하게 되어 있어 
group에서 address에 해당하는 candidate가 없을 경우 Null로 설정하도록 변경했습니다.~~