### PR TITLE
FIX: change the fast shutdown time

### DIFF
--- a/src/test/java/net/spy/memcached/ProtocolBaseCase.java
+++ b/src/test/java/net/spy/memcached/ProtocolBaseCase.java
@@ -717,7 +717,7 @@ public abstract class ProtocolBaseCase extends ClientBaseCase {
       client.set("t" + i, 10, i);
     }
     assertFalse("Weird, shut down too fast",
-            client.shutdown(1, TimeUnit.MILLISECONDS));
+            client.shutdown(700, TimeUnit.MICROSECONDS));
 
     try {
       Map<SocketAddress, String> m = client.getVersions();


### PR DESCRIPTION
#462에 관련 pr입니다.

간헐적으로 testGracefulShutdownTooSlow() test가 fail되는 문제가 발생합니다.
그 이유는 현재 fast shutdown 기준인 1 millisecond보다 조금 더 빠르게 shutdown이 이루어지는 경우가
아주 가끔 (몇백번)에 한번 정도 발생하는 것을 테스트로 확인했습니다.

 fast shutdown 기준을 조금 더 낮추었고 (700micro == 0.7milli), 5000번 정도 테스트 했을 때 실패 없이 테스트를 통과했습니다.