### PR TITLE
CLEANUP: remove socket channel argument in MemcachedNode constructor

### DIFF
--- a/src/main/java/net/spy/memcached/BinaryConnectionFactory.java
+++ b/src/main/java/net/spy/memcached/BinaryConnectionFactory.java
@@ -1,10 +1,26 @@
+/*
+ * arcus-java-client : Arcus Java client
+ * Copyright 2010-2014 NAVER Corp.
+ * Copyright 2014-2022 JaM2in Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package net.spy.memcached;
-
-import java.net.SocketAddress;
-import java.nio.channels.SocketChannel;
 
 import net.spy.memcached.protocol.binary.BinaryMemcachedNodeImpl;
 import net.spy.memcached.protocol.binary.BinaryOperationFactory;
+
+import java.net.SocketAddress;
 
 /**
  * Default connection factory for binary wire protocol connections.
@@ -40,10 +56,10 @@ public class BinaryConnectionFactory extends DefaultConnectionFactory {
   @Override
   public MemcachedNode createMemcachedNode(String name,
                                            SocketAddress sa,
-                                           SocketChannel c, int bufSize) {
+                                           int bufSize) {
     boolean doAuth = false;
     return new BinaryMemcachedNodeImpl(name,
-            sa, c, bufSize,
+            sa, bufSize,
             createReadOperationQueue(),
             createWriteOperationQueue(),
             createOperationQueue(),

--- a/src/main/java/net/spy/memcached/ConnectionFactory.java
+++ b/src/main/java/net/spy/memcached/ConnectionFactory.java
@@ -20,7 +20,6 @@ package net.spy.memcached;
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
-import java.nio.channels.SocketChannel;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -48,14 +47,12 @@ public interface ConnectionFactory {
   MemcachedConnection createConnection(String name, List<InetSocketAddress> addrs)
           throws IOException;
 
-
   /**
    * Create a new memcached node.
    */
   MemcachedNode createMemcachedNode(String name,
                                     SocketAddress sa,
-                                    SocketChannel c, int bufSize);
-
+                                    int bufSize);
 
   /**
    * Create a BlockingQueue for operations for a connection.

--- a/src/main/java/net/spy/memcached/DefaultConnectionFactory.java
+++ b/src/main/java/net/spy/memcached/DefaultConnectionFactory.java
@@ -20,7 +20,6 @@ package net.spy.memcached;
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
-import java.nio.channels.SocketChannel;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -214,12 +213,12 @@ public class DefaultConnectionFactory extends SpyObject
 
   public MemcachedNode createMemcachedNode(String name,
                                            SocketAddress sa,
-                                           SocketChannel c, int bufSize) {
+                                           int bufSize) {
 
     OperationFactory of = getOperationFactory();
     if (of instanceof AsciiOperationFactory) {
       return new AsciiMemcachedNodeImpl(name,
-              sa, c, bufSize,
+              sa, bufSize,
               createReadOperationQueue(),
               createWriteOperationQueue(),
               createOperationQueue(),
@@ -230,7 +229,7 @@ public class DefaultConnectionFactory extends SpyObject
         doAuth = true;
       }
       return new BinaryMemcachedNodeImpl(name,
-              sa, c, bufSize,
+              sa, bufSize,
               createReadOperationQueue(),
               createWriteOperationQueue(),
               createOperationQueue(),

--- a/src/main/java/net/spy/memcached/MemcachedConnection.java
+++ b/src/main/java/net/spy/memcached/MemcachedConnection.java
@@ -583,19 +583,20 @@ public final class MemcachedConnection extends SpyObject {
 
   MemcachedNode attachMemcachedNode(String name,
                                     SocketAddress sa) throws IOException {
-    SocketChannel ch = SocketChannel.open();
-    ch.configureBlocking(false);
-    MemcachedNode qa = connFactory.createMemcachedNode(name, sa, ch, connFactory.getReadBufSize());
+    MemcachedNode qa = connFactory.createMemcachedNode(name, sa, connFactory.getReadBufSize());
     if (timeoutRatioThreshold > 0) {
       qa.enableTimeoutRatio();
     }
-    int ops = 0;
+
+    SocketChannel ch = SocketChannel.open();
+    ch.configureBlocking(false);
     ch.socket().setTcpNoDelay(!connFactory.useNagleAlgorithm());
     ch.socket().setReuseAddress(true);
     /* The codes above can be replaced by the codes below since java 1.7 */
     // ch.setOption(StandardSocketOptions.TCP_NODELAY, !f.useNagleAlgorithm());
     // ch.setOption(StandardSocketOptions.SO_REUSEADDR, true);
