### PR TITLE
FIX: CollectionOperationimpl command buffer

### DIFF
--- a/src/main/java/net/spy/memcached/protocol/ascii/CollectionExistOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/CollectionExistOperationImpl.java
@@ -86,13 +86,12 @@ public class CollectionExistOperationImpl extends OperationImpl
   public void initialize() {
     String args = collectionExist.stringify();
     byte[] additionalArgs = collectionExist.getAdditionalArgs();
-    ByteBuffer bb = ByteBuffer.allocate(null == additionalArgs ? 0 : additionalArgs.length +
-            +KeyUtil.getKeyBytes(key).length
+    ByteBuffer bb = ByteBuffer.allocate((null == additionalArgs ? 0 : additionalArgs.length)
+            + KeyUtil.getKeyBytes(key).length
             + KeyUtil.getKeyBytes(subkey).length
             + args.length()
             + OVERHEAD);
-    setArguments(bb, collectionExist.getCommand(), key, subkey,
-            null == additionalArgs ? 0 : additionalArgs.length, args);
+    setArguments(bb, collectionExist.getCommand(), key, subkey, args);
 
     if (null != additionalArgs) {
       bb.put(additionalArgs);


### PR DESCRIPTION
#400 이슈 관련 pr 입니다.

args를 지우고 additionalArgs.length로 표현하였고, subkey와 additionalArgs null 체크하는 부분을 제거하였습니다.