### PR TITLE
FIX: fixed long type string to unsigned long type string on bkey

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -101,6 +101,11 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>20.0</version>
+        </dependency>
 
         <!-- TEST -->
         <dependency>

--- a/src/main/java/net/spy/memcached/ArcusClient.java
+++ b/src/main/java/net/spy/memcached/ArcusClient.java
@@ -1811,7 +1811,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
                                                   CollectionAttributes attributesForCreate) {
     BTreeInsert<Object> bTreeInsert = new BTreeInsert<Object>(value,
             eFlag, (attributesForCreate != null), null, attributesForCreate);
-    return asyncCollectionInsert(key, String.valueOf(bkey), bTreeInsert, collectionTranscoder);
+    return asyncCollectionInsert(key, BTreeUtil.toULong(bkey), bTreeInsert, collectionTranscoder);
   }
 
   @Override
@@ -1848,7 +1848,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
                                                       Transcoder<T> tc) {
     BTreeInsert<T> bTreeInsert = new BTreeInsert<T>(value, eFlag,
             (attributesForCreate != null), null, attributesForCreate);
-    return asyncCollectionInsert(key, String.valueOf(bkey), bTreeInsert, tc);
+    return asyncCollectionInsert(key, BTreeUtil.toULong(bkey), bTreeInsert, tc);
   }
 
   @Override
@@ -2764,7 +2764,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
     BTreeUpsert<Object> bTreeUpsert = new BTreeUpsert<Object>(value,
             elementFlag, (attributesForCreate != null), null, attributesForCreate);
 
-    return asyncCollectionInsert(key, String.valueOf(bkey), bTreeUpsert,
+    return asyncCollectionInsert(key, BTreeUtil.toULong(bkey), bTreeUpsert,
             collectionTranscoder);
   }
 
@@ -2777,14 +2777,14 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
     BTreeUpsert<T> bTreeUpsert = new BTreeUpsert<T>(value, elementFlag,
             (attributesForCreate != null), null, attributesForCreate);
 
-    return asyncCollectionInsert(key, String.valueOf(bkey), bTreeUpsert, tc);
+    return asyncCollectionInsert(key, BTreeUtil.toULong(bkey), bTreeUpsert, tc);
   }
 
   @Override
   public CollectionFuture<Boolean> asyncBopUpdate(String key, long bkey,
                                                   ElementFlagUpdate eFlagUpdate, Object value) {
     BTreeUpdate<Object> collectionUpdate = new BTreeUpdate<Object>(value, eFlagUpdate, false);
-    return asyncCollectionUpdate(key, String.valueOf(bkey), collectionUpdate,
+    return asyncCollectionUpdate(key, BTreeUtil.toULong(bkey), collectionUpdate,
             collectionTranscoder);
   }
 
@@ -2793,7 +2793,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
                                                       ElementFlagUpdate eFlagUpdate, T value,
                                                       Transcoder<T> tc) {
     BTreeUpdate<T> collectionUpdate = new BTreeUpdate<T>(value, eFlagUpdate, false);
-    return asyncCollectionUpdate(key, String.valueOf(bkey), collectionUpdate, tc);
+    return asyncCollectionUpdate(key, BTreeUtil.toULong(bkey), collectionUpdate, tc);
   }
 
   @Override
@@ -4438,7 +4438,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
   public CollectionFuture<Long> asyncBopIncr(String key, long bkey,
                                              int by) {
     CollectionMutate collectionMutate = new BTreeMutate(Mutator.incr, by);
-    return asyncCollectionMutate(key, String.valueOf(bkey), collectionMutate);
+    return asyncCollectionMutate(key, BTreeUtil.toULong(bkey), collectionMutate);
   }
 
   @Override
