### PR TITLE
ENHANCE: Fix BaseOperationFactory.clone() to clone missing operations #210

### DIFF
--- a/src/main/java/net/spy/memcached/ops/BaseOperationFactory.java
+++ b/src/main/java/net/spy/memcached/ops/BaseOperationFactory.java
@@ -31,10 +31,6 @@ import net.spy.memcached.OperationFactory;
  */
 public abstract class BaseOperationFactory implements OperationFactory {
 
-  private String first(Collection<String> keys) {
-    return keys.iterator().next();
-  }
-
   public Collection<Operation> clone(KeyedOperation op) {
     assert op.getState() == OperationState.WRITE_QUEUED
             : "Who passed me an operation in the " + op.getState() + "state?";
@@ -55,52 +51,8 @@ public abstract class BaseOperationFactory implements OperationFactory {
       for (String k : op.getKeys()) {
         rv.add(gets(k, getsCb));
       }
-    } else if (op instanceof CASOperation) {
-      CASOperation cop = (CASOperation) op;
-      rv.add(cas(cop.getStoreType(), first(op.getKeys()),
-              cop.getCasValue(), cop.getFlags(), cop.getExpiration(),
-              cop.getBytes(), cop.getCallback()));
-    } else if (op instanceof DeleteOperation) {
-      rv.add(delete(first(op.getKeys()), op.getCallback()));
-    } else if (op instanceof MutatorOperation) {
-      MutatorOperation mo = (MutatorOperation) op;
-      rv.add(mutate(mo.getType(), first(op.getKeys()),
-              mo.getBy(), mo.getDefault(), mo.getExpiration(),
-              op.getCallback()));
-    } else if (op instanceof StoreOperation) {
-      StoreOperation so = (StoreOperation) op;
-      rv.add(store(so.getStoreType(), first(op.getKeys()), so.getFlags(),
-              so.getExpiration(), so.getData(), op.getCallback()));
-    } else if (op instanceof ConcatenationOperation) {
-      ConcatenationOperation c = (ConcatenationOperation) op;
-      rv.add(cat(c.getStoreType(), c.getCasValue(), first(op.getKeys()),
-              c.getData(), c.getCallback()));
-    } else if (op instanceof SetAttrOperation) {
-      SetAttrOperation c = (SetAttrOperation) op;
-      rv.add(setAttr(first(c.getKeys()), c.getAttributes(),
-              c.getCallback()));
-    } else if (op instanceof GetAttrOperation) {
-      GetAttrOperation c = (GetAttrOperation) op;
-      rv.add(getAttr(first(c.getKeys()),
-              (GetAttrOperation.Callback) c.getCallback()));
-    } else if (op instanceof CollectionInsertOperation) {
-      CollectionInsertOperation c = (CollectionInsertOperation) op;
-      rv.add(collectionInsert(first(c.getKeys()), c.getSubKey(),
-              c.getInsert(), c.getData(), c.getCallback()));
-    } else if (op instanceof CollectionGetOperation) {
-      CollectionGetOperation c = (CollectionGetOperation) op;
-      rv.add(collectionGet(first(c.getKeys()), c.getGet(),
-              (CollectionGetOperation.Callback) c.getCallback()));
-    } else if (op instanceof CollectionDeleteOperation) {
-      CollectionDeleteOperation c = (CollectionDeleteOperation) op;
-      rv.add(collectionDelete(first(c.getKeys()), c.getDelete(),
-              c.getCallback()));
-    } else if (op instanceof CollectionExistOperation) {
-      CollectionExistOperation c = (CollectionExistOperation) op;
-      rv.add(collectionExist(first(c.getKeys()), c.getSubKey(),
-              c.getExist(), c.getCallback()));
     } else {
-      assert false : "Unhandled operation type: " + op.getClass();
+      rv.add(op.clone());
     }
     return rv;
   }

--- a/src/main/java/net/spy/memcached/ops/KeyedOperation.java
+++ b/src/main/java/net/spy/memcached/ops/KeyedOperation.java
@@ -12,4 +12,5 @@ public interface KeyedOperation extends Operation {
    */
   Collection<String> getKeys();
 
+  Operation clone();
 }

--- a/src/main/java/net/spy/memcached/protocol/ascii/BTreeFindPositionOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/BTreeFindPositionOperationImpl.java
@@ -28,6 +28,7 @@ import net.spy.memcached.collection.CollectionResponse;
 import net.spy.memcached.ops.APIType;
 import net.spy.memcached.ops.BTreeFindPositionOperation;
 import net.spy.memcached.ops.CollectionOperationStatus;
+import net.spy.memcached.ops.Operation;
 import net.spy.memcached.ops.OperationCallback;
 import net.spy.memcached.ops.OperationState;
 import net.spy.memcached.ops.OperationStatus;
@@ -108,6 +109,11 @@ public class BTreeFindPositionOperationImpl extends OperationImpl implements
     }
 
     transitionState(OperationState.COMPLETE);
