### PR TITLE
FIX: resolve ConcurrentModificationException occurs in handleNodesToR…

### DIFF
--- a/src/main/java/net/spy/memcached/MemcachedConnection.java
+++ b/src/main/java/net/spy/memcached/MemcachedConnection.java
@@ -292,7 +292,7 @@ public final class MemcachedConnection extends SpyObject {
       for (Entry<Long, MemcachedNode> each : reconnectQueue.entrySet()) {
         if (node.equals(each.getValue())) {
           reconnectQueue.remove(each.getKey());
-          break;
+          break; // this break statement can avoid ConcurrentModificationException while iterating the entrySet.
         }
       }
       // removing node is not related to failure mode.


### PR DESCRIPTION
~~for each에서 Map의 entry를 제거하면 ConcurrentModificationException이 발생됩니다.
Exception 발생 해결을 위해 iterator로 제거하도록 변경하였습니다.~~

기존 코드에서 break문이 존재하기 때문에 Exception이 발생되지 않습니다. 
이와 별개로 논의사항이 존재하여 해결될 때까지 오픈해두겠습니다.