### PR TITLE
CLEANUP: refactored get exist bkey

### DIFF
--- a/src/main/java/net/spy/memcached/collection/CollectionPipedInsert.java
+++ b/src/main/java/net/spy/memcached/collection/CollectionPipedInsert.java
@@ -361,9 +361,8 @@ public abstract class CollectionPipedInsert<T> extends CollectionObject {
       int i = 0;
       for (Element<T> each : elements) {
         capacity += KeyUtil.getKeyBytes(key).length;
-        capacity += KeyUtil.getKeyBytes((each.isByteArraysBkey() ? each
-                .getBkeyByHex() : String.valueOf(each.getLongBkey()))).length;
-        capacity += KeyUtil.getKeyBytes(each.getFlagByHex()).length;
+        capacity += KeyUtil.getKeyBytes(each.getStringBkey()).length;
+        capacity += KeyUtil.getKeyBytes(each.getStringEFlag()).length;
         capacity += decodedList.get(i++).length;
         capacity += 128;
       }
@@ -381,9 +380,8 @@ public abstract class CollectionPipedInsert<T> extends CollectionObject {
                 bb,
                 COMMAND,
                 key,
-                (element.isByteArraysBkey() ? element.getBkeyByHex()
-                        : String.valueOf(element.getLongBkey())),
-                element.getFlagByHex(),
+                element.getStringBkey(),
+                element.getStringEFlag(),
                 value.length,
                 (createKeyIfNotExists) ? "create" : "",
                 (createKeyIfNotExists) ? cd.getFlags() : "",

--- a/src/main/java/net/spy/memcached/collection/CollectionPipedUpdate.java
+++ b/src/main/java/net/spy/memcached/collection/CollectionPipedUpdate.java
@@ -99,8 +99,7 @@ public abstract class CollectionPipedUpdate<T> extends CollectionObject {
         }
 
         capacity += KeyUtil.getKeyBytes(key).length;
-        capacity += KeyUtil.getKeyBytes((each.isByteArraysBkey() ? each
-                .getBkeyByHex() : String.valueOf(each.getLongBkey()))).length;
+        capacity += KeyUtil.getKeyBytes(each.getStringBkey()).length;
         if (decodedList.get(i) != null) {
           capacity += decodedList.get(i++).length;
         }
@@ -127,9 +126,11 @@ public abstract class CollectionPipedUpdate<T> extends CollectionObject {
           b.append(eflagUpdate.getElementFlagByHex());
         }
 
-        setArguments(bb, COMMAND, key,
-                (element.isByteArraysBkey() ? element.getBkeyByHex()
-                        : String.valueOf(element.getLongBkey())),
+        setArguments(
+                bb,
+                COMMAND,
+                key,
+                (element.getStringBkey()),
                 b.toString(), (value == null ? -1 : value.length),
                 (i < eSize - 1) ? PIPE : "");
         if (value != null) {

--- a/src/main/java/net/spy/memcached/collection/Element.java
+++ b/src/main/java/net/spy/memcached/collection/Element.java
@@ -80,7 +80,7 @@ public class Element<T> {
    *
    * @return element flag by hex (e.g. 0x01)
    */
-  public String getFlagByHex() {
+  public String getStringEFlag() {
     // convert to hex based on its real byte array
     if (eflag == null) {
       return "";
@@ -94,7 +94,7 @@ public class Element<T> {
    *
    * @return bkey by hex (e.g. 0x01)
    */
-  public String getBkeyByHex() {
+  private String getStringByteArrayBkey() {
     return BTreeUtil.toHex(bkey);
   }
 
@@ -110,10 +110,27 @@ public class Element<T> {
   /**
    * get bkey
    *
+   * @return bkey by string (-1 if not available)
+   */
+  private String getStringLongBkey() {
+    return String.valueOf(getLongBkey());
+  }
+
+  /**
+   * get bkey
+   *
    * @return bkey (-1 if not available)
    */
   public long getLongBkey() {
     return (longBkey == null) ? -1 : longBkey;
+  }
+
+  /**
+   * if byte bkey exist return hex string and if not return type of string long bkey
+   * @return type of hex byte bkey or type of String Long bkey
+   */
+  public String getStringBkey() {
+    return isByteArraysBkey ? getStringByteArrayBkey() : getStringLongBkey();
   }
 
   /**
@@ -130,12 +147,8 @@ public class Element<T> {
    *
    * @return element flag
    */
-  public byte[] getFlag() {
+  public byte[] getEFlag() {
     return eflag;
-  }
-
-  public boolean isByteArraysBkey() {
-    return isByteArraysBkey;
   }
 
   public ElementFlagUpdate getElementFlagUpdate() {
@@ -146,14 +159,10 @@ public class Element<T> {
   public String toString() {
     StringBuilder sb = new StringBuilder();
     sb.append("{ \"");
-    if (isByteArraysBkey) {
-      sb.append(getBkeyByHex());
-    } else {
-      sb.append(getLongBkey());
-    }
+    sb.append(getStringBkey());
     sb.append("\" : { ");
 
-    sb.append(" \"eflag\" : \"").append(BTreeUtil.toHex(eflag)).append("\"");
+    sb.append(" \"eflag\" : \"").append(getStringEFlag()).append("\"");
     sb.append(",");
     sb.append(" \"value\" : \"").append(value.toString()).append("\"");
     sb.append(" }");

--- a/src/test/manual/net/spy/memcached/bulkoperation/BopPipeUpdateTest.java
+++ b/src/test/manual/net/spy/memcached/bulkoperation/BopPipeUpdateTest.java
@@ -144,7 +144,7 @@ public class BopPipeUpdateTest extends BaseIntegrationTest {
 
         // System.out.println(element.getFlagByHex());
         assertEquals("value" + i, element.getValue());
-        assertEquals("0x01010101", element.getFlagByHex());
+        assertEquals("0x01010101", element.getStringEFlag());
       }
 
     } catch (Exception e) {
@@ -182,7 +182,7 @@ public class BopPipeUpdateTest extends BaseIntegrationTest {
 
         // System.out.println(element.getFlagByHex());
         assertEquals("value" + i, element.getValue());
-        assertEquals("", element.getFlagByHex());
+        assertEquals("", element.getStringEFlag());
       }
 
     } catch (Exception e) {

--- a/src/test/manual/net/spy/memcached/collection/btree/longbkey/BopGetTest.java
+++ b/src/test/manual/net/spy/memcached/collection/btree/longbkey/BopGetTest.java
@@ -61,7 +61,7 @@ public class BopGetTest extends BaseIntegrationTest {
     Assert.assertNotNull(el);
 
     Assert.assertEquals("value", el.getValue());
-    Assert.assertEquals("0x01", el.getBkeyByHex());
-    Assert.assertEquals("", el.getFlagByHex());
+    Assert.assertEquals("0x01", el.getStringBkey());
+    Assert.assertEquals("", el.getStringEFlag());
   }
 }

--- a/src/test/manual/net/spy/memcached/collection/btree/longbkey/BopInsertAndGetWithElementFlagTest.java
+++ b/src/test/manual/net/spy/memcached/collection/btree/longbkey/BopInsertAndGetWithElementFlagTest.java
@@ -70,7 +70,7 @@ public class BopInsertAndGetWithElementFlagTest extends BaseIntegrationTest {
     for (Entry<ByteArrayBKey, Element<Object>> i : map.entrySet()) {
       Assert.assertTrue(Arrays.equals(BKEY, i.getKey().getBytes()));
       Assert.assertEquals(VALUE, i.getValue().getValue());
-      Assert.assertTrue(Arrays.equals(FLAG, i.getValue().getFlag()));
+      Assert.assertTrue(Arrays.equals(FLAG, i.getValue().getEFlag()));
     }
 
     // delete
@@ -106,9 +106,9 @@ public class BopInsertAndGetWithElementFlagTest extends BaseIntegrationTest {
     Assert.assertEquals(VALUE, map.get(BKEY2).getValue());
     Assert.assertEquals(VALUE, map.get(BKEY3).getValue());
 
-    Assert.assertTrue(Arrays.equals(FLAG, map.get(BKEY).getFlag()));
-    Assert.assertTrue(Arrays.equals(FLAG2, map.get(BKEY2).getFlag()));
-    Assert.assertTrue(Arrays.equals(FLAG3, map.get(BKEY3).getFlag()));
+    Assert.assertTrue(Arrays.equals(FLAG, map.get(BKEY).getEFlag()));
+    Assert.assertTrue(Arrays.equals(FLAG2, map.get(BKEY2).getEFlag()));
+    Assert.assertTrue(Arrays.equals(FLAG3, map.get(BKEY3).getEFlag()));
 
     // delete only 2 elements
     Assert.assertTrue(mc.asyncBopDelete(KEY, BKEY, BKEY2,
@@ -120,6 +120,6 @@ public class BopInsertAndGetWithElementFlagTest extends BaseIntegrationTest {
 
     Assert.assertEquals(1, map.size());
     Assert.assertEquals(VALUE, map.get(BKEY3).getValue());
-    Assert.assertTrue(Arrays.equals(FLAG3, map.get(BKEY3).getFlag()));
+    Assert.assertTrue(Arrays.equals(FLAG3, map.get(BKEY3).getEFlag()));
   }
 }

--- a/src/test/manual/net/spy/memcached/collection/btree/longbkey/BopUpsertTest.java
+++ b/src/test/manual/net/spy/memcached/collection/btree/longbkey/BopUpsertTest.java
@@ -67,7 +67,7 @@ public class BopUpsertTest extends BaseIntegrationTest {
     for (Entry<ByteArrayBKey, Element<Object>> i : map.entrySet()) {
       Assert.assertTrue(Arrays.equals(BKEY, i.getKey().getBytes()));
       Assert.assertEquals(VALUE, i.getValue().getValue());
-      Assert.assertTrue(Arrays.equals(FLAG, i.getValue().getFlag()));
+      Assert.assertTrue(Arrays.equals(FLAG, i.getValue().getEFlag()));
     }
 
     // upsert
@@ -82,7 +82,7 @@ public class BopUpsertTest extends BaseIntegrationTest {
     for (Entry<ByteArrayBKey, Element<Object>> i : map.entrySet()) {
       Assert.assertTrue(Arrays.equals(BKEY, i.getKey().getBytes()));
       Assert.assertEquals(VALUE2, i.getValue().getValue());
-      Assert.assertNull(i.getValue().getFlag());
+      Assert.assertNull(i.getValue().getEFlag());
     }
   }
 
@@ -100,7 +100,7 @@ public class BopUpsertTest extends BaseIntegrationTest {
     for (Entry<ByteArrayBKey, Element<Object>> i : map.entrySet()) {
       Assert.assertTrue(Arrays.equals(BKEY, i.getKey().getBytes()));
       Assert.assertEquals(VALUE2, i.getValue().getValue());
-      Assert.assertNull(i.getValue().getFlag());
+      Assert.assertNull(i.getValue().getEFlag());
     }
   }
 
@@ -119,7 +119,7 @@ public class BopUpsertTest extends BaseIntegrationTest {
     for (Entry<ByteArrayBKey, Element<Object>> i : map.entrySet()) {
       Assert.assertTrue(Arrays.equals(BKEY, i.getKey().getBytes()));
       Assert.assertEquals(VALUE, i.getValue().getValue());
-      Assert.assertTrue(Arrays.equals(FLAG, i.getValue().getFlag()));
+      Assert.assertTrue(Arrays.equals(FLAG, i.getValue().getEFlag()));
     }
 
     // upsert
@@ -134,7 +134,7 @@ public class BopUpsertTest extends BaseIntegrationTest {
     for (Entry<ByteArrayBKey, Element<Object>> i : map.entrySet()) {
       Assert.assertTrue(Arrays.equals(BKEY, i.getKey().getBytes()));
       Assert.assertEquals(VALUE2, i.getValue().getValue());
-      Assert.assertTrue(Arrays.equals(FLAG2, i.getValue().getFlag()));
+      Assert.assertTrue(Arrays.equals(FLAG2, i.getValue().getEFlag()));
     }
   }
 


### PR DESCRIPTION
#410 이슈 pr입니다.

처음에는 code readability를 위해 element class 내에 
long 타입의 bkey를 String.valueOf 메서드를 이용해 String으로 변환하는 메소드를 추가했었는데

코드를 조금 더 보니, 사용되는 곳이 capacity와 argument를 설정하는 부분에서만 사용이 되고 있었고 
사용되는 부분에서 bkey가 byte 형태인지 long 형태인지 비교하여 값을 가져오는 코드 형태로 구현하고 있었습니다.

해당 코드도 element 내부에서 처리해서 가져오면 code readability가 더 좋을 것 같아
byte형태인지 long 형태인지 비교한후 hex 또는 long을 string으로 변환하여 가져오도록 메소드를 추가했습니다.