@@ -4453,7 +4453,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
   public CollectionFuture<Long> asyncBopIncr(String key, long bkey,
                                              int by, long initial, byte[] eFlag) {
     CollectionMutate collectionMutate = new BTreeMutate(Mutator.incr, by, initial, eFlag);
-    return asyncCollectionMutate(key, String.valueOf(bkey), collectionMutate);
+    return asyncCollectionMutate(key, BTreeUtil.toULong(bkey), collectionMutate);
   }
 
   @Override
@@ -4468,7 +4468,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
   public CollectionFuture<Long> asyncBopDecr(String key, long bkey,
                                              int by) {
     CollectionMutate collectionMutate = new BTreeMutate(Mutator.decr, by);
-    return asyncCollectionMutate(key, String.valueOf(bkey), collectionMutate);
+    return asyncCollectionMutate(key, BTreeUtil.toULong(bkey), collectionMutate);
   }
 
   @Override
@@ -4483,7 +4483,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
   public CollectionFuture<Long> asyncBopDecr(String key, long bkey,
                                              int by, long initial, byte[] eFlag) {
     CollectionMutate collectionMutate = new BTreeMutate(Mutator.decr, by, initial, eFlag);
-    return asyncCollectionMutate(key, String.valueOf(bkey), collectionMutate);
+    return asyncCollectionMutate(key, BTreeUtil.toULong(bkey), collectionMutate);
   }
 
   @Override

