### PR TITLE
ENHANCE: Remove getRepresentKey() and add getMemcachedNode() to BTreeSMGet to skip key iteration for searching MemcachedNode #385

### DIFF
--- a/src/main/java/net/spy/memcached/MemcachedClient.java
+++ b/src/main/java/net/spy/memcached/MemcachedClient.java
@@ -359,6 +359,12 @@ public class MemcachedClient extends SpyThread
     return op;
   }
 
+  protected Operation addOp(final MemcachedNode node, final Operation op) {
+    checkState();
+    conn.addOperation(node, op);
+    return op;
+  }
+
   protected CountDownLatch broadcastOp(final BroadcastOpFactory of) {
     return broadcastOp(of, conn.getLocator().getAll(), true);
   }

--- a/src/main/java/net/spy/memcached/collection/BTreeGetBulk.java
+++ b/src/main/java/net/spy/memcached/collection/BTreeGetBulk.java
@@ -16,6 +16,8 @@
  */
 package net.spy.memcached.collection;
 
+import net.spy.memcached.MemcachedNode;
+
 import java.util.List;
 
 public interface BTreeGetBulk<T> {
@@ -24,7 +26,7 @@ public interface BTreeGetBulk<T> {
 
   public String getSpaceSeparatedKeys();
 
-  public String getRepresentKey();
+  public MemcachedNode getMemcachedNode();
 
   public List<String> getKeyList();
 

--- a/src/main/java/net/spy/memcached/collection/BTreeGetBulkImpl.java
+++ b/src/main/java/net/spy/memcached/collection/BTreeGetBulkImpl.java
@@ -20,11 +20,14 @@ import java.util.List;
 import java.util.Map;
 
 import net.spy.memcached.KeyUtil;
+import net.spy.memcached.MemcachedNode;
 import net.spy.memcached.util.BTreeUtil;
 
 public abstract class BTreeGetBulkImpl<T> implements BTreeGetBulk<T> {
 
   private static final String command = "bop mget";
+
+  private MemcachedNode node;
 
   private String keySeparator;
   private String spaceSeparatedKeys;
@@ -47,9 +50,11 @@ public abstract class BTreeGetBulkImpl<T> implements BTreeGetBulk<T> {
   protected int dataLength;
   protected byte[] eflag = null;
 
-  protected BTreeGetBulkImpl(List<String> keyList, byte[] from, byte[] to,
-                             ElementFlagFilter eFlagFilter, int offset, int count) {
-
+  protected BTreeGetBulkImpl(MemcachedNode node, List<String> keyList,
+                             byte[] from, byte[] to,
+                             ElementFlagFilter eFlagFilter, int offset,
+                             int count) {
+    this.node = node;
     this.keyList = keyList;
     this.range = BTreeUtil.toHex(from) + ".." + BTreeUtil.toHex(to);
     this.eFlagFilter = eFlagFilter;
@@ -58,9 +63,11 @@ public abstract class BTreeGetBulkImpl<T> implements BTreeGetBulk<T> {
     this.reverse = BTreeUtil.compareByteArraysInLexOrder(from, to) > 0;
   }
 
-  protected BTreeGetBulkImpl(List<String> keyList, long from, long to,
-                             ElementFlagFilter eFlagFilter, int offset, int count) {
-
+  protected BTreeGetBulkImpl(MemcachedNode node, List<String> keyList,
+                             long from, long to,
+                             ElementFlagFilter eFlagFilter, int offset,
+                             int count) {
+    this.node = node;
     this.keyList = keyList;
     this.range = String.valueOf(from) + ((to > -1) ? ".." + String.valueOf(to) : "");
     this.eFlagFilter = eFlagFilter;
@@ -90,11 +97,8 @@ public abstract class BTreeGetBulkImpl<T> implements BTreeGetBulk<T> {
     return spaceSeparatedKeys;
   }
 
-  public String getRepresentKey() {
-    if (keyList == null || keyList.isEmpty()) {
-      throw new IllegalStateException("Key list is empty.");
-    }
-    return keyList.get(0);
+  public MemcachedNode getMemcachedNode() {
+    return node;
   }
 
   public List<String> getKeyList() {

--- a/src/main/java/net/spy/memcached/collection/BTreeGetBulkWithByteTypeBkey.java
+++ b/src/main/java/net/spy/memcached/collection/BTreeGetBulkWithByteTypeBkey.java
@@ -18,13 +18,16 @@ package net.spy.memcached.collection;
 
 import java.util.List;
 
+import net.spy.memcached.MemcachedNode;
 import net.spy.memcached.util.BTreeUtil;
 
 public class BTreeGetBulkWithByteTypeBkey<T> extends BTreeGetBulkImpl<T> {
 
-  public BTreeGetBulkWithByteTypeBkey(List<String> keyList, byte[] from, byte[] to,
-                                      ElementFlagFilter eFlagFilter, int offset, int count) {
-    super(keyList, from, to, eFlagFilter, offset, count);
+  public BTreeGetBulkWithByteTypeBkey(MemcachedNode node, List<String> keyList,
+                                      byte[] from, byte[] to,
+                                      ElementFlagFilter eFlagFilter,
+                                      int offset, int count) {
+    super(node, keyList, from, to, eFlagFilter, offset, count);
   }
 
   public byte[] getSubkey() {

--- a/src/main/java/net/spy/memcached/collection/BTreeGetBulkWithLongTypeBkey.java
+++ b/src/main/java/net/spy/memcached/collection/BTreeGetBulkWithLongTypeBkey.java
@@ -18,13 +18,16 @@ package net.spy.memcached.collection;
 
 import java.util.List;
 
+import net.spy.memcached.MemcachedNode;
 import net.spy.memcached.util.BTreeUtil;
 
 public class BTreeGetBulkWithLongTypeBkey<T> extends BTreeGetBulkImpl<T> {
 
-  public BTreeGetBulkWithLongTypeBkey(List<String> keyList, long from, long to,
-                                      ElementFlagFilter eFlagFilter, int offset, int count) {
-    super(keyList, from, to, eFlagFilter, offset, count);
+  public BTreeGetBulkWithLongTypeBkey(MemcachedNode node, List<String> keyList,
+                                      long from, long to,
+                                      ElementFlagFilter eFlagFilter,
+                                      int offset, int count) {
+    super(node, keyList, from, to, eFlagFilter, offset, count);
   }
 
   public Long getSubkey() {
@@ -55,4 +58,5 @@ public class BTreeGetBulkWithLongTypeBkey<T> extends BTreeGetBulkImpl<T> {
       this.flag = Integer.valueOf(splited[3]);
     }
   }
+
 }

--- a/src/main/java/net/spy/memcached/collection/BTreeSMGet.java
+++ b/src/main/java/net/spy/memcached/collection/BTreeSMGet.java
@@ -16,6 +16,8 @@
  */
 package net.spy.memcached.collection;
 
+import net.spy.memcached.MemcachedNode;
+
 import java.util.List;
 
 public interface BTreeSMGet<T> {
@@ -26,7 +28,7 @@ public interface BTreeSMGet<T> {
 
   public String getSpaceSeparatedKeys();
 
-  public String getRepresentKey();
+  public MemcachedNode getMemcachedNode();
 
   public List<String> getKeyList();
 

--- a/src/main/java/net/spy/memcached/collection/BTreeSMGetWithByteTypeBkey.java
+++ b/src/main/java/net/spy/memcached/collection/BTreeSMGetWithByteTypeBkey.java
@@ -20,11 +20,14 @@ import java.util.List;
 import java.util.Map;
 
 import net.spy.memcached.KeyUtil;
+import net.spy.memcached.MemcachedNode;
 import net.spy.memcached.util.BTreeUtil;
 
 public class BTreeSMGetWithByteTypeBkey<T> implements BTreeSMGet<T> {
 
   private static final String command = "bop smget";
+
+  protected MemcachedNode node;
 
   protected String str;
 
@@ -51,8 +54,11 @@ public class BTreeSMGetWithByteTypeBkey<T> implements BTreeSMGet<T> {
 
   private ElementFlagFilter eFlagFilter;
 
-  public BTreeSMGetWithByteTypeBkey(List<String> keyList, byte[] from, byte[] to,
-                                    ElementFlagFilter eFlagFilter, int count, SMGetMode smgetMode) {
+  public BTreeSMGetWithByteTypeBkey(MemcachedNode node, List<String> keyList,
+                                    byte[] from, byte[] to,
+                                    ElementFlagFilter eFlagFilter, int count,
+                                    SMGetMode smgetMode) {
+    this.node = node;
     this.keyList = keyList;
     this.range = BTreeUtil.toHex(from) + ".." + BTreeUtil.toHex(to);
     this.eFlagFilter = eFlagFilter;
@@ -82,11 +88,8 @@ public class BTreeSMGetWithByteTypeBkey<T> implements BTreeSMGet<T> {
     return spaceSeparatedKeys;
   }
 
-  public String getRepresentKey() {
-    if (keyList == null || keyList.isEmpty()) {
-      throw new IllegalStateException("Key list is empty.");
-    }
-    return keyList.get(0);
+  public MemcachedNode getMemcachedNode() {
+    return node;
   }
 
   public List<String> getKeyList() {

--- a/src/main/java/net/spy/memcached/collection/BTreeSMGetWithByteTypeBkeyOld.java
+++ b/src/main/java/net/spy/memcached/collection/BTreeSMGetWithByteTypeBkeyOld.java
@@ -20,11 +20,14 @@ import java.util.List;
 import java.util.Map;
 
 import net.spy.memcached.KeyUtil;
+import net.spy.memcached.MemcachedNode;
 import net.spy.memcached.util.BTreeUtil;
 
 public class BTreeSMGetWithByteTypeBkeyOld<T> implements BTreeSMGet<T> {
 
   private static final String command = "bop smget";
+
+  protected MemcachedNode node;
 
   protected String str;
 
@@ -50,8 +53,11 @@ public class BTreeSMGetWithByteTypeBkeyOld<T> implements BTreeSMGet<T> {
 
   private ElementFlagFilter eFlagFilter;
 
-  public BTreeSMGetWithByteTypeBkeyOld(List<String> keyList, byte[] from, byte[] to,
-                                       ElementFlagFilter eFlagFilter, int offset, int count) {
+  public BTreeSMGetWithByteTypeBkeyOld(MemcachedNode node, List<String> keyList,
+                                       byte[] from, byte[] to,
+                                       ElementFlagFilter eFlagFilter,
+                                       int offset, int count) {
+    this.node = node;
     this.keyList = keyList;
     this.range = BTreeUtil.toHex(from) + ".." + BTreeUtil.toHex(to);
     this.eFlagFilter = eFlagFilter;
@@ -81,11 +87,8 @@ public class BTreeSMGetWithByteTypeBkeyOld<T> implements BTreeSMGet<T> {
     return spaceSeparatedKeys;
   }
 
-  public String getRepresentKey() {
-    if (keyList == null || keyList.isEmpty()) {
-      throw new IllegalStateException("Key list is empty.");
-    }
-    return keyList.get(0);
+  public MemcachedNode getMemcachedNode() {
+    return node;
   }
 
   public List<String> getKeyList() {

--- a/src/main/java/net/spy/memcached/collection/BTreeSMGetWithLongTypeBkey.java
+++ b/src/main/java/net/spy/memcached/collection/BTreeSMGetWithLongTypeBkey.java
@@ -20,11 +20,14 @@ import java.util.List;
 import java.util.Map;
 
 import net.spy.memcached.KeyUtil;
+import net.spy.memcached.MemcachedNode;
 import net.spy.memcached.util.BTreeUtil;
 
 public class BTreeSMGetWithLongTypeBkey<T> implements BTreeSMGet<T> {
 
   private static final String command = "bop smget";
+
+  protected MemcachedNode node;
 
   protected String str;
 
@@ -51,8 +54,12 @@ public class BTreeSMGetWithLongTypeBkey<T> implements BTreeSMGet<T> {
 
   private ElementFlagFilter eFlagFilter;
 
-  public BTreeSMGetWithLongTypeBkey(List<String> keyList, long from, long to,
-                                    ElementFlagFilter eFlagFilter, int count, SMGetMode smgetMode) {
+  public BTreeSMGetWithLongTypeBkey(MemcachedNode node, List<String> keyList,
+                                    long from,
+                                    long to,
+                                    ElementFlagFilter eFlagFilter, int count,
+                                    SMGetMode smgetMode) {
+    this.node = node;
     this.keyList = keyList;
 
     this.range = String.valueOf(from) + ((to > -1) ? ".." + String.valueOf(to) : "");
@@ -84,11 +91,8 @@ public class BTreeSMGetWithLongTypeBkey<T> implements BTreeSMGet<T> {
     return spaceSeparatedKeys;
   }
 
-  public String getRepresentKey() {
-    if (keyList == null || keyList.isEmpty()) {
-      throw new IllegalStateException("Key list is empty.");
-    }
-    return keyList.get(0);
+  public MemcachedNode getMemcachedNode() {
+    return node;
   }
 
   public List<String> getKeyList() {

--- a/src/main/java/net/spy/memcached/collection/BTreeSMGetWithLongTypeBkeyOld.java
+++ b/src/main/java/net/spy/memcached/collection/BTreeSMGetWithLongTypeBkeyOld.java
@@ -20,11 +20,14 @@ import java.util.List;
 import java.util.Map;
 
 import net.spy.memcached.KeyUtil;
+import net.spy.memcached.MemcachedNode;
 import net.spy.memcached.util.BTreeUtil;
 
 public class BTreeSMGetWithLongTypeBkeyOld<T> implements BTreeSMGet<T> {
 
   private static final String command = "bop smget";
+
+  protected MemcachedNode node;
 
   protected String str;
 
@@ -50,8 +53,11 @@ public class BTreeSMGetWithLongTypeBkeyOld<T> implements BTreeSMGet<T> {
 
   private ElementFlagFilter eFlagFilter;
 
-  public BTreeSMGetWithLongTypeBkeyOld(List<String> keyList, long from, long to,
-                                       ElementFlagFilter eFlagFilter, int offset, int count) {
+  public BTreeSMGetWithLongTypeBkeyOld(MemcachedNode node,
+                                       List<String> keyList, long from, long to,
+                                       ElementFlagFilter eFlagFilter,
+                                       int offset, int count) {
+    this.node = node;
     this.keyList = keyList;
 
     this.range = String.valueOf(from) + ((to > -1) ? ".." + String.valueOf(to) : "");
@@ -83,11 +89,8 @@ public class BTreeSMGetWithLongTypeBkeyOld<T> implements BTreeSMGet<T> {
     return spaceSeparatedKeys;
   }
 
-  public String getRepresentKey() {
-    if (keyList == null || keyList.isEmpty()) {
-      throw new IllegalStateException("Key list is empty.");
-    }
-    return keyList.get(0);
+  public MemcachedNode getMemcachedNode() {
+    return node;
   }
 
   public List<String> getKeyList() {

--- a/src/main/java/net/spy/memcached/collection/CollectionBulkInsert.java
+++ b/src/main/java/net/spy/memcached/collection/CollectionBulkInsert.java
@@ -23,6 +23,7 @@ import java.util.List;
 
 import net.spy.memcached.CachedData;
 import net.spy.memcached.KeyUtil;
+import net.spy.memcached.MemcachedNode;
 import net.spy.memcached.transcoders.Transcoder;
 import net.spy.memcached.util.BTreeUtil;
 
@@ -39,6 +40,7 @@ public abstract class CollectionBulkInsert<T> extends CollectionObject {
   protected int itemCount;
 
   protected CollectionAttributes attribute;
+  protected MemcachedNode node;
 
   protected int nextOpIndex = 0;
 
@@ -52,6 +54,10 @@ public abstract class CollectionBulkInsert<T> extends CollectionObject {
 
   public int getNextOpIndex() {
     return nextOpIndex;
+  }
+
+  public MemcachedNode getMemcachedNode() {
+    return node;
   }
 
   public abstract ByteBuffer getAsciiCommand();
@@ -68,8 +74,9 @@ public abstract class CollectionBulkInsert<T> extends CollectionObject {
     private final String bkey;
     private final String eflag;
 
-    public BTreeBulkInsert(List<String> keyList, long bkey, byte[] eflag,
-                           T value, CollectionAttributes attr, Transcoder<T> tc) {
+    public BTreeBulkInsert(MemcachedNode node, List<String> keyList, long bkey,
+                           byte[] eflag, T value, CollectionAttributes attr,
+                           Transcoder<T> tc) {
       if (attr != null) {
         CollectionOverflowAction overflowAction = attr.getOverflowAction();
         if (overflowAction != null
@@ -78,6 +85,7 @@ public abstract class CollectionBulkInsert<T> extends CollectionObject {
               overflowAction + " is unavailable overflow action in " + CollectionType.btree + ".");
         }
       }
+      this.node = node;
       this.keyList = keyList;
       this.bkey = String.valueOf(bkey);
       this.eflag = BTreeUtil.toHex(eflag);
@@ -89,9 +97,9 @@ public abstract class CollectionBulkInsert<T> extends CollectionObject {
       this.cachedData = tc.encode(value);
     }
 
-    public BTreeBulkInsert(List<String> keyList, byte[] bkey,
-                           byte[] eflag, T value, CollectionAttributes attr,
-                           Transcoder<T> tc) {
+    public BTreeBulkInsert(MemcachedNode node, List<String> keyList,
+                           byte[] bkey, byte[] eflag, T value,
+                           CollectionAttributes attr, Transcoder<T> tc) {
       if (attr != null) {
         CollectionOverflowAction overflowAction = attr.getOverflowAction();
         if (overflowAction != null
@@ -100,6 +108,7 @@ public abstract class CollectionBulkInsert<T> extends CollectionObject {
               overflowAction + " is unavailable overflow action in " + CollectionType.btree + ".");
         }
       }
+      this.node = node;
       this.keyList = keyList;
       this.bkey = BTreeUtil.toHex(bkey);
       this.eflag = BTreeUtil.toHex(eflag);
@@ -178,8 +187,8 @@ public abstract class CollectionBulkInsert<T> extends CollectionObject {
     private static final String COMMAND = "mop insert";
     private final String mkey;
 
-    public MapBulkInsert(List<String> keyList, String mkey, T value,
-                         CollectionAttributes attr, Transcoder<T> tc) {
+    public MapBulkInsert(MemcachedNode node, List<String> keyList, String mkey,
+                         T value, CollectionAttributes attr, Transcoder<T> tc) {
       if (attr != null) {
         CollectionOverflowAction overflowAction = attr.getOverflowAction();
         if (overflowAction != null
@@ -188,6 +197,7 @@ public abstract class CollectionBulkInsert<T> extends CollectionObject {
               overflowAction + " is unavailable overflow action in " + CollectionType.map + ".");
         }
       }
+      this.node = node;
       this.keyList = keyList;
       this.mkey = mkey;
       this.value = value;
@@ -262,7 +272,7 @@ public abstract class CollectionBulkInsert<T> extends CollectionObject {
 
     private static final String COMMAND = "sop insert";
 
-    public SetBulkInsert(List<String> keyList, T value,
+    public SetBulkInsert(MemcachedNode node, List<String> keyList, T value,
                          CollectionAttributes attr, Transcoder<T> tc) {
       if (attr != null) {
         CollectionOverflowAction overflowAction = attr.getOverflowAction();
@@ -272,6 +282,7 @@ public abstract class CollectionBulkInsert<T> extends CollectionObject {
               overflowAction + " is unavailable overflow action in " + CollectionType.set + ".");
         }
       }
+      this.node = node;
       this.keyList = keyList;
       this.value = value;
       this.attribute = attr;
@@ -343,8 +354,9 @@ public abstract class CollectionBulkInsert<T> extends CollectionObject {
     private static final String COMMAND = "lop insert";
     private int index;
 
-    public ListBulkInsert(List<String> keyList, int index, T value,
-                          CollectionAttributes attr, Transcoder<T> tc) {
+    public ListBulkInsert(MemcachedNode node, List<String> keyList, int index,
+                          T value, CollectionAttributes attr,
+                          Transcoder<T> tc) {
       if (attr != null) {
         CollectionOverflowAction overflowAction = attr.getOverflowAction();
         if (overflowAction != null
@@ -353,6 +365,7 @@ public abstract class CollectionBulkInsert<T> extends CollectionObject {
               overflowAction + " is unavailable overflow action in " + CollectionType.list + ".");
         }
       }
+      this.node = node;
       this.keyList = keyList;
       this.index = index;
       this.value = value;

--- a/src/test/manual/net/spy/memcached/MultibyteKeyTest.java
+++ b/src/test/manual/net/spy/memcached/MultibyteKeyTest.java
@@ -281,7 +281,7 @@ public class MultibyteKeyTest {
   public void BTreeSortMergeGetOperationImplTest() {
     try {
       opFact.bopsmget(
-          new BTreeSMGetWithLongTypeBkey<Object>(
+          new BTreeSMGetWithLongTypeBkey<Object>(null,
               keyList, 0L, 100L, ElementFlagFilter.DO_NOT_FILTER, 0, SMGetMode.UNIQUE),
           new BTreeSortMergeGetOperation.Callback() {
             @Override
@@ -313,7 +313,7 @@ public class MultibyteKeyTest {
   public void BTreeSortMergeGetOperationOldImplTest() {
     try {
       opFact.bopsmget(
-          new BTreeSMGetWithLongTypeBkeyOld<Object>(
+          new BTreeSMGetWithLongTypeBkeyOld<Object>(null,
               keyList, 0L, 100L, ElementFlagFilter.DO_NOT_FILTER, 0, 0),
           new BTreeSortMergeGetOperationOld.Callback() {
             @Override
@@ -478,16 +478,18 @@ public class MultibyteKeyTest {
           }
         };
 
-    insert = new CollectionBulkInsert.BTreeBulkInsert<Integer>(keyList, 1L, new byte[]{0, 0},
-            new Random().nextInt(), new CollectionAttributes(), new IntegerTranscoder());
+    insert = new CollectionBulkInsert.BTreeBulkInsert<Integer>(null, keyList,
+        1L, new byte[]{0, 0}, new Random().nextInt(),
+        new CollectionAttributes(), new IntegerTranscoder());
     try {
       opFact.collectionBulkInsert(insert.getKeyList(), insert, cbsCallback).initialize();
     } catch (java.nio.BufferOverflowException e) {
       Assert.fail();
     }
 
-    insert = new CollectionBulkInsert.ListBulkInsert<Integer>(keyList, 0, new Random().nextInt(),
-            new CollectionAttributes(), new IntegerTranscoder());
+    insert = new CollectionBulkInsert.ListBulkInsert<Integer>(null, keyList, 0,
+        new Random().nextInt(), new CollectionAttributes(),
+        new IntegerTranscoder());
 
     try {
       opFact.collectionBulkInsert(insert.getKeyList(), insert, cbsCallback).initialize();
@@ -495,8 +497,9 @@ public class MultibyteKeyTest {
       Assert.fail();
     }
 
-    insert = new CollectionBulkInsert.SetBulkInsert<Integer>(keyList, new Random().nextInt(),
-            new CollectionAttributes(), new IntegerTranscoder());
+    insert = new CollectionBulkInsert.SetBulkInsert<Integer>(null, keyList,
+        new Random().nextInt(), new CollectionAttributes(),
+        new IntegerTranscoder());
     try {
       opFact.collectionBulkInsert(insert.getKeyList(), insert, cbsCallback).initialize();
     } catch (java.nio.BufferOverflowException e) {
@@ -508,7 +511,7 @@ public class MultibyteKeyTest {
   public void BTreeGetBulkOperationImplTest() {
     try {
       opFact.bopGetBulk(
-          new BTreeGetBulkWithLongTypeBkey<Integer>(
+          new BTreeGetBulkWithLongTypeBkey<Integer>(null,
               keyList, 0L, 10L, ElementFlagFilter.DO_NOT_FILTER, 0, 0
           ),
           new BTreeGetBulkOperation.Callback<Integer>() {


### PR DESCRIPTION
```java
public interface BTreeSMGet<T> {
  public String getRepresentKey();
}
```

- getRepresentKey() 메소드는 smget() 메소드에서 노드를 찾기 위해서만 사용됩니다. 따라서 다음과 같이 인터페이스를 변경합니다.

```java
public interface BTreeSMGet<T> {
  public MemcachedNode getMemcachedNode();
}
```

- MemcachedNode 객체는 groupingKeys() 메소드에서 가져옵니다. groupingKeys() 메소드의 반환 값에 MemcachedNode 객체를 포함하기 위해 반환 타입을 변경합니다.

```java
private List<Entry<MemcachedNode, List<String>>> groupingKeys(List<String> keyList)
```

- addOp(final MemcachedNode node, final Operation op) 메소드를 추가하여 key로 노드를 찾는 과정을 거치지 않고 Operation을 InputQ에 추가합니다.

```java
protected Operation addOp(final MemcachedNode node, final Operation op) {
  checkState();
  conn.addOperation(node, op);
  return op;
}
```