+  }
+
+  @Override
+  public Operation clone() {
+    return new BTreeFindPositionOperationImpl(key, get, callback);
   }
 
   @Override

--- a/src/main/java/net/spy/memcached/protocol/ascii/BTreeFindPositionWithGetOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/BTreeFindPositionWithGetOperationImpl.java
@@ -28,6 +28,7 @@ import net.spy.memcached.collection.CollectionResponse;
 import net.spy.memcached.ops.APIType;
 import net.spy.memcached.ops.BTreeFindPositionWithGetOperation;
 import net.spy.memcached.ops.CollectionOperationStatus;
+import net.spy.memcached.ops.Operation;
 import net.spy.memcached.ops.OperationCallback;
 import net.spy.memcached.ops.OperationState;
 import net.spy.memcached.ops.OperationStatus;
@@ -121,6 +122,11 @@ public class BTreeFindPositionWithGetOperationImpl extends OperationImpl impleme
       getCallback().receivedStatus(status);
       transitionState(OperationState.COMPLETE);
     }
+  }
+
+  @Override
+  public Operation clone() {
+    return new BTreeFindPositionWithGetOperationImpl(key, get, callback);
   }
 
   @Override

--- a/src/main/java/net/spy/memcached/protocol/ascii/BTreeGetBulkOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/BTreeGetBulkOperationImpl.java
@@ -28,6 +28,7 @@ import net.spy.memcached.collection.CollectionResponse;
 import net.spy.memcached.ops.APIType;
 import net.spy.memcached.ops.BTreeGetBulkOperation;
 import net.spy.memcached.ops.CollectionOperationStatus;
+import net.spy.memcached.ops.Operation;
 import net.spy.memcached.ops.OperationCallback;
 import net.spy.memcached.ops.OperationState;
 import net.spy.memcached.ops.OperationStatus;
@@ -103,6 +104,11 @@ public class BTreeGetBulkOperationImpl extends OperationImpl implements
 
       transitionState(OperationState.COMPLETE);
     }
+  }
+
+  @Override
+  public Operation clone() {
+    return new BTreeGetBulkOperationImpl(getBulk, callback);
   }
 
   @Override

--- a/src/main/java/net/spy/memcached/protocol/ascii/BTreeGetByPositionOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/BTreeGetByPositionOperationImpl.java
@@ -29,6 +29,7 @@ import net.spy.memcached.collection.CollectionResponse;
 import net.spy.memcached.ops.APIType;
 import net.spy.memcached.ops.BTreeGetByPositionOperation;
 import net.spy.memcached.ops.CollectionOperationStatus;
+import net.spy.memcached.ops.Operation;
 import net.spy.memcached.ops.OperationCallback;
 import net.spy.memcached.ops.OperationState;
 import net.spy.memcached.ops.OperationStatus;
@@ -119,6 +120,11 @@ public class BTreeGetByPositionOperationImpl extends OperationImpl implements
       transitionState(OperationState.COMPLETE);
       return;
     }
+  }
+
+  @Override
+  public Operation clone() {
+    return new BTreeGetByPositionOperationImpl(key, get, callback);
   }
 
   @Override

--- a/src/main/java/net/spy/memcached/protocol/ascii/BTreeInsertAndGetOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/BTreeInsertAndGetOperationImpl.java
@@ -30,6 +30,7 @@ import net.spy.memcached.collection.CollectionResponse;
 import net.spy.memcached.ops.APIType;
 import net.spy.memcached.ops.BTreeInsertAndGetOperation;
 import net.spy.memcached.ops.CollectionOperationStatus;
+import net.spy.memcached.ops.Operation;
 import net.spy.memcached.ops.OperationCallback;
 import net.spy.memcached.ops.OperationState;
 import net.spy.memcached.ops.OperationStatus;
@@ -161,6 +162,11 @@ public class BTreeInsertAndGetOperationImpl extends OperationImpl implements
       transitionState(OperationState.COMPLETE);
       return;
     }
+  }
+
+  @Override
+  public Operation clone() {
+    return new BTreeInsertAndGetOperationImpl(key, get, dataToStore, callback);
   }
 
   @Override

--- a/src/main/java/net/spy/memcached/protocol/ascii/BTreeSortMergeGetOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/BTreeSortMergeGetOperationImpl.java
@@ -30,6 +30,7 @@ import net.spy.memcached.collection.CollectionResponse;
 import net.spy.memcached.ops.APIType;
 import net.spy.memcached.ops.BTreeSortMergeGetOperation;
 import net.spy.memcached.ops.CollectionOperationStatus;
