### PR TITLE
CLEANUP: refactored bkey 

### DIFF
--- a/src/main/java/net/spy/memcached/ArcusClient.java
+++ b/src/main/java/net/spy/memcached/ArcusClient.java
@@ -1,7 +1,7 @@
 /*
  * arcus-java-client : Arcus Java client
  * Copyright 2010-2014 NAVER Corp.
- * Copyright 2014-2021 JaM2in Co., Ltd.
+ * Copyright 2014-2022 JaM2in Co., Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -1480,6 +1480,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
                                                                   ElementFlagFilter eFlagFilter,
                                                                   boolean withDelete,
                                                                   boolean dropIfEmpty) {
+    BTreeUtil.validateBkey(bkey);
     BTreeGet get = new BTreeGet(bkey, withDelete, dropIfEmpty, eFlagFilter);
     return asyncBopGet(key, get, false, collectionTranscoder);
   }
@@ -1491,6 +1492,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
                                                                   int offset, int count,
                                                                   boolean withDelete,
                                                                   boolean dropIfEmpty) {
+    BTreeUtil.validateBkey(from, to);
     BTreeGet get = new BTreeGet(from, to, offset, count, withDelete, dropIfEmpty, eFlagFilter);
     boolean reverse = from > to;
     return asyncBopGet(key, get, reverse, collectionTranscoder);
@@ -1503,6 +1505,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
                                                                  boolean withDelete,
                                                                  boolean dropIfEmpty,
                                                                  Transcoder<T> tc) {
+    BTreeUtil.validateBkey(bkey);
     BTreeGet get = new BTreeGet(bkey, withDelete, dropIfEmpty, eFlagFilter);
     return asyncBopGet(key, get, false, tc);
   }
@@ -1515,6 +1518,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
                                                                  boolean withDelete,
                                                                  boolean dropIfEmpty,
                                                                  Transcoder<T> tc) {
+    BTreeUtil.validateBkey(from, to);
     BTreeGet get = new BTreeGet(from, to, offset, count, withDelete, dropIfEmpty, eFlagFilter);
     boolean reverse = from > to;
     return asyncBopGet(key, get, reverse, tc);
@@ -1649,6 +1653,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
   public CollectionFuture<Boolean> asyncBopDelete(String key, long bkey,
                                                   ElementFlagFilter eFlagFilter,
                                                   boolean dropIfEmpty) {
+    BTreeUtil.validateBkey(bkey);
     BTreeDelete delete = new BTreeDelete(bkey, false, dropIfEmpty, eFlagFilter);
     return asyncCollectionDelete(key, delete);
   }
@@ -1658,6 +1663,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
                                                   long from, long to,
                                                   ElementFlagFilter eFlagFilter, int count,
                                                   boolean dropIfEmpty) {
+    BTreeUtil.validateBkey(from, to);
     BTreeDelete delete = new BTreeDelete(from, to, count, false, dropIfEmpty, eFlagFilter);
     return asyncCollectionDelete(key, delete);
   }
@@ -1764,6 +1770,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
   public CollectionFuture<Integer> asyncBopGetItemCount(String key,
                                                         long from, long to,
                                                         ElementFlagFilter eFlagFilter) {
+    BTreeUtil.validateBkey(from, to);
     CollectionCount collectionCount = new BTreeCount(from, to, eFlagFilter);
     return asyncCollectionCount(key, collectionCount);
   }
@@ -1772,6 +1779,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
   public CollectionFuture<Boolean> asyncBopInsert(String key, long bkey,
                                                   byte[] eFlag, Object value,
                                                   CollectionAttributes attributesForCreate) {
+    BTreeUtil.validateBkey(bkey);
     BTreeInsert<Object> bTreeInsert = new BTreeInsert<Object>(value,
             eFlag, (attributesForCreate != null), null, attributesForCreate);
     return asyncCollectionInsert(key, String.valueOf(bkey), bTreeInsert, collectionTranscoder);
@@ -1809,6 +1817,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
                                                       byte[] eFlag, T value,
                                                       CollectionAttributes attributesForCreate,
                                                       Transcoder<T> tc) {
+    BTreeUtil.validateBkey(bkey);
     BTreeInsert<T> bTreeInsert = new BTreeInsert<T>(value, eFlag,
             (attributesForCreate != null), null, attributesForCreate);
     return asyncCollectionInsert(key, String.valueOf(bkey), bTreeInsert, tc);
@@ -2583,11 +2592,11 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
                 // remove trimed keys whose bkeys are behind of the last element.
                 SMGetElement<T> lastElement = mergedResult.get(mergedResult.size() - 1);
                 SMGetTrimKey lastTrimKey = new SMGetTrimKey(lastElement.getKey(),
-                        lastElement.getBkeyByObject());
+                        lastElement.getBkeyObject());
                 for (int i = mergedTrimmedKeys.size() - 1; i >= 0; i--) {
                   SMGetTrimKey me = mergedTrimmedKeys.get(i);
-                  if ((reverse) ? (0 >= me.compareBkeyTo(lastTrimKey))
-                                : (0 <= me.compareBkeyTo(lastTrimKey))) {
+                  if ((reverse) ? (0 >= me.compareTo(lastTrimKey))
+                                : (0 <= me.compareTo(lastTrimKey))) {
                     mergedTrimmedKeys.remove(i);
                   } else {
                     break;
@@ -2729,6 +2738,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
                                                   byte[] elementFlag, Object value,
                                                   CollectionAttributes attributesForCreate) {
 
+    BTreeUtil.validateBkey(bkey);
     BTreeUpsert<Object> bTreeUpsert = new BTreeUpsert<Object>(value,
             elementFlag, (attributesForCreate != null), null, attributesForCreate);
 
@@ -2742,6 +2752,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
                                                       CollectionAttributes attributesForCreate,
                                                       Transcoder<T> tc) {
 
+    BTreeUtil.validateBkey(bkey);
     BTreeUpsert<T> bTreeUpsert = new BTreeUpsert<T>(value, elementFlag,
             (attributesForCreate != null), null, attributesForCreate);
 
@@ -2751,6 +2762,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
   @Override
   public CollectionFuture<Boolean> asyncBopUpdate(String key, long bkey,
                                                   ElementFlagUpdate eFlagUpdate, Object value) {
+    BTreeUtil.validateBkey(bkey);
     BTreeUpdate<Object> collectionUpdate = new BTreeUpdate<Object>(value, eFlagUpdate, false);
     return asyncCollectionUpdate(key, String.valueOf(bkey), collectionUpdate,
             collectionTranscoder);
@@ -2760,6 +2772,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
   public <T> CollectionFuture<Boolean> asyncBopUpdate(String key, long bkey,
                                                       ElementFlagUpdate eFlagUpdate, T value,
                                                       Transcoder<T> tc) {
+    BTreeUtil.validateBkey(bkey);
     BTreeUpdate<T> collectionUpdate = new BTreeUpdate<T>(value, eFlagUpdate, false);
     return asyncCollectionUpdate(key, String.valueOf(bkey), collectionUpdate, tc);
   }
@@ -3171,6 +3184,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
   @Override
   public CollectionFuture<Integer> asyncBopFindPosition(String key, long bkey,
                                                         BTreeOrder order) {
+    BTreeUtil.validateBkey(bkey);
     if (order == null) {
       throw new IllegalArgumentException("BTreeOrder must not be null.");
     }
@@ -3233,8 +3247,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
             break;
           case BKEY_MISMATCH:
             rv.set(null, cstatus);
-            getLogger().debug("Collection(%s) has wrong bkey : %s(%s)", k, cstatus,
-                    get.getBkeyObject().getType());
+            getLogger().debug("Collection(%s) has wrong bkey : %s", k, cstatus);
             break;
           case TYPE_MISMATCH:
             rv.set(null, cstatus);
@@ -3275,7 +3288,6 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
   @Override
   public CollectionFuture<Map<Integer, Element<Object>>> asyncBopFindPositionWithGet(
           String key, byte[] bkey, BTreeOrder order, int count) {
-    BTreeUtil.validateBkey(bkey);
     BTreeFindPositionWithGet get = new BTreeFindPositionWithGet(bkey, order, count);
     return asyncBopFindPositionWithGet(key, get, collectionTranscoder);
   }
@@ -3283,7 +3295,6 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
   @Override
   public <T> CollectionFuture<Map<Integer, Element<T>>> asyncBopFindPositionWithGet(
           String key, byte[] bkey, BTreeOrder order, int count, Transcoder<T> tc) {
-    BTreeUtil.validateBkey(bkey);
     BTreeFindPositionWithGet get = new BTreeFindPositionWithGet(bkey, order, count);
     return asyncBopFindPositionWithGet(key, get, tc);
   }
@@ -3396,7 +3407,6 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
   public BTreeStoreAndGetFuture<Boolean, Object> asyncBopInsertAndGetTrimmed(
           String key, byte[] bkey, byte[] eFlag, Object value,
           CollectionAttributes attributesForCreate) {
-    BTreeUtil.validateBkey(bkey);
     BTreeInsertAndGet<Object> insertAndGet = new BTreeInsertAndGet<Object>(
             BTreeInsertAndGet.Command.INSERT, bkey, eFlag, value, attributesForCreate);
     return asyncBTreeInsertAndGet(key, insertAndGet, collectionTranscoder);
@@ -3406,7 +3416,6 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
   public <E> BTreeStoreAndGetFuture<Boolean, E> asyncBopInsertAndGetTrimmed(
           String key, byte[] bkey, byte[] eFlag, E value,
           CollectionAttributes attributesForCreate, Transcoder<E> transcoder) {
-    BTreeUtil.validateBkey(bkey);
     BTreeInsertAndGet<E> insertAndGet = new BTreeInsertAndGet<E>(
             BTreeInsertAndGet.Command.INSERT, bkey, eFlag, value, attributesForCreate);
     return asyncBTreeInsertAndGet(key, insertAndGet, transcoder);
@@ -3434,7 +3443,6 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
   public BTreeStoreAndGetFuture<Boolean, Object> asyncBopUpsertAndGetTrimmed(
           String key, byte[] bkey, byte[] eFlag, Object value,
           CollectionAttributes attributesForCreate) {
-    BTreeUtil.validateBkey(bkey);
     BTreeInsertAndGet<Object> insertAndGet = new BTreeInsertAndGet<Object>(
             BTreeInsertAndGet.Command.UPSERT, bkey, eFlag, value, attributesForCreate);
     return asyncBTreeInsertAndGet(key, insertAndGet, collectionTranscoder);
@@ -3444,7 +3452,6 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
   public <E> BTreeStoreAndGetFuture<Boolean, E> asyncBopUpsertAndGetTrimmed(
           String key, byte[] bkey, byte[] eFlag, E value,
           CollectionAttributes attributesForCreate, Transcoder<E> transcoder) {
-    BTreeUtil.validateBkey(bkey);
     BTreeInsertAndGet<E> insertAndGet = new BTreeInsertAndGet<E>(
             BTreeInsertAndGet.Command.UPSERT, bkey, eFlag, value, attributesForCreate);
     return asyncBTreeInsertAndGet(key, insertAndGet, transcoder);
@@ -3931,7 +3938,6 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
   public Future<Map<String, CollectionOperationStatus>> asyncBopInsertBulk(
           List<String> keyList, long bkey, byte[] eFlag, Object value,
           CollectionAttributes attributesForCreate) {
-
     return asyncBopInsertBulk(keyList, bkey, eFlag, value,
             attributesForCreate, collectionTranscoder);
   }
@@ -3941,6 +3947,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
           List<String> keyList, long bkey, byte[] eFlag, T value,
           CollectionAttributes attributesForCreate, Transcoder<T> tc) {
 
+    BTreeUtil.validateBkey(bkey);
     Collection<Entry<MemcachedNode, List<String>>> arrangedKey =
             groupingKeys(keyList, NON_PIPED_BULK_INSERT_CHUNK_SIZE);
 
@@ -3959,8 +3966,6 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
   public Future<Map<String, CollectionOperationStatus>> asyncBopInsertBulk(
           List<String> keyList, byte[] bkey, byte[] eFlag, Object value,
           CollectionAttributes attributesForCreate) {
-
-    BTreeUtil.validateBkey(bkey);
     return asyncBopInsertBulk(keyList, bkey, eFlag, value,
             attributesForCreate, collectionTranscoder);
   }
@@ -4375,6 +4380,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
   @Override
   public CollectionFuture<Long> asyncBopIncr(String key, long bkey,
                                              int by) {
+    BTreeUtil.validateBkey(bkey);
     CollectionMutate collectionMutate = new BTreeMutate(Mutator.incr, by);
     return asyncCollectionMutate(key, String.valueOf(bkey), collectionMutate);
   }
@@ -4390,6 +4396,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
   @Override
   public CollectionFuture<Long> asyncBopIncr(String key, long bkey,
                                              int by, long initial, byte[] eFlag) {
+    BTreeUtil.validateBkey(bkey);
     CollectionMutate collectionMutate = new BTreeMutate(Mutator.incr, by, initial, eFlag);
     return asyncCollectionMutate(key, String.valueOf(bkey), collectionMutate);
   }
@@ -4405,6 +4412,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
   @Override
   public CollectionFuture<Long> asyncBopDecr(String key, long bkey,
                                              int by) {
+    BTreeUtil.validateBkey(bkey);
     CollectionMutate collectionMutate = new BTreeMutate(Mutator.decr, by);
     return asyncCollectionMutate(key, String.valueOf(bkey), collectionMutate);
   }
@@ -4420,6 +4428,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
   @Override
   public CollectionFuture<Long> asyncBopDecr(String key, long bkey,
                                              int by, long initial, byte[] eFlag) {
+    BTreeUtil.validateBkey(bkey);
     CollectionMutate collectionMutate = new BTreeMutate(Mutator.decr, by, initial, eFlag);
     return asyncCollectionMutate(key, String.valueOf(bkey), collectionMutate);
   }

--- a/src/main/java/net/spy/memcached/collection/BTreeFindPosition.java
+++ b/src/main/java/net/spy/memcached/collection/BTreeFindPosition.java
@@ -1,6 +1,7 @@
 /*
  * arcus-java-client : Arcus Java client
  * Copyright 2010-2014 NAVER Corp.
+ * Copyright 2014-2022 JaM2in Co., Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +17,8 @@
  */
 package net.spy.memcached.collection;
 