--- a/src/main/java/net/spy/memcached/collection/BKeyObject.java
+++ b/src/main/java/net/spy/memcached/collection/BKeyObject.java
@@ -92,7 +92,7 @@ public class BKeyObject {
 
   public String getBKeyAsString() {
     if (BKeyType.LONG == type) {
-      return String.valueOf(longBKey);
+      return BTreeUtil.toULong(longBKey);
     } else if (BKeyType.BYTEARRAY == type) {
       return BTreeUtil.toHex(byteArrayBKey.getBytes());
     } else {

--- a/src/main/java/net/spy/memcached/collection/BTreeCount.java
+++ b/src/main/java/net/spy/memcached/collection/BTreeCount.java
@@ -27,7 +27,7 @@ public class BTreeCount extends CollectionCount {
   protected final ElementFlagFilter elementFlagFilter;
 
   public BTreeCount(long from, long to, ElementFlagFilter elementFlagFilter) {
-    this.range = String.valueOf(from) + ".." + String.valueOf(to);
+    this.range = BTreeUtil.toULong(from) + ".." + BTreeUtil.toULong(to);
     this.elementFlagFilter = elementFlagFilter;
   }
 
@@ -37,7 +37,7 @@ public class BTreeCount extends CollectionCount {
   }
 
   public BTreeCount(long from, long to, ElementMultiFlagsFilter elementMultiFlagsFilter) {
-    this.range = String.valueOf(from) + ".." + String.valueOf(to);
+    this.range = BTreeUtil.toULong(from) + ".." + BTreeUtil.toULong(to);
     this.elementFlagFilter = (ElementFlagFilter) elementMultiFlagsFilter;
   }
 

--- a/src/main/java/net/spy/memcached/collection/BTreeDelete.java
+++ b/src/main/java/net/spy/memcached/collection/BTreeDelete.java
@@ -26,7 +26,7 @@ public class BTreeDelete extends CollectionDelete {
   protected ElementFlagFilter elementFlagFilter;
 
   public BTreeDelete(long bkey, boolean noreply) {
-    this.range = String.valueOf(bkey);
+    this.range = BTreeUtil.toULong(bkey);
     this.noreply = noreply;
   }
 
@@ -38,12 +38,12 @@ public class BTreeDelete extends CollectionDelete {
   }
 
   public BTreeDelete(long from, long to, boolean noreply) {
-    this.range = String.valueOf(from) + ".." + String.valueOf(to);
+    this.range = BTreeUtil.toULong(from) + ".." + BTreeUtil.toULong(to);
     this.noreply = noreply;
   }
 
   public BTreeDelete(long from, long to, int count, boolean noreply) {
-    this.range = String.valueOf(from) + ".." + String.valueOf(to);
+    this.range = BTreeUtil.toULong(from) + ".." + BTreeUtil.toULong(to);
     this.count = count;
     this.noreply = noreply;
   }

--- a/src/main/java/net/spy/memcached/collection/BTreeGet.java
+++ b/src/main/java/net/spy/memcached/collection/BTreeGet.java
@@ -29,7 +29,7 @@ public class BTreeGet extends CollectionGet {
 
   public BTreeGet(long bkey, boolean delete) {
     this.headerCount = 2;
-    this.range = String.valueOf(bkey);
+    this.range = BTreeUtil.toULong(bkey);
     this.delete = delete;
   }
 
@@ -42,7 +42,7 @@ public class BTreeGet extends CollectionGet {
 
   public BTreeGet(long from, long to, int offset, int count, boolean delete) {
     this.headerCount = 2;
-    this.range = String.valueOf(from) + ".." + String.valueOf(to);
+    this.range = BTreeUtil.toULong(from) + ".." + BTreeUtil.toULong(to);
     this.offset = offset;
     this.count = count;
     this.delete = delete;

--- a/src/main/java/net/spy/memcached/collection/BTreeGetBulkImpl.java
+++ b/src/main/java/net/spy/memcached/collection/BTreeGetBulkImpl.java
@@ -62,7 +62,8 @@ public abstract class BTreeGetBulkImpl<T> implements BTreeGetBulk<T> {
                              ElementFlagFilter eFlagFilter, int offset, int count) {
 
     this.keyList = keyList;
-    this.range = String.valueOf(from) + ((to > -1) ? ".." + String.valueOf(to) : "");
+    this.range = BTreeUtil.toULong(from) +
+            ((to > -1) ? ".." + BTreeUtil.toULong(to) : "");
     this.eFlagFilter = eFlagFilter;
     this.offset = offset;
     this.count = count;

--- a/src/main/java/net/spy/memcached/collection/BTreeSMGetWithLongTypeBkey.java
+++ b/src/main/java/net/spy/memcached/collection/BTreeSMGetWithLongTypeBkey.java
@@ -55,8 +55,8 @@ public class BTreeSMGetWithLongTypeBkey<T> implements BTreeSMGet<T> {
                                     ElementFlagFilter eFlagFilter, int count, SMGetMode smgetMode) {
     this.keyList = keyList;
 
-    this.range = String.valueOf(from)
-            + ((to > -1) ? ".." + String.valueOf(to) : "");
+    this.range = BTreeUtil.toULong(from)
+            + ((to > -1) ? ".." + BTreeUtil.toULong(to) : "");
 
     this.eFlagFilter = eFlagFilter;
     this.count = count;

--- a/src/main/java/net/spy/memcached/collection/BTreeSMGetWithLongTypeBkeyOld.java
+++ b/src/main/java/net/spy/memcached/collection/BTreeSMGetWithLongTypeBkeyOld.java
@@ -54,8 +54,8 @@ public class BTreeSMGetWithLongTypeBkeyOld<T> implements BTreeSMGet<T> {
                                        ElementFlagFilter eFlagFilter, int offset, int count) {
     this.keyList = keyList;
 
-    this.range = String.valueOf(from)
-            + ((to > -1) ? ".." + String.valueOf(to) : "");
+    this.range = BTreeUtil.toULong(from)
+            + ((to > -1) ? ".." + BTreeUtil.toULong(to) : "");
 
     this.eFlagFilter = eFlagFilter;
     this.offset = offset;

--- a/src/main/java/net/spy/memcached/collection/CollectionAttributes.java
+++ b/src/main/java/net/spy/memcached/collection/CollectionAttributes.java
@@ -75,7 +75,7 @@ public class CollectionAttributes extends Attributes {
     }
     if (maxBkeyRange != null || maxBkeyRangeByBytes != null) {
       if (maxBkeyRange != null) {
-        b.append(" maxbkeyrange=").append(String.valueOf(maxBkeyRange));
+        b.append(" maxbkeyrange=").append(BTreeUtil.toULong(maxBkeyRange));
       } else {
         b.append(" maxbkeyrange=").append(
                 BTreeUtil.toHex(maxBkeyRangeByBytes));

--- a/src/main/java/net/spy/memcached/collection/CollectionBulkInsert.java
+++ b/src/main/java/net/spy/memcached/collection/CollectionBulkInsert.java
@@ -79,7 +79,7 @@ public abstract class CollectionBulkInsert<T> extends CollectionObject {
         }
       }
       this.keyList = keyList;
-      this.bkey = String.valueOf(bkey);
+      this.bkey = BTreeUtil.toULong(bkey);
       this.eflag = BTreeUtil.toHex(eflag);
       this.value = value;
       this.attribute = attr;

--- a/src/main/java/net/spy/memcached/collection/CollectionPipedInsert.java
+++ b/src/main/java/net/spy/memcached/collection/CollectionPipedInsert.java
@@ -27,6 +27,7 @@ import java.util.Map;
 import net.spy.memcached.CachedData;
 import net.spy.memcached.KeyUtil;
 import net.spy.memcached.transcoders.Transcoder;
+import net.spy.memcached.util.BTreeUtil;
 
 public abstract class CollectionPipedInsert<T> extends CollectionObject {
 
@@ -270,7 +271,7 @@ public abstract class CollectionPipedInsert<T> extends CollectionObject {
       int i = 0;
       for (Long eachBkey : map.keySet()) {
         capacity += KeyUtil.getKeyBytes(key).length;
-        capacity += KeyUtil.getKeyBytes(String.valueOf(eachBkey)).length;
+        capacity += KeyUtil.getKeyBytes(BTreeUtil.toULong(eachBkey)).length;
         capacity += decodedList.get(i++).length;
         capacity += 128;
       }
@@ -362,7 +363,7 @@ public abstract class CollectionPipedInsert<T> extends CollectionObject {
       for (Element<T> each : elements) {
         capacity += KeyUtil.getKeyBytes(key).length;
         capacity += KeyUtil.getKeyBytes((each.isByteArraysBkey() ? each
-                .getBkeyByHex() : String.valueOf(each.getLongBkey()))).length;
+                .getBkeyByHex() : BTreeUtil.toULong(each.getLongBkey()))).length;
         capacity += KeyUtil.getKeyBytes(each.getFlagByHex()).length;
         capacity += decodedList.get(i++).length;
         capacity += 128;
@@ -382,7 +383,7 @@ public abstract class CollectionPipedInsert<T> extends CollectionObject {
                 COMMAND,
                 key,
                 (element.isByteArraysBkey() ? element.getBkeyByHex()
-                        : String.valueOf(element.getLongBkey())),
+                        : BTreeUtil.toULong(element.getLongBkey())),
                 element.getFlagByHex(),
                 value.length,
                 (createKeyIfNotExists) ? "create" : "",

--- a/src/main/java/net/spy/memcached/collection/CollectionPipedUpdate.java
+++ b/src/main/java/net/spy/memcached/collection/CollectionPipedUpdate.java
@@ -26,6 +26,7 @@ import java.util.Map;
 import net.spy.memcached.CachedData;
 import net.spy.memcached.KeyUtil;
 import net.spy.memcached.transcoders.Transcoder;
+import net.spy.memcached.util.BTreeUtil;
 
 public abstract class CollectionPipedUpdate<T> extends CollectionObject {
 
@@ -100,7 +101,7 @@ public abstract class CollectionPipedUpdate<T> extends CollectionObject {
 
         capacity += KeyUtil.getKeyBytes(key).length;
         capacity += KeyUtil.getKeyBytes((each.isByteArraysBkey() ? each
-                .getBkeyByHex() : String.valueOf(each.getLongBkey()))).length;
+                .getBkeyByHex() : BTreeUtil.toULong(each.getLongBkey()))).length;
         if (decodedList.get(i) != null) {
           capacity += decodedList.get(i++).length;
         }
@@ -129,7 +130,7 @@ public abstract class CollectionPipedUpdate<T> extends CollectionObject {
 
         setArguments(bb, COMMAND, key,
                 (element.isByteArraysBkey() ? element.getBkeyByHex()
-                        : String.valueOf(element.getLongBkey())),
+                        : BTreeUtil.toULong(element.getLongBkey())),
                 b.toString(), (value == null ? -1 : value.length),
                 (i < eSize - 1) ? PIPE : "");
         if (value != null) {

--- a/src/main/java/net/spy/memcached/collection/SMGetElement.java
+++ b/src/main/java/net/spy/memcached/collection/SMGetElement.java
@@ -42,7 +42,7 @@ public class SMGetElement<T> implements Comparable<SMGetElement<T>> {
   @Override
   public String toString() {
     return "SMGetElement {KEY:" + key + ", BKEY:"
-            + ((bytebkey == null) ? bkey : BTreeUtil.toHex(bytebkey))
+            + ((bytebkey == null) ? BTreeUtil.toULong(bkey) : BTreeUtil.toHex(bytebkey))
             + ", VALUE:" + value + "}";
   }
 

--- a/src/main/java/net/spy/memcached/collection/SMGetTrimKey.java
+++ b/src/main/java/net/spy/memcached/collection/SMGetTrimKey.java
@@ -38,7 +38,7 @@ public class SMGetTrimKey implements Comparable<SMGetTrimKey> {
   @Override
   public String toString() {
     return "SMGetElement {KEY:" + key + ", BKEY:"
-            + ((bytebkey == null) ? bkey : BTreeUtil.toHex(bytebkey)) + "}";
+            + ((bytebkey == null) ? BTreeUtil.toULong(bkey) : BTreeUtil.toHex(bytebkey)) + "}";
   }
 
   @Override

--- a/src/main/java/net/spy/memcached/util/BTreeUtil.java
+++ b/src/main/java/net/spy/memcached/util/BTreeUtil.java
@@ -17,6 +17,8 @@
 package net.spy.memcached.util;
 
 
+import com.google.common.primitives.UnsignedLong;
+
 public final class BTreeUtil {
 
   private static final String HEXES = "0123456789ABCDEF";
@@ -87,5 +89,12 @@ public final class BTreeUtil {
         throw new IllegalArgumentException("bkey size exceeded 31");
       }
     }
+  }
+
+  public static String toULong(long bkey) {
+    if (bkey < 0) {
+      return UnsignedLong.fromLongBits(bkey).toString();
+    }
+    return String.valueOf(bkey);
   }
 }

--- a/src/test/java/net/spy/memcached/util/BTreeUtilTest.java
+++ b/src/test/java/net/spy/memcached/util/BTreeUtilTest.java
@@ -89,4 +89,11 @@ public class BTreeUtilTest extends BaseMockCase {
       }
     });
   }
+
+  public void testToUnsignedLong() {
+    assertEquals("9223372036854775807", BTreeUtil.toULong(Long.MAX_VALUE));
+    assertEquals("9223372036854775808", BTreeUtil.toULong(Long.MIN_VALUE));
+    assertEquals("1", BTreeUtil.toULong(1));
+    assertEquals("18446744073709551615", BTreeUtil.toULong(-1));
+  }
 }


### PR DESCRIPTION
#335 이슈에서 bkey를 unsigned long string으로 출력하는 pr입니다.

long type의 bkey를 사용할 때에도 현재는 String.valueof()를 사용하여서 signed long 형태로 bkey가 변환되어,
 unsinged long 형태로 변환될 수 있도록 변경하였습니다.

기존 리뷰 의견 반영하여 toHex -> toHexString으로 convertBkey -> toULongString으로 수정했습니다.