+import net.spy.memcached.ops.Operation;
 import net.spy.memcached.ops.OperationCallback;
 import net.spy.memcached.ops.OperationState;
 import net.spy.memcached.ops.OperationStatus;
@@ -148,6 +149,11 @@ public class BTreeSortMergeGetOperationImpl extends OperationImpl implements
       transitionState(OperationState.COMPLETE);
       return;
     }
+  }
+
+  @Override
+  public Operation clone() {
+    return new BTreeSortMergeGetOperationImpl(smGet, callback);
   }
 
   @Override

--- a/src/main/java/net/spy/memcached/protocol/ascii/BTreeSortMergeGetOperationOldImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/BTreeSortMergeGetOperationOldImpl.java
@@ -28,6 +28,7 @@ import net.spy.memcached.collection.CollectionResponse;
 import net.spy.memcached.ops.APIType;
 import net.spy.memcached.ops.BTreeSortMergeGetOperationOld;
 import net.spy.memcached.ops.CollectionOperationStatus;
+import net.spy.memcached.ops.Operation;
 import net.spy.memcached.ops.OperationCallback;
 import net.spy.memcached.ops.OperationState;
 import net.spy.memcached.ops.OperationStatus;
@@ -121,6 +122,11 @@ public class BTreeSortMergeGetOperationOldImpl extends OperationImpl implements
       transitionState(OperationState.COMPLETE);
       return;
     }
+  }
+
+  @Override
+  public Operation clone() {
+    return new BTreeSortMergeGetOperationOldImpl(smGet, callback);
   }
 
   @Override

--- a/src/main/java/net/spy/memcached/protocol/ascii/CASOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/CASOperationImpl.java
@@ -27,6 +27,7 @@ import net.spy.memcached.KeyUtil;
 import net.spy.memcached.ops.APIType;
 import net.spy.memcached.ops.CASOperation;
 import net.spy.memcached.ops.CASOperationStatus;
+import net.spy.memcached.ops.Operation;
 import net.spy.memcached.ops.OperationCallback;
 import net.spy.memcached.ops.OperationState;
 import net.spy.memcached.ops.OperationStatus;
@@ -81,6 +82,11 @@ class CASOperationImpl extends OperationImpl implements CASOperation {
     /* ENABLE_REPLICATION end */
     getCallback().receivedStatus(matchStatus(line, STORED, NOT_FOUND, EXISTS));
     transitionState(OperationState.COMPLETE);
+  }
+
+  @Override
+  public Operation clone() {
+    return new CASOperationImpl(key, casValue, flags, exp, data, callback);
   }
 
   @Override

--- a/src/main/java/net/spy/memcached/protocol/ascii/CollectionBulkInsertOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/CollectionBulkInsertOperationImpl.java
@@ -26,6 +26,7 @@ import net.spy.memcached.collection.CollectionResponse;
 import net.spy.memcached.ops.APIType;
 import net.spy.memcached.ops.CollectionOperationStatus;
 import net.spy.memcached.ops.CollectionBulkInsertOperation;
+import net.spy.memcached.ops.Operation;
 import net.spy.memcached.ops.OperationCallback;
 import net.spy.memcached.ops.OperationState;
 import net.spy.memcached.ops.OperationStatus;
@@ -146,6 +147,11 @@ public class CollectionBulkInsertOperationImpl extends OperationImpl
 
       index++;
     }
+  }
+
+  @Override
+  public Operation clone() {
+    return new CollectionBulkInsertOperationImpl(Collections.singletonList(key), insert, callback);
   }
 
   @Override

--- a/src/main/java/net/spy/memcached/protocol/ascii/CollectionCountOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/CollectionCountOperationImpl.java
@@ -29,6 +29,7 @@ import net.spy.memcached.collection.CollectionResponse;
 import net.spy.memcached.ops.APIType;
 import net.spy.memcached.ops.CollectionCountOperation;
 import net.spy.memcached.ops.CollectionOperationStatus;
+import net.spy.memcached.ops.Operation;
 import net.spy.memcached.ops.OperationCallback;
 import net.spy.memcached.ops.OperationState;
 import net.spy.memcached.ops.OperationStatus;
@@ -89,6 +90,11 @@ public class CollectionCountOperationImpl extends OperationImpl implements
       transitionState(OperationState.COMPLETE);
       return;
     }
