### PR TITLE
FIX: throw unsupported exception getTimeoutDuration() in MemachedNode…

### DIFF
--- a/src/main/java/net/spy/memcached/MemcachedNodeROImpl.java
+++ b/src/main/java/net/spy/memcached/MemcachedNodeROImpl.java
@@ -227,7 +227,7 @@ public class MemcachedNodeROImpl implements MemcachedNode {
 
   @Override
   public long getTimeoutDuration() {
-    return 0;
+    throw new UnsupportedOperationException();
   }
 
   public void shutdown() throws IOException {


### PR DESCRIPTION
아래 에러가 발생하면서 Test 실패합니다.
```
Results :

Failed tests:
  MemcachedNodeROImplTest>VerifyingTestCase.runBare:39->testReadOnliness:42 Failed to break on getTimeoutDuration

Tests run: 921, Failures: 1, Errors: 0, Skipped: 9
```

최근에 추가한 getTimeoutDuration 메서드는 UnsupportedOperationException throw 하지 않아서 fail()에서 실패한 것입니다. 

```java
public class MemcachedNodeROImplTest extends MockObjectTestCase {

  public void testReadOnliness() throws Exception {
    SocketAddress sa = new InetSocketAddress(11211);
    Mock m = mock(MemcachedNode.class, "node");
    MemcachedNodeROImpl node =
            new MemcachedNodeROImpl((MemcachedNode) m.proxy());
    m.expects(once()).method("getSocketAddress").will(returnValue(sa));

    assertSame(sa, node.getSocketAddress());
    assertEquals(m.proxy().toString(), node.toString());

    Set<String> acceptable = new HashSet<String>(Arrays.asList(
            "toString", "getSocketAddress", "getBytesRemainingToWrite",
            "getReconnectCount", "getSelectionOps", "getNodeName", "hasReadOp",
            "hasWriteOp", "isActive", "isFirstConnecting"));

    for (Method meth : MemcachedNode.class.getMethods()) {
      if (acceptable.contains(meth.getName())) {
        // ok
      } else {
        Object[] args = new Object[meth.getParameterTypes().length];
        fillArgs(meth.getParameterTypes(), args);
        try {
          meth.invoke(node, args);
          fail("Failed to break on " + meth.getName());
        } catch (InvocationTargetException e) {
          assertSame("Fail at " + meth.getName(),
                  UnsupportedOperationException.class,
                  e.getCause().getClass());
        }
      }
    }
  }
```