### PR TITLE
FIX: missing to set false to delayedSwitchover of replica group

### DIFF
--- a/src/main/java/net/spy/memcached/MemcachedConnection.java
+++ b/src/main/java/net/spy/memcached/MemcachedConnection.java
@@ -1500,6 +1500,7 @@ public final class MemcachedConnection extends SpyObject {
         } else {
           switchoverMemcachedReplGroup(entry.getValue().getMasterNode(), true);
           iterator.remove();
+          entry.getValue().setDelayedSwitchover(false);
         }
       }
     }


### PR DESCRIPTION
switchover timeout이 발생될 경우, delayedSwitchover 플래그에 false로 초기화하지 못하여, write 작업을 처리하지 못함에따라 op timeout이 발생하는 현상을 수정하였습니다.