+  }
+
+  @Override
+  public Operation clone() {
+    return new CollectionCountOperationImpl(key, collectionCount, callback);
   }
 
   public void initialize() {

--- a/src/main/java/net/spy/memcached/protocol/ascii/CollectionCreateOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/CollectionCreateOperationImpl.java
@@ -32,6 +32,7 @@ import net.spy.memcached.collection.MapCreate;
 import net.spy.memcached.ops.APIType;
 import net.spy.memcached.ops.CollectionCreateOperation;
 import net.spy.memcached.ops.CollectionOperationStatus;
+import net.spy.memcached.ops.Operation;
 import net.spy.memcached.ops.OperationCallback;
 import net.spy.memcached.ops.OperationState;
 import net.spy.memcached.ops.OperationStatus;
@@ -87,6 +88,11 @@ public class CollectionCreateOperationImpl extends OperationImpl
     /* ENABLE_REPLICATION end */
     getCallback().receivedStatus(matchStatus(line, CREATED, EXISTS, SERVER_ERROR));
     transitionState(OperationState.COMPLETE);
+  }
+
+  @Override
+  public Operation clone() {
+    return new CollectionCreateOperationImpl(key, collectionCreate, callback);
   }
 
   @Override

--- a/src/main/java/net/spy/memcached/protocol/ascii/CollectionDeleteOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/CollectionDeleteOperationImpl.java
@@ -32,6 +32,7 @@ import net.spy.memcached.collection.MapDelete;
 import net.spy.memcached.ops.APIType;
 import net.spy.memcached.ops.CollectionDeleteOperation;
 import net.spy.memcached.ops.CollectionOperationStatus;
+import net.spy.memcached.ops.Operation;
 import net.spy.memcached.ops.OperationCallback;
 import net.spy.memcached.ops.OperationState;
 import net.spy.memcached.ops.OperationStatus;
@@ -96,6 +97,11 @@ public class CollectionDeleteOperationImpl extends OperationImpl
             BKEY_MISMATCH);
     getCallback().receivedStatus(status);
     transitionState(OperationState.COMPLETE);
+  }
+
+  @Override
+  public Operation clone() {
+    return new CollectionDeleteOperationImpl(key, collectionDelete, callback);
   }
 
   @Override

--- a/src/main/java/net/spy/memcached/protocol/ascii/CollectionExistOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/CollectionExistOperationImpl.java
@@ -29,6 +29,7 @@ import net.spy.memcached.collection.SetExist;
 import net.spy.memcached.ops.APIType;
 import net.spy.memcached.ops.CollectionExistOperation;
 import net.spy.memcached.ops.CollectionOperationStatus;
+import net.spy.memcached.ops.Operation;
 import net.spy.memcached.ops.OperationCallback;
 import net.spy.memcached.ops.OperationState;
 import net.spy.memcached.ops.OperationStatus;
@@ -80,6 +81,12 @@ public class CollectionExistOperationImpl extends OperationImpl
             matchStatus(line, EXIST, NOT_EXIST, NOT_FOUND, NOT_FOUND,
                     TYPE_MISMATCH, UNREADABLE));
     transitionState(OperationState.COMPLETE);
+  }
+
+  @Override
+  public Operation clone() {
+    return new CollectionExistOperationImpl(key, subkey, collectionExist,
+        callback);
   }
 
   @Override

--- a/src/main/java/net/spy/memcached/protocol/ascii/CollectionGetOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/CollectionGetOperationImpl.java
@@ -33,6 +33,7 @@ import net.spy.memcached.collection.MapGet;
 import net.spy.memcached.ops.APIType;
 import net.spy.memcached.ops.CollectionGetOperation;
 import net.spy.memcached.ops.CollectionOperationStatus;
+import net.spy.memcached.ops.Operation;
 import net.spy.memcached.ops.OperationCallback;
 import net.spy.memcached.ops.OperationState;
 import net.spy.memcached.ops.OperationStatus;
@@ -135,6 +136,11 @@ public class CollectionGetOperationImpl extends OperationImpl
       transitionState(OperationState.COMPLETE);
       return;
     }
+  }
+
+  @Override
+  public Operation clone() {
+    return new CollectionGetOperationImpl(key, collectionGet, callback);
   }
 
   @Override

--- a/src/main/java/net/spy/memcached/protocol/ascii/CollectionInsertOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/CollectionInsertOperationImpl.java
@@ -33,6 +33,7 @@ import net.spy.memcached.collection.SetInsert;
 import net.spy.memcached.ops.APIType;
 import net.spy.memcached.ops.CollectionOperationStatus;
 import net.spy.memcached.ops.CollectionInsertOperation;
+import net.spy.memcached.ops.Operation;
 import net.spy.memcached.ops.OperationCallback;
 import net.spy.memcached.ops.OperationState;
 import net.spy.memcached.ops.OperationStatus;
@@ -110,6 +111,12 @@ public class CollectionInsertOperationImpl extends OperationImpl
                     ELEMENT_EXISTS, OVERFLOWED, OUT_OF_RANGE,
                     TYPE_MISMATCH, BKEY_MISMATCH));
     transitionState(OperationState.COMPLETE);
