### PR TITLE
CLEANUP: separate constructor for searching condition

### DIFF
--- a/src/main/java/net/spy/memcached/collection/BTreeGetBulkImpl.java
+++ b/src/main/java/net/spy/memcached/collection/BTreeGetBulkImpl.java
@@ -69,11 +69,24 @@ public abstract class BTreeGetBulkImpl<T> implements BTreeGetBulk<T> {
                              int count) {
     this.node = node;
     this.keyList = keyList;
-    this.range = String.valueOf(from) + ((to > -1) ? ".." + String.valueOf(to) : "");
+    this.range = String.valueOf(from) + ".." + String.valueOf(to);
     this.eFlagFilter = eFlagFilter;
     this.offset = offset;
     this.count = count;
     this.reverse = (from > to);
+  }
+
+  protected BTreeGetBulkImpl(MemcachedNode node, List<String> keyList,
+                             long bkey,
+                             ElementFlagFilter eFlagFilter, int offset,
+                             int count) {
+    this.node = node;
+    this.keyList = keyList;
+    this.range = String.valueOf(bkey);
+    this.eFlagFilter = eFlagFilter;
+    this.offset = offset;
+    this.count = count;
+    this.reverse = false;
   }
 
   public void setKeySeparator(String keySeparator) {

--- a/src/main/java/net/spy/memcached/collection/BTreeSMGetWithLongTypeBkey.java
+++ b/src/main/java/net/spy/memcached/collection/BTreeSMGetWithLongTypeBkey.java
@@ -61,13 +61,24 @@ public class BTreeSMGetWithLongTypeBkey<T> implements BTreeSMGet<T> {
                                     SMGetMode smgetMode) {
     this.node = node;
     this.keyList = keyList;
-
-    this.range = String.valueOf(from) + ((to > -1) ? ".." + String.valueOf(to) : "");
-
+    this.range = String.valueOf(from) + ".." + String.valueOf(to);
     this.eFlagFilter = eFlagFilter;
     this.count = count;
     this.smgetMode = smgetMode;
     this.reverse = (from > to);
+  }
+
+  public BTreeSMGetWithLongTypeBkey(MemcachedNode node, List<String> keyList,
+                                    long bkey,
+                                    ElementFlagFilter eFlagFilter, int count,
+                                    SMGetMode smgetMode) {
+    this.node = node;
+    this.keyList = keyList;
+    this.range = String.valueOf(bkey);
+    this.eFlagFilter = eFlagFilter;
+    this.count = count;
+    this.smgetMode = smgetMode;
+    this.reverse = false;
   }
 
   public void setKeySeparator(String keySeparator) {

--- a/src/main/java/net/spy/memcached/collection/BTreeSMGetWithLongTypeBkeyOld.java
+++ b/src/main/java/net/spy/memcached/collection/BTreeSMGetWithLongTypeBkeyOld.java
@@ -60,13 +60,24 @@ public class BTreeSMGetWithLongTypeBkeyOld<T> implements BTreeSMGet<T> {
                                        int offset, int count) {
     this.node = node;
     this.keyList = keyList;
-
-    this.range = String.valueOf(from) + ((to > -1) ? ".." + String.valueOf(to) : "");
-
+    this.range = String.valueOf(from) + ".." + String.valueOf(to);
     this.eFlagFilter = eFlagFilter;
     this.offset = offset;
     this.count = count;
     this.reverse = (from > to);
+  }
+
+  public BTreeSMGetWithLongTypeBkeyOld(MemcachedNode node,
+                                       List<String> keyList, long bkey,
+                                       ElementFlagFilter eFlagFilter,
+                                       int offset, int count) {
+    this.node = node;
+    this.keyList = keyList;
+    this.range = String.valueOf(bkey);
+    this.eFlagFilter = eFlagFilter;
+    this.offset = offset;
+    this.count = count;
+    this.reverse = false;
   }
 
   public void setKeySeparator(String keySeparator) {


### PR DESCRIPTION
#409 관련 pr입니다.

1. single bkey일 경우엔 bkey 변수 하나에만 설정
2. from, to 2개의 bkey 를 통해 range를 설정

하도록 생성자를 분리 하였습니다.

이전의 코드를 보면 bkey 하나만을 사용하는(to < 0) 경우가 있는데, 실제 사용하는 api 상에서는
from, to를 사용하여 range를 나타내고 있습니다.

내부에서 한개의 bkey를 사용하는 코드가 구현 되있는것 으로 보아 1개의 bkey를 사용하는 경우도 있는 것 같아 일단 생성자를 추가하였습니다.