-
+    qa.setChannel(ch);
+    int ops = 0;
     // Initially I had attempted to skirt this by queueing every
     // connect, but it considerably slowed down start time.
     try {

--- a/src/main/java/net/spy/memcached/MemcachedNode.java
+++ b/src/main/java/net/spy/memcached/MemcachedNode.java
@@ -176,11 +176,6 @@ public interface MemcachedNode {
   int getReconnectCount();
 
   /**
-   * Register a channel with this node.
-   */
-  void registerChannel(SocketChannel ch, SelectionKey selectionKey);
-
-  /**
    * Set the SocketChannel this node uses.
    */
   void setChannel(SocketChannel to);

--- a/src/main/java/net/spy/memcached/MemcachedNodeROImpl.java
+++ b/src/main/java/net/spy/memcached/MemcachedNodeROImpl.java
@@ -15,9 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/**
- *
- */
 package net.spy.memcached;
 
 import java.io.IOException;
@@ -134,10 +131,6 @@ public class MemcachedNodeROImpl implements MemcachedNode {
   }
 
   public void reconnecting() {
-    throw new UnsupportedOperationException();
-  }
-
-  public void registerChannel(SocketChannel ch, SelectionKey selectionKey) {
     throw new UnsupportedOperationException();
   }
 

--- a/src/main/java/net/spy/memcached/protocol/TCPMemcachedNodeImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/TCPMemcachedNodeImpl.java
@@ -129,14 +129,13 @@ public abstract class TCPMemcachedNodeImpl extends SpyObject
   }
 
   public TCPMemcachedNodeImpl(String name,
-                              SocketAddress sa, SocketChannel c,
+                              SocketAddress sa,
                               int bufSize, BlockingQueue<Operation> rq,
                               BlockingQueue<Operation> wq, BlockingQueue<Operation> iq,
                               long opQueueMaxBlockTime, boolean waitForAuth,
                               boolean asciiProtocol) {
     super();
     assert sa != null : "No SocketAddress";
-    assert c != null : "No SocketChannel";
     assert bufSize > 0 : "Invalid buffer size: " + bufSize;
     assert rq != null : "No operation read queue";
     assert wq != null : "No operation write queue";
@@ -144,7 +143,6 @@ public abstract class TCPMemcachedNodeImpl extends SpyObject
 
     this.name = name;
     setSocketAddress(sa);
-    setChannel(c);
     rbuf = ByteBuffer.allocate(bufSize);
     wbuf = ByteBuffer.allocate(bufSize);
     ((Buffer) getWbuf()).clear();
@@ -469,11 +467,6 @@ public abstract class TCPMemcachedNodeImpl extends SpyObject
             + ", topWop=" + getCurrentWriteOp()
             + ", toWrite=" + toWrite
             + ", interested=" + sops + "}";
-  }
-
-  public final void registerChannel(SocketChannel ch, SelectionKey skey) {
-    setChannel(ch);
-    setSk(skey);
   }
 
   public final void setChannel(SocketChannel to) {

--- a/src/main/java/net/spy/memcached/protocol/ascii/AsciiMemcachedNodeImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/AsciiMemcachedNodeImpl.java
@@ -1,7 +1,23 @@
+/*
+ * arcus-java-client : Arcus Java client
+ * Copyright 2010-2014 NAVER Corp.
+ * Copyright 2014-2022 JaM2in Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package net.spy.memcached.protocol.ascii;
 
 import java.net.SocketAddress;
-import java.nio.channels.SocketChannel;
 import java.util.concurrent.BlockingQueue;
 
 import net.spy.memcached.ops.GetOperation;
@@ -16,11 +32,11 @@ import net.spy.memcached.protocol.TCPMemcachedNodeImpl;
  */
 public final class AsciiMemcachedNodeImpl extends TCPMemcachedNodeImpl {
   public AsciiMemcachedNodeImpl(String name,
-                                SocketAddress sa, SocketChannel c,
+                                SocketAddress sa,
                                 int bufSize, BlockingQueue<Operation> rq,
                                 BlockingQueue<Operation> wq, BlockingQueue<Operation> iq,
                                 Long opQueueMaxBlockTimeNs) {
-    super(name, sa, c, bufSize, rq, wq, iq, opQueueMaxBlockTimeNs,
+    super(name, sa, bufSize, rq, wq, iq, opQueueMaxBlockTimeNs,
         false /* ascii never does auth */, true /* ascii protocol */);
   }
 

--- a/src/main/java/net/spy/memcached/protocol/binary/BinaryMemcachedNodeImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/binary/BinaryMemcachedNodeImpl.java
@@ -1,7 +1,23 @@
+/*
+ * arcus-java-client : Arcus Java client
+ * Copyright 2010-2014 NAVER Corp.
+ * Copyright 2014-2022 JaM2in Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package net.spy.memcached.protocol.binary;
 
 import java.net.SocketAddress;
-import java.nio.channels.SocketChannel;
 import java.util.concurrent.BlockingQueue;
 
 import net.spy.memcached.ops.CASOperation;
@@ -21,11 +37,11 @@ public class BinaryMemcachedNodeImpl extends TCPMemcachedNodeImpl {
   private final int MAX_SET_OPTIMIZATION_BYTES = 2 * 1024 * 1024;
 
   public BinaryMemcachedNodeImpl(String name,
-                                 SocketAddress sa, SocketChannel c,
+                                 SocketAddress sa,
                                  int bufSize, BlockingQueue<Operation> rq,
                                  BlockingQueue<Operation> wq, BlockingQueue<Operation> iq,
                                  Long opQueueMaxBlockTimeNs, boolean waitForAuth) {
-    super(name, sa, c, bufSize, rq, wq, iq, opQueueMaxBlockTimeNs,
+    super(name, sa, bufSize, rq, wq, iq, opQueueMaxBlockTimeNs,
             waitForAuth, false /* binary protocol */);
   }
 

--- a/src/test/java/net/spy/memcached/ClientBaseCase.java
+++ b/src/test/java/net/spy/memcached/ClientBaseCase.java
@@ -1,6 +1,7 @@
 /*
  * arcus-java-client : Arcus Java client
  * Copyright 2010-2014 NAVER Corp.
+ * Copyright 2014-2022 JaM2in Co., Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,7 +20,6 @@ package net.spy.memcached;
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
-import java.nio.channels.SocketChannel;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -100,8 +100,8 @@ public abstract class ClientBaseCase extends TestCase {
         @Override
         public MemcachedNode createMemcachedNode(String name,
                                                  SocketAddress sa,
-                                                 SocketChannel c, int bufSize) {
-          return inner.createMemcachedNode(name, sa, c, bufSize);
+                                                 int bufSize) {
+          return inner.createMemcachedNode(name, sa, bufSize);
         }
 
         @Override

--- a/src/test/java/net/spy/memcached/ConnectionFactoryBuilderTest.java
+++ b/src/test/java/net/spy/memcached/ConnectionFactoryBuilderTest.java
@@ -18,7 +18,6 @@ package net.spy.memcached;
 
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
-import java.nio.channels.SocketChannel;
 import java.util.Collections;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
@@ -88,16 +87,9 @@ public class ConnectionFactoryBuilderTest extends BaseMockCase {
         instanceof ArrayModNodeLocator);
     */
 
-    SocketChannel sc = SocketChannel.open();
-    try {
-      assertTrue(f.createMemcachedNode("factory builder test node",
-              InetSocketAddress.createUnresolved("localhost", 11211),
-              sc, 1)
-              instanceof AsciiMemcachedNodeImpl);
-    } finally {
-      sc.close();
-    }
-
+    assertTrue(f.createMemcachedNode("factory builder test node",
+            InetSocketAddress.createUnresolved("localhost", 11211), 1)
+            instanceof AsciiMemcachedNodeImpl);
     assertTrue(f.isDaemon());
     assertFalse(f.shouldOptimize());
     assertFalse(f.useNagleAlgorithm());
@@ -164,16 +156,9 @@ public class ConnectionFactoryBuilderTest extends BaseMockCase {
             InetSocketAddress.createUnresolved("localhost", 11211));
     assertTrue(f.createLocator(Collections.singletonList(n))
             instanceof KetamaNodeLocator);
-
-    SocketChannel sc = SocketChannel.open();
-    try {
-      assertTrue(f.createMemcachedNode("factory builder test node",
-              InetSocketAddress.createUnresolved("localhost", 11211),
-              sc, 1)
-              instanceof BinaryMemcachedNodeImpl);
-    } finally {
-      sc.close();
-    }
+    assertTrue(f.createMemcachedNode("factory builder test node",
+            InetSocketAddress.createUnresolved("localhost", 11211), 1)
+            instanceof BinaryMemcachedNodeImpl);
   }
 
   public void testProtocolSetterBinary() {

--- a/src/test/java/net/spy/memcached/MockMemcachedNode.java
+++ b/src/test/java/net/spy/memcached/MockMemcachedNode.java
@@ -15,9 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/**
- *
- */
 package net.spy.memcached;
 
 import java.io.IOException;
@@ -150,10 +147,6 @@ public class MockMemcachedNode implements MemcachedNode {
 
   public int getReconnectCount() {
     return 0;
-  }
-
-  public void registerChannel(SocketChannel ch, SelectionKey selectionKey) {
-    // noop
   }
 
   public void setChannel(SocketChannel to) {

--- a/src/test/java/net/spy/memcached/protocol/TCPMemcachedNodeImplTest.java
+++ b/src/test/java/net/spy/memcached/protocol/TCPMemcachedNodeImplTest.java
@@ -22,10 +22,10 @@ import net.spy.memcached.DefaultConnectionFactory;
 import net.spy.memcached.ops.GetOperation;
 import net.spy.memcached.ops.Operation;
 import net.spy.memcached.ops.OperationStatus;
+
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
 import java.net.InetSocketAddress;
-import java.nio.channels.SocketChannel;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Queue;
@@ -67,14 +67,12 @@ public class TCPMemcachedNodeImplTest extends TestCase {
     TCPMemcachedNodeImpl fromNode = (TCPMemcachedNodeImpl) factory.createMemcachedNode(
         "tcp node impl test node",
         InetSocketAddress.createUnresolved("127.0.0.1", 11211),
-        SocketChannel.open(),
         4096
     );
 
     TCPMemcachedNodeImpl toNode = (TCPMemcachedNodeImpl) factory.createMemcachedNode(
         "tcp node impl test node",
         InetSocketAddress.createUnresolved("127.0.0.2", 11211),
-        SocketChannel.open(),
         4096
     );
 


### PR DESCRIPTION
memcachednode 생성자에서 socket channel 인자를 제거하고 setter로 초기화할 수 있도록 수정하였습니다.