+  }
+
+  @Override
+  public Operation clone() {
+    return new CollectionInsertOperationImpl(key, subkey, collectionInsert,
+        data, callback);
   }
 
   @Override

--- a/src/main/java/net/spy/memcached/protocol/ascii/CollectionMutateOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/CollectionMutateOperationImpl.java
@@ -30,6 +30,7 @@ import net.spy.memcached.ops.APIType;
 import net.spy.memcached.ops.CollectionMutateOperation;
 import net.spy.memcached.ops.CollectionOperationStatus;
 import net.spy.memcached.ops.Mutator;
+import net.spy.memcached.ops.Operation;
 import net.spy.memcached.ops.OperationCallback;
 import net.spy.memcached.ops.OperationState;
 import net.spy.memcached.ops.OperationStatus;
@@ -102,6 +103,12 @@ public class CollectionMutateOperationImpl extends OperationImpl implements
     }
 
     transitionState(OperationState.COMPLETE);
+  }
+
+  @Override
+  public Operation clone() {
+    return new CollectionMutateOperationImpl(key, subkey, collectionMutate,
+        callback);
   }
 
   public void initialize() {

--- a/src/main/java/net/spy/memcached/protocol/ascii/CollectionPipedExistOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/CollectionPipedExistOperationImpl.java
@@ -25,6 +25,7 @@ import net.spy.memcached.collection.CollectionResponse;
 import net.spy.memcached.ops.APIType;
 import net.spy.memcached.ops.CollectionOperationStatus;
 import net.spy.memcached.ops.CollectionPipedExistOperation;
+import net.spy.memcached.ops.Operation;
 import net.spy.memcached.ops.OperationCallback;
 import net.spy.memcached.ops.OperationState;
 import net.spy.memcached.ops.OperationStatus;
@@ -117,6 +118,11 @@ public class CollectionPipedExistOperationImpl extends OperationImpl implements
       cb.gotStatus(index, status);
       index++;
     }
+  }
+
+  @Override
+  public Operation clone() {
+    return new CollectionPipedExistOperationImpl(key, setPipedExist, cb);
   }
 
   @Override

--- a/src/main/java/net/spy/memcached/protocol/ascii/CollectionPipedInsertOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/CollectionPipedInsertOperationImpl.java
@@ -25,6 +25,7 @@ import net.spy.memcached.collection.CollectionResponse;
 import net.spy.memcached.ops.APIType;
 import net.spy.memcached.ops.CollectionOperationStatus;
 import net.spy.memcached.ops.CollectionPipedInsertOperation;
+import net.spy.memcached.ops.Operation;
 import net.spy.memcached.ops.OperationCallback;
 import net.spy.memcached.ops.OperationState;
 import net.spy.memcached.ops.OperationStatus;
@@ -147,6 +148,11 @@ public class CollectionPipedInsertOperationImpl extends OperationImpl
       }
       index++;
     }
+  }
+
+  @Override
+  public Operation clone() {
+    return new CollectionPipedInsertOperationImpl(key, insert, cb);
   }
 
   @Override

--- a/src/main/java/net/spy/memcached/protocol/ascii/CollectionPipedUpdateOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/CollectionPipedUpdateOperationImpl.java
@@ -27,6 +27,7 @@ import net.spy.memcached.collection.CollectionResponse;
 import net.spy.memcached.ops.APIType;
 import net.spy.memcached.ops.CollectionOperationStatus;
 import net.spy.memcached.ops.CollectionPipedUpdateOperation;
+import net.spy.memcached.ops.Operation;
 import net.spy.memcached.ops.OperationCallback;
 import net.spy.memcached.ops.OperationState;
 import net.spy.memcached.ops.OperationStatus;
@@ -143,6 +144,11 @@ public class CollectionPipedUpdateOperationImpl extends OperationImpl implements
       }
       index++;
     }
+  }
+
+  @Override
+  public Operation clone() {
+    return new CollectionPipedUpdateOperationImpl(key, update, cb);
   }
 
   @Override

--- a/src/main/java/net/spy/memcached/protocol/ascii/CollectionUpdateOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/CollectionUpdateOperationImpl.java
@@ -31,6 +31,7 @@ import net.spy.memcached.collection.ElementFlagUpdate;
 import net.spy.memcached.ops.APIType;
 import net.spy.memcached.ops.CollectionOperationStatus;
 import net.spy.memcached.ops.CollectionUpdateOperation;
+import net.spy.memcached.ops.Operation;
 import net.spy.memcached.ops.OperationCallback;
 import net.spy.memcached.ops.OperationState;
 import net.spy.memcached.ops.OperationStatus;
