### PR TITLE
FEATURE: delayed switchover task from switchover event of zookeeper

### DIFF
--- a/src/main/java/net/spy/memcached/MemcachedNode.java
+++ b/src/main/java/net/spy/memcached/MemcachedNode.java
@@ -1,6 +1,7 @@
 /*
  * arcus-java-client : Arcus Java client
  * Copyright 2010-2014 NAVER Corp.
+ * Copyright 2014-2022 JaM2in Co., Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -289,6 +290,8 @@ public interface MemcachedNode {
 
   int addAllOpToWriteQ(BlockingQueue<Operation> allOp);
 
-  int moveOperations(final MemcachedNode toNode);
+  int moveOperations(final MemcachedNode toNode, boolean cancelNonIdempontent);
+
+  boolean hasNonIdempotentOperationInReadQ();
   /* ENABLE_REPLICATION end */
 }

--- a/src/main/java/net/spy/memcached/MemcachedNodeROImpl.java
+++ b/src/main/java/net/spy/memcached/MemcachedNodeROImpl.java
@@ -1,6 +1,7 @@
 /*
  * arcus-java-client : Arcus Java client
  * Copyright 2010-2014 NAVER Corp.
+ * Copyright 2014-2022 JaM2in Co., Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -245,7 +246,12 @@ public class MemcachedNodeROImpl implements MemcachedNode {
     throw new UnsupportedOperationException();
   }
 
-  public int moveOperations(final MemcachedNode toNode) {
+  public int moveOperations(final MemcachedNode toNode, boolean cancelNonIdempontent) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public boolean hasNonIdempotentOperationInReadQ() {
     throw new UnsupportedOperationException();
   }
   /* ENABLE_REPLICATION end */