+import net.spy.memcached.util.BTreeUtil;
+
 /**
  * Ascii protocol implementation for "bop position" (B+Tree find position)
  *
@@ -29,17 +32,17 @@ public class BTreeFindPosition {
 
   private static final String command = "bop position";
 
-  private final BKeyObject bkeyObject;
+  private final String bkey;
   private final BTreeOrder order;
   private String str;
 
   public BTreeFindPosition(long longBKey, BTreeOrder order) {
-    this.bkeyObject = new BKeyObject(longBKey);
+    this.bkey = String.valueOf(longBKey);
     this.order = order;
   }
 
   public BTreeFindPosition(byte[] byteArrayBKey, BTreeOrder order) {
-    this.bkeyObject = new BKeyObject(byteArrayBKey);
+    this.bkey = BTreeUtil.toHex(byteArrayBKey);
     this.order = order;
   }
 
@@ -48,7 +51,7 @@ public class BTreeFindPosition {
       return str;
     }
     StringBuilder b = new StringBuilder();
-    b.append(bkeyObject.getBKeyAsString());
+    b.append(bkey);
     b.append(" ");
     b.append(order.getAscii());
 
@@ -58,10 +61,6 @@ public class BTreeFindPosition {
 
   public String getCommand() {
     return command;
-  }
-
-  public BKeyObject getBkeyObject() {
-    return bkeyObject;
   }
 
   public BTreeOrder getOrder() {

--- a/src/main/java/net/spy/memcached/collection/BTreeFindPositionWithGet.java
+++ b/src/main/java/net/spy/memcached/collection/BTreeFindPositionWithGet.java
@@ -1,6 +1,7 @@
 /*
  * arcus-java-client : Arcus Java client
  * Copyright 2014 JaM2in Co., Ltd.
+ * Copyright 2014-2022 JaM2in Co., Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -68,7 +69,7 @@ public class BTreeFindPositionWithGet extends CollectionGet {
   public String stringify() {
     if (str == null) {
       StringBuilder b = new StringBuilder();
-      b.append(bkeyObject.getBKeyAsString());
+      b.append(bkeyObject);
       b.append(" ");
       b.append(order.getAscii());
       if (count > 0) {
@@ -116,7 +117,7 @@ public class BTreeFindPositionWithGet extends CollectionGet {
 
     // <bkey>
     if (splited[0].startsWith("0x")) {
-      this.bkey = new BKeyObject(splited[0].substring(2));
+      this.bkey = new BKeyObject(BTreeUtil.hexStringToByteArrays(splited[0].substring(2)));
     } else {
       this.bkey = new BKeyObject(Long.parseLong(splited[0]));
     }

--- a/src/main/java/net/spy/memcached/collection/BTreeGetByPosition.java
+++ b/src/main/java/net/spy/memcached/collection/BTreeGetByPosition.java
@@ -1,6 +1,7 @@
 /*
  * arcus-java-client : Arcus Java client
  * Copyright 2010-2014 NAVER Corp.
+ * Copyright 2014-2022 JaM2in Co., Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -109,7 +110,7 @@ public class BTreeGetByPosition extends CollectionGet {
 
     // <bkey>
     if (splited[BKEY].startsWith("0x")) {
-      this.bkey = new BKeyObject(splited[0].substring(2));
+      this.bkey = new BKeyObject(BTreeUtil.hexStringToByteArrays(splited[0].substring(2)));
     } else {
       this.bkey = new BKeyObject(Long.parseLong(splited[0]));
     }

--- a/src/main/java/net/spy/memcached/collection/BTreeInsertAndGet.java
+++ b/src/main/java/net/spy/memcached/collection/BTreeInsertAndGet.java
@@ -1,6 +1,7 @@
 /*
  * arcus-java-client : Arcus Java client
  * Copyright 2010-2014 NAVER Corp.
+ * Copyright 2014-2022 JaM2in Co., Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -88,7 +89,7 @@ public class BTreeInsertAndGet<T> extends BTreeInsert<T> {
 
     // <bkey>
     if (splited[BKEY].startsWith("0x")) {
-      this.bkeyObject = new BKeyObject(splited[0].substring(2));
+      this.bkeyObject = new BKeyObject(BTreeUtil.hexStringToByteArrays(splited[0].substring(2)));
     } else {
       this.bkeyObject = new BKeyObject(Long.parseLong(splited[0]));
     }

--- a/src/main/java/net/spy/memcached/collection/BTreeSMGetWithByteTypeBkeyOld.java
+++ b/src/main/java/net/spy/memcached/collection/BTreeSMGetWithByteTypeBkeyOld.java
@@ -1,6 +1,7 @@
 /*
  * arcus-java-client : Arcus Java client
  * Copyright 2010-2014 NAVER Corp.
+ * Copyright 2014-2022 JaM2in Co., Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/spy/memcached/collection/BTreeSMGetWithLongTypeBkey.java
+++ b/src/main/java/net/spy/memcached/collection/BTreeSMGetWithLongTypeBkey.java
@@ -47,7 +47,7 @@ public class BTreeSMGetWithLongTypeBkey<T> implements BTreeSMGet<T> {
 
   private String key;
   private int flag;
-  private long subkey;
+  private Long subkey;
   private int dataLength;
 
   private byte[] eflag = null;

--- a/src/main/java/net/spy/memcached/collection/BTreeSMGetWithLongTypeBkeyOld.java
+++ b/src/main/java/net/spy/memcached/collection/BTreeSMGetWithLongTypeBkeyOld.java
@@ -1,6 +1,7 @@
 /*
  * arcus-java-client : Arcus Java client
  * Copyright 2010-2014 NAVER Corp.
+ * Copyright 2014-2021 JaM2in Co., Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -46,7 +47,7 @@ public class BTreeSMGetWithLongTypeBkeyOld<T> implements BTreeSMGet<T> {
 
   private String key;
   private int flag;
-  private long subkey;
+  private Long subkey;
   private int dataLength;
 
   private byte[] eflag = null;

--- a/src/main/java/net/spy/memcached/collection/ByteArrayBKey.java
+++ b/src/main/java/net/spy/memcached/collection/ByteArrayBKey.java
@@ -1,6 +1,7 @@
 /*
  * arcus-java-client : Arcus Java client
  * Copyright 2010-2014 NAVER Corp.
+ * Copyright 2014-2022 JaM2in Co., Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -36,6 +37,7 @@ public class ByteArrayBKey implements Comparable<ByteArrayBKey> {
   private final byte[] bkey;
 
   public ByteArrayBKey(byte[] bkey) {
+    BTreeUtil.validateBkey(bkey);
     this.bkey = bkey;
   }
 

--- a/src/main/java/net/spy/memcached/collection/Element.java
+++ b/src/main/java/net/spy/memcached/collection/Element.java
@@ -1,6 +1,7 @@
 /*
  * arcus-java-client : Arcus Java client
  * Copyright 2010-2014 NAVER Corp.
+ * Copyright 2014-2022 JaM2in Co., Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,13 +25,10 @@ import net.spy.memcached.util.BTreeUtil;
  * @param <T> the expected class of the value
  */
 public class Element<T> {
-  private final byte[] bkey;
-  private final Long longBkey;
+  private BKeyObject bKeyObject;
   private final T value;
   private final byte[] eflag;
   private final ElementFlagUpdate elementFlagUpdate;
-
-  private final boolean isByteArraysBkey;
 
   /**
    * Create an element
@@ -40,38 +38,30 @@ public class Element<T> {
    * @param eflag flag of element (minimun length is 1. maximum length is 31)
    */
   public Element(byte[] bkey, T value, byte[] eflag) {
-    this.bkey = bkey;
-    this.longBkey = null;
+    this.bKeyObject = new BKeyObject(bkey);
     this.value = value;
     this.eflag = eflag;
-    this.isByteArraysBkey = true;
     this.elementFlagUpdate = null;
   }
 
   public Element(long bkey, T value, byte[] eflag) {
-    this.bkey = null;
-    this.longBkey = bkey;
+    this.bKeyObject = new BKeyObject(bkey);
     this.value = value;
     this.eflag = eflag;
-    this.isByteArraysBkey = false;
     this.elementFlagUpdate = null;
   }
 
   public Element(byte[] bkey, T value, ElementFlagUpdate elementFlagUpdate) {
-    this.bkey = bkey;
-    this.longBkey = null;
+    this.bKeyObject = new BKeyObject(bkey);
     this.value = value;
     this.eflag = null;
-    this.isByteArraysBkey = true;
     this.elementFlagUpdate = elementFlagUpdate;
   }
 
   public Element(long bkey, T value, ElementFlagUpdate elementFlagUpdate) {
-    this.bkey = null;
-    this.longBkey = bkey;
+    this.bKeyObject = new BKeyObject(bkey);
     this.value = value;
     this.eflag = null;
-    this.isByteArraysBkey = false;
     this.elementFlagUpdate = elementFlagUpdate;
   }
 
@@ -92,37 +82,19 @@ public class Element<T> {
   /**
    * get bkey
    *
-   * @return bkey by hex (e.g. 0x01)
-   */
-  private String getStringByteArrayBkey() {
-    return BTreeUtil.toHex(bkey);
-  }
-
-  /**
-   * get bkey
-   *
    * @return bkey by byte[]
    */
   public byte[] getByteArrayBkey() {
-    return bkey;
+    return bKeyObject.getByteArrayBKeyRaw();
   }
 
   /**
    * get bkey
    *
-   * @return bkey by string (-1 if not available)
-   */
-  private String getStringLongBkey() {
-    return String.valueOf(getLongBkey());
-  }
-
-  /**
-   * get bkey
-   *
-   * @return bkey (-1 if not available)
+   * @return bkey
    */
   public long getLongBkey() {
-    return (longBkey == null) ? -1 : longBkey;
+    return bKeyObject.getLongBKey();
   }
 
   /**
@@ -130,7 +102,7 @@ public class Element<T> {
    * @return type of hex byte bkey or type of String Long bkey
    */
   public String getStringBkey() {
-    return isByteArraysBkey ? getStringByteArrayBkey() : getStringLongBkey();
+    return bKeyObject.toString();
   }
 
   /**

--- a/src/main/java/net/spy/memcached/collection/SMGetElement.java
+++ b/src/main/java/net/spy/memcached/collection/SMGetElement.java
@@ -1,6 +1,7 @@
 /*
  * arcus-java-client : Arcus Java client
  * Copyright 2010-2014 NAVER Corp.
+ * Copyright 2014-2022 JaM2in Co., Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,47 +17,35 @@
  */
 package net.spy.memcached.collection;
 
-import net.spy.memcached.util.BTreeUtil;
-
 public class SMGetElement<T> implements Comparable<SMGetElement<T>> {
 
   private String key;
-  private long bkey;
-  private byte[] bytebkey;
+  private BKeyObject bKeyObject;
   private T value;
 
   public SMGetElement(String key, long bkey, T value) {
     this.key = key;
-    this.bkey = bkey;
-    this.bytebkey = null;
+    this.bKeyObject = new BKeyObject(bkey);
     this.value = value;
   }
 
   public SMGetElement(String key, byte[] bkey, T value) {
     this.key = key;
-    this.bkey = -1;
-    this.bytebkey = bkey;
+    this.bKeyObject = new BKeyObject(bkey);
     this.value = value;
   }
 
   @Override
   public String toString() {
-    return "SMGetElement {KEY:" + key + ", BKEY:"
-            + ((bytebkey == null) ? String.valueOf(bkey) : BTreeUtil.toHex(bytebkey))
-            + ", VALUE:" + value + "}";
+    return "SMGetElement {KEY:" + key + ", BKEY:" + bKeyObject + ", VALUE:" + value + "}";
   }
 
   @Override
   public int compareTo(SMGetElement<T> param) {
     assert param != null;
 
-    int comp;
-        /* compare bkey */
-    if (bytebkey == null) {
-      comp = Long.valueOf(bkey).compareTo(param.getBkey());
-    } else {
-      comp = BTreeUtil.compareByteArraysInLexOrder(bytebkey, param.getByteBkey());
-    }
+    /* compare bkey */
+    int comp = bKeyObject.compareTo(param.bKeyObject);
 
     /* if bkey is equal, then compare key */
     if (comp == 0) {
@@ -70,11 +59,7 @@ public class SMGetElement<T> implements Comparable<SMGetElement<T>> {
     assert param != null;
 
     /* compare bkey */
-    if (bytebkey == null) {
-      return Long.valueOf(bkey).compareTo(param.getBkey());
-    } else {
-      return BTreeUtil.compareByteArraysInLexOrder(bytebkey, param.getByteBkey());
-    }
+    return bKeyObject.compareTo(param.bKeyObject);
   }
 
   public int compareKeyTo(SMGetElement<T> param) {
@@ -88,46 +73,19 @@ public class SMGetElement<T> implements Comparable<SMGetElement<T>> {
     return key;
   }
 
-  public void setKey(String key) {
-    this.key = key;
-  }
-
   public long getBkey() {
-    if (bkey == -1) {
-      throw new IllegalStateException("This element has byte[] bkey. " + toString());
-    }
-    return bkey;
+    return bKeyObject.getLongBKey();
   }
 
   public byte[] getByteBkey() {
-    if (bytebkey == null) {
-      throw new IllegalStateException(
-              "This element has java.lang.Long type bkey. " + toString());
-    }
-    return bytebkey;
+    return bKeyObject.getByteArrayBKeyRaw();
   }
 
-  public Object getBkeyByObject() {
-    if (bytebkey != null) {
-      return bytebkey;
-    } else {
-      return bkey;
-    }
-  }
-
-  public void setBkey(long bkey) {
-    this.bkey = bkey;
+  public BKeyObject getBkeyObject() {
+    return bKeyObject;
   }
 
   public T getValue() {
     return value;
-  }
-
-  public void setValue(T value) {
-    this.value = value;
-  }
-
-  public boolean hasByteArrayBkey() {
-    return bytebkey != null;
   }
 }

--- a/src/main/java/net/spy/memcached/collection/SMGetTrimKey.java
+++ b/src/main/java/net/spy/memcached/collection/SMGetTrimKey.java
@@ -1,6 +1,7 @@
 /*
  * arcus-java-client : Arcus Java client
  * Copyright 2010-2014 NAVER Corp.
+ * Copyright 2014-2022 JaM2in Co., Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,42 +17,36 @@
  */
 package net.spy.memcached.collection;
 
-import net.spy.memcached.util.BTreeUtil;
-
 public class SMGetTrimKey implements Comparable<SMGetTrimKey> {
   private String key;
-  private long bkey;
-  private byte[] bytebkey;
+  private BKeyObject bKeyObject;
 
-  public SMGetTrimKey(String key, Object bkey) {
+  public SMGetTrimKey(String key, byte[] bkey) {
     this.key = key;
-    if (bkey instanceof byte[]) {
-      this.bytebkey = new ByteArrayBKey((byte[]) bkey).getBytes();
-      this.bkey = -1;
-    } else {
-      this.bkey = (Long) bkey;
-      this.bytebkey = null;
-    }
+    this.bKeyObject = new BKeyObject(bkey);
+  }
 
+  public SMGetTrimKey(String key, long bkey) {
+    this.key = key;
+    this.bKeyObject = new BKeyObject(bkey);
+  }
+
+  public SMGetTrimKey(String key, BKeyObject bkeyObject) {
+    this.key = key;
+    this.bKeyObject = bkeyObject;
   }
 
   @Override
   public String toString() {
-    return "SMGetElement {KEY:" + key + ", BKEY:"
-            + ((bytebkey == null) ? String.valueOf(bkey) : BTreeUtil.toHex(bytebkey)) + "}";
+    return "SMGetElement {KEY:" + key + ", BKEY:" + bKeyObject + "}";
   }
 
   @Override
   public int compareTo(SMGetTrimKey param) {
     assert param != null;
 
-    int comp;
-        /* compare bkey */
-    if (bytebkey == null) {
-      comp = Long.valueOf(bkey).compareTo(param.getBkey());
-    } else {
-      comp = BTreeUtil.compareByteArraysInLexOrder(bytebkey, param.getByteBkey());
-    }
+    /* compare bkey */
+    int comp = bKeyObject.compareTo(param.bKeyObject);
 
     /* if bkey is equal, then compare key */
     if (comp == 0) {
@@ -61,53 +56,16 @@ public class SMGetTrimKey implements Comparable<SMGetTrimKey> {
     return comp;
   }
 
-  public int compareBkeyTo(SMGetTrimKey param) {
-    assert param != null;
-
-    /* compare bkey */
-    if (bytebkey == null) {
-      return Long.valueOf(bkey).compareTo(param.getBkey());
-    } else {
-      return BTreeUtil.compareByteArraysInLexOrder(bytebkey, param.getByteBkey());
-    }
-  }
-
   public String getKey() {
     return key;
   }
 
-  public void setKey(String key) {
-    this.key = key;
-  }
-
   public long getBkey() {
-    if (bkey == -1) {
-      throw new IllegalStateException("This element has byte[] bkey. " + toString());
-    }
-    return bkey;
+    return bKeyObject.getLongBKey();
   }
 
   public byte[] getByteBkey() {
-    if (bytebkey == null) {
-      throw new IllegalStateException(
-              "This element has java.lang.Long type bkey. " + toString());
-    }
-    return bytebkey;
+    return bKeyObject.getByteArrayBKeyRaw();
   }
 
-  public Object getBkeyByObject() {
-    if (bytebkey != null) {
-      return bytebkey;
-    } else {
-      return bkey;
-    }
-  }
-
-  public void setBkey(long bkey) {
-    this.bkey = bkey;
-  }
-
-  public boolean hasByteArrayBkey() {
-    return bytebkey != null;
-  }
 }

--- a/src/main/java/net/spy/memcached/protocol/ascii/BTreeInsertAndGetOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/BTreeInsertAndGetOperationImpl.java
@@ -1,7 +1,7 @@
 /*
  * arcus-java-client : Arcus Java client
  * Copyright 2010-2014 NAVER Corp.
- * Copyright 2014-2021 JaM2in Co., Ltd.
+ * Copyright 2014-2022 JaM2in Co., Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -275,11 +275,11 @@ public class BTreeInsertAndGetOperationImpl extends OperationImpl implements
     String args = get.stringify();
     ByteBuffer bb = ByteBuffer.allocate(dataToStore.length
             + KeyUtil.getKeyBytes(key).length
-            + KeyUtil.getKeyBytes(get.getBkeyObject().getBKeyAsString()).length
+            + KeyUtil.getKeyBytes(get.getBkeyObject().toString()).length
             + KeyUtil.getKeyBytes(get.getElementFlagByHex()).length
             + args.length()
             + OVERHEAD);
-    setArguments(bb, get.getCommand(), key, get.getBkeyObject().getBKeyAsString(),
+    setArguments(bb, get.getCommand(), key, get.getBkeyObject().toString(),
             get.getElementFlagByHex(), dataToStore.length, args);
     bb.put(dataToStore);
     bb.put(CRLF);

--- a/src/main/java/net/spy/memcached/util/BTreeUtil.java
+++ b/src/main/java/net/spy/memcached/util/BTreeUtil.java
@@ -1,6 +1,7 @@
 /*
  * arcus-java-client : Arcus Java client
  * Copyright 2010-2014 NAVER Corp.
+ * Copyright 2014-2022 JaM2in Co., Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -83,8 +84,20 @@ public final class BTreeUtil {
 
   public static void validateBkey(byte[] ...bkeys) {
     for (byte[] bkey : bkeys) {
+      if (bkey == null) {
+        throw new IllegalArgumentException("bkey is null");
+      }
       if (bkey.length > MAX_BKEY_BYTE_ARRAY_SIZE) {
         throw new IllegalArgumentException("bkey size exceeded 31");
+      }
+    }
+  }
+
+  public static void validateBkey(long ...bkeys) {
+    for (long bkey : bkeys) {
+      if (bkey < 0) {
+        throw new IllegalArgumentException(
+                String.format("not supported unsigned long bkey : %s, use byte array bkey", bkey));
       }
     }
   }

--- a/src/test/java/net/spy/memcached/util/BTreeUtilTest.java
+++ b/src/test/java/net/spy/memcached/util/BTreeUtilTest.java
@@ -89,4 +89,14 @@ public class BTreeUtilTest extends BaseMockCase {
       }
     });
   }
+
+  public void testMinusLongBkey() {
+    final long bkey = -1;
+    assertThrows(IllegalArgumentException.class, new ThrowingRunnable() {
+      @Override
+      public void run() throws Throwable {
+        BTreeUtil.validateBkey(bkey);
+      }
+    });
+  }
 }

--- a/src/test/manual/net/spy/memcached/collection/attribute/MaxBkeyRangeTest.java
+++ b/src/test/manual/net/spy/memcached/collection/attribute/MaxBkeyRangeTest.java
@@ -25,6 +25,9 @@ import net.spy.memcached.collection.CollectionAttributes;
 import net.spy.memcached.collection.Element;
 import net.spy.memcached.collection.ElementFlagFilter;
 import net.spy.memcached.collection.ElementValueType;
+import org.junit.function.ThrowingRunnable;
+
+import static org.junit.Assert.assertThrows;
 
 public class MaxBkeyRangeTest extends BaseIntegrationTest {
 
@@ -59,18 +62,28 @@ public class MaxBkeyRangeTest extends BaseIntegrationTest {
               attribute).get());
 
       // get current maxbkeyrange
-      CollectionAttributes btreeAttrs = mc.asyncGetAttr(KEY).get();
-      Assert.assertNull(btreeAttrs.getMaxBkeyRangeByBytes());
-      Assert.assertEquals(new Long(0), btreeAttrs.getMaxBkeyRange());
+      final CollectionAttributes btreeAttrs = mc.asyncGetAttr(KEY).get();
+      assertThrows(IllegalStateException.class, new ThrowingRunnable() {
+        @Override
+        public void run() throws Throwable {
+          btreeAttrs.getMaxBkeyRangeByBytes();
+        }
+      });
+      Assert.assertEquals(Long.valueOf(0), btreeAttrs.getMaxBkeyRange());
 
       // change maxbkeyrange
       attribute.setMaxBkeyRange(2L);
       Assert.assertTrue(mc.asyncSetAttr(KEY, attribute).get());
 
       // get current maxbkeyrange
-      CollectionAttributes changedBtreeAttrs = mc.asyncGetAttr(KEY).get();
-      Assert.assertNull(btreeAttrs.getMaxBkeyRangeByBytes());
-      Assert.assertEquals(new Long(2),
+      final CollectionAttributes changedBtreeAttrs = mc.asyncGetAttr(KEY).get();
+      assertThrows(IllegalStateException.class, new ThrowingRunnable() {
+        @Override
+        public void run() throws Throwable {
+          changedBtreeAttrs.getMaxBkeyRangeByBytes();
+        }
+      });
+      Assert.assertEquals(Long.valueOf(2),
               changedBtreeAttrs.getMaxBkeyRange());
 
       // insert bkey
@@ -125,7 +138,7 @@ public class MaxBkeyRangeTest extends BaseIntegrationTest {
 
       // get current maxbkeyrange
       CollectionAttributes btreeAttrs = mc.asyncGetAttr(KEY).get();
-      Assert.assertNull(btreeAttrs.getMaxBkeyRangeByBytes());
+      Assert.assertEquals(Long.valueOf(0), btreeAttrs.getMaxBkeyRange());
 
       // change maxbkeyrange
       attribute.setMaxBkeyRangeByBytes(new byte[]{(byte) 2});

--- a/src/test/manual/net/spy/memcached/collection/btree/BKeyObjectTest.java
+++ b/src/test/manual/net/spy/memcached/collection/btree/BKeyObjectTest.java
@@ -1,0 +1,88 @@
+package net.spy.memcached.collection.btree;
+
+import net.spy.memcached.collection.BKeyObject;
+import net.spy.memcached.util.BTreeUtil;
+import org.junit.Test;
+import org.junit.function.ThrowingRunnable;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
+public class BKeyObjectTest {
+
+  public final static long longBkey = 1;
+  public final static byte[] byteArrayBkey = {0x35};
+
+  @Test
+  public void createLongBkey() {
+    final BKeyObject bKeyObject = new BKeyObject(longBkey);
+
+    assertEquals(longBkey, (long) bKeyObject.getLongBKey());
+    assertTrue(bKeyObject.isLong());
+    assertEquals(String.valueOf(longBkey), bKeyObject.toString());
+    assertEquals(BKeyObject.BKeyType.LONG, bKeyObject.getType());
+    assertFalse(bKeyObject.isByteArray());
+    assertThrows(IllegalStateException.class, new ThrowingRunnable() {
+      @Override
+      public void run() throws Throwable {
+        bKeyObject.getByteArrayBKeyRaw();
+      }
+    });
+    assertThrows(IllegalStateException.class, new ThrowingRunnable() {
+      @Override
+      public void run() throws Throwable {
+        bKeyObject.getByteArrayBKey();
+      }
+    });
+  }
+
+  @Test
+  public void createByteArrayBkey() {
+    final BKeyObject bKeyObject = new BKeyObject(byteArrayBkey);
+
+    assertEquals(byteArrayBkey, bKeyObject.getByteArrayBKeyRaw());
+    assertTrue(bKeyObject.isByteArray());
+    assertEquals(BTreeUtil.toHex(byteArrayBkey), bKeyObject.toString());
+    assertEquals(BKeyObject.BKeyType.BYTEARRAY, bKeyObject.getType());
+    assertFalse(bKeyObject.isLong());
+    assertThrows(IllegalStateException.class, new ThrowingRunnable() {
+      @Override
+      public void run() throws Throwable {
+        bKeyObject.getLongBKey();
+      }
+    });
+  }
+
+  @Test
+  public void compareLongBkeyTest() {
+    BKeyObject bKeyObject = new BKeyObject(longBkey);
+    BKeyObject another = new BKeyObject(longBkey);
+
+    assertEquals(0, bKeyObject.compareTo(another));
+  }
+
+  @Test
+  public void compareByteArrayBkeyTest() {
+    BKeyObject bKeyObject = new BKeyObject(byteArrayBkey);
+    BKeyObject another = new BKeyObject(byteArrayBkey);
+
+    assertEquals(0, bKeyObject.compareTo(another));
+  }
+
+  @Test
+  public void compareDifferentTypeTest() {
+    final BKeyObject bKeyObject = new BKeyObject(longBkey);
+    final BKeyObject another = new BKeyObject(byteArrayBkey);
+
+    assertThrows(IllegalArgumentException.class, new ThrowingRunnable() {
+      @Override
+      public void run() throws Throwable {
+        bKeyObject.compareTo(another);
+      }
+    });
+  }
+
+
+}

--- a/src/test/manual/net/spy/memcached/collection/btree/ElementTest.java
+++ b/src/test/manual/net/spy/memcached/collection/btree/ElementTest.java
@@ -1,0 +1,109 @@
+package net.spy.memcached.collection.btree;
+
+import net.spy.memcached.collection.Element;
+import net.spy.memcached.collection.ElementFlagUpdate;
+import net.spy.memcached.util.BTreeUtil;
+import org.junit.Test;
+import org.junit.function.ThrowingRunnable;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
+
+public class ElementTest {
+
+  private static final String VALUE = "testValue";
+
+  @Test
+  public void createWithLongBkeyAndEFlag() {
+    //given
+    long bkey = 1;
+    byte[] eflag = {0x34};
+
+    final Element<String> element = new Element<String>(bkey, VALUE, eflag);
+
+    //when, then
+    assertEquals(bkey, element.getLongBkey());
+    assertEquals(String.valueOf(bkey), element.getStringBkey());
+    assertThrows(IllegalStateException.class, new ThrowingRunnable() {
+      @Override
+      public void run() throws Throwable {
+        element.getByteArrayBkey();
+      }
+    });
+    assertEquals(VALUE, element.getValue());
+    assertEquals(eflag, element.getEFlag());
+    assertEquals(BTreeUtil.toHex(eflag), element.getStringEFlag());
+    assertNull(element.getElementFlagUpdate());
+  }
+
+  @Test
+  public void createWithByteArrayBkeyAndEFlag() {
+    //given
+    byte[] bkey = {0x3F};
+    byte[] eflag = {0x34};
+
+    final Element<String> element = new Element<String>(bkey, VALUE, eflag);
+
+    //when, then
+    assertEquals(bkey, element.getByteArrayBkey());
+    assertEquals(BTreeUtil.toHex(bkey), element.getStringBkey());
+    assertThrows(IllegalStateException.class, new ThrowingRunnable() {
+      @Override
+      public void run() throws Throwable {
+        element.getLongBkey();
+      }
+    });
+    assertEquals(VALUE, element.getValue());
+    assertEquals(eflag, element.getEFlag());
+    assertEquals(BTreeUtil.toHex(eflag), element.getStringEFlag());
+    assertNull(element.getElementFlagUpdate());
+  }
+
+  @Test
+  public void createWithLongBkeyAndElementFlagUpdate() {
+    //given
+    long bkey = 1;
+    byte[] eflag = {0x34};
+    ElementFlagUpdate elementFlagUpdate = new ElementFlagUpdate(eflag);
+
+    final Element<String> element = new Element<String>(bkey, VALUE, elementFlagUpdate);
+
+    //when, then
+    assertEquals(bkey, element.getLongBkey());
+    assertThrows(IllegalStateException.class, new ThrowingRunnable() {
+      @Override
+      public void run() throws Throwable {
+        element.getByteArrayBkey();
+      }
+    });
+    assertEquals(VALUE, element.getValue());
+    assertNull(element.getEFlag());
+    assertEquals("", element.getStringEFlag());
+    assertEquals(elementFlagUpdate, element.getElementFlagUpdate());
+  }
+
+  @Test
+  public void createWithByteArrayBkeyAndElementFlagUpdate() {
+    //given
+    byte[] bkey = {0x3F};
+    byte[] eflag = {0x34};
+    ElementFlagUpdate elementFlagUpdate = new ElementFlagUpdate(eflag);
+
+    final Element<String> element = new Element<String>(bkey, VALUE, elementFlagUpdate);
+
+    //when, then
+    assertEquals(bkey, element.getByteArrayBkey());
+    assertThrows(IllegalStateException.class, new ThrowingRunnable() {
+      @Override
+      public void run() throws Throwable {
+        element.getLongBkey();
+      }
+    });
+    assertEquals(VALUE, element.getValue());
+    assertNull(element.getEFlag());
+    assertEquals("", element.getStringEFlag());
+    assertEquals(elementFlagUpdate, element.getElementFlagUpdate());
+  }
+
+}

--- a/src/test/manual/net/spy/memcached/collection/btree/SMGetElementTest.java
+++ b/src/test/manual/net/spy/memcached/collection/btree/SMGetElementTest.java
@@ -1,0 +1,79 @@
+package net.spy.memcached.collection.btree;
+
+import net.spy.memcached.collection.SMGetElement;
+import org.junit.Test;
+import org.junit.function.ThrowingRunnable;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
+public class SMGetElementTest {
+
+  private static final String KEY = "test";
+  private static final String VALUE = "testValue";
+
+  @Test
+  public void createWithLongBkey() {
+    //given
+    long bkey = 1;
+
+    final SMGetElement<String> element = new SMGetElement<String>(KEY, bkey, VALUE);
+
+    //when, then
+    assertEquals(KEY, element.getKey());
+    assertEquals(bkey, element.getBkey());
+    assertThrows(IllegalStateException.class, new ThrowingRunnable() {
+      @Override
+      public void run() throws Throwable {
+        element.getByteBkey();
+      }
+    });
+    assertEquals(VALUE, element.getValue());
+  }
+
+  @Test
+  public void createWithByteArrayBkey() {
+    //given
+    byte[] bkey = {0x34};
+
+    final SMGetElement<String> element = new SMGetElement<String>(KEY, bkey, VALUE);
+
+    //when, then
+    assertEquals(KEY, element.getKey());
+    assertEquals(bkey, element.getByteBkey());
+    assertThrows(IllegalStateException.class, new ThrowingRunnable() {
+      @Override
+      public void run() throws Throwable {
+        element.getBkey();
+      }
+    });
+    assertEquals(VALUE, element.getValue());
+  }
+
+  @Test
+  public void compareToTest() {
+    //given
+    long bkey = 2;
+
+    SMGetElement<String> element = new SMGetElement<String>(KEY, bkey, VALUE);
+    SMGetElement<String> anotherElement = new SMGetElement<String>(KEY, bkey, VALUE);
+
+    //when, then
+    assertEquals(0, element.compareTo(anotherElement));
+  }
+
+  @Test
+  public void compareBkeyToTest() {
+    //given
+    long bkey = 2;
+    long anotherBkey = 1;
+
+    SMGetElement<String> element = new SMGetElement<String>(KEY, bkey, VALUE);
+    SMGetElement<String> anotherElement = new SMGetElement<String>(KEY, anotherBkey, VALUE);
+
+    //when, then
+    assertTrue(element.compareBkeyTo(anotherElement) > 0);
+  }
+
+}

--- a/src/test/manual/net/spy/memcached/collection/btree/SMGetTrimKeyTest.java
+++ b/src/test/manual/net/spy/memcached/collection/btree/SMGetTrimKeyTest.java
@@ -1,0 +1,59 @@
+package net.spy.memcached.collection.btree;
+
+import net.spy.memcached.collection.SMGetTrimKey;
+import org.junit.Test;
+import org.junit.function.ThrowingRunnable;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+
+public class SMGetTrimKeyTest {
+
+  private static final String KEY = "test";
+
+  @Test
+  public void createWithLongBkey() {
+    //given
+    long bkey = 1;
+    final SMGetTrimKey trimKey = new SMGetTrimKey(KEY, bkey);
+
+    //when, then
+    assertEquals(KEY, trimKey.getKey());
+    assertEquals(bkey, trimKey.getBkey());
+    assertThrows(IllegalStateException.class, new ThrowingRunnable() {
+      @Override
+      public void run() throws Throwable {
+        trimKey.getByteBkey();
+      }
+    });
+  }
+
+  @Test
+  public void createWithByteArrayBkey() {
+    //given
+    byte[] bkey = {0x34};
+    final SMGetTrimKey trimKey = new SMGetTrimKey(KEY, bkey);
+
+    //when, then
+    assertEquals(KEY, trimKey.getKey());
+    assertEquals(bkey, trimKey.getByteBkey());
+    assertThrows(IllegalStateException.class, new ThrowingRunnable() {
+      @Override
+      public void run() throws Throwable {
+        trimKey.getBkey();
+      }
+    });
+  }
+
+  @Test
+  public void compareToTest() {
+    //given
+    long bkey = 2;
+
+    SMGetTrimKey trimKey = new SMGetTrimKey(KEY, bkey);
+    SMGetTrimKey anotherTrimKey = new SMGetTrimKey(KEY, bkey);
+
+    //when, then
+    assertEquals(0, trimKey.compareTo(anotherTrimKey));
+  }
+}


### PR DESCRIPTION
issue : #335 , #419 

변경 지점이 많아 각 주제별로 commit을 나눠 두었습니다.

1. long primitive type -> Long wrapper class로 변경
2. long type과 byte array type 혼합 사용 field BkeyObject로 통합, 테스트 코드 추가
3. long bkey의 음수 사용 제한을 위해 API 수준 및 Bkeyobject에 validation 로직 추가, 테스트 코드 추가
    - API 수준 변경
       - BTreeCreate, BTreeGet, BTreeInsert, BTreeUpdate BTreeUpsert, BTreeDelete, BTreeCount,  BTreeMutate
    - Class 내에 BkeyObject를 field로 가지고 있는 API 들은 따로 API에 validation 로직을 추가하지 않았습니다.
   

     