@@ -100,6 +101,12 @@ public class CollectionUpdateOperationImpl extends OperationImpl implements
                     NOTHING_TO_UPDATE, TYPE_MISMATCH, BKEY_MISMATCH,
                     EFLAG_MISMATCH, SERVER_ERROR));
     transitionState(OperationState.COMPLETE);
+  }
+
+  @Override
+  public Operation clone() {
+    return new CollectionUpdateOperationImpl(key, subkey, collectionUpdate,
+        data, callback);
   }
 
   @Override

--- a/src/main/java/net/spy/memcached/protocol/ascii/ConcatenationOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/ConcatenationOperationImpl.java
@@ -3,6 +3,7 @@ package net.spy.memcached.protocol.ascii;
 import net.spy.memcached.ops.APIType;
 import net.spy.memcached.ops.ConcatenationOperation;
 import net.spy.memcached.ops.ConcatenationType;
+import net.spy.memcached.ops.Operation;
 import net.spy.memcached.ops.OperationCallback;
 
 /**
@@ -33,4 +34,8 @@ public class ConcatenationOperationImpl extends BaseStoreOperationImpl
     return concatType;
   }
 
+  @Override
+  public Operation clone() {
+    return new ConcatenationOperationImpl(concatType, key, data, callback);
+  }
 }

--- a/src/main/java/net/spy/memcached/protocol/ascii/DeleteOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/DeleteOperationImpl.java
@@ -27,6 +27,7 @@ import java.util.Collections;
 import net.spy.memcached.KeyUtil;
 import net.spy.memcached.ops.APIType;
 import net.spy.memcached.ops.DeleteOperation;
+import net.spy.memcached.ops.Operation;
 import net.spy.memcached.ops.OperationCallback;
 import net.spy.memcached.ops.OperationState;
 import net.spy.memcached.ops.OperationStatus;
@@ -66,6 +67,11 @@ final class DeleteOperationImpl extends OperationImpl
     /* ENABLE_REPLICATION end */
     getCallback().receivedStatus(matchStatus(line, DELETED, NOT_FOUND));
     transitionState(OperationState.COMPLETE);
+  }
+
+  @Override
+  public Operation clone() {
+    return new DeleteOperationImpl(key, callback);
   }
 
   @Override

--- a/src/main/java/net/spy/memcached/protocol/ascii/GetAttrOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/GetAttrOperationImpl.java
@@ -27,6 +27,7 @@ import net.spy.memcached.collection.CollectionResponse;
 import net.spy.memcached.ops.APIType;
 import net.spy.memcached.ops.CollectionOperationStatus;
 import net.spy.memcached.ops.GetAttrOperation;
+import net.spy.memcached.ops.Operation;
 import net.spy.memcached.ops.OperationState;
 import net.spy.memcached.ops.OperationStatus;
 import net.spy.memcached.ops.OperationType;
@@ -80,6 +81,11 @@ class GetAttrOperationImpl extends OperationImpl implements GetAttrOperation {
       getCallback().receivedStatus(status);
       transitionState(OperationState.COMPLETE);
     }
+  }
+
+  @Override
+  public Operation clone() {
+    return new GetAttrOperationImpl(key, cb);
   }
 
   @Override

--- a/src/main/java/net/spy/memcached/protocol/ascii/GetOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/GetOperationImpl.java
@@ -8,6 +8,7 @@ import java.util.HashSet;
 
 import net.spy.memcached.ops.APIType;
 import net.spy.memcached.ops.GetOperation;