--- a/src/main/java/net/spy/memcached/MemcachedReplicaGroup.java
+++ b/src/main/java/net/spy/memcached/MemcachedReplicaGroup.java
@@ -31,6 +31,7 @@ public abstract class MemcachedReplicaGroup extends SpyObject {
   private int nextSlaveIndex = -1;
   protected MemcachedNode masterCandidate;
   private final StringBuilder sb = new StringBuilder();
+  private boolean delayedSwitchover = false;
 
   public static final int MAX_REPL_SLAVE_SIZE = 2;
   public static final int MAX_REPL_GROUP_SIZE = MAX_REPL_SLAVE_SIZE + 1;
@@ -136,6 +137,13 @@ public abstract class MemcachedReplicaGroup extends SpyObject {
     return node;
   }
 
+  public boolean isDelayedSwitchover() {
+    return delayedSwitchover;
+  }
+
+  public void setDelayedSwitchover(boolean delayedSwitchover) {
+    this.delayedSwitchover = delayedSwitchover;
+  }
 
   private MemcachedNode getNextActiveSlaveNodeRotate() {
     MemcachedNode node = null;

--- a/src/main/java/net/spy/memcached/collection/CollectionGet.java
+++ b/src/main/java/net/spy/memcached/collection/CollectionGet.java
@@ -37,6 +37,10 @@ public abstract class CollectionGet<K> {
     this.delete = delete;
   }
 
+  public boolean isDropIfEmpty() {
+    return dropIfEmpty;
+  }
+
   public String getSubkey() {
     return subkey;
   }

--- a/src/main/java/net/spy/memcached/ops/Operation.java
+++ b/src/main/java/net/spy/memcached/ops/Operation.java
@@ -1,3 +1,20 @@
+/*
+ * arcus-java-client : Arcus Java client
+ * Copyright 2010-2014 NAVER Corp.
+ * Copyright 2014-2022 JaM2in Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package net.spy.memcached.ops;
 
 import java.io.IOException;
@@ -110,6 +127,8 @@ public interface Operation {
   boolean isBulkOperation();
 
   boolean isPipeOperation();
+
+  boolean isIdempotentOperation();
 
   APIType getAPIType();
 }

--- a/src/main/java/net/spy/memcached/protocol/ascii/BTreeFindPositionOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/BTreeFindPositionOperationImpl.java
@@ -1,7 +1,7 @@
 /*
  * arcus-java-client : Arcus Java client
  * Copyright 2010-2014 NAVER Corp.
- * Copyright 2014-2021 JaM2in Co., Ltd.
+ * Copyright 2014-2022 JaM2in Co., Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -142,4 +142,10 @@ public class BTreeFindPositionOperationImpl extends OperationImpl implements
   public boolean isPipeOperation() {
     return false;
   }
+
+  @Override
+  public boolean isIdempotentOperation() {
+    return true;
+  }
+
 }

--- a/src/main/java/net/spy/memcached/protocol/ascii/BTreeFindPositionWithGetOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/BTreeFindPositionWithGetOperationImpl.java
@@ -1,6 +1,6 @@
 /*
  * arcus-java-client : Arcus Java client
- * Copyright 2014-2021 JaM2in Co., Ltd.
+ * Copyright 2014-2022 JaM2in Co., Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -261,4 +261,10 @@ public class BTreeFindPositionWithGetOperationImpl extends OperationImpl impleme
   public boolean isPipeOperation() {
     return false;
   }
+
+  @Override
+  public boolean isIdempotentOperation() {
+    return true;
+  }
+
 }

--- a/src/main/java/net/spy/memcached/protocol/ascii/BTreeGetBulkOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/BTreeGetBulkOperationImpl.java
@@ -1,7 +1,7 @@
 /*
  * arcus-java-client : Arcus Java client
  * Copyright 2010-2014 NAVER Corp.
- * Copyright 2014-2021 JaM2in Co., Ltd.
+ * Copyright 2014-2022 JaM2in Co., Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -259,4 +259,10 @@ public class BTreeGetBulkOperationImpl extends OperationImpl implements
   public boolean isPipeOperation() {
     return false;
   }
+
+  @Override
+  public boolean isIdempotentOperation() {
+    return true;
+  }
+
 }

--- a/src/main/java/net/spy/memcached/protocol/ascii/BTreeGetByPositionOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/BTreeGetByPositionOperationImpl.java
@@ -1,7 +1,7 @@
 /*
  * arcus-java-client : Arcus Java client
  * Copyright 2010-2014 NAVER Corp.
- * Copyright 2014-2021 JaM2in Co., Ltd.
+ * Copyright 2014-2022 JaM2in Co., Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -269,4 +269,10 @@ public class BTreeGetByPositionOperationImpl extends OperationImpl implements
   public boolean isPipeOperation() {
     return false;
   }
+
+  @Override
+  public boolean isIdempotentOperation() {
+    return true;
+  }
+
 }

--- a/src/main/java/net/spy/memcached/protocol/ascii/BTreeInsertAndGetOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/BTreeInsertAndGetOperationImpl.java
@@ -311,4 +311,10 @@ public class BTreeInsertAndGetOperationImpl extends OperationImpl implements
   public boolean isPipeOperation() {
     return false;
   }
+
+  @Override
+  public boolean isIdempotentOperation() {
+    return true;
+  }
+
 }

--- a/src/main/java/net/spy/memcached/protocol/ascii/BTreeSortMergeGetOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/BTreeSortMergeGetOperationImpl.java
@@ -1,7 +1,7 @@
 /*
  * arcus-java-client : Arcus Java client
  * Copyright 2010-2014 NAVER Corp.
- * Copyright 2014-2021 JaM2in Co., Ltd.
+ * Copyright 2014-2022 JaM2in Co., Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -446,4 +446,10 @@ public class BTreeSortMergeGetOperationImpl extends OperationImpl implements
   public boolean isPipeOperation() {
     return false;
   }
+
+  @Override
+  public boolean isIdempotentOperation() {
+    return true;
+  }
+
 }

--- a/src/main/java/net/spy/memcached/protocol/ascii/BTreeSortMergeGetOperationOldImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/BTreeSortMergeGetOperationOldImpl.java
@@ -1,7 +1,7 @@
 /*
  * arcus-java-client : Arcus Java client
  * Copyright 2010-2014 NAVER Corp.
- * Copyright 2014-2021 JaM2in Co., Ltd.
+ * Copyright 2014-2022 JaM2in Co., Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -326,4 +326,10 @@ public class BTreeSortMergeGetOperationOldImpl extends OperationImpl implements
   public boolean isPipeOperation() {
     return false;
   }
+
+  @Override
+  public boolean isIdempotentOperation() {
+    return true;
+  }
+
 }

--- a/src/main/java/net/spy/memcached/protocol/ascii/BaseGetOpImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/BaseGetOpImpl.java
@@ -1,7 +1,7 @@
 /*
  * arcus-java-client : Arcus Java client
  * Copyright 2010-2014 NAVER Corp.
- * Copyright 2014-2021 JaM2in Co., Ltd.
+ * Copyright 2014-2022 JaM2in Co., Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -224,6 +224,11 @@ abstract class BaseGetOpImpl extends OperationImpl {
   @Override
   public boolean isPipeOperation() {
     return false;
+  }
+
+  @Override
+  public boolean isIdempotentOperation() {
+    return true;
   }
 
 }

--- a/src/main/java/net/spy/memcached/protocol/ascii/CASOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/CASOperationImpl.java
@@ -1,7 +1,7 @@
 /*
  * arcus-java-client : Arcus Java client
  * Copyright 2010-2014 NAVER Corp.
- * Copyright 2014-2021 JaM2in Co., Ltd.
+ * Copyright 2014-2022 JaM2in Co., Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -136,4 +136,10 @@ class CASOperationImpl extends OperationImpl implements CASOperation {
   public boolean isPipeOperation() {
     return false;
   }
+
+  @Override
+  public boolean isIdempotentOperation() {
+    return true;
+  }
+
 }

--- a/src/main/java/net/spy/memcached/protocol/ascii/CollectionBulkInsertOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/CollectionBulkInsertOperationImpl.java
@@ -1,6 +1,7 @@
 /*
  * arcus-java-client : Arcus Java client
  * Copyright 2010-2014 NAVER Corp.
+ * Copyright 2014-2022 JaM2in Co., Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -181,4 +182,10 @@ public class CollectionBulkInsertOperationImpl extends OperationImpl
   public boolean isPipeOperation() {
     return false;
   }
+
+  @Override
+  public boolean isIdempotentOperation() {
+    return !(insert instanceof CollectionBulkInsert.ListBulkInsert);
+  }
+
 }

--- a/src/main/java/net/spy/memcached/protocol/ascii/CollectionCountOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/CollectionCountOperationImpl.java
@@ -1,7 +1,7 @@
 /*
  * arcus-java-client : Arcus Java client
  * Copyright 2010-2014 NAVER Corp.
- * Copyright 2014-2021 JaM2in Co., Ltd.
+ * Copyright 2014-2022 JaM2in Co., Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -125,4 +125,10 @@ public class CollectionCountOperationImpl extends OperationImpl implements
   public boolean isPipeOperation() {
     return false;
   }
+
+  @Override
+  public boolean isIdempotentOperation() {
+    return true;
+  }
+
 }

--- a/src/main/java/net/spy/memcached/protocol/ascii/CollectionCreateOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/CollectionCreateOperationImpl.java
@@ -1,7 +1,7 @@
 /*
  * arcus-java-client : Arcus Java client
  * Copyright 2010-2014 NAVER Corp.
- * Copyright 2014-2021 JaM2in Co., Ltd.
+ * Copyright 2014-2022 JaM2in Co., Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -129,4 +129,10 @@ public class CollectionCreateOperationImpl extends OperationImpl
   public boolean isPipeOperation() {
     return false;
   }
+
+  @Override
+  public boolean isIdempotentOperation() {
+    return true;
+  }
+
 }

--- a/src/main/java/net/spy/memcached/protocol/ascii/CollectionDeleteOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/CollectionDeleteOperationImpl.java
@@ -1,7 +1,7 @@
 /*
  * arcus-java-client : Arcus Java client
  * Copyright 2010-2014 NAVER Corp.
- * Copyright 2014-2021 JaM2in Co., Ltd.
+ * Copyright 2014-2022 JaM2in Co., Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -154,4 +154,10 @@ public class CollectionDeleteOperationImpl extends OperationImpl
   public boolean isPipeOperation() {
     return false;
   }
+
+  @Override
+  public boolean isIdempotentOperation() {
+    return !(collectionDelete instanceof ListDelete);
+  }
+
 }

--- a/src/main/java/net/spy/memcached/protocol/ascii/CollectionExistOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/CollectionExistOperationImpl.java
@@ -1,7 +1,7 @@
 /*
  * arcus-java-client : Arcus Java client
  * Copyright 2010-2014 NAVER Corp.
- * Copyright 2014-2021 JaM2in Co., Ltd.
+ * Copyright 2014-2022 JaM2in Co., Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -133,4 +133,10 @@ public class CollectionExistOperationImpl extends OperationImpl
   public boolean isPipeOperation() {
     return false;
   }
+
+  @Override
+  public boolean isIdempotentOperation() {
+    return true;
+  }
+
 }

--- a/src/main/java/net/spy/memcached/protocol/ascii/CollectionGetOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/CollectionGetOperationImpl.java
@@ -1,7 +1,7 @@
 /*
  * arcus-java-client : Arcus Java client
  * Copyright 2010-2014 NAVER Corp.
- * Copyright 2014-2021 JaM2in Co., Ltd.
+ * Copyright 2014-2022 JaM2in Co., Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -301,4 +301,10 @@ public class CollectionGetOperationImpl extends OperationImpl
   public boolean isPipeOperation() {
     return false;
   }
+
+  @Override
+  public boolean isIdempotentOperation() {
+    return !collectionGet.isDelete() && !collectionGet.isDropIfEmpty();
+  }
+
 }

--- a/src/main/java/net/spy/memcached/protocol/ascii/CollectionInsertOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/CollectionInsertOperationImpl.java
@@ -1,7 +1,7 @@
 /*
  * arcus-java-client : Arcus Java client
  * Copyright 2010-2014 NAVER Corp.
- * Copyright 2014-2021 JaM2in Co., Ltd.
+ * Copyright 2014-2022 JaM2in Co., Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -164,4 +164,10 @@ public class CollectionInsertOperationImpl extends OperationImpl
   public boolean isPipeOperation() {
     return false;
   }
+
+  @Override
+  public boolean isIdempotentOperation() {
+    return !(collectionInsert instanceof ListInsert);
+  }
+
 }

--- a/src/main/java/net/spy/memcached/protocol/ascii/CollectionMutateOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/CollectionMutateOperationImpl.java
@@ -1,7 +1,7 @@
 /*
  * arcus-java-client : Arcus Java client
  * Copyright 2010-2014 NAVER Corp.
- * Copyright 2014-2021 JaM2in Co., Ltd.
+ * Copyright 2014-2022 JaM2in Co., Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -143,4 +143,10 @@ public class CollectionMutateOperationImpl extends OperationImpl implements
   public boolean isPipeOperation() {
     return false;
   }
+
+  @Override
+  public boolean isIdempotentOperation() {
+    return false;
+  }
+
 }

--- a/src/main/java/net/spy/memcached/protocol/ascii/CollectionPipedExistOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/CollectionPipedExistOperationImpl.java
@@ -1,6 +1,7 @@
 /*
  * arcus-java-client : Arcus Java client
  * Copyright 2010-2014 NAVER Corp.
+ * Copyright 2014-2022 JaM2in Co., Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -152,4 +153,10 @@ public class CollectionPipedExistOperationImpl extends OperationImpl implements
   public boolean isPipeOperation() {
     return true;
   }
+
+  @Override
+  public boolean isIdempotentOperation() {
+    return true;
+  }
+
 }

--- a/src/main/java/net/spy/memcached/protocol/ascii/CollectionPipedInsertOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/CollectionPipedInsertOperationImpl.java
@@ -1,6 +1,7 @@
 /*
  * arcus-java-client : Arcus Java client
  * Copyright 2010-2014 NAVER Corp.
+ * Copyright 2014-2022 JaM2in Co., Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -182,4 +183,10 @@ public class CollectionPipedInsertOperationImpl extends OperationImpl
   public boolean isPipeOperation() {
     return true;
   }
+
+  @Override
+  public boolean isIdempotentOperation() {
+    return !(insert instanceof CollectionPipedInsert.ListPipedInsert);
+  }
+
 }

--- a/src/main/java/net/spy/memcached/protocol/ascii/CollectionPipedUpdateOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/CollectionPipedUpdateOperationImpl.java
@@ -1,6 +1,7 @@
 /*
  * arcus-java-client : Arcus Java client
  * Copyright 2010-2014 NAVER Corp.
+ * Copyright 2014-2022 JaM2in Co., Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -179,4 +180,10 @@ public class CollectionPipedUpdateOperationImpl extends OperationImpl implements
   public boolean isPipeOperation() {
     return true;
   }
+
+  @Override
+  public boolean isIdempotentOperation() {
+    return true;
+  }
+
 }

--- a/src/main/java/net/spy/memcached/protocol/ascii/CollectionUpdateOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/CollectionUpdateOperationImpl.java
@@ -1,7 +1,7 @@
 /*
  * arcus-java-client : Arcus Java client
  * Copyright 2010-2014 NAVER Corp.
- * Copyright 2014-2021 JaM2in Co., Ltd.
+ * Copyright 2014-2022 JaM2in Co., Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -171,4 +171,10 @@ public class CollectionUpdateOperationImpl extends OperationImpl implements
   public boolean isPipeOperation() {
     return false;
   }
+
+  @Override
+  public boolean isIdempotentOperation() {
+    return true;
+  }
+
 }

--- a/src/main/java/net/spy/memcached/protocol/ascii/ConcatenationOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/ConcatenationOperationImpl.java
@@ -1,3 +1,20 @@
+/*
+ * arcus-java-client : Arcus Java client
+ * Copyright 2010-2014 NAVER Corp.
+ * Copyright 2014-2022 JaM2in Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package net.spy.memcached.protocol.ascii;
 
 import net.spy.memcached.ops.APIType;
@@ -31,6 +48,11 @@ public class ConcatenationOperationImpl extends BaseStoreOperationImpl
 
   public ConcatenationType getStoreType() {
     return concatType;
+  }
+
+  @Override
+  public boolean isIdempotentOperation() {
+    return false;
   }
 
 }

--- a/src/main/java/net/spy/memcached/protocol/ascii/DeleteOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/DeleteOperationImpl.java
@@ -1,7 +1,7 @@
 /*
  * arcus-java-client : Arcus Java client
  * Copyright 2010-2014 NAVER Corp.
- * Copyright 2014-2021 JaM2in Co., Ltd.
+ * Copyright 2014-2022 JaM2in Co., Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -90,4 +90,10 @@ final class DeleteOperationImpl extends OperationImpl
   public boolean isPipeOperation() {
     return false;
   }
+
+  @Override
+  public boolean isIdempotentOperation() {
+    return true;
+  }
+
 }

--- a/src/main/java/net/spy/memcached/protocol/ascii/FlushByPrefixOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/FlushByPrefixOperationImpl.java
@@ -1,7 +1,7 @@
 /*
  * arcus-java-client : Arcus Java client
  * Copyright 2010-2014 NAVER Corp.
- * Copyright 2014-2021 JaM2in Co., Ltd.
+ * Copyright 2014-2022 JaM2in Co., Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -94,4 +94,10 @@ final class FlushByPrefixOperationImpl extends OperationImpl implements
   public boolean isPipeOperation() {
     return false;
   }
+
+  @Override
+  public boolean isIdempotentOperation() {
+    return false;
+  }
+
 }

--- a/src/main/java/net/spy/memcached/protocol/ascii/FlushOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/FlushOperationImpl.java
@@ -1,7 +1,7 @@
 /*
  * arcus-java-client : Arcus Java client
  * Copyright 2010-2014 NAVER Corp.
- * Copyright 2014-2021 JaM2in Co., Ltd.
+ * Copyright 2014-2022 JaM2in Co., Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -85,4 +85,10 @@ final class FlushOperationImpl extends OperationImpl
   public boolean isPipeOperation() {
     return false;
   }
+
+  @Override
+  public boolean isIdempotentOperation() {
+    return false;
+  }
+
 }

--- a/src/main/java/net/spy/memcached/protocol/ascii/GetAttrOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/GetAttrOperationImpl.java
@@ -1,7 +1,7 @@
 /*
  * arcus-java-client : Arcus Java client
  * Copyright 2010-2014 NAVER Corp.
- * Copyright 2014-2021 JaM2in Co., Ltd.
+ * Copyright 2014-2022 JaM2in Co., Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -113,4 +113,10 @@ class GetAttrOperationImpl extends OperationImpl implements GetAttrOperation {
   public boolean isPipeOperation() {
     return false;
   }
+
+  @Override
+  public boolean isIdempotentOperation() {
+    return true;
+  }
+
 }

--- a/src/main/java/net/spy/memcached/protocol/ascii/MutatorOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/MutatorOperationImpl.java
@@ -1,7 +1,7 @@
 /*
  * arcus-java-client : Arcus Java client
  * Copyright 2010-2014 NAVER Corp.
- * Copyright 2014-2021 JaM2in Co., Ltd.
+ * Copyright 2014-2022 JaM2in Co., Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -137,4 +137,10 @@ final class MutatorOperationImpl extends OperationImpl
   public boolean isPipeOperation() {
     return false;
   }
+
+  @Override
+  public boolean isIdempotentOperation() {
+    return false;
+  }
+
 }

--- a/src/main/java/net/spy/memcached/protocol/ascii/SetAttrOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/SetAttrOperationImpl.java
@@ -1,7 +1,7 @@
 /*
  * arcus-java-client : Arcus Java client
  * Copyright 2010-2014 NAVER Corp.
- * Copyright 2014-2021 JaM2in Co., Ltd.
+ * Copyright 2014-2022 JaM2in Co., Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -121,4 +121,10 @@ class SetAttrOperationImpl extends OperationImpl
   public boolean isPipeOperation() {
     return false;
   }
+
+  @Override
+  public boolean isIdempotentOperation() {
+    return true;
+  }
+
 }

--- a/src/main/java/net/spy/memcached/protocol/ascii/StatsOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/StatsOperationImpl.java
@@ -1,6 +1,7 @@
 /*
  * arcus-java-client : Arcus Java client
  * Copyright 2010-2014 NAVER Corp.
+ * Copyright 2014-2022 JaM2in Co., Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -84,4 +85,10 @@ final class StatsOperationImpl extends OperationImpl
   public boolean isPipeOperation() {
     return false;
   }
+
+  @Override
+  public boolean isIdempotentOperation() {
+    return true;
+  }
+
 }

--- a/src/main/java/net/spy/memcached/protocol/ascii/StoreOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/StoreOperationImpl.java
@@ -1,3 +1,20 @@
+/*
+ * arcus-java-client : Arcus Java client
+ * Copyright 2010-2014 NAVER Corp.
+ * Copyright 2014-2022 JaM2in Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 // Copyright (c) 2006  Dustin Sallings <dustin@spy.net>
 
 package net.spy.memcached.protocol.ascii;
@@ -31,6 +48,11 @@ final class StoreOperationImpl extends BaseStoreOperationImpl
 
   public StoreType getStoreType() {
     return storeType;
+  }
+
+  @Override
+  public boolean isIdempotentOperation() {
+    return true;
   }
 
 }

--- a/src/main/java/net/spy/memcached/protocol/ascii/VersionOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/VersionOperationImpl.java
@@ -1,3 +1,20 @@
+/*
+ * arcus-java-client : Arcus Java client
+ * Copyright 2010-2014 NAVER Corp.
+ * Copyright 2014-2022 JaM2in Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 // Copyright (c) 2006  Dustin Sallings <dustin@spy.net>
 
 package net.spy.memcached.protocol.ascii;
@@ -54,4 +71,10 @@ final class VersionOperationImpl extends OperationImpl
   public boolean isPipeOperation() {
     return false;
   }
+
+  @Override
+  public boolean isIdempotentOperation() {
+    return true;
+  }
+
 }

--- a/src/main/java/net/spy/memcached/protocol/binary/ConcatenationOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/binary/ConcatenationOperationImpl.java
@@ -1,3 +1,20 @@
+/*
+ * arcus-java-client : Arcus Java client
+ * Copyright 2010-2014 NAVER Corp.
+ * Copyright 2014-2022 JaM2in Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package net.spy.memcached.protocol.binary;
 
 import java.util.Collection;
@@ -90,4 +107,10 @@ class ConcatenationOperationImpl extends OperationImpl
   public boolean isPipeOperation() {
     return false;
   }
+
+  @Override
+  public boolean isIdempotentOperation() {
+    return false;
+  }
+
 }

--- a/src/main/java/net/spy/memcached/protocol/binary/DeleteOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/binary/DeleteOperationImpl.java
@@ -1,3 +1,20 @@
+/*
+ * arcus-java-client : Arcus Java client
+ * Copyright 2010-2014 NAVER Corp.
+ * Copyright 2014-2022 JaM2in Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package net.spy.memcached.protocol.binary;
 
 import java.util.Collection;
@@ -48,4 +65,10 @@ class DeleteOperationImpl extends OperationImpl implements
   public boolean isPipeOperation() {
     return false;
   }
+
+  @Override
+  public boolean isIdempotentOperation() {
+    return true;
+  }
+
 }

--- a/src/main/java/net/spy/memcached/protocol/binary/FlushOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/binary/FlushOperationImpl.java
@@ -1,3 +1,20 @@
+/*
+ * arcus-java-client : Arcus Java client
+ * Copyright 2010-2014 NAVER Corp.
+ * Copyright 2014-2022 JaM2in Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package net.spy.memcached.protocol.binary;
 
 import net.spy.memcached.ops.FlushOperation;
@@ -31,4 +48,10 @@ class FlushOperationImpl extends OperationImpl implements FlushOperation {
   public boolean isPipeOperation() {
     return false;
   }
+
+  @Override
+  public boolean isIdempotentOperation() {
+    return false;
+  }
+
 }

--- a/src/main/java/net/spy/memcached/protocol/binary/GetOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/binary/GetOperationImpl.java
@@ -1,3 +1,20 @@
+/*
+ * arcus-java-client : Arcus Java client
+ * Copyright 2010-2014 NAVER Corp.
+ * Copyright 2014-2022 JaM2in Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package net.spy.memcached.protocol.binary;
 
 import java.util.Collection;
@@ -68,4 +85,10 @@ class GetOperationImpl extends OperationImpl
   public boolean isPipeOperation() {
     return false;
   }
+
+  @Override
+  public boolean isIdempotentOperation() {
+    return true;
+  }
+
 }

--- a/src/main/java/net/spy/memcached/protocol/binary/MultiGetOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/binary/MultiGetOperationImpl.java
@@ -1,7 +1,7 @@
 /*
  * arcus-java-client : Arcus Java client
  * Copyright 2010-2014 NAVER Corp.
- * Copyright 2014-2021 JaM2in Co., Ltd.
+ * Copyright 2014-2022 JaM2in Co., Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -140,4 +140,10 @@ class MultiGetOperationImpl extends OperationImpl implements GetOperation {
   public boolean isPipeOperation() {
     return false;
   }
+
+  @Override
+  public boolean isIdempotentOperation() {
+    return true;
+  }
+
 }

--- a/src/main/java/net/spy/memcached/protocol/binary/MutatorOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/binary/MutatorOperationImpl.java
@@ -1,3 +1,20 @@
+/*
+ * arcus-java-client : Arcus Java client
+ * Copyright 2010-2014 NAVER Corp.
+ * Copyright 2014-2022 JaM2in Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package net.spy.memcached.protocol.binary;
 
 import java.util.Collection;
@@ -87,4 +104,10 @@ class MutatorOperationImpl extends OperationImpl implements
   public boolean isPipeOperation() {
     return false;
   }
+
+  @Override
+  public boolean isIdempotentOperation() {
+    return false;
+  }
+
 }

--- a/src/main/java/net/spy/memcached/protocol/binary/NoopOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/binary/NoopOperationImpl.java
@@ -1,3 +1,20 @@
+/*
+ * arcus-java-client : Arcus Java client
+ * Copyright 2010-2014 NAVER Corp.
+ * Copyright 2014-2022 JaM2in Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package net.spy.memcached.protocol.binary;
 
 import net.spy.memcached.ops.NoopOperation;
@@ -28,4 +45,10 @@ class NoopOperationImpl extends OperationImpl implements NoopOperation {
   public boolean isPipeOperation() {
     return false;
   }
+
+  @Override
+  public boolean isIdempotentOperation() {
+    return true;
+  }
+
 }

--- a/src/main/java/net/spy/memcached/protocol/binary/OptimizedSetImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/binary/OptimizedSetImpl.java
@@ -1,7 +1,7 @@
 /*
  * arcus-java-client : Arcus Java client
  * Copyright 2010-2014 NAVER Corp.
- * Copyright 2014-2021 JaM2in Co., Ltd.
+ * Copyright 2014-2022 JaM2in Co., Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -201,4 +201,10 @@ public class OptimizedSetImpl extends OperationImpl implements Operation {
   public boolean isPipeOperation() {
     return false;
   }
+
+  @Override
+  public boolean isIdempotentOperation() {
+    return true;
+  }
+
 }

--- a/src/main/java/net/spy/memcached/protocol/binary/SASLAuthOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/binary/SASLAuthOperationImpl.java
@@ -1,3 +1,20 @@
+/*
+ * arcus-java-client : Arcus Java client
+ * Copyright 2010-2014 NAVER Corp.
+ * Copyright 2014-2022 JaM2in Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package net.spy.memcached.protocol.binary;
 
 import java.util.Map;
@@ -26,4 +43,10 @@ public class SASLAuthOperationImpl extends SASLBaseOperationImpl
             : EMPTY_BYTES;
 
   }
+
+  @Override
+  public boolean isIdempotentOperation() {
+    return false;
+  }
+
 }

--- a/src/main/java/net/spy/memcached/protocol/binary/SASLMechsOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/binary/SASLMechsOperationImpl.java
@@ -1,3 +1,20 @@
+/*
+ * arcus-java-client : Arcus Java client
+ * Copyright 2010-2014 NAVER Corp.
+ * Copyright 2014-2022 JaM2in Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package net.spy.memcached.protocol.binary;
 
 import net.spy.memcached.ops.OperationCallback;
@@ -34,4 +51,10 @@ class SASLMechsOperationImpl extends OperationImpl implements
   public boolean isPipeOperation() {
     return false;
   }
+
+  @Override
+  public boolean isIdempotentOperation() {
+    return false;
+  }
+
 }

--- a/src/main/java/net/spy/memcached/protocol/binary/SASLStepOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/binary/SASLStepOperationImpl.java
@@ -1,3 +1,20 @@
+/*
+ * arcus-java-client : Arcus Java client
+ * Copyright 2010-2014 NAVER Corp.
+ * Copyright 2014-2022 JaM2in Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package net.spy.memcached.protocol.binary;
 
 import java.util.Map;
@@ -22,6 +39,11 @@ public class SASLStepOperationImpl extends SASLBaseOperationImpl
   @Override
   protected byte[] buildResponse(SaslClient sc) throws SaslException {
     return sc.evaluateChallenge(challenge);
-
   }
+
+  @Override
+  public boolean isIdempotentOperation() {
+    return false;
+  }
+
 }

--- a/src/main/java/net/spy/memcached/protocol/binary/StatsOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/binary/StatsOperationImpl.java
@@ -1,3 +1,20 @@
+/*
+ * arcus-java-client : Arcus Java client
+ * Copyright 2010-2014 NAVER Corp.
+ * Copyright 2014-2022 JaM2in Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package net.spy.memcached.protocol.binary;
 
 import java.io.IOException;
@@ -47,4 +64,10 @@ public class StatsOperationImpl extends OperationImpl
   public boolean isPipeOperation() {
     return false;
   }
+
+  @Override
+  public boolean isIdempotentOperation() {
+    return true;
+  }
+
 }

--- a/src/main/java/net/spy/memcached/protocol/binary/StoreOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/binary/StoreOperationImpl.java
@@ -1,3 +1,20 @@
+/*
+ * arcus-java-client : Arcus Java client
+ * Copyright 2010-2014 NAVER Corp.
+ * Copyright 2014-2022 JaM2in Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package net.spy.memcached.protocol.binary;
 
 import java.util.Collection;
@@ -115,4 +132,10 @@ class StoreOperationImpl extends OperationImpl
   public boolean isPipeOperation() {
     return false;
   }
+
+  @Override
+  public boolean isIdempotentOperation() {
+    return true;
+  }
+
 }

--- a/src/main/java/net/spy/memcached/protocol/binary/VersionOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/binary/VersionOperationImpl.java
@@ -1,3 +1,20 @@
+/*
+ * arcus-java-client : Arcus Java client
+ * Copyright 2010-2014 NAVER Corp.
+ * Copyright 2014-2022 JaM2in Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package net.spy.memcached.protocol.binary;
 
 import net.spy.memcached.ops.OperationCallback;
@@ -33,4 +50,10 @@ class VersionOperationImpl extends OperationImpl implements VersionOperation {
   public boolean isPipeOperation() {
     return false;
   }
+
+  @Override
+  public boolean isIdempotentOperation() {
+    return true;
+  }
+
 }

--- a/src/test/java/net/spy/memcached/AsciiClientTest.java
+++ b/src/test/java/net/spy/memcached/AsciiClientTest.java
@@ -1,3 +1,20 @@
+/*
+ * arcus-java-client : Arcus Java client
+ * Copyright 2010-2014 NAVER Corp.
+ * Copyright 2014-2022 JaM2in Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package net.spy.memcached;
 
 import java.nio.ByteBuffer;
@@ -39,6 +56,11 @@ public class AsciiClientTest extends ProtocolBaseCase {
 
       @Override
       public boolean isPipeOperation() {
+        return false;
+      }
+
+      @Override
+      public boolean isIdempotentOperation() {
         return false;
       }
     });

--- a/src/test/java/net/spy/memcached/MockMemcachedNode.java
+++ b/src/test/java/net/spy/memcached/MockMemcachedNode.java
@@ -1,6 +1,7 @@
 /*
  * arcus-java-client : Arcus Java client
  * Copyright 2010-2014 NAVER Corp.
+ * Copyright 2014-2022 JaM2in Co., Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -268,9 +269,15 @@ public class MockMemcachedNode implements MemcachedNode {
   }
 
   @Override
-  public int moveOperations(final MemcachedNode toNode) {
+  public int moveOperations(final MemcachedNode toNode, boolean cancelNonIdempontent) {
     // noop
     return 0;
+  }
+
+  @Override
+  public boolean hasNonIdempotentOperationInReadQ() {
+    // noop
+    return false;
   }
   /* ENABLE_REPLICATION end */
 }

--- a/src/test/java/net/spy/memcached/internal/CheckedOperationTimeoutExceptionTest.java
+++ b/src/test/java/net/spy/memcached/internal/CheckedOperationTimeoutExceptionTest.java
@@ -1,6 +1,7 @@
 /*
  * arcus-java-client : Arcus Java client
  * Copyright 2010-2014 NAVER Corp.
+ * Copyright 2014-2022 JaM2in Co., Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -88,6 +89,11 @@ public class CheckedOperationTimeoutExceptionTest extends TestCase {
 
     @Override
     public boolean isPipeOperation() {
+      return false;
+    }
+
+    @Override
+    public boolean isIdempotentOperation() {
       return false;
     }
   }

--- a/src/test/java/net/spy/memcached/protocol/TCPMemcachedNodeImplTest.java
+++ b/src/test/java/net/spy/memcached/protocol/TCPMemcachedNodeImplTest.java
@@ -1,7 +1,7 @@
 /*
  * arcus-java-client : Arcus Java client
  * Copyright 2010-2014 NAVER Corp.
- * Copyright 2014-2020 JaM2in Co., Ltd.
+ * Copyright 2014-2022 JaM2in Co., Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -112,7 +112,7 @@ public class TCPMemcachedNodeImplTest extends TestCase {
     }
 
     // when
-    assertEquals(fromAllOpCount, fromNode.moveOperations(toNode));
+    assertEquals(fromAllOpCount, fromNode.moveOperations(toNode, false));
 
     // then
     assertEquals(0, fromNode.getInputQueueSize());

--- a/src/test/java/net/spy/memcached/protocol/ascii/BaseOpTest.java
+++ b/src/test/java/net/spy/memcached/protocol/ascii/BaseOpTest.java
@@ -1,3 +1,20 @@
+/*
+ * arcus-java-client : Arcus Java client
+ * Copyright 2010-2014 NAVER Corp.
+ * Copyright 2014-2022 JaM2in Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 // Copyright (c) 2006  Dustin Sallings <dustin@spy.net>
 
 package net.spy.memcached.protocol.ascii;
@@ -142,6 +159,11 @@ public class BaseOpTest extends BaseMockCase {
 
     @Override
     public boolean isPipeOperation() {
+      return false;
+    }
+
+    @Override
+    public boolean isIdempotentOperation() {
       return false;
     }
   }


### PR DESCRIPTION
https://github.com/naver/arcus-java-client/issues/233 이슈에 관한 PR입니다.

수정 사항은 아래와 같습니다.

- ZK로부터 SWITCHOVER 이벤트를 수신하면
  - Non Idempotent Operation이 Old Master에 존재하지 않으면 ChangeRole, MoveOperation 작업을 수행한다.
  - Non Idempotent Operation이 Old Master에 존재한다면, ChangeRole, MoveOperation 작업을 바로 진행하지 않고, 서버의 SWITCHOVER, REPL_SLAVE 응답을 받을 때까지 작업을 보류한다. 
    - SWITCHOVER, REPL_SLAVE 응답을 50ms 내로 수신하였다면, ChangeRole, MoveOperation 작업을 수행한다.
    - SWITCHOVER, REPL_SLAVE 응답이 50ms 동안 수신되지 않으면, ChangeRole, MoveOperation 작업을 수행한다. MoveOperation 작업에서 Non Idempotent Operation은 제외된다.
    - SwitchOver 작업이 보류된 ReplicaGroup 노드의 Write 작업을 중단한다.
      - 중단하지 않으면 Old Master의 새로운 Non Idempotent Operation이 ReadQ에 삽입되어 Cancel될 가능성이 존재한다.
 - FailOver 이벤트 수신시 ReadQ의 모든 Operation을 취소하지 않고, Non Idempotent Operation만 취소하고, 나머지 Operation은 New Master로 이동한다. 