### PR TITLE
FEATURE: block to use redistribute failure mode in ArcusClient

### DIFF
--- a/src/main/java/net/spy/memcached/CacheManager.java
+++ b/src/main/java/net/spy/memcached/CacheManager.java
@@ -91,6 +91,11 @@ public class CacheManager extends SpyThread implements Watcher,
 
   public CacheManager(String hostPort, String serviceCode,
                       ConnectionFactoryBuilder cfb, int poolSize, int waitTimeForConnect) {
+    if (cfb.getFailureMode() == FailureMode.Redistribute) {
+      throw new InitializeClientException(
+          "Redistribute failure mode is not compatible with ArcusClient. " +
+          "Use other failure mode.");
+    }
 
     this.zkConnectString = hostPort;
     this.serviceCode = serviceCode;

--- a/src/main/java/net/spy/memcached/ConnectionFactoryBuilder.java
+++ b/src/main/java/net/spy/memcached/ConnectionFactoryBuilder.java
@@ -114,6 +114,10 @@ public class ConnectionFactoryBuilder {
   }
   /* ENABLE_REPLICATION end */
 
+  public FailureMode getFailureMode() {
+    return failureMode;
+  }
+
   /**
    * Set the operation queue factory.
    */

--- a/src/main/java/net/spy/memcached/MemcachedNode.java
+++ b/src/main/java/net/spy/memcached/MemcachedNode.java
@@ -61,10 +61,8 @@ public interface MemcachedNode {
   /**
    * Clear the queue of currently processing operations by either cancelling
    * them or setting them up to be reapplied after a reconnect.
-   *
-   * @param cancelWrite if true, cancel all operations in write queue
    */
-  void setupResend(boolean cancelWrite, String cause);
+  void setupResend(String cause);
 
   /**
    * Fill the write buffer with data from the next operations in the queue.

--- a/src/main/java/net/spy/memcached/MemcachedNodeROImpl.java
+++ b/src/main/java/net/spy/memcached/MemcachedNodeROImpl.java
@@ -176,7 +176,7 @@ public class MemcachedNodeROImpl implements MemcachedNode {
     throw new UnsupportedOperationException();
   }
 
-  public void setupResend(boolean cancelWrite, String cause) {
+  public void setupResend(String cause) {
     throw new UnsupportedOperationException();
   }
 

--- a/src/main/java/net/spy/memcached/protocol/TCPMemcachedNodeImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/TCPMemcachedNodeImpl.java
@@ -191,11 +191,11 @@ public abstract class TCPMemcachedNodeImpl extends SpyObject
     return destroyQueue(readQ, resend);
   }
 
-  public final void setupResend(boolean cancelWrite, String cause) {
+  public final void setupResend(String cause) {
     // First, reset the current write op, or cancel it if we should
     // be authenticating
     Operation op = getCurrentWriteOp();
-    if ((cancelWrite || shouldAuth) && op != null) {
+    if (shouldAuth && op != null) {
       /*
        * Do not cancel the operation.
        * There is no reason to cancel it first
@@ -221,7 +221,7 @@ public abstract class TCPMemcachedNodeImpl extends SpyObject
       }
     }
 
-    while ((cancelWrite || shouldAuth) && hasWriteOp()) {
+    while (shouldAuth && hasWriteOp()) {
       op = removeCurrentWriteOp();
       getLogger().warn("Discarding partially completed op: %s", op);
       op.cancel(cause);
@@ -619,7 +619,7 @@ public abstract class TCPMemcachedNodeImpl extends SpyObject
         inputQueue.drainTo(reconnectBlocked);
       }
       assert (inputQueue.size() == 0);
-      setupResend(false, cause);
+      setupResend(cause);
     } else {
       authLatch = new CountDownLatch(0);
     }

--- a/src/test/java/net/spy/memcached/MockMemcachedNode.java
+++ b/src/test/java/net/spy/memcached/MockMemcachedNode.java
@@ -70,7 +70,7 @@ public class MockMemcachedNode implements MemcachedNode {
     // noop
   }
 
-  public void setupResend(boolean cancelWrite, String cause) {
+  public void setupResend(String cause) {
     // noop
   }
 


### PR DESCRIPTION
Redistribute 옵션은 노드 구성이 변경되지 않는 고정된 클러스터 구조에서, 실패한 노드로 향하는 연산을 다른 담당 노드가 처리될 수 있게 하기 위해서 만들어진 옵션이다. ARCUS는 클러스터 구성이 유연하므로, 실패한 노드는 ZK로부터 클러스터에서 제거되므로 Operation을 재분배할 필요가 없다.

ArcusClient 사용시 redistribute failure mode를 사용하면 Exception을 던질 수 있도록 수정하였습니다.
또한 ARCUS 노드가 클러스터로부터 제거될 때 failure mode와 관계 없이 operation을 취소처리할 수 있도록 하였고, redistribute로 인한 resend시 inputQ 뿐만아니라 writeQ에 있는 operation도 함께 재분배될 수 있도록 수정하였습니다.