+import net.spy.memcached.ops.Operation;
 
 /**
  * Operation for retrieving data.
@@ -26,4 +27,8 @@ class GetOperationImpl extends BaseGetOpImpl implements GetOperation {
     setAPIType(APIType.GET);
   }
 
+  @Override
+  public Operation clone() {
+    return new GetOperationImpl(getKeys(), (GetOperation.Callback)callback);
+  }
 }

--- a/src/main/java/net/spy/memcached/protocol/ascii/GetsOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/GetsOperationImpl.java
@@ -6,6 +6,7 @@ import java.util.HashSet;
 
 import net.spy.memcached.ops.APIType;
 import net.spy.memcached.ops.GetsOperation;
+import net.spy.memcached.ops.Operation;
 
 /**
  * Implementation of the gets operation.
@@ -24,4 +25,8 @@ class GetsOperationImpl extends BaseGetOpImpl implements GetsOperation {
     setAPIType(APIType.GETS);
   }
 
+  @Override
+  public Operation clone() {
+    return new GetsOperationImpl(getKeys(), (GetsOperation.Callback)callback);
+  }
 }

--- a/src/main/java/net/spy/memcached/protocol/ascii/MGetOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/MGetOperationImpl.java
@@ -2,6 +2,7 @@ package net.spy.memcached.protocol.ascii;
 
 import net.spy.memcached.ops.APIType;
 import net.spy.memcached.ops.GetOperation;
+import net.spy.memcached.ops.Operation;
 
 import java.util.Collection;
 import java.util.HashSet;
@@ -26,5 +27,10 @@ public class MGetOperationImpl extends BaseGetOpImpl implements GetOperation {
   @Override
   public boolean isPipeOperation() {
     return false;
+  }
+
+  @Override
+  public Operation clone() {
+    return new MGetOperationImpl(getKeys(), (Callback)callback);
   }
 }

--- a/src/main/java/net/spy/memcached/protocol/ascii/MGetsOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/MGetsOperationImpl.java
@@ -2,6 +2,7 @@ package net.spy.memcached.protocol.ascii;
 
 import net.spy.memcached.ops.APIType;
 import net.spy.memcached.ops.GetsOperation;
+import net.spy.memcached.ops.Operation;
 
 import java.util.Collection;
 import java.util.HashSet;
@@ -18,4 +19,8 @@ public class MGetsOperationImpl extends BaseGetOpImpl implements GetsOperation {
     setAPIType(APIType.MGETS);
   }
 
+  @Override
+  public Operation clone() {
+    return new MGetsOperationImpl(getKeys(), (Callback)callback);
+  }
 }

--- a/src/main/java/net/spy/memcached/protocol/ascii/MutatorOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/MutatorOperationImpl.java
@@ -28,6 +28,7 @@ import net.spy.memcached.KeyUtil;
 import net.spy.memcached.ops.APIType;
 import net.spy.memcached.ops.MutatorOperation;
 import net.spy.memcached.ops.Mutator;
+import net.spy.memcached.ops.Operation;
 import net.spy.memcached.ops.OperationCallback;
 import net.spy.memcached.ops.OperationState;
 import net.spy.memcached.ops.OperationStatus;
@@ -110,6 +111,11 @@ final class MutatorOperationImpl extends OperationImpl
 
   public Collection<String> getKeys() {
     return Collections.singleton(key);
+  }
+
+  @Override
+  public Operation clone() {
+    return new MutatorOperationImpl(mutator, key, amount, def, exp, callback);
   }
 
   public int getBy() {

--- a/src/main/java/net/spy/memcached/protocol/ascii/SetAttrOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/SetAttrOperationImpl.java
@@ -28,6 +28,7 @@ import net.spy.memcached.collection.CollectionAttributes;
 import net.spy.memcached.collection.CollectionResponse;
 import net.spy.memcached.ops.APIType;
 import net.spy.memcached.ops.CollectionOperationStatus;
+import net.spy.memcached.ops.Operation;
 import net.spy.memcached.ops.OperationCallback;
 import net.spy.memcached.ops.OperationState;
 import net.spy.memcached.ops.OperationStatus;
@@ -81,6 +82,11 @@ class SetAttrOperationImpl extends OperationImpl
             matchStatus(line, OK, NOT_FOUND, ATTR_ERROR_NOT_FOUND,
                     ATTR_ERROR_BAD_VALUE));
     transitionState(OperationState.COMPLETE);
+  }
+
+  @Override
+  public Operation clone() {
+    return new SetAttrOperationImpl(key, attrs, callback);
   }
 
   @Override

--- a/src/main/java/net/spy/memcached/protocol/ascii/StoreOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/StoreOperationImpl.java
@@ -4,6 +4,7 @@ package net.spy.memcached.protocol.ascii;
 
 
 import net.spy.memcached.ops.APIType;
+import net.spy.memcached.ops.Operation;
 import net.spy.memcached.ops.OperationCallback;
 import net.spy.memcached.ops.StoreOperation;
 import net.spy.memcached.ops.StoreType;
@@ -33,4 +34,8 @@ final class StoreOperationImpl extends BaseStoreOperationImpl
     return storeType;
   }
 
+  @Override
+  public Operation clone() {
+    return new StoreOperationImpl(storeType, key, flags, exp, data, callback);
+  }
 }

--- a/src/main/java/net/spy/memcached/protocol/binary/ConcatenationOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/binary/ConcatenationOperationImpl.java
@@ -5,6 +5,7 @@ import java.util.Collections;
 
 import net.spy.memcached.ops.ConcatenationOperation;
 import net.spy.memcached.ops.ConcatenationType;
+import net.spy.memcached.ops.Operation;
 import net.spy.memcached.ops.OperationCallback;
 import net.spy.memcached.ops.OperationStatus;
 
@@ -89,5 +90,10 @@ class ConcatenationOperationImpl extends OperationImpl
   @Override
   public boolean isPipeOperation() {
     return false;
+  }
+
+  @Override
+  public Operation clone() {
+    return new ConcatenationOperationImpl(catType, key, data, cas, callback);
   }
 }

--- a/src/main/java/net/spy/memcached/protocol/binary/DeleteOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/binary/DeleteOperationImpl.java
@@ -4,6 +4,7 @@ import java.util.Collection;
 import java.util.Collections;
 
 import net.spy.memcached.ops.DeleteOperation;
+import net.spy.memcached.ops.Operation;
 import net.spy.memcached.ops.OperationCallback;
 import net.spy.memcached.ops.OperationStatus;
 
@@ -47,5 +48,10 @@ class DeleteOperationImpl extends OperationImpl implements
   @Override
   public boolean isPipeOperation() {
     return false;
+  }
+
+  @Override
+  public Operation clone() {
+    return new DeleteOperationImpl(key, cas, callback);
   }
 }

--- a/src/main/java/net/spy/memcached/protocol/binary/GetOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/binary/GetOperationImpl.java
@@ -5,6 +5,7 @@ import java.util.Collections;
 
 import net.spy.memcached.ops.GetOperation;
 import net.spy.memcached.ops.GetsOperation;
+import net.spy.memcached.ops.Operation;
 import net.spy.memcached.ops.OperationStatus;
 
 class GetOperationImpl extends OperationImpl
@@ -67,5 +68,17 @@ class GetOperationImpl extends OperationImpl
   @Override
   public boolean isPipeOperation() {
     return false;
+  }
+
+  @Override
+  public Operation clone() {
+    if (callback instanceof GetOperation.Callback) {
+      return new GetOperationImpl(key, (GetOperation.Callback)callback);
+    } else if (callback instanceof GetsOperation.Callback) {
+      return new GetOperationImpl(key, (GetsOperation.Callback)callback);
+    }
+
+    assert false : "Unexpected callback type";
+    return null;
   }
 }

--- a/src/main/java/net/spy/memcached/protocol/binary/MultiGetOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/binary/MultiGetOperationImpl.java
@@ -29,6 +29,7 @@ import java.util.Map;
 
 import net.spy.memcached.KeyUtil;
 import net.spy.memcached.ops.GetOperation;
+import net.spy.memcached.ops.Operation;
 import net.spy.memcached.ops.OperationCallback;
 import net.spy.memcached.ops.OperationState;
 
@@ -139,5 +140,10 @@ class MultiGetOperationImpl extends OperationImpl implements GetOperation {
   @Override
   public boolean isPipeOperation() {
     return false;
+  }
+
+  @Override
+  public Operation clone() {
+    return new MultiGetOperationImpl(rkeys.keySet(), callback);
   }
 }

--- a/src/main/java/net/spy/memcached/protocol/binary/MutatorOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/binary/MutatorOperationImpl.java
@@ -5,6 +5,7 @@ import java.util.Collections;
 
 import net.spy.memcached.ops.MutatorOperation;
 import net.spy.memcached.ops.Mutator;
+import net.spy.memcached.ops.Operation;
 import net.spy.memcached.ops.OperationCallback;
 import net.spy.memcached.ops.OperationStatus;
 import net.spy.memcached.ops.StatusCode;
@@ -60,6 +61,11 @@ class MutatorOperationImpl extends OperationImpl implements
 
   public Collection<String> getKeys() {
     return Collections.singleton(key);
+  }
+
+  @Override
+  public Operation clone() {
+    return new MutatorOperationImpl(mutator, key, by, def, exp, callback);
   }
 
   public int getBy() {

--- a/src/main/java/net/spy/memcached/protocol/binary/StoreOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/binary/StoreOperationImpl.java
@@ -4,6 +4,7 @@ import java.util.Collection;
 import java.util.Collections;
 
 import net.spy.memcached.ops.CASOperation;
+import net.spy.memcached.ops.Operation;
 import net.spy.memcached.ops.OperationCallback;
 import net.spy.memcached.ops.OperationStatus;
 import net.spy.memcached.ops.StoreOperation;
@@ -114,5 +115,11 @@ class StoreOperationImpl extends OperationImpl
   @Override
   public boolean isPipeOperation() {
     return false;
+  }
+
+  @Override
+  public Operation clone() {
+    return new StoreOperationImpl(storeType, key, flags, exp, data, cas,
+        callback);
   }
 }


### PR DESCRIPTION
https://github.com/naver/arcus-java-client/issues/210#issuecomment-616903360

KeyedOperation 인터페이스에 Operation clone() 추가한 뒤 BaseOperationFactory.clone() 함수에서 operation이 GetOperation일 때, GetsOperation일 때, 둘 다 아닐 때로 구분하여 둘 다 아닐 때는 KeyedOperation.clone() 함수 호출하도록 수정했습니다.