### PR TITLE
FEATURE: developed migration feature.

### DIFF
--- a/src/main/java/net/spy/memcached/AddrUtil.java
+++ b/src/main/java/net/spy/memcached/AddrUtil.java
@@ -52,4 +52,8 @@ public final class AddrUtil {
     assert !addrs.isEmpty() : "No addrs found";
     return addrs;
   }
+
+  public static InetSocketAddress getAddress(String s) {
+    return getAddresses(s).get(0);
+  }
 }

--- a/src/main/java/net/spy/memcached/ArcusKetamaNodeLocator.java
+++ b/src/main/java/net/spy/memcached/ArcusKetamaNodeLocator.java
@@ -24,6 +24,7 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.NavigableMap;
 import java.util.SortedMap;
 import java.util.TreeMap;
 import java.util.SortedSet;
@@ -39,6 +40,17 @@ public class ArcusKetamaNodeLocator extends SpyObject implements NodeLocator {
   private final TreeMap<Long, SortedSet<MemcachedNode>> ketamaNodes;
   private final Collection<MemcachedNode> allNodes;
 
+  /* ENABLE_MIGRATION if */
+  private TreeMap<Long, SortedSet<MemcachedNode>> ketamaAlterNodes;
+  private Collection<MemcachedNode> existNodes;
+  private Collection<MemcachedNode> alterNodes;
+
+  private MigrationType migrationType;
+  private Long migrationBasePoint;
+  private Long migrationLastPoint;
+  private boolean migrationInProgress;
+  /* ENABLE_MIGRATION end */
+
   private final HashAlgorithm hashAlg = HashAlgorithm.KETAMA_HASH;
   private final ArcusKetamaNodeLocatorConfiguration config;
 
@@ -53,12 +65,17 @@ public class ArcusKetamaNodeLocator extends SpyObject implements NodeLocator {
     super();
     allNodes = nodes;
     ketamaNodes = new TreeMap<Long, SortedSet<MemcachedNode>>();
+    /* ENABLE_MIGRATION if */
+    existNodes = new ArrayList<MemcachedNode>();
+    alterNodes = new ArrayList<MemcachedNode>();
+    ketamaAlterNodes = new TreeMap<Long, SortedSet<MemcachedNode>>();
+    /* ENABLE_MIGRATION end */
     config = conf;
 
     int numReps = config.getNodeRepetitions();
     // Ketama does some special work with md5 where it reuses chunks.
     for (MemcachedNode node : nodes) {
-      insertHash(node);
+      insertHash(node, ketamaNodes);
     }
 
     /* ketamaNodes.size() < numReps*nodes.size() : hash collision */
@@ -77,6 +94,16 @@ public class ArcusKetamaNodeLocator extends SpyObject implements NodeLocator {
   public Collection<MemcachedNode> getAll() {
     return Collections.unmodifiableCollection(allNodes);
   }
+
+  /* ENABLE_MIGRATION if */
+  public Collection<MemcachedNode> getAlterAll() {
+    return Collections.unmodifiableCollection(alterNodes);
+  }
+
+  public Collection<MemcachedNode> getExistAll() {
+    return Collections.unmodifiableCollection(existNodes);
+  }
+  /* ENABLE_MIGRATION end */
 
   public SortedMap<Long, SortedSet<MemcachedNode>> getKetamaNodes() {
     return Collections.unmodifiableSortedMap(ketamaNodes);
@@ -151,13 +178,46 @@ public class ArcusKetamaNodeLocator extends SpyObject implements NodeLocator {
       // Add memcached nodes.
       for (MemcachedNode node : toAttach) {
         allNodes.add(node);
-        insertHash(node);
+        /* ENABLE_MIGRATION if */
+        if (migrationInProgress) {
+          if (alterNodes.contains(node)) { /* joining node has joined */
+            migrateKetamaEntireJOIN(node);
+            alterNodes.remove(node);
+          }
+        /* ENABLE_MIGRATION end */
+        } else {
+          insertHash(node, ketamaNodes);
+        }
       }
 
       // Remove memcached nodes.
       for (MemcachedNode node : toDelete) {
         allNodes.remove(node);
-        removeHash(node);
+        /* ENABLE_MIGRATION if */
+        if (migrationInProgress) {
+          if (existNodes.contains(node)) { /* existing node down */
+            if (migrationType == MigrationType.JOIN) {
+              automaticJoinCompletion(node);
+            } else { /* MigrationType.LEAVE */
+              if (existNodes.size() > 1) {
+                automaticLeaveAbort(node);
+              }
+              removeHash(node, ketamaNodes);
+            }
+            existNodes.remove(node);
+          } else if (alterNodes.contains(node)) { /* alter node down or leaving node has left */
+            if (migrationType == MigrationType.JOIN) {
+              removeKetamaJOIN(node); /* remove down joining hpoint */
+            } else { /* MigrationType.LEAVE */
+              migrateKetamaEntireLEAVE(node); /* change leaving hpoint. leaving => leaved */
+            }
+            config.removeNode(node);
+            alterNodes.remove(node);
+          }
+        /* ENABLE_MIGRATION end */
+        } else {
+          removeHash(node, ketamaNodes);
+        }
         try {
           node.closeChannel();
         } catch (IOException e) {
@@ -166,6 +226,12 @@ public class ArcusKetamaNodeLocator extends SpyObject implements NodeLocator {
         }
       }
     } finally {
+      /* ENABLE_MIGRATION if */
+      if (migrationInProgress && (alterNodes.isEmpty() || existNodes.isEmpty())) {
+        getLogger().info("Migration " + migrationType + " has been finished.");
+        clearMigration();
+      }
+      /* ENABLE_MIGRATION end */
       lock.unlock();
     }
   }
@@ -177,8 +243,129 @@ public class ArcusKetamaNodeLocator extends SpyObject implements NodeLocator {
          | (digest[h * 4] & 0xFF);
   }
 
-  private void insertHash(MemcachedNode node) {
+  private void insertHash(MemcachedNode node, TreeMap<Long, SortedSet<MemcachedNode>> continuum) {
     config.insertNode(node);
+    // Ketama does some special work with md5 where it reuses chunks.
+    for (int i = 0; i < config.getNodeRepetitions() / 4; i++) {
+      byte[] digest = HashAlgorithm.computeMd5(config.getKeyForNode(node, i));
+      for (int h = 0; h < 4; h++) {
+        Long k = getKetamaHashPoint(digest, h);
+        SortedSet<MemcachedNode> nodeSet = continuum.get(k);
+        if (nodeSet == null) {
+          nodeSet = new TreeSet<MemcachedNode>(config.new NodeNameComparator());
+          continuum.put(k, nodeSet);
+        }
+        nodeSet.add(node);
+      }
+    }
+  }
+
+  private void removeHash(MemcachedNode node, TreeMap<Long, SortedSet<MemcachedNode>> continuum) {
+    // Ketama does some special work with md5 where it reuses chunks.
+    for (int i = 0; i < config.getNodeRepetitions() / 4; i++) {
+      byte[] digest = HashAlgorithm.computeMd5(config.getKeyForNode(node, i));
+      for (int h = 0; h < 4; h++) {
+        Long k = getKetamaHashPoint(digest, h);
+        SortedSet<MemcachedNode> nodeSet = continuum.get(k);
+        assert nodeSet != null;
+        nodeSet.remove(node);
+        if (nodeSet.size() == 0) {
+          continuum.remove(k);
+        }
+      }
+    }
+    config.removeNode(node);
+  }
+
+  /* ENABLE_MIGRATION if */
+  public void prepareMigration(Collection<MemcachedNode> toAlter, MigrationType type) {
+    getLogger().info("Prepare ketama info for migration. type=" + type);
+    clearMigration();
+    assert type != MigrationType.UNKNOWN;
+    migrationType = type;
+    migrationInProgress = true;
+    /* prepare alterNodes, existNodes, ketamaAlterNodes */
+    for (MemcachedNode node : toAlter) {
+      alterNodes.add(node);
+      if (migrationType == MigrationType.JOIN) {
+        insertHash(node, ketamaAlterNodes);
+      }
+    }
+    for (MemcachedNode node : allNodes) {
+      if (!alterNodes.contains(node)) {
+        existNodes.add(node);
+      }
+    }
+  }
+
+  private void clearMigration() {
+    existNodes.clear();
+    alterNodes.clear();
+    ketamaAlterNodes.clear();
+    migrationBasePoint = -1L;
+    migrationLastPoint = -1L;
+    migrationType = MigrationType.UNKNOWN;
+    migrationInProgress = false;
+  }
+
+  /* remove all hpoints of the joining node */
+  private void removeKetamaJOIN(MemcachedNode node) {
+    /* joining hpoints can be in ketamaNodes or ketamaAlterNodes. */
+    for (int i = 0; i < config.getNodeRepetitions() / 4; i++) {
+      byte[] digest = HashAlgorithm.computeMd5(config.getKeyForNode(node, i));
+      for (int h = 0; h < 4; h++) {
+        Long k = getKetamaHashPoint(digest, h);
+        boolean removed;
+        SortedSet<MemcachedNode> nodeSet = ketamaNodes.get(k);
+        if (nodeSet != null) {
+          removed = nodeSet.remove(node);
+          if (nodeSet.isEmpty()) {
+            ketamaNodes.remove(k);
+          }
+          if (removed) {
+            continue;
+          }
+        }
+        nodeSet = ketamaAlterNodes.get(k);
+        assert nodeSet != null;
+        removed = nodeSet.remove(node);
+        if (nodeSet.isEmpty()) {
+          ketamaAlterNodes.remove(k);
+        }
+        assert removed;
+      }
+    }
+  }
+
+  /* remove joining hpoints from ketamaAlterNodes and add to ketamaNodes. */
+  private void migrateKetamaEntireJOIN(MemcachedNode node) {
+    // Ketama does some special work with md5 where it reuses chunks.
+    for (int i = 0; i < config.getNodeRepetitions() / 4; i++) {
+      byte[] digest = HashAlgorithm.computeMd5(config.getKeyForNode(node, i));
+      for (int h = 0; h < 4; h++) {
+        Long hpoint = getKetamaHashPoint(digest, h);
+        SortedSet<MemcachedNode> alterSet = ketamaAlterNodes.get(hpoint);
+        if (alterSet == null) {
+          continue; /* already joined hpoint */
+        }
+        if (alterSet.remove(node)) { /* remove joining hpoint */
+          continue;
+        }
+        if (alterSet.size() == 0) {
+          ketamaAlterNodes.remove(hpoint);
+        }
+        SortedSet<MemcachedNode> existSet = ketamaNodes.get(hpoint);
+        if (existSet == null) {
+          existSet = new TreeSet<MemcachedNode>(config.new NodeNameComparator());
+          ketamaNodes.put(hpoint, existSet);
+        }
+        existSet.add(node); /* joining => joined */
+      }
+    }
+  }
+
+  /* remove leaving hpoints from ketamaNodes. */
+  private void migrateKetamaEntireLEAVE(MemcachedNode node) {
     // Ketama does some special work with md5 where it reuses chunks.
     for (int i = 0; i < config.getNodeRepetitions() / 4; i++) {
       byte[] digest = HashAlgorithm.computeMd5(config.getKeyForNode(node, i));
@@ -186,30 +373,308 @@ public class ArcusKetamaNodeLocator extends SpyObject implements NodeLocator {
         Long k = getKetamaHashPoint(digest, h);
         SortedSet<MemcachedNode> nodeSet = ketamaNodes.get(k);
         if (nodeSet == null) {
-          nodeSet = new TreeSet<MemcachedNode>(config.new NodeNameComparator());
-          ketamaNodes.put(k, nodeSet);
+          continue; /* already leaved hpoint */
         }
-        nodeSet.add(node);
-      }
-    }
-  }
-
-  private void removeHash(MemcachedNode node) {
-    // Ketama does some special work with md5 where it reuses chunks.
-    for (int i = 0; i < config.getNodeRepetitions() / 4; i++) {
-      byte[] digest = HashAlgorithm.computeMd5(config.getKeyForNode(node, i));
-      for (int h = 0; h < 4; h++) {
-        Long k = getKetamaHashPoint(digest, h);
-        SortedSet<MemcachedNode> nodeSet = ketamaNodes.get(k);
-        assert nodeSet != null;
-        nodeSet.remove(node);
+        nodeSet.remove(node); /* leaving => leaved */
         if (nodeSet.size() == 0) {
           ketamaNodes.remove(k);
         }
       }
     }
-    config.removeNode(node);
   }
+
+  private void migrateKetamaPartialJOIN(Map<Long, SortedSet<MemcachedNode>> range) {
+    Iterator<Map.Entry<Long, SortedSet<MemcachedNode>>> itr = range.entrySet().iterator();
+    Map.Entry<Long, SortedSet<MemcachedNode>> entry;
+    Long hpoint;
+    SortedSet<MemcachedNode> alterSet, existSet;
+    while (itr.hasNext()) {
+      entry = itr.next();
+      hpoint = entry.getKey();
+      alterSet = entry.getValue();
+      assert alterSet != null;
+      existSet = ketamaNodes.get(hpoint);
+      if (existSet == null) {
+        existSet = new TreeSet<MemcachedNode>(config.new NodeNameComparator());
+        ketamaNodes.put(hpoint, existSet);
+      }
+      existSet.addAll(alterSet); /* joining => joined */
+      itr.remove();
+    }
+  }
+
+  private void migrateKetamaPartialLEAVE(Map<Long, SortedSet<MemcachedNode>> range) {
+    Iterator<Map.Entry<Long, SortedSet<MemcachedNode>>> itr = range.entrySet().iterator();
+    Iterator<MemcachedNode> nodeItr;
+    Map.Entry<Long, SortedSet<MemcachedNode>> entry;
+    Long hpoint;
+    SortedSet<MemcachedNode> allSet, leavingSet;
+    while (itr.hasNext()) {
+      entry = itr.next();
+      hpoint = entry.getKey();
+      allSet = entry.getValue();
+      nodeItr = allSet.iterator();
+      while (nodeItr.hasNext()) {
+        MemcachedNode node = nodeItr.next();
+        if (alterNodes.contains(node)) {
+          nodeItr.remove(); /* leaving => leaved */
+          leavingSet = ketamaAlterNodes.get(hpoint);
+          if (leavingSet == null) {
+            leavingSet = new TreeSet<MemcachedNode>(config.new NodeNameComparator());
+            ketamaAlterNodes.put(hpoint, leavingSet); /* for auto leave abort */
+          }
+          leavingSet.add(node);
+          if (allSet.isEmpty()) {
+            itr.remove();
+          }
+        }
+      }
+    }
+  }
+
+  /* check migrationLastPoint belongs to the (spoint, epoint) range. */
+  private boolean needMigrateRange(Long spoint, Long epoint) {
+    Long hash = migrationLastPoint;
+    if (spoint == epoint) { /* full range */
+      return spoint != hash;
+    }
+    if (spoint < epoint) {
+      if (spoint < hash && hash < epoint) {
+        return true;
+      }
+    } else { /* spoint > epoint */
+      if (spoint < hash || hash < epoint) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private void migrateJOIN(Long spoint, Long epoint) {
+    lock.lock();
+    try {
+      spoint = (migrationLastPoint == -1 ? spoint : migrationLastPoint);
+      NavigableMap<Long, SortedSet<MemcachedNode>> targetRange;
+      if (spoint <= epoint) {
+        targetRange = ketamaAlterNodes.subMap(spoint, true, epoint, true);
+        migrateKetamaPartialJOIN(targetRange);
+      } else {
+        targetRange = ketamaAlterNodes.subMap(spoint, true, ketamaAlterNodes.lastKey(), true);
+        migrateKetamaPartialJOIN(targetRange);
+        targetRange = ketamaAlterNodes.subMap(0L, true, epoint, true);
+        migrateKetamaPartialJOIN(targetRange);
+      }
+      migrationLastPoint = epoint;
+    } finally {
+      lock.unlock();
+    }
+    getLogger().info("Applied migration completion range. spoint=" + spoint + ", epoint=" + epoint);
+  }
+
+  private void migrateLEAVE(Long spoint, Long epoint) {
+    lock.lock();
+    try {
+      spoint = (migrationLastPoint == -1 ? spoint : migrationLastPoint);
+      NavigableMap<Long, SortedSet<MemcachedNode>> migratedRange;
+      if (spoint < epoint) {
+        migratedRange = ketamaNodes.subMap(spoint, true, epoint, true);
+        migrateKetamaPartialLEAVE(migratedRange);
+      } else {
+        migratedRange = ketamaNodes.subMap(spoint, true, ketamaNodes.lastKey(), true);
+        migrateKetamaPartialLEAVE(migratedRange);
+        migratedRange = ketamaNodes.subMap(0L, true, epoint, true);
+        migrateKetamaPartialLEAVE(migratedRange);
+      }
+      migrationLastPoint = spoint;
+    } finally {
+      lock.unlock();
+    }
+    getLogger().info("Applied migration completion range. spoint=" + spoint + ", epoint=" + epoint);
+  }
+
+  public boolean updateMigration(Long spoint, Long epoint) {
+    if (migrationInProgress == false) {
+      return true;
+    }
+    if (migrationLastPoint != -1) { /* first migrated ? */
+      /* skip if the range is already migrated. */
+      if (!needMigrateRange(spoint, epoint)) {
+        return true;
+      }
+    }
+    if (migrationType == MigrationType.JOIN) {
+      migrateJOIN(spoint, epoint);
+    } else {
+      migrateLEAVE(spoint, epoint);
+    }
+    return true;
+  }
+
+  private void automaticJoinCompletion(MemcachedNode mine) {
+    getLogger().info("Started automatic join completion. node=" + mine.getNodeName());
+    ArrayList<Long> hpoints = new ArrayList<Long>();
+
+    // Ketama does some special work with md5 where it reuses chunks.
+    for (int i = 0; i < config.getNodeRepetitions() / 4; i++) {
+      byte[] digest = HashAlgorithm.computeMd5(config.getKeyForNode(mine, i));
+      for (int h = 0; h < 4; h++) {
+        Long k = getKetamaHashPoint(digest, h);
+        hpoints.add(k);
+      }
+    }
+
+    SortedSet<MemcachedNode> existSet;
+    SortedSet<MemcachedNode> joinSet;
+    Long existPoint, joinPoint;
+    boolean visible;
+    for (Long currPoint : hpoints) {
+      existSet = ketamaNodes.get(currPoint);
+      assert existSet != null;
+      visible = existSet.first() == mine;
+
+      /* remove currPoint */
+      existSet.remove(mine);
+      if (existSet.size() == 0) {
+        ketamaNodes.remove(currPoint);
+      }
+
+      /* is visible EXIST hpoint? */
+      if (!visible) {
+        /* it's a hidden hpoint. (<EXIST>, <JOIN>, <EXIST (mine)>) */
+        continue; /* skip */
+      }
+
+      /* move the hidden joining hpoints on currPoint */
+      if (ketamaAlterNodes.containsKey(currPoint)) {
+        joinSet = ketamaAlterNodes.get(currPoint);
+        existSet.addAll(joinSet); /* joining => joined */
+        ketamaAlterNodes.remove(currPoint); /* remove all joining hpoint */
+      }
+
+      /* move all joining hpoints (existPoint ~ currPoint) range */
+      joinPoint = ketamaAlterNodes.lowerKey(currPoint);
+      existPoint = ketamaNodes.lowerKey(currPoint);
+      if (existPoint == null) {
+        existPoint = ketamaNodes.lastKey(); /* will be existPoint > currPoint */
+      }
+
+      if (existPoint > currPoint) {
+        /* move [0 ~ joinPoint] range */
+        while (joinPoint != null && 0L <= joinPoint) {
+          ketamaNodes.put(joinPoint, ketamaAlterNodes.get(joinPoint)); /* joining => joined */
+          ketamaAlterNodes.remove(joinPoint); /* remove all joining hpoint */
+          joinPoint = ketamaAlterNodes.lowerKey(joinPoint);
+        }
+        joinPoint = ketamaAlterNodes.lastKey();
+      }
+      /* move (existPoint ~ joinPoint] range */
+      while (joinPoint != null && existPoint < joinPoint) {
+        ketamaNodes.put(joinPoint, ketamaAlterNodes.get(joinPoint)); /* joining => joined */
+        ketamaAlterNodes.remove(joinPoint); /* remove all joining hpoint */
+        joinPoint = ketamaAlterNodes.lowerKey(joinPoint);
+      }
+
+      /* move the hidden joining hpoints on existPoint */
+      if (existPoint.equals(joinPoint)) {
+        /*    <JOIN>, <EXIST>, <JOIN>, <JOIN>
+         * => <JOIN>, <EXIST>, <EXIST>, <EXIST>
+         */
+        existSet = ketamaNodes.get(joinPoint);
+        joinSet = ketamaAlterNodes.get(joinPoint);
+        SortedSet<MemcachedNode> hiddenJoinSet = joinSet.tailSet(existSet.last());
+        existSet.addAll(hiddenJoinSet);
+        joinSet.removeAll(hiddenJoinSet);
+        if (joinSet.isEmpty()) {
+          ketamaAlterNodes.remove(joinPoint);
+        }
+      }
+    }
+    config.removeNode(mine);
+    getLogger().info("Completed automatic join completion. node=" + mine.getNodeName());
+  }
+
+  private Long findMigrationBasePointLEAVE(Long hpoint) {
+    Long key = ketamaNodes.lowerKey(hpoint);
+    assert key != null;
+    while (key >= 0L) {
+      for (MemcachedNode node : ketamaNodes.get(key)) {
+        if (existNodes.contains(node)) {
+          return key;
+        }
+      }
+      key = ketamaNodes.lowerKey(key);
+    }
+    assert key != null && key != -1L;
+    return key;
+  }
+
+  private void automaticLeaveAbort(MemcachedNode mine) {
+    if (migrationLastPoint == -1L) {
+      return; /* nothing to abort */
+    }
+    MemcachedNode visibleExist = mine;
+    migrationBasePoint = findMigrationBasePointLEAVE(0xFFFFFFFFL);
+    for (MemcachedNode mn : ketamaNodes.get(migrationBasePoint)) { /* duplicate hpoints */
+      if (existNodes.contains(mn)) {
+        visibleExist = mn;
+        break;
+      }
+    }
+    if (visibleExist != mine) {
+      return; /* not first exist */
+    }
+
+    getLogger().info("Started automatic leave abort. node=" + mine.getNodeName());
+
+    /* find new base point */
+    Long curBasePoint = migrationBasePoint;
+    Long newBasePoint = migrationBasePoint;
+    while (true) {
+      newBasePoint = findMigrationBasePointLEAVE(newBasePoint);
+      SortedSet<MemcachedNode> mg = ketamaNodes.get(newBasePoint);
+      if (mg.size() == 1 && mg.contains(mine)) {
+        continue; /* next exist point is also mine.. skip */
+      }
+      /* found new base point or all migration range is aborted */
+      break;
+    }
+
+    /* abort (newBasePoint ~ curBasePoint) leaved hpoints */
+    List<Long> aborts = new ArrayList<Long>();
+    NavigableMap<Long, SortedSet<MemcachedNode>> abortRange =
+        ketamaAlterNodes.subMap(newBasePoint, false, curBasePoint, false);
+    for (Map.Entry<Long, SortedSet<MemcachedNode>> e : abortRange.entrySet()) {
+      ketamaNodes.put(e.getKey(), e.getValue()); /* leaved => leaving */
+      aborts.add(e.getKey());
+    }
+    for (Long key : aborts) {
+      ketamaAlterNodes.remove(key); /* remove abort hpoints */
+    }
+
+    /* abort the hidden leaved hpoints on curBasePoint */
+    SortedSet<MemcachedNode> leavedSet = ketamaAlterNodes.get(curBasePoint);
+    if (leavedSet != null) {
+      ketamaNodes.get(curBasePoint).addAll(leavedSet);
+    }
+
+    /* abort the hidden leaved hpoints on newBasePoint */
+    leavedSet = ketamaAlterNodes.get(newBasePoint);
+    if (leavedSet != null) {
+      SortedSet<MemcachedNode> existSet = ketamaNodes.get(newBasePoint);
+      SortedSet<MemcachedNode> hiddenLeavedSet = leavedSet.tailSet(existSet.last());
+      if (!hiddenLeavedSet.isEmpty()) {
+        existSet.addAll(hiddenLeavedSet); /* leaved => leaving */
+        leavedSet.removeAll(hiddenLeavedSet);
+        if (leavedSet.isEmpty()) {
+          ketamaAlterNodes.remove(newBasePoint); /* remove leaved hpoint */
+        }
+      }
+    }
+    migrationBasePoint = -1L;
+    migrationLastPoint = -1L;
+    getLogger().info("Completed automatic leave abort. node=" + mine.getNodeName());
+  }
+  /* ENABLE_MIGRATION end */
 
   class KetamaIterator implements Iterator<MemcachedNode> {
 

--- a/src/main/java/net/spy/memcached/ArcusReplKetamaNodeLocator.java
+++ b/src/main/java/net/spy/memcached/ArcusReplKetamaNodeLocator.java
@@ -26,6 +26,7 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.NavigableMap;
 import java.util.TreeMap;
 import java.util.SortedSet;
 import java.util.TreeSet;
@@ -41,6 +42,19 @@ public class ArcusReplKetamaNodeLocator extends SpyObject implements NodeLocator
   private final HashMap<String, MemcachedReplicaGroup> allGroups;
   private final Collection<MemcachedNode> allNodes;
 
+  /* ENABLE_MIGRATION if */
+  private TreeMap<Long, SortedSet<MemcachedReplicaGroup>> ketamaAlterGroups;
+  private HashMap<String, MemcachedReplicaGroup> alterGroups;
+  private HashMap<String, MemcachedReplicaGroup> existGroups;
+  private Collection<MemcachedNode> existNodes;
+  private Collection<MemcachedNode> alterNodes;
+
+  private MigrationType migrationType;
+  private Long migrationBasePoint;
+  private Long migrationLastPoint;
+  private boolean migrationInProgress;
+  /* ENABLE_MIGRATION end */
+
   private final HashAlgorithm hashAlg = HashAlgorithm.KETAMA_HASH;
   private final ArcusReplKetamaNodeLocatorConfiguration config
           = new ArcusReplKetamaNodeLocatorConfiguration();
@@ -52,6 +66,14 @@ public class ArcusReplKetamaNodeLocator extends SpyObject implements NodeLocator
     allNodes = nodes;
     ketamaGroups = new TreeMap<Long, SortedSet<MemcachedReplicaGroup>>();
     allGroups = new HashMap<String, MemcachedReplicaGroup>();
+
+    /* ENABLE_MIGRATION if */
+    existNodes = new ArrayList<MemcachedNode>();
+    alterNodes = new ArrayList<MemcachedNode>();
+    ketamaAlterGroups = new TreeMap<Long, SortedSet<MemcachedReplicaGroup>>();
+    alterGroups = new HashMap<String, MemcachedReplicaGroup>();
+    existGroups = new HashMap<String, MemcachedReplicaGroup>();
+    /* ENABLE_MIGRATION end */
 
     // create all memcached replica group
     for (MemcachedNode node : nodes) {
@@ -70,7 +92,7 @@ public class ArcusReplKetamaNodeLocator extends SpyObject implements NodeLocator
     int numReps = config.getNodeRepetitions();
     // Ketama does some special work with md5 where it reuses chunks.
     for (MemcachedReplicaGroup group : allGroups.values()) {
-      insertHash(group);
+      insertHash(group, ketamaGroups);
     }
 
     /* ketamaNodes.size() < numReps*nodes.size() : hash collision */
@@ -93,6 +115,24 @@ public class ArcusReplKetamaNodeLocator extends SpyObject implements NodeLocator
   public Map<String, MemcachedReplicaGroup> getAllGroups() {
     return Collections.unmodifiableMap(allGroups);
   }
+
+  /* ENABLE_MIGRATION if */
+  public Collection<MemcachedNode> getAlterAll() {
+    return Collections.unmodifiableCollection(alterNodes);
+  }
+
+  public Collection<MemcachedNode> getExistAll() {
+    return Collections.unmodifiableCollection(existNodes);
+  }
+
+  public Map<String, MemcachedReplicaGroup> getAlterGroups() {
+    return Collections.unmodifiableMap(alterGroups);
+  }
+
+  public Map<String, MemcachedReplicaGroup> getExistGroups() {
+    return Collections.unmodifiableMap(existGroups);
+  }
+  /* ENABLE_MIGRATION end */
 
   public Collection<MemcachedNode> getMasterNodes() {
     List<MemcachedNode> masterNodes = new ArrayList<MemcachedNode>(allGroups.size());
@@ -199,9 +239,27 @@ public class ArcusReplKetamaNodeLocator extends SpyObject implements NodeLocator
       // Remove memcached nodes.
       for (MemcachedNode node : toDelete) {
         allNodes.remove(node);
-        MemcachedReplicaGroup mrg =
-                allGroups.get(MemcachedReplicaGroup.getGroupNameFromNode(node));
-        mrg.deleteMemcachedNode(node);
+        /* ENABLE_MIGRATION if */
+        if (migrationInProgress) {
+          if (existNodes.contains(node)) {
+            existNodes.remove(node); /* existing node down */
+          } else if (alterNodes.contains(node)) {
+            alterNodes.remove(node); /* alter node down or leaving node has left */
+            if (migrationType == MigrationType.JOIN) {
+              alterGroups.get(MemcachedReplicaGroup.getGroupNameFromNode(node))
+                      .deleteMemcachedNode(node);
+            }
+          }
+          if (migrationType == MigrationType.LEAVE || existNodes.contains(node)) {
+            allGroups.get(MemcachedReplicaGroup.getGroupNameFromNode(node))
+                .deleteMemcachedNode(node);
+          }
+        /* ENABLE_MIGRATION end */
+        } else {
+          MemcachedReplicaGroup mrg =
+              allGroups.get(MemcachedReplicaGroup.getGroupNameFromNode(node));
+          mrg.deleteMemcachedNode(node);
+        }
 
         try {
           node.closeChannel();
@@ -218,15 +276,30 @@ public class ArcusReplKetamaNodeLocator extends SpyObject implements NodeLocator
       // Add memcached nodes.
       for (MemcachedNode node : toAttach) {
         allNodes.add(node);
-        MemcachedReplicaGroup mrg =
-                allGroups.get(MemcachedReplicaGroup.getGroupNameFromNode(node));
-        if (mrg == null) {
-          mrg = new MemcachedReplicaGroupImpl(node);
-          getLogger().info("new memcached replica group added %s", mrg.getGroupName());
+        MemcachedReplicaGroup mrg;
+        /* ENABLE_MIGRATION if */
+        if (migrationInProgress) { /* joining group has joined */
+          if (alterNodes.contains(node)) {
+            alterNodes.remove(node);
+          }
+          mrg = alterGroups.get(MemcachedReplicaGroup.getGroupNameFromNode(node));
+          if (mrg == null) {
+            continue;
+          }
+          migrateKetamaEntireJOIN(mrg);
           allGroups.put(mrg.getGroupName(), mrg);
-          insertHash(mrg);
+          alterGroups.remove(mrg.getGroupName());
+        /* ENABLE_MIGRATION end */
         } else {
-          mrg.setMemcachedNode(node);
+          mrg = allGroups.get(MemcachedReplicaGroup.getGroupNameFromNode(node));
+          if (mrg == null) {
+            mrg = new MemcachedReplicaGroupImpl(node);
+            getLogger().info("new memcached replica group added %s", mrg.getGroupName());
+            allGroups.put(mrg.getGroupName(), mrg);
+            insertHash(mrg, ketamaGroups);
+          } else {
+            mrg.setMemcachedNode(node);
+          }
         }
       }
 
@@ -240,12 +313,55 @@ public class ArcusReplKetamaNodeLocator extends SpyObject implements NodeLocator
         }
       }
 
+      /* ENABLE_MIGRATION if */
+      if (migrationInProgress && migrationType == MigrationType.JOIN) { /* down joining group */
+        for (Map.Entry<String, MemcachedReplicaGroup> entry : alterGroups.entrySet()) {
+          MemcachedReplicaGroup group = entry.getValue();
+          if (group.isEmptyGroup()) {
+            toDeleteGroup.add(group);
+          }
+        }
+      }
+      /* ENABLE_MIGRATION end */
+
       for (MemcachedReplicaGroup group : toDeleteGroup) {
-        getLogger().info("old memcached replica group removed %s", group.getGroupName());
-        allGroups.remove(group.getGroupName());
-        removeHash(group);
+        String groupName = group.getGroupName();
+        getLogger().info("old memcached replica group removed %s", groupName);
+        allGroups.remove(groupName);
+        /* ENABLE_MIGRATION if */
+        if (migrationInProgress) {
+          if (existGroups.containsKey(groupName)) {
+            /* existing group down */
+            if (migrationType == MigrationType.JOIN) {
+              automaticJoinCompletion(group);
+            } else { /* MigrationType.LEAVE */
+              if (existGroups.size() > 1) {
+                automaticLeaveAbort(group);
+              }
+              removeHash(group, ketamaGroups);
+              existGroups.remove(groupName);
+            }
+          } else if (alterGroups.containsKey(groupName)) {
+            /* alter node down or leaving node has left */
+            if (migrationType == MigrationType.JOIN) {
+              removeKetamaJOIN(group); /* remove down joining hpoint */
+            } else { /* MigrationType.LEAVE */
+              migrateKetamaEntireLEAVE(group); /* change leaving hpoint. leaving => leaved */
+            }
+            alterGroups.remove(groupName);
+          }
+        /* ENABLE_MIGRATION end */
+        } else {
+          removeHash(group, ketamaGroups);
+        }
       }
     } finally {
+      /* ENABLE_MIGRATION if */
+      if (migrationInProgress && (alterNodes.isEmpty() || existNodes.isEmpty())) {
+        getLogger().info("Migration " + migrationType + " has been finished.");
+        clearMigration();
+      }
+      /* ENABLE_MIGRATION end */
       lock.unlock();
     }
   }
@@ -263,37 +379,457 @@ public class ArcusReplKetamaNodeLocator extends SpyObject implements NodeLocator
          | (digest[h * 4] & 0xFF);
   }
 
-  private void insertHash(MemcachedReplicaGroup group) {
+  private void insertHash(MemcachedReplicaGroup group,
+                          TreeMap<Long, SortedSet<MemcachedReplicaGroup>> continuum) {
     // Ketama does some special work with md5 where it reuses chunks.
     for (int i = 0; i < config.getNodeRepetitions() / 4; i++) {
       byte[] digest = HashAlgorithm.computeMd5(config.getKeyForGroup(group, i));
       for (int h = 0; h < 4; h++) {
         Long k = getKetamaHashPoint(digest, h);
-        SortedSet<MemcachedReplicaGroup> nodeSet = ketamaGroups.get(k);
+        SortedSet<MemcachedReplicaGroup> nodeSet = continuum.get(k);
         if (nodeSet == null) {
           nodeSet = new TreeSet<MemcachedReplicaGroup>(
               new ArcusReplKetamaNodeLocatorConfiguration.MemcachedReplicaGroupComparator());
-          ketamaGroups.put(k, nodeSet);
+          continuum.put(k, nodeSet);
         }
         nodeSet.add(group);
       }
     }
   }
 
-  private void removeHash(MemcachedReplicaGroup group) {
+  private void removeHash(MemcachedReplicaGroup group,
+                          TreeMap<Long, SortedSet<MemcachedReplicaGroup>> continuum) {
     // Ketama does some special work with md5 where it reuses chunks.
     for (int i = 0; i < config.getNodeRepetitions() / 4; i++) {
       byte[] digest = HashAlgorithm.computeMd5(config.getKeyForGroup(group, i));
       for (int h = 0; h < 4; h++) {
         Long k = getKetamaHashPoint(digest, h);
-        SortedSet<MemcachedReplicaGroup> nodeSet = ketamaGroups.get(k);
+        SortedSet<MemcachedReplicaGroup> nodeSet = continuum.get(k);
         nodeSet.remove(group);
         if (nodeSet.size() == 0) {
-          ketamaGroups.remove(k);
+          continuum.remove(k);
         }
       }
     }
   }
+
+  /* ENABLE_MIGRATION if */
+  public void prepareMigration(Collection<MemcachedNode> toAlter, MigrationType type) {
+    getLogger().info("Prepare ketama info for migration. type=" + type);
+    clearMigration();
+    assert type != MigrationType.UNKNOWN;
+    migrationType = type;
+    migrationInProgress = true;
+    MemcachedReplicaGroup mrg;
+    for (MemcachedNode node : toAlter) {
+      alterNodes.add(node);
+      String groupName = MemcachedReplicaGroup.getGroupNameFromNode(node);
+      if (type == MigrationType.JOIN) {
+        mrg = alterGroups.get(groupName);
+        if (mrg == null) {
+          mrg = new MemcachedReplicaGroupImpl(node);
+          alterGroups.put(groupName, mrg); /* add joining group to alterGroups */
+          insertHash(mrg, ketamaAlterGroups);
+        } else {
+          mrg.setMemcachedNode(node); /* add joining slave node */
+        }
+      } else { /* MigrationType.LEAVE */
+        mrg = allGroups.get(groupName);
+        assert (mrg != null);
+        alterGroups.put(groupName, mrg); /* add leaving group to alterGroups */
+      }
+    }
+    for (String groupName : allGroups.keySet()) {
+      if (!alterGroups.containsKey(groupName)) {
+        mrg = allGroups.get(groupName);
+        existGroups.put(groupName, mrg);
+        existNodes.add(mrg.getMasterNode());
+        existNodes.addAll(mrg.getSlaveNodes());
+      }
+    }
+  }
+
+  private void clearMigration() {
+    migrationType = MigrationType.UNKNOWN;
+    migrationBasePoint = -1L;
+    migrationLastPoint = -1L;
+    existNodes.clear();
+    alterNodes.clear();
+    existGroups.clear();
+    alterGroups.clear();
+    ketamaAlterGroups.clear();
+    migrationInProgress = false;
+  }
+
+  /* remove all hpoints of the joining group */
+  private void removeKetamaJOIN(MemcachedReplicaGroup group) {
+    /* joining hpoints can be in ketamaGroups or ketamaAlterGroups. */
+    for (int i = 0; i < config.getNodeRepetitions() / 4; i++) {
+      byte[] digest = HashAlgorithm.computeMd5(config.getKeyForGroup(group, i));
+      for (int h = 0; h < 4; h++) {
+        Long k = getKetamaHashPoint(digest, h);
+        boolean removed;
+        SortedSet<MemcachedReplicaGroup> groupSet = ketamaGroups.get(k);
+        if (groupSet != null) {
+          removed = groupSet.remove(group);
+          if (groupSet.isEmpty()) {
+            ketamaGroups.remove(k);
+          }
+          if (removed) {
+            continue;
+          }
+        }
+        groupSet = ketamaAlterGroups.get(k);
+        assert groupSet != null;
+        removed = groupSet.remove(group);
+        if (groupSet.isEmpty()) {
+          ketamaAlterGroups.remove(k);
+        }
+        assert removed;
+      }
+    }
+  }
+
+  /* remove joining hpoints from ketamaAlterGroups and add to ketamaGroups. */
+  private void migrateKetamaEntireJOIN(MemcachedReplicaGroup group) {
+    // Ketama does some special work with md5 where it reuses chunks.
+    for (int i = 0; i < config.getNodeRepetitions() / 4; i++) {
+      byte[] digest = HashAlgorithm.computeMd5(config.getKeyForGroup(group, i));
+      for (int h = 0; h < 4; h++) {
+        Long k = getKetamaHashPoint(digest, h);
+        SortedSet<MemcachedReplicaGroup> alterSet = ketamaAlterGroups.get(k);
+        if (alterSet == null) {
+          continue; /* already joined hpoint */
+        }
+        if (!alterSet.remove(group)) { /* remove joining hpoint */
+          continue;
+        }
+        if (alterSet.size() == 0) {
+          ketamaAlterGroups.remove(k);
+        }
+        SortedSet<MemcachedReplicaGroup> existSet = ketamaGroups.get(k);
+        if (existSet == null) {
+          existSet = new TreeSet<MemcachedReplicaGroup>(
+              new ArcusReplKetamaNodeLocatorConfiguration.MemcachedReplicaGroupComparator());
+          ketamaGroups.put(k, existSet);
+        }
+        existSet.add(group); /* joining => joined */
+      }
+    }
+  }
+
+  /* remove leaving hpoints from ketamaGroups. */
+  private void migrateKetamaEntireLEAVE(MemcachedReplicaGroup group) {
+    // Ketama does some special work with md5 where it reuses chunks.
+    for (int i = 0; i < config.getNodeRepetitions() / 4; i++) {
+      byte[] digest = HashAlgorithm.computeMd5(config.getKeyForGroup(group, i));
+      for (int h = 0; h < 4; h++) {
+        Long hpoint = getKetamaHashPoint(digest, h);
+        SortedSet<MemcachedReplicaGroup> allGroups = ketamaGroups.get(hpoint);
+        if (allGroups == null) {
+          continue; /* already leaved hpoint */
+        }
+        allGroups.remove(group); /* leaving => leaved */
+        if (allGroups.size() == 0) {
+          ketamaGroups.remove(hpoint);
+        }
+      }
+    }
+  }
+
+  private void migrateKetamaPartialJOIN(Map<Long, SortedSet<MemcachedReplicaGroup>> range) {
+    Iterator<Map.Entry<Long, SortedSet<MemcachedReplicaGroup>>> itr = range.entrySet().iterator();
+    Map.Entry<Long, SortedSet<MemcachedReplicaGroup>> entry;
+    Long hpoint;
+    SortedSet<MemcachedReplicaGroup> alterSet, existSet;
+    while (itr.hasNext()) {
+      entry = itr.next();
+      hpoint = entry.getKey();
+      alterSet = entry.getValue();
+      assert alterSet != null;
+      existSet = ketamaGroups.get(hpoint);
+      if (existSet == null) {
+        existSet = new TreeSet<MemcachedReplicaGroup>(
+            new ArcusReplKetamaNodeLocatorConfiguration.MemcachedReplicaGroupComparator());
+        ketamaGroups.put(hpoint, existSet);
+      }
+      existSet.addAll(alterSet); /* joining => joined */
+      itr.remove();
+    }
+  }
+
+  private void migrateKetamaPartialLEAVE(Map<Long, SortedSet<MemcachedReplicaGroup>> range) {
+    Iterator<Map.Entry<Long, SortedSet<MemcachedReplicaGroup>>> itr = range.entrySet().iterator();
+    Map.Entry<Long, SortedSet<MemcachedReplicaGroup>> entry;
+    Iterator<MemcachedReplicaGroup> groupItr;
+    Long hpoint;
+    SortedSet<MemcachedReplicaGroup> allSet, leavedSet;
+    while (itr.hasNext()) {
+      entry = itr.next();
+      hpoint = entry.getKey();
+      allSet = entry.getValue();
+      groupItr = allSet.iterator();
+      while (groupItr.hasNext()) { /* find leaving group */
+        MemcachedReplicaGroup group = groupItr.next();
+        if (alterGroups.containsKey(group.getGroupName())) {
+          groupItr.remove(); /* leaving => leaved */
+          leavedSet = ketamaAlterGroups.get(hpoint);
+          if (leavedSet == null) {
+            leavedSet = new TreeSet<MemcachedReplicaGroup>(
+                new ArcusReplKetamaNodeLocatorConfiguration.MemcachedReplicaGroupComparator());
+            ketamaAlterGroups.put(hpoint, leavedSet); /* for auto leave abort */
+          }
+          leavedSet.add(group);
+          if (allSet.isEmpty()) {
+            itr.remove();
+          }
+        }
+      }
+    }
+  }
+
+  /* check migrationLastPoint belongs to the (spoint, epoint) range. */
+  private boolean needMigrateRange(Long spoint, Long epoint) {
+    Long hash = migrationLastPoint;
+    if (spoint == epoint) { /* full range */
+      return spoint != hash;
+    }
+    if (spoint < epoint) {
+      if (spoint < hash && hash < epoint) {
+        return true;
+      }
+    } else { /* spoint > epoint */
+      if (spoint < hash || hash < epoint) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private void migrateJOIN(Long spoint, Long epoint) {
+    lock.lock();
+    try {
+      spoint = (migrationLastPoint == -1 ? spoint : migrationLastPoint);
+      NavigableMap<Long, SortedSet<MemcachedReplicaGroup>> targetRange;
+      if (spoint <= epoint) {
+        targetRange = ketamaAlterGroups.subMap(spoint, true, epoint, true);
+        migrateKetamaPartialJOIN(targetRange);
+      } else {
+        targetRange = ketamaAlterGroups.subMap(spoint, true, ketamaAlterGroups.lastKey(), true);
+        migrateKetamaPartialJOIN(targetRange);
+        targetRange = ketamaAlterGroups.subMap(0L, true, epoint, true);
+        migrateKetamaPartialJOIN(targetRange);
+      }
+      migrationLastPoint = epoint;
+    } finally {
+      lock.unlock();
+    }
+    getLogger().info("Applied migration completion range. spoint=" + spoint + ", epoint=" + epoint);
+  }
+
+  private void migrateLEAVE(Long spoint, Long epoint) {
+    lock.lock();
+    try {
+      epoint = (migrationLastPoint == -1 ? epoint : migrationLastPoint);
+      NavigableMap<Long, SortedSet<MemcachedReplicaGroup>> migratedRange;
+      if (spoint < epoint) {
+        migratedRange = ketamaGroups.subMap(spoint, true, epoint, true);
+        migrateKetamaPartialLEAVE(migratedRange);
+      } else {
+        migratedRange = ketamaGroups.subMap(spoint, true, ketamaGroups.lastKey(), true);
+        migrateKetamaPartialLEAVE(migratedRange);
+        migratedRange = ketamaGroups.subMap(0L, true, epoint, true);
+        migrateKetamaPartialLEAVE(migratedRange);
+      }
+      migrationLastPoint = spoint;
+    } finally {
+      lock.unlock();
+    }
+    getLogger().info("Applied migration completion range. spoint=" + spoint + ", epoint=" + epoint);
+  }
+
+  public boolean updateMigration(Long spoint, Long epoint) {
+    if (migrationInProgress == false) {
+      return true;
+    }
+    if (migrationLastPoint != -1) { /* first migrated ? */
+      /* skip if the range is already migrated. */
+      if (!needMigrateRange(spoint, epoint)) {
+        return true;
+      }
+    }
+    if (migrationType == MigrationType.JOIN) {
+      migrateJOIN(spoint, epoint);
+    } else {
+      migrateLEAVE(spoint < 0xFFFFFFFFL ? spoint + 1 : 0, epoint);
+    }
+    return true;
+  }
+
+  private void automaticJoinCompletion(MemcachedReplicaGroup mine) {
+    getLogger().info("Started automatic join completion. group=" + mine.getGroupName());
+    ArrayList<Long> hpoints = new ArrayList<Long>();
+
+    // Ketama does some special work with md5 where it reuses chunks.
+    for (int i = 0; i < config.getNodeRepetitions() / 4; i++) {
+      byte[] digest = HashAlgorithm.computeMd5(config.getKeyForGroup(mine, i));
+      for (int h = 0; h < 4; h++) {
+        Long k = getKetamaHashPoint(digest, h);
+        hpoints.add(k);
+      }
+    }
+
+    SortedSet<MemcachedReplicaGroup> existSet;
+    SortedSet<MemcachedReplicaGroup> joinSet;
+    Long existPoint, joinPoint;
+    boolean visible;
+    for (Long currPoint : hpoints) {
+      existSet = ketamaGroups.get(currPoint);
+      assert existSet != null;
+      visible = existSet.first() == mine;
+
+      /* remove currPoint */
+      existSet.remove(mine);
+      if (existSet.size() == 0) {
+        ketamaGroups.remove(currPoint);
+      }
+
+      /* is visible EXIST hpoint? */
+      if (!visible) {
+        /* it's a hidden hpoint. (<EXIST>, <JOIN>, <EXIST (mine)>) */
+        continue; /* skip */
+      }
+
+      /* move the hidden joining hpoints on currPoint */
+      if (ketamaAlterGroups.containsKey(currPoint)) {
+        joinSet = ketamaAlterGroups.get(currPoint);
+        existSet.addAll(joinSet); /* joining => joined */
+        ketamaAlterGroups.remove(currPoint); /* remove all joining hpoint */
+      }
+
+      /* move all joining hpoints (existPoint ~ currPoint) range */
+      joinPoint = ketamaAlterGroups.lowerKey(currPoint);
+      existPoint = ketamaGroups.lowerKey(currPoint);
+      if (existPoint == null) {
+        existPoint = ketamaGroups.lastKey(); /* will be existPoint > currPoint */
+      }
+
+      if (existPoint > currPoint) {
+        /* move [0 ~ joinPoint] range */
+        while (joinPoint != null && 0L <= joinPoint) {
+          ketamaGroups.put(joinPoint, ketamaAlterGroups.get(joinPoint)); /* joining => joined */
+          ketamaAlterGroups.remove(joinPoint); /* remove all joining hpoint */
+          joinPoint = ketamaAlterGroups.lowerKey(joinPoint);
+        }
+        joinPoint = ketamaAlterGroups.lastKey();
+      }
+      /* move (existPoint ~ joinPoint] range */
+      while (joinPoint != null && existPoint < joinPoint) {
+        ketamaGroups.put(joinPoint, ketamaAlterGroups.get(joinPoint)); /* joining => joined */
+        ketamaAlterGroups.remove(joinPoint); /* remove all joining hpoint */
+        joinPoint = ketamaAlterGroups.lowerKey(joinPoint);
+      }
+
+      /* move the hidden joining hpoints on existPoint */
+      if (existPoint.equals(joinPoint)) {
+        /*    <JOIN>, <EXIST>, <JOIN>, <JOIN>
+         * => <JOIN>, <EXIST>, <EXIST>, <EXIST>
+         */
+        existSet = ketamaGroups.get(joinPoint);
+        joinSet = ketamaAlterGroups.get(joinPoint);
+        SortedSet<MemcachedReplicaGroup> hiddenJoinSet = joinSet.tailSet(existSet.last());
+        existSet.addAll(hiddenJoinSet);
+        joinSet.removeAll(hiddenJoinSet);
+        if (joinSet.isEmpty()) {
+          ketamaAlterGroups.remove(joinPoint);
+        }
+      }
+    }
+    getLogger().info("Completed automatic join completion. group=" + mine.getGroupName());
+  }
+
+  private Long findMigrationBasePointLEAVE(Long hpoint) {
+    Long key = ketamaGroups.lowerKey(hpoint);
+    assert key != null;
+    while (key >= 0L) {
+      for (MemcachedReplicaGroup group : ketamaGroups.get(key)) {
+        if (existGroups.containsKey(group.getGroupName())) {
+          return key;
+        }
+      }
+      key = ketamaGroups.lowerKey(key);
+    }
+    assert key != null && key != -1L;
+    return key;
+  }
+
+  private void automaticLeaveAbort(MemcachedReplicaGroup mine) {
+    if (migrationLastPoint == -1L) {
+      return; /* nothing to abort */
+    }
+    MemcachedReplicaGroup visibleExist = mine;
+    migrationBasePoint = findMigrationBasePointLEAVE(0xFFFFFFFFL);
+    for (MemcachedReplicaGroup mg : ketamaGroups.get(migrationBasePoint)) { /* duplicate hpoints */
+      if (existGroups.containsKey(mg.getGroupName())) {
+        visibleExist = mg;
+        break;
+      }
+    }
+    if (visibleExist != mine) {
+      return; /* not first exist */
+    }
+
+    getLogger().info("Started automatic leave abort. group=" + mine.getGroupName());
+
+    /* find new base point */
+    Long curBasePoint = migrationBasePoint;
+    Long newBasePoint = migrationBasePoint;
+    while (true) {
+      newBasePoint = findMigrationBasePointLEAVE(newBasePoint);
+      SortedSet<MemcachedReplicaGroup> mg = ketamaGroups.get(newBasePoint);
+      if (mg.size() == 1 && mg.contains(mine)) {
+        continue; /* next exist point is also mine.. skip */
+      }
+      /* found new base point or all migration range is aborted */
+      break;
+    }
+
+    /* abort (newBasePoint ~ curBasePoint) leaved hpoints */
+    List<Long> aborts = new ArrayList<Long>();
+    NavigableMap<Long, SortedSet<MemcachedReplicaGroup>> abortRange =
+            ketamaAlterGroups.subMap(newBasePoint, false, curBasePoint, false);
+    for (Map.Entry<Long, SortedSet<MemcachedReplicaGroup>> e : abortRange.entrySet()) {
+      ketamaGroups.put(e.getKey(), e.getValue()); /* leaved => leaving */
+      aborts.add(e.getKey());
+    }
+    for (Long key : aborts) {
+      ketamaAlterGroups.remove(key); /* remove abort hpoints */
+    }
+
+    /* abort the hidden leaved hpoints on curBasePoint */
+    SortedSet<MemcachedReplicaGroup> leavedSet = ketamaAlterGroups.get(curBasePoint);
+    if (leavedSet != null) {
+      ketamaGroups.get(curBasePoint).addAll(leavedSet);
+    }
+
+    /* abort the hidden leaved hpoints on newBasePoint */
+    leavedSet = ketamaAlterGroups.get(newBasePoint);
+    if (leavedSet != null) {
+      SortedSet<MemcachedReplicaGroup> existSet = ketamaGroups.get(newBasePoint);
+      SortedSet<MemcachedReplicaGroup> hiddenLeavedSet = leavedSet.tailSet(existSet.last());
+      if (!hiddenLeavedSet.isEmpty()) {
+        existSet.addAll(hiddenLeavedSet); /* leaved => leaving */
+        leavedSet.removeAll(hiddenLeavedSet);
+        if (leavedSet.isEmpty()) {
+          ketamaAlterGroups.remove(newBasePoint); /* remove leaved hpoint */
+        }
+      }
+    }
+    migrationBasePoint = -1L;
+    migrationLastPoint = -1L;
+    getLogger().info("Completed automatic leave abort. group=" + mine.getGroupName());
+  }
+  /* ENABLE_MIGRATION end */
 
   private class ReplKetamaIterator implements Iterator<MemcachedNode> {
     private final String key;

--- a/src/main/java/net/spy/memcached/ArrayModNodeLocator.java
+++ b/src/main/java/net/spy/memcached/ArrayModNodeLocator.java
@@ -54,6 +54,26 @@ public final class ArrayModNodeLocator implements NodeLocator {
     return Arrays.asList(nodes);
   }
 
+  /* ENABLE_MIGRATION if */
+  public Collection<MemcachedNode> getAlterAll() {
+    return null;
+  }
+
+  public Collection<MemcachedNode> getExistAll() {
+    return null;
+  }
+  @Override
+  public void prepareMigration(Collection<MemcachedNode> toAlter, MigrationType type) {
+    throw new UnsupportedOperationException("not supported");
+  }
+
+
+  @Override
+  public boolean updateMigration(Long spoint, Long epoint) {
+    throw new UnsupportedOperationException("not supported");
+  }
+  /* ENABLE_MIGRATION end */
+
   public MemcachedNode getPrimary(String k) {
     return nodes[getServerForKey(k)];
   }

--- a/src/main/java/net/spy/memcached/ConnectionFactoryBuilder.java
+++ b/src/main/java/net/spy/memcached/ConnectionFactoryBuilder.java
@@ -89,7 +89,12 @@ public class ConnectionFactoryBuilder {
 
   private ReadPriority readPriority = ReadPriority.MASTER;
   private Map<APIType, ReadPriority> apiReadPriorityList = new HashMap<APIType, ReadPriority>();
+  /* ENABLE_REPLICATION end */
+  /* ENABLE_MIGRATION if */
+  private boolean arcusMigrEnabled = false;
+  /* ENABLE_MIGRATION end */
 
+  /* ENABLE_REPLICATION if */
   /* Called by cache manager after checking ZK nodes */
   public void internalArcusReplEnabled(boolean b) {
     arcusReplEnabled = b;
@@ -119,6 +124,14 @@ public class ConnectionFactoryBuilder {
   public FailureMode getFailureMode() {
     return failureMode;
   }
+  /* ENABLE_REPLICATION end */
+
+  /* ENABLE_MIGRATION if */
+  /* Called by cache manager after checking ZK nodes */
+  public void internalArcusMigrEnabled(boolean b) {
+    arcusMigrEnabled = b;
+  }
+  /* ENABLE_MIGRATION end */
 
   /**
    * Set the operation queue factory.
@@ -460,6 +473,7 @@ public class ConnectionFactoryBuilder {
               throws IOException {
         MemcachedConnection c = super.createConnection(name, addrs);
         c.setArcusReplEnabled(arcusReplEnabled);
+        c.setArcusMigrEnabled(arcusMigrEnabled);
         return c;
       }
       /* ENABLE_REPLICATION end */

--- a/src/main/java/net/spy/memcached/KetamaNodeLocator.java
+++ b/src/main/java/net/spy/memcached/KetamaNodeLocator.java
@@ -97,6 +97,26 @@ public final class KetamaNodeLocator extends SpyObject implements NodeLocator {
     return allNodes;
   }
 
+  /* ENABLE_MIGRATION if */
+  public Collection<MemcachedNode> getAlterAll() {
+    return null;
+  }
+
+  public Collection<MemcachedNode> getExistAll() {
+    return null;
+  }
+
+  @Override
+  public void prepareMigration(Collection<MemcachedNode> toAlter, MigrationType type) {
+    throw new UnsupportedOperationException("not supported");
+  }
+
+  @Override
+  public boolean updateMigration(Long spoint, Long epoint) {
+    throw new UnsupportedOperationException("not supported");
+  }
+  /* ENABLE_MIGRATION end */
+
   public MemcachedNode getPrimary(final String k) {
     MemcachedNode rv = getNodeForKey(hashAlg.hash(k));
     assert rv != null : "Found no node for key " + k;

--- a/src/main/java/net/spy/memcached/MigrationMonitor.java
+++ b/src/main/java/net/spy/memcached/MigrationMonitor.java
@@ -1,0 +1,310 @@
+/*
+ * arcus-java-client : Arcus Java client
+ * Copyright 2014-2022 JaM2in Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.spy.memcached;
+
+import net.spy.memcached.compat.SpyObject;
+import org.apache.zookeeper.AsyncCallback;
+import org.apache.zookeeper.KeeperException.Code;
+import org.apache.zookeeper.WatchedEvent;
+import org.apache.zookeeper.Watcher;
+import org.apache.zookeeper.ZooKeeper;
+import org.apache.zookeeper.data.Stat;
+
+import java.util.AbstractMap;
+import java.util.List;
+
+/**
+ * MigrationMonitor monitors the changes of the cloud_stat
+ * in the ZooKeeper node{@code (/arcus/cloud_stat/<service_code>)}.
+ */
+public class MigrationMonitor extends SpyObject implements Watcher {
+
+  private final ZooKeeper zk;
+
+  private final String alterListZPath;
+
+  private final String cloudStatZPath;
+
+  private final String serviceCode;
+
+  private final AsyncCallback.Children2Callback cloudStatCallback;
+
+  private final AsyncCallback.Children2Callback alterListCallback;
+
+  private final MigrationMonitorListener listener;
+
+  private MigrationType type = MigrationType.UNKNOWN;
+
+  private MigrationState state = MigrationState.UNKNOWN;
+
+  private volatile boolean dead;
+
+  /**
+   * Constructor
+   *
+   * @param zk             ZooKeeper Connection
+   * @param cloudStatZPath path of cloud_stat znode
+   * @param serviceCode    service code (or cloud name) to identity each cloud
+   * @param listener       Callback listener
+   */
+  public MigrationMonitor(ZooKeeper zk, String cloudStatZPath,
+                          String serviceCode, final MigrationMonitorListener listener) {
+    this.zk = zk;
+    this.cloudStatZPath = cloudStatZPath + serviceCode;
+    this.alterListZPath = cloudStatZPath + serviceCode + "/alter_list";
+    this.serviceCode = serviceCode;
+    this.listener = listener;
+
+    getLogger().info("Initializing the MigrationMonitor.");
+
+    this.cloudStatCallback = new AsyncCallback.Children2Callback() {
+      /**
+       * A callback function to process the result of cloud_stat getChildren(watch=true).
+       */
+      @Override
+      public void processResult(int rc, String s, Object o, List<String> list, Stat stat) {
+        switch (Code.get(rc)) {
+          case OK:
+            commandCloudStatChange(list);
+            return;
+          case SESSIONEXPIRED:
+            getLogger().warn("Session expired. Reconnect to the Arcus admin. "
+                + getInfo());
+            shutdown();
+            return;
+          default:
+            getLogger().warn("Ignoring an unexpected event on cloud_stat. code="
+                + Code.get(rc) + ", " + getInfo());
+            asyncGetCloudStat();
+            return;
+        }
+      }
+    };
+    this.alterListCallback = new AsyncCallback.Children2Callback() {
+      /**
+       * A callback function to process the result of alter_list getChildren(watch=true).
+       */
+      @Override
+      public void processResult(int rc, String s, Object o, List<String> list, Stat stat) {
+        switch (Code.get(rc)) {
+          case OK:
+            listener.commandAlterListChange(list);
+            return;
+          case SESSIONEXPIRED:
+            getLogger().warn("Session expired. Reconnect to the Arcus admin. "
+                + getInfo());
+            shutdown();
+            return;
+          case NONODE:
+            getLogger().fatal("Cannot find the alter_list znode. Stop watching. " + getInfo());
+            return; /* stop watching */
+          default:
+            getLogger().warn("Ignoring an unexpected event on alter_list. code="
+                    + Code.get(rc) + ", " + getInfo());
+            asyncGetAlterList();
+            return;
+        }
+      }
+    };
+
+    // Get the cloud_stat from the Arcus admin asynchronously.
+    // Returning result would be processed in processResult().
+    asyncGetCloudStat();
+  }
+
+  /**
+   * Processes every events from the ZooKeeper.
+   */
+  public void process(WatchedEvent event) {
+    if (event.getType() == Event.EventType.NodeChildrenChanged) {
+      String path = event.getPath();
+      if (path != null && path.equals(cloudStatZPath)) {
+        asyncGetCloudStat();
+      } else if (path != null && path.equals(alterListZPath)) {
+        asyncGetAlterList();
+      }
+    }
+  }
+
+  private AbstractMap.SimpleEntry<MigrationType, MigrationState> validateCloudStatZNodes(
+      List<String> children) {
+    /* There are following znodes in cloud_stat :
+     * INTERNAL, STATE, alter_list
+     */
+    int child_count = 3;
+    int valid_count = 0;
+    if (children.size() != child_count) {
+      return null;
+    }
+
+    MigrationType type = MigrationType.UNKNOWN;
+    MigrationState state = MigrationState.UNKNOWN;
+
+    for (String znode : children) {
+      if (znode.equals("INTERNAL") || znode.equals("alter_list")) {
+        valid_count++;
+        continue;
+      }
+
+      /* STATE znode format:
+       * <STATE>^<JOIN|LEAVE>^<BEGIN|PREPARED|DONE>
+       */
+      if (znode.startsWith("STATE^")) {
+        String[] tokens = znode.split("\\^");
+        if (tokens.length < 3) {
+          break;
+        }
+        try {
+          type = MigrationType.valueOf(tokens[1]);
+          state = MigrationState.valueOf(tokens[2]);
+          valid_count++;
+        } catch (IllegalArgumentException e) {
+          return null;
+        }
+      }
+    }
+    if (valid_count != child_count) {
+      getLogger().warn("Invalid cloud_stat znodes. zpath=" + cloudStatZPath);
+      return null;
+    }
+    return new AbstractMap.SimpleEntry<MigrationType, MigrationState>(type, state);
+  }
+
+  private void commandCloudStatChange(List<String> children) {
+    if (children.size() == 0) {
+      resetMigrationTypeAndState();
+      return;
+    }
+
+    AbstractMap.SimpleEntry<MigrationType, MigrationState> typeAndState =
+        validateCloudStatZNodes(children);
+    if (typeAndState == null) {
+      return;
+    }
+    MigrationType newType = typeAndState.getKey();
+    MigrationState newState = typeAndState.getValue();
+    getLogger().info("MigrationMonitor reads cloud_stat. type=" + newType + ", state=" + newState);
+
+    if (newState == MigrationState.DONE) {
+      getLogger().warn("Migration state is DONE. reset type and state.");
+      resetMigrationTypeAndState();
+      return;
+    }
+
+    if (type != MigrationType.UNKNOWN && type != newType) {
+      getLogger().error("The cloud_stat type mismatch. curType=" + type +
+          ", newType=" + newType + ", zpath=" + cloudStatZPath);
+      resetMigrationTypeAndState();
+      return;
+    }
+
+    if (newState == MigrationState.BEGIN) {
+      /* All alter_list is not yet registered. */
+      setMigrationTypeAndState(newType, newState);
+    } else if (newState == MigrationState.PREPARED) {
+      /* All alter_list has been registered.
+       * Read the alter_list and pass it to the IO Thread to prepare for the migration.
+       */
+      if (state == MigrationState.UNKNOWN || state == MigrationState.BEGIN) {
+        setMigrationTypeAndState(newType, newState);
+      }
+      asyncGetAlterList();
+    }
+  }
+
+  private void setMigrationTypeAndState(MigrationType type, MigrationState state) {
+    this.type = type;
+    this.state = state;
+    listener.setMigrationTypeAndState(type, state);
+  }
+
+  private void resetMigrationTypeAndState() {
+    this.type = MigrationType.UNKNOWN;
+    this.state = MigrationState.UNKNOWN;
+    listener.setMigrationTypeAndState(type, state);
+  }
+
+  /**
+   * Get the cloud_stat asynchronously from the Arcus admin.
+   */
+  private void asyncGetCloudStat() {
+    String zpath = cloudStatZPath;
+    if (getLogger().isDebugEnabled()) {
+      getLogger().debug("Set a new watch on " + zpath);
+    }
+    zk.getChildren(zpath, this, cloudStatCallback, null);
+  }
+
+  /**
+   * Get the alter_list asynchronously from the Arcus admin.
+   */
+  private void asyncGetAlterList() {
+    if (getLogger().isDebugEnabled()) {
+      getLogger().debug("Set a new watch on " + alterListZPath);
+    }
+    zk.getChildren(alterListZPath, this, alterListCallback, null);
+  }
+
+  /**
+   * Other classes use the MigrationMonitor by implementing this method
+   */
+  public interface MigrationMonitorListener {
+    /**
+     * The children of the alter_list has changed.
+     *
+     * @param children new children node list
+     */
+    void commandAlterListChange(List<String> children);
+    /**
+     *
+     * @param type   migration type
+     * @param state  migration state
+     */
+    void setMigrationTypeAndState(MigrationType type, MigrationState state);
+    /**
+     * The ZooKeeper session is no longer valid.
+     */
+    void closing();
+  }
+
+  /**
+   * Shutdown the MigrationMonitor.
+   */
+  public void shutdown() {
+    if (!dead) {
+      getLogger().info("Shutting down the MigrationMonitor. " + getInfo());
+      dead = true;
+      listener.closing();
+    }
+  }
+
+  /**
+   * Check if the MigrationMonitor is dead.
+   */
+  public boolean isDead() {
+    return dead;
+  }
+
+  private String getInfo() {
+    String zkSessionId = null;
+    if (zk != null) {
+      zkSessionId = "0x" + Long.toHexString(zk.getSessionId());
+    }
+
+    return "[serviceCode=" + serviceCode + ", adminSessionId=" + zkSessionId + "]";
+  }
+}

--- a/src/main/java/net/spy/memcached/MigrationState.java
+++ b/src/main/java/net/spy/memcached/MigrationState.java
@@ -1,0 +1,9 @@
+package net.spy.memcached;
+
+public enum MigrationState {
+  UNKNOWN,
+  BEGIN,
+  PREPARED,
+  PROGRESS,
+  DONE
+}

--- a/src/main/java/net/spy/memcached/MigrationType.java
+++ b/src/main/java/net/spy/memcached/MigrationType.java
@@ -1,0 +1,7 @@
+package net.spy.memcached;
+
+public enum MigrationType {
+  UNKNOWN,
+  JOIN,
+  LEAVE
+}

--- a/src/main/java/net/spy/memcached/NodeLocator.java
+++ b/src/main/java/net/spy/memcached/NodeLocator.java
@@ -46,6 +46,18 @@ public interface NodeLocator {
    */
   Collection<MemcachedNode> getAll();
 
+  /* ENABLE_MIGRATION if */
+  /**
+   * Get all alter memcached nodes.
+   */
+  Collection<MemcachedNode> getAlterAll();
+
+  /**
+   * Get all exist memcached nodes.
+   */
+  Collection<MemcachedNode> getExistAll();
+  /* ENABLE_MIGRATION if */
+
   /**
    * Create a read-only copy of this NodeLocator.
    */
@@ -56,4 +68,10 @@ public interface NodeLocator {
    * only available in ArcusKetamaNodeLocator.
    */
   void update(Collection<MemcachedNode> toAttach, Collection<MemcachedNode> toDelete);
+
+  /* ENABLE_MIGRATION if */
+  void prepareMigration(Collection<MemcachedNode> toAlter, MigrationType type);
+
+  boolean updateMigration(Long spoint, Long epoint);
+  /* ENABLE_MIGRATION end */
 }

--- a/src/main/java/net/spy/memcached/OperationFactory.java
+++ b/src/main/java/net/spy/memcached/OperationFactory.java
@@ -17,6 +17,7 @@
 package net.spy.memcached;
 
 import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 
 import javax.security.auth.callback.CallbackHandler;
@@ -68,10 +69,12 @@ import net.spy.memcached.ops.GetAttrOperation;
 import net.spy.memcached.ops.GetOperation;
 import net.spy.memcached.ops.GetsOperation;
 import net.spy.memcached.ops.KeyedOperation;
+import net.spy.memcached.ops.MultiOperationCallback;
 import net.spy.memcached.ops.Mutator;
 import net.spy.memcached.ops.MutatorOperation;
 import net.spy.memcached.ops.NoopOperation;
 import net.spy.memcached.ops.Operation;
+import net.spy.memcached.ops.OperationStatus;
 import net.spy.memcached.ops.OperationCallback;
 import net.spy.memcached.ops.SASLAuthOperation;
 import net.spy.memcached.ops.SASLMechsOperation;
@@ -81,6 +84,7 @@ import net.spy.memcached.ops.StatsOperation;
 import net.spy.memcached.ops.StoreOperation;
 import net.spy.memcached.ops.StoreType;
 import net.spy.memcached.ops.VersionOperation;
+
 
 /**
  * Factory that builds operations for protocol handlers.
@@ -359,6 +363,13 @@ public interface OperationFactory {
    */
   Collection<Operation> clone(KeyedOperation op);
 
+  /* ENABLE_MIGRATION if */
+  MultiOperationCallback createMultiOperationCallback(KeyedOperation op, int count,
+                                                      OperationStatus operationStatus);
+
+  Operation cloneMultiOperation(KeyedOperation op, MemcachedNode node,
+                                List<Integer> keyIndexes, MultiOperationCallback mcb);
+  /* ENABLE_MIGRATION end */
   /**
    * Create operation for collection items.
    *

--- a/src/main/java/net/spy/memcached/RedirectHandler.java
+++ b/src/main/java/net/spy/memcached/RedirectHandler.java
@@ -1,0 +1,147 @@
+/*
+ * arcus-java-client : Arcus Java client
+ * Copyright 2022 JaM2in Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.spy.memcached;
+
+import net.spy.memcached.ops.OperationStatus;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public abstract class RedirectHandler {
+
+  private Long spoint;
+  private Long epoint;
+  private OperationStatus operationStatus;
+
+  public abstract void addRedirectKey(String response, String key, Integer keyIndex);
+
+  protected String parseRedirectResponse(String response) {
+    /* response format : NOT_MY_KEY <spoint> <epoint> <owner_name> */
+    String[] tokens = response.split(" ");
+    assert tokens.length >= 3;
+    spoint = Long.valueOf(tokens[1]);
+    epoint = Long.valueOf(tokens[2]);
+    return tokens.length == 3 ? null : tokens[3]; /* no owner in pipe response */
+  }
+
+  public final Long getMigrationBasePoint() {
+    return spoint;
+  }
+
+  public final Long getMigrationEndPoint() {
+    return epoint;
+  }
+
+  public final void setOperationStatus(OperationStatus operationStatus) {
+    this.operationStatus = operationStatus;
+  }
+
+  public final OperationStatus getOperationStatus() {
+    return operationStatus;
+  }
+
+  public static class RedirectHandlerSingleKey extends RedirectHandler {
+
+    private String key;
+    private String owner;
+
+    @Override
+    public void addRedirectKey(String response, String key, Integer keyIndex) {
+      this.key = key;
+      this.owner = parseRedirectResponse(response);
+    }
+
+    public String getOwner() {
+      return owner;
+    }
+
+    public String getKey() {
+      return key;
+    }
+  }
+
+  public static class RedirectHandlerMultiKey extends RedirectHandler {
+
+    private List<String> keys;
+    private List<Integer> keyIndexes;
+    private Map<String, ArrayList<Integer>> keyIndexesByOwner;
+
+    @Override
+    public void addRedirectKey(String response, String key, Integer keyIndex) {
+      String owner = parseRedirectResponse(response);
+      if (owner == null) {
+        if (keys == null) {
+          keys = new ArrayList<String>();
+          keyIndexes = new ArrayList<Integer>();
+        }
+        keys.add(key);
+        keyIndexes.add(keyIndex);
+      } else {
+        if (keyIndexesByOwner == null) {
+          keyIndexesByOwner = new HashMap<String, ArrayList<Integer>>();
+        }
+        ArrayList<Integer> keyIndexes = keyIndexesByOwner.get(owner);
+        if (keyIndexes == null) {
+          keyIndexes = new ArrayList<Integer>();
+          keyIndexesByOwner.put(owner, keyIndexes);
+        }
+        keyIndexes.add(keyIndex);
+      }
+    }
+
+    public Map<MemcachedNode, ArrayList<Integer>> groupRedirectKeysWithOwner(
+            MemcachedConnection conn) {
+      Map<MemcachedNode, ArrayList<Integer>> keyIndexesByNode =
+          new HashMap<MemcachedNode, ArrayList<Integer>>();
+      for (Map.Entry<String, ArrayList<Integer>> entry : keyIndexesByOwner.entrySet()) {
+        MemcachedNode node = conn.getOwnerNodeByName(entry.getKey());
+        if (node == null) {
+          return null;
+        }
+        keyIndexesByNode.put(node, entry.getValue());
+      }
+      return keyIndexesByNode;
+    }
+
+    public Map<MemcachedNode, ArrayList<Integer>> groupRedirectKeysWithoutOwner(
+            MemcachedConnection conn) {
+      Map<MemcachedNode, ArrayList<Integer>> keyIndexesByNode =
+          new HashMap<MemcachedNode, ArrayList<Integer>>();
+      for (int i = 0; i < keys.size(); i++) {
+        MemcachedNode node = conn.findNodeByKey(keys.get(i));
+        if (node == null) {
+          return null;
+        }
+        ArrayList<Integer> keyIndexes = keyIndexesByNode.get(node);
+        if (keyIndexes == null) {
+          keyIndexes = new ArrayList<Integer>();
+          keyIndexesByNode.put(node, keyIndexes);
+        }
+        keyIndexes.add(this.keyIndexes.get(i));
+      }
+      return keyIndexesByNode;
+    }
+
+    public Map<MemcachedNode, ArrayList<Integer>> groupRedirectKeys(
+            MemcachedConnection conn) {
+      return keyIndexesByOwner == null ?
+              groupRedirectKeysWithoutOwner(conn) : groupRedirectKeysWithOwner(conn);
+    }
+  }
+}

--- a/src/main/java/net/spy/memcached/collection/BTreeGetBulkImpl.java
+++ b/src/main/java/net/spy/memcached/collection/BTreeGetBulkImpl.java
@@ -78,6 +78,11 @@ public abstract class BTreeGetBulkImpl<T> implements BTreeGetBulk<T> {
         BTreeUtil.compareByteArraysInLexOrder(from, to) > 0, eFlagFilter, offset, count);
   }
 
+  protected BTreeGetBulkImpl(BTreeGetBulkImpl<T> bTreeGetBulk) {
+    this(bTreeGetBulk.node, bTreeGetBulk.keyList, bTreeGetBulk.range, bTreeGetBulk.reverse,
+        bTreeGetBulk.eFlagFilter, bTreeGetBulk.offset, bTreeGetBulk.count);
+  }
+
   public void setKeySeparator(String keySeparator) {
     this.keySeparator = keySeparator;
   }
@@ -105,6 +110,11 @@ public abstract class BTreeGetBulkImpl<T> implements BTreeGetBulk<T> {
 
   public List<String> getKeyList() {
     return keyList;
+  }
+
+  public void setRedirect(MemcachedNode owner, List<String> redirectKeys) {
+    this.node = owner;
+    this.keyList = redirectKeys;
   }
 
   public String stringify() {

--- a/src/main/java/net/spy/memcached/collection/BTreeGetBulkWithByteTypeBkey.java
+++ b/src/main/java/net/spy/memcached/collection/BTreeGetBulkWithByteTypeBkey.java
@@ -30,6 +30,10 @@ public class BTreeGetBulkWithByteTypeBkey<T> extends BTreeGetBulkImpl<T> {
     super(node, keyList, from, to, eFlagFilter, offset, count);
   }
 
+  public BTreeGetBulkWithByteTypeBkey(BTreeGetBulkImpl bTreeGetBulk) {
+    super(bTreeGetBulk);
+  }
+
   public byte[] getSubkey() {
     return (byte[]) subkey;
   }

--- a/src/main/java/net/spy/memcached/collection/BTreeGetBulkWithLongTypeBkey.java
+++ b/src/main/java/net/spy/memcached/collection/BTreeGetBulkWithLongTypeBkey.java
@@ -30,6 +30,10 @@ public class BTreeGetBulkWithLongTypeBkey<T> extends BTreeGetBulkImpl<T> {
     super(node, keyList, from, to, eFlagFilter, offset, count);
   }
 
+  public BTreeGetBulkWithLongTypeBkey(BTreeGetBulkImpl bTreeGetBulk) {
+    super(bTreeGetBulk);
+  }
+
   public Long getSubkey() {
     return (Long) subkey;
   }

--- a/src/main/java/net/spy/memcached/collection/CollectionBulkInsert.java
+++ b/src/main/java/net/spy/memcached/collection/CollectionBulkInsert.java
@@ -42,6 +42,10 @@ public abstract class CollectionBulkInsert<T> extends CollectionObject {
 
   protected int nextOpIndex = 0;
 
+  /* ENABLE_MIGRATION if */
+  private List<Integer> redirectKeyIndexes;
+  /* ENABLE_MIGRATION end */
+
   /**
    * set next index of operation
    * that will be processed after when operation moved by switchover
@@ -61,6 +65,20 @@ public abstract class CollectionBulkInsert<T> extends CollectionObject {
   public abstract ByteBuffer getAsciiCommand();
 
   public abstract ByteBuffer getBinaryCommand();
+
+  /* ENABLE_MIGRATION if */
+  public Integer getRedirectKeyIndex(int index) {
+    return redirectKeyIndexes.get(index);
+  }
+
+  public final void setRedirect(MemcachedNode node,
+                                List<String> redirectKeys, List<Integer> redirectKeyIndexes) {
+    this.node = node;
+    this.redirectKeyIndexes = redirectKeyIndexes;
+    keyList = redirectKeys;
+    itemCount = keyList.size();
+  }
+  /* ENABLE_MIGRATION end */
 
   /**
    *
@@ -96,6 +114,11 @@ public abstract class CollectionBulkInsert<T> extends CollectionObject {
     public BTreeBulkInsert(MemcachedNode node, List<String> keyList, byte[] bkey,
                            byte[] eflag, T value, CollectionAttributes attr, Transcoder<T> tc) {
       this(node, keyList, BTreeUtil.toHex(bkey), BTreeUtil.toHex(eflag), value, attr, tc);
+    }
+
+    public BTreeBulkInsert(BTreeBulkInsert<T> insert) {
+      this(insert.node, insert.keyList, insert.bkey, insert.eflag, insert.value,
+          insert.attribute, insert.tc);
     }
 
     public ByteBuffer getAsciiCommand() {
@@ -157,6 +180,10 @@ public abstract class CollectionBulkInsert<T> extends CollectionObject {
       this.cachedData = tc.encode(value);
     }
 
+    public MapBulkInsert(MapBulkInsert<T> insert) {
+      this(insert.node, insert.keyList, insert.mkey, insert.value, insert.attribute, insert.tc);
+    }
+
     public ByteBuffer getAsciiCommand() {
       int capacity = 0;
 
@@ -213,6 +240,10 @@ public abstract class CollectionBulkInsert<T> extends CollectionObject {
       this.cachedData = tc.encode(value);
     }
 
+    public SetBulkInsert(SetBulkInsert<T> insert) {
+      this(insert.node, insert.keyList, insert.value, insert.attribute, insert.tc);
+    }
+
     public ByteBuffer getAsciiCommand() {
       int capacity = 0;
 
@@ -267,6 +298,10 @@ public abstract class CollectionBulkInsert<T> extends CollectionObject {
       this.tc = tc;
       this.itemCount = keyList.size();
       this.cachedData = tc.encode(value);
+    }
+
+    public ListBulkInsert(ListBulkInsert<T> insert) {
+      this(insert.node, insert.keyList, insert.index, insert.value, insert.attribute, insert.tc);
     }
 
     public ByteBuffer getAsciiCommand() {

--- a/src/main/java/net/spy/memcached/collection/CollectionPipedInsert.java
+++ b/src/main/java/net/spy/memcached/collection/CollectionPipedInsert.java
@@ -40,6 +40,9 @@ public abstract class CollectionPipedInsert<T> extends CollectionObject {
   protected CollectionAttributes attribute;
 
   protected int nextOpIndex = 0;
+  /* ENABLE_MIGRATION if */
+  protected int redirectIndex = 0;
+  /* ENABLE_MIGRATION end */
 
   /**
    * set next index of operation
@@ -52,6 +55,12 @@ public abstract class CollectionPipedInsert<T> extends CollectionObject {
   public int getNextOpIndex() {
     return nextOpIndex;
   }
+
+  /* ENABLE_MIGRATION if */
+  public void setRedirectIndex(int i) {
+    this.redirectIndex = i;
+  }
+  /* ENABLE_MIGRATION end */
 
   public abstract ByteBuffer getAsciiCommand();
 
@@ -104,7 +113,8 @@ public abstract class CollectionPipedInsert<T> extends CollectionObject {
       int eSize = encodedList.size();
       String createOption = attribute != null ?
           CollectionCreate.makeCreateClause(attribute, cd.getFlags()) : "";
-      for (int i = this.nextOpIndex; i < eSize; i++) {
+      int index = nextOpIndex > 0 ? nextOpIndex : redirectIndex;
+      for (int i = index; i < eSize; i++) {
         byte[] each = encodedList.get(i);
         setArguments(bb, COMMAND, key, index, each.length,
                      createOption, (i < eSize - 1) ? PIPE : "");
@@ -168,7 +178,8 @@ public abstract class CollectionPipedInsert<T> extends CollectionObject {
       int eSize = encodedList.size();
       String createOption = attribute != null ?
           CollectionCreate.makeCreateClause(attribute, cd.getFlags()) : "";
-      for (int i = this.nextOpIndex; i < eSize; i++) {
+      int index = nextOpIndex > 0 ? nextOpIndex : redirectIndex;
+      for (int i = index; i < eSize; i++) {
         byte[] each = encodedList.get(i);
         setArguments(bb, COMMAND, key, each.length,
                      createOption, (i < eSize - 1) ? PIPE : "");
@@ -234,7 +245,8 @@ public abstract class CollectionPipedInsert<T> extends CollectionObject {
       List<Long> keyList = new ArrayList<Long>(map.keySet());
       String createOption = attribute != null ?
           CollectionCreate.makeCreateClause(attribute, cd.getFlags()) : "";
-      for (i = this.nextOpIndex; i < keySize; i++) {
+      int index = nextOpIndex > 0 ? nextOpIndex : redirectIndex;
+      for (i = index; i < keySize; i++) {
         Long bkey = keyList.get(i);
         byte[] value = decodedList.get(i);
         setArguments(bb, COMMAND, key, bkey, value.length,
@@ -303,7 +315,8 @@ public abstract class CollectionPipedInsert<T> extends CollectionObject {
       int eSize = elements.size();
       String createOption = attribute != null ?
           CollectionCreate.makeCreateClause(attribute, cd.getFlags()) : "";
-      for (i = this.nextOpIndex; i < eSize; i++) {
+      int index = nextOpIndex > 0 ? nextOpIndex : redirectIndex;
+      for (i = index; i < eSize; i++) {
         Element<T> element = elements.get(i);
         byte[] value = decodedList.get(i);
         setArguments(bb, COMMAND, key,
@@ -372,7 +385,8 @@ public abstract class CollectionPipedInsert<T> extends CollectionObject {
       List<String> keyList = new ArrayList<String>(map.keySet());
       String createOption = attribute != null ?
           CollectionCreate.makeCreateClause(attribute, cd.getFlags()) : "";
-      for (i = this.nextOpIndex; i < mkeySize; i++) {
+      int index = nextOpIndex > 0 ? nextOpIndex : redirectIndex;
+      for (i = index; i < mkeySize; i++) {
         String mkey = keyList.get(i);
         byte[] value = encodedList.get(i);
         setArguments(bb, COMMAND, key, mkey, value.length,

--- a/src/main/java/net/spy/memcached/collection/CollectionPipedUpdate.java
+++ b/src/main/java/net/spy/memcached/collection/CollectionPipedUpdate.java
@@ -36,6 +36,9 @@ public abstract class CollectionPipedUpdate<T> extends CollectionObject {
   protected Transcoder<T> tc;
   protected int itemCount;
   protected int nextOpIndex = 0;
+  /* ENABLE_MIGRATION if */
+  protected int redirectIndex = 0;
+  /* ENABLE_MIGRATION end */
 
   /**
    * set next index of operation
@@ -48,6 +51,12 @@ public abstract class CollectionPipedUpdate<T> extends CollectionObject {
   public int getNextOpIndex() {
     return nextOpIndex;
   }
+
+  /* ENABLE_MIGRATION if */
+  public void setRedirectIndex(int i) {
+    this.redirectIndex = i;
+  }
+  /* ENABLE_MIGRATION end */
 
   public abstract ByteBuffer getAsciiCommand();
 
@@ -110,7 +119,8 @@ public abstract class CollectionPipedUpdate<T> extends CollectionObject {
       ByteBuffer bb = ByteBuffer.allocate(capacity);
 
       int eSize = elements.size();
-      for (i = this.nextOpIndex; i < eSize; i++) {
+      int index = nextOpIndex > 0 ? nextOpIndex : redirectIndex;
+      for (i = index; i < eSize; i++) {
         Element<T> element = elements.get(i);
         value = decodedList.get(i);
         eflagUpdate = element.getElementFlagUpdate();
@@ -195,7 +205,8 @@ public abstract class CollectionPipedUpdate<T> extends CollectionObject {
       // create ascii operation string
       int mkeySize = elements.keySet().size();
       List<String> keyList = new ArrayList<String>(elements.keySet());
-      for (i = this.nextOpIndex; i < mkeySize; i++) {
+      int index = nextOpIndex > 0 ? nextOpIndex : redirectIndex;
+      for (i = index; i < mkeySize; i++) {
         String mkey = keyList.get(i);
         value = encodedList.get(i);
         b = new StringBuilder();

--- a/src/main/java/net/spy/memcached/collection/SetPipedExist.java
+++ b/src/main/java/net/spy/memcached/collection/SetPipedExist.java
@@ -38,6 +38,24 @@ public class SetPipedExist<T> extends CollectionObject {
   private final Transcoder<T> tc;
   private int itemCount;
 
+  protected int redirectIndex = 0;
+
+  /* ENABLE_MIGRATION if */
+  private ArrayList<Integer> redirectIndexes;
+  /* ENABLE_MIGRATION end */
+
+  /* ENABLE_MIGRATION if */
+  public void addRedirectIndex(int index) {
+    if (redirectIndexes == null) {
+      redirectIndexes = new ArrayList<Integer>();
+    }
+    redirectIndexes.add(index);
+  }
+  public void setRedirectIndex(int i) {
+    this.redirectIndex = i;
+  }
+  /* ENABLE_MIGRATION end */
+
   public List<T> getValues() {
     return this.values;
   }
@@ -76,7 +94,7 @@ public class SetPipedExist<T> extends CollectionObject {
 
     // create ascii operation string
     int eSize = encodedList.size();
-    for (int i = 0; i < eSize; i++) {
+    for (int i = redirectIndex; i < eSize; i++) {
       byte[] each = encodedList.get(i);
 
       setArguments(bb, COMMAND, key, each.length,

--- a/src/main/java/net/spy/memcached/ops/BTreeGetBulkOperation.java
+++ b/src/main/java/net/spy/memcached/ops/BTreeGetBulkOperation.java
@@ -16,7 +16,11 @@
  */
 package net.spy.memcached.ops;
 
+import net.spy.memcached.collection.BTreeGetBulk;
+
 public interface BTreeGetBulkOperation extends KeyedOperation {
+  BTreeGetBulk<?> getBulk();
+
   interface Callback<K> extends OperationCallback {
     void gotElement(String key, Object subkey, int flags, byte[] eflag, byte[] data);
 

--- a/src/main/java/net/spy/memcached/ops/BaseOperationFactory.java
+++ b/src/main/java/net/spy/memcached/ops/BaseOperationFactory.java
@@ -1,6 +1,7 @@
 /*
  * arcus-java-client : Arcus Java client
  * Copyright 2010-2014 NAVER Corp.
+ * Copyright 2014-2022 JaM2in Co., Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,8 +19,14 @@ package net.spy.memcached.ops;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.List;
 
+import net.spy.memcached.MemcachedNode;
 import net.spy.memcached.OperationFactory;
+import net.spy.memcached.collection.BTreeGetBulkImpl;
+import net.spy.memcached.collection.BTreeGetBulkWithByteTypeBkey;
+import net.spy.memcached.collection.BTreeGetBulkWithLongTypeBkey;
+import net.spy.memcached.collection.CollectionBulkInsert;
 
 /**
  * Base class for operation factories.
@@ -104,4 +111,97 @@ public abstract class BaseOperationFactory implements OperationFactory {
     }
     return rv;
   }
+
+  @Override
+  public MultiOperationCallback createMultiOperationCallback(KeyedOperation op, int count,
+                                                             OperationStatus operationStatus) {
+    OperationCallback originalCallback = op.getCallback();
+    if (op instanceof GetOperation) {
+      return new MultiGetOperationCallback(originalCallback, count);
+    } else if (op instanceof GetsOperation) {
+      return new MultiGetsOperationCallback(originalCallback, count);
+    } else if (op instanceof CollectionBulkInsertOperation) {
+      return new MultiCollectionBulkInsertOperationCallback(
+          originalCallback, count, operationStatus);
+    } else if (op instanceof CollectionPipedInsertOperation) {
+      return new MultiCollectionPipedInsertOperationCallback(originalCallback, count);
+    } else if (op instanceof BTreeGetBulkOperation) {
+      return new MultiBTreeGetBulkOperationCallback(originalCallback, count);
+    } else {
+      assert false : "Unhandled operation type: " + op.getClass();
+    }
+    return null;
+  }
+
+  /* ENABLE_MIGRATION if */
+  public Operation cloneMultiOperation(KeyedOperation op, MemcachedNode node,
+                                       List<Integer> keyIndexes, MultiOperationCallback mcb) {
+    assert !op.isCancelled() : "Attempted to clone a canceled op";
+    assert !op.hasErrored() : "Attempted to clone an errored op";
+
+    List<String> redirectKeys = new ArrayList<String>();
+    if (op instanceof GetOperation) {
+      GetOperation so = (GetOperation) op;
+      List<String> keys = (ArrayList<String>) op.getKeys();
+      for (Integer idx : keyIndexes) {
+        redirectKeys.add(keys.get(idx));
+      }
+      if (so.isMGetOperation()) {
+        return mget(redirectKeys, (GetOperation.Callback) mcb);
+      } else {
+        return get(redirectKeys, (GetOperation.Callback) mcb);
+      }
+    } else if (op instanceof GetsOperation) {
+      GetsOperation so = (GetsOperation) op;
+      List<String> keys = (ArrayList<String>) op.getKeys();
+      for (Integer idx : keyIndexes) {
+        redirectKeys.add(keys.get(idx));
+      }
+      if (so.isMGetOperation()) {
+        return mgets(redirectKeys, (GetsOperation.Callback) mcb);
+      } else {
+        return gets(redirectKeys, (GetsOperation.Callback) mcb);
+      }
+    } else if (op instanceof CollectionBulkInsertOperation) {
+      CollectionBulkInsert insert = ((CollectionBulkInsertOperation) op).getInsert();
+      List<String> keys = insert.getKeyList();
+      for (Integer idx : keyIndexes) {
+        redirectKeys.add(keys.get(idx));
+      }
+      if (insert instanceof CollectionBulkInsert.ListBulkInsert) {
+        insert = new CollectionBulkInsert.ListBulkInsert(
+            (CollectionBulkInsert.ListBulkInsert) insert);
+      } else if (insert instanceof CollectionBulkInsert.SetBulkInsert) {
+        insert = new CollectionBulkInsert.SetBulkInsert(
+            (CollectionBulkInsert.SetBulkInsert) insert);
+      } else if (insert instanceof CollectionBulkInsert.MapBulkInsert) {
+        insert = new CollectionBulkInsert.MapBulkInsert(
+            (CollectionBulkInsert.MapBulkInsert) insert);
+      } else if (insert instanceof CollectionBulkInsert.BTreeBulkInsert) {
+        insert = new CollectionBulkInsert.BTreeBulkInsert(
+            (CollectionBulkInsert.BTreeBulkInsert) insert);
+      } else {
+        assert false : "Unhandled operation type: " + op.getClass();
+      }
+      insert.setRedirect(node, redirectKeys, keyIndexes);
+      return collectionBulkInsert(insert, mcb);
+    } else if (op instanceof BTreeGetBulkOperation) {
+      BTreeGetBulkImpl getbulk = (BTreeGetBulkImpl) ((BTreeGetBulkOperation) op).getBulk();
+      List<String> keys = getbulk.getKeyList();
+      for (Integer idx : keyIndexes) {
+        redirectKeys.add(keys.get(idx));
+      }
+      if (getbulk instanceof BTreeGetBulkWithByteTypeBkey) {
+        getbulk = new BTreeGetBulkWithByteTypeBkey(getbulk);
+      } else if (getbulk instanceof BTreeGetBulkWithLongTypeBkey) {
+        getbulk = new BTreeGetBulkWithLongTypeBkey(getbulk);
+      }
+      getbulk.setRedirect(node, redirectKeys);
+      return bopGetBulk(getbulk, (BTreeGetBulkOperation.Callback) mcb);
+    } else {
+      assert false : "Unhandled operation type: " + op.getClass();
+    }
+    return null;
+  }
+  /* ENABLE_MIGRATION end */
 }

--- a/src/main/java/net/spy/memcached/ops/GetOperation.java
+++ b/src/main/java/net/spy/memcached/ops/GetOperation.java
@@ -6,6 +6,7 @@ package net.spy.memcached.ops;
  */
 public interface GetOperation extends KeyedOperation {
 
+  boolean isMGetOperation();
   /**
    * Operation callback for the get request.
    */

--- a/src/main/java/net/spy/memcached/ops/GetsOperation.java
+++ b/src/main/java/net/spy/memcached/ops/GetsOperation.java
@@ -6,6 +6,7 @@ package net.spy.memcached.ops;
  */
 public interface GetsOperation extends KeyedOperation {
 
+  boolean isMGetOperation();
   /**
    * Operation callback for the Gets request.
    */

--- a/src/main/java/net/spy/memcached/ops/MultiBTreeGetBulkOperationCallback.java
+++ b/src/main/java/net/spy/memcached/ops/MultiBTreeGetBulkOperationCallback.java
@@ -1,0 +1,19 @@
+package net.spy.memcached.ops;
+
+public class MultiBTreeGetBulkOperationCallback extends MultiOperationCallback
+        implements BTreeGetBulkOperation.Callback {
+
+  public MultiBTreeGetBulkOperationCallback(OperationCallback original, int todo) {
+    super(original, todo);
+  }
+
+  @Override
+  public void gotElement(String key, Object subkey, int flags, byte[] eflag, byte[] data) {
+    ((BTreeGetBulkOperation.Callback) originalCallback).gotElement(key, subkey, flags, eflag, data);
+  }
+
+  @Override
+  public void gotKey(String key, int elementCount, OperationStatus status) {
+    ((BTreeGetBulkOperation.Callback) originalCallback).gotKey(key, elementCount, status);
+  }
+}

--- a/src/main/java/net/spy/memcached/ops/MultiCollectionBulkInsertOperationCallback.java
+++ b/src/main/java/net/spy/memcached/ops/MultiCollectionBulkInsertOperationCallback.java
@@ -1,0 +1,14 @@
+package net.spy.memcached.ops;
+
+public class MultiCollectionBulkInsertOperationCallback extends MultiOperationCallback
+    implements CollectionBulkInsertOperation.Callback {
+
+  public MultiCollectionBulkInsertOperationCallback(OperationCallback original,
+                                                    int todo, OperationStatus status) {
+    super(original, status, todo);
+  }
+
+  public void gotStatus(Integer index, OperationStatus status) {
+    ((CollectionBulkInsertOperation.Callback) originalCallback).gotStatus(index, status);
+  }
+}

--- a/src/main/java/net/spy/memcached/ops/MultiCollectionPipedInsertOperationCallback.java
+++ b/src/main/java/net/spy/memcached/ops/MultiCollectionPipedInsertOperationCallback.java
@@ -1,0 +1,13 @@
+package net.spy.memcached.ops;
+
+public class MultiCollectionPipedInsertOperationCallback extends MultiOperationCallback
+    implements CollectionPipedInsertOperation.Callback {
+
+  public MultiCollectionPipedInsertOperationCallback(OperationCallback original, int todo) {
+    super(original, todo);
+  }
+
+  public void gotStatus(Integer index, OperationStatus status) {
+    ((CollectionPipedInsertOperation.Callback) originalCallback).gotStatus(index, status);
+  }
+}

--- a/src/main/java/net/spy/memcached/ops/MultiOperationCallback.java
+++ b/src/main/java/net/spy/memcached/ops/MultiOperationCallback.java
@@ -11,8 +11,8 @@ package net.spy.memcached.ops;
  */
 public abstract class MultiOperationCallback implements OperationCallback {
 
-  private OperationStatus mostRecentStatus = null;
-  private int remaining = 0;
+  private OperationStatus mostRecentStatus;
+  private int remaining;
   protected final OperationCallback originalCallback;
 
   /**
@@ -27,6 +27,12 @@ public abstract class MultiOperationCallback implements OperationCallback {
     remaining = todo;
   }
 
+  public MultiOperationCallback(OperationCallback original, OperationStatus status, int todo) {
+    this(original, todo);
+    mostRecentStatus = status;
+  }
+
+  @Override
   public void complete() {
     if (--remaining == 0) {
       originalCallback.receivedStatus(mostRecentStatus);
@@ -34,8 +40,18 @@ public abstract class MultiOperationCallback implements OperationCallback {
     }
   }
 
+  @Override
   public void receivedStatus(OperationStatus status) {
-    mostRecentStatus = status;
+    if (mostRecentStatus == null) {
+      mostRecentStatus = status;
+    } else {
+      if (!status.isSuccess()) {
+        mostRecentStatus = status;
+      }
+    }
   }
 
+  public OperationCallback getCallback() {
+    return originalCallback;
+  }
 }

--- a/src/main/java/net/spy/memcached/ops/Operation.java
+++ b/src/main/java/net/spy/memcached/ops/Operation.java
@@ -21,6 +21,7 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 
 import net.spy.memcached.MemcachedNode;
+import net.spy.memcached.RedirectHandler;
 
 
 /**
@@ -129,6 +130,10 @@ public interface Operation {
   boolean isPipeOperation();
 
   boolean isIdempotentOperation();
+
+  /* ENABLE_MIGRATION if */
+  RedirectHandler getRedirectHandler();
+  /* ENABLE_MIGRATION end */
 
   APIType getAPIType();
 }

--- a/src/main/java/net/spy/memcached/ops/OperationState.java
+++ b/src/main/java/net/spy/memcached/ops/OperationState.java
@@ -40,6 +40,13 @@ public enum OperationState {
   /**
    * State indicating this operation will be moved by switchover or failover
    */
-  MOVING
+  MOVING,
   /* ENABLE_REPLICATION end */
+
+  /* ENABLE_MIGRATION if */
+  /**
+   * State indicating this operation will be redirected by migration
+   */
+  REDIRECT
+  /* ENABLE_MIGRATION end */
 }

--- a/src/main/java/net/spy/memcached/protocol/ascii/BTreeFindPositionOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/BTreeFindPositionOperationImpl.java
@@ -80,6 +80,14 @@ public class BTreeFindPositionOperationImpl extends OperationImpl implements
 
     Integer position = null;
 
+    /* ENABLE_MIGRATION if */
+    if (line.startsWith("NOT_MY_KEY")) {
+      addRedirectSingleKeyOperation(line, key);
+      transitionState(OperationState.REDIRECT);
+      return;
+    }
+    /* ENABLE_MIGRATION end */
+
     if (line.startsWith("POSITION=")) {
       String[] stuff = line.split("=");
       assert stuff.length == 2;

--- a/src/main/java/net/spy/memcached/protocol/ascii/BTreeFindPositionWithGetOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/BTreeFindPositionWithGetOperationImpl.java
@@ -88,6 +88,14 @@ public class BTreeFindPositionWithGetOperationImpl extends OperationImpl impleme
   public void handleLine(String line) {
     getLogger().debug("Got line %s", line);
 
+    /* ENABLE_MIGRATION if */
+    if (line.startsWith("NOT_MY_KEY")) {
+      addRedirectSingleKeyOperation(line, key);
+      transitionState(OperationState.REDIRECT);
+      return;
+    }
+    /* ENABLE_MIGRATION end */
+
     /*
       VALUE <position> <flags> <count> <index>\r\n
       <bkey> [<eflag>] <bytes> <data>\r\n

--- a/src/main/java/net/spy/memcached/protocol/ascii/BTreeGetByPositionOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/BTreeGetByPositionOperationImpl.java
@@ -85,6 +85,14 @@ public class BTreeGetByPositionOperationImpl extends OperationImpl implements
   public void handleLine(String line) {
     getLogger().debug("Got line %s", line);
 
+    /* ENABLE_MIGRATION if */
+    if (line.startsWith("NOT_MY_KEY")) {
+      addRedirectSingleKeyOperation(line, key);
+      transitionState(OperationState.REDIRECT);
+      return;
+    }
+    /* ENABLE_MIGRATION end */
+
     /*
       VALUE <flags> <count>\r\n
       <bkey> [<eflag>] <bytes> <data>\r\n

--- a/src/main/java/net/spy/memcached/protocol/ascii/BTreeInsertAndGetOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/BTreeInsertAndGetOperationImpl.java
@@ -122,7 +122,13 @@ public class BTreeInsertAndGetOperationImpl extends OperationImpl implements
       return;
     }
     /* ENABLE_REPLICATION end */
-
+    /* ENABLE_MIGRATION if */
+    if (line.startsWith("NOT_MY_KEY")) {
+      addRedirectSingleKeyOperation(line, key);
+      transitionState(OperationState.REDIRECT);
+      return;
+    }
+    /* ENABLE_MIGRATION end */
     /*
       VALUE <flags> <count>\r\n
       <bkey> [<eflag>] <bytes> <data>\r\n

--- a/src/main/java/net/spy/memcached/protocol/ascii/BaseStoreOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/BaseStoreOperationImpl.java
@@ -70,6 +70,13 @@ abstract class BaseStoreOperationImpl extends OperationImpl {
       return;
     }
     /* ENABLE_REPLICATION end */
+    /* ENABLE_MIGRATION if */
+    if (line.startsWith("NOT_MY_KEY")) {
+      addRedirectSingleKeyOperation(line, key);
+      transitionState(OperationState.REDIRECT);
+      return;
+    }
+    /* ENABLE_MIGRATION end */
     getCallback().receivedStatus(matchStatus(line, STORED, NOT_FOUND, EXISTS));
     transitionState(OperationState.COMPLETE);
   }

--- a/src/main/java/net/spy/memcached/protocol/ascii/CASOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/CASOperationImpl.java
@@ -79,6 +79,13 @@ class CASOperationImpl extends OperationImpl implements CASOperation {
       return;
     }
     /* ENABLE_REPLICATION end */
+    /* ENABLE_MIGRATION if */
+    if (line.startsWith("NOT_MY_KEY")) {
+      addRedirectSingleKeyOperation(line, key);
+      transitionState(OperationState.REDIRECT);
+      return;
+    }
+    /* ENABLE_MIGRATION end */
     getCallback().receivedStatus(matchStatus(line, STORED, NOT_FOUND, EXISTS));
     transitionState(OperationState.COMPLETE);
   }

--- a/src/main/java/net/spy/memcached/protocol/ascii/CollectionCountOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/CollectionCountOperationImpl.java
@@ -69,6 +69,13 @@ public class CollectionCountOperationImpl extends OperationImpl implements
   }
 
   public void handleLine(String line) {
+    /* ENABLE_MIGRATION if */
+    if (line.startsWith("NOT_MY_KEY")) {
+      addRedirectSingleKeyOperation(line, key);
+      transitionState(OperationState.REDIRECT);
+      return;
+    }
+    /* ENABLE_MIGRATION end */
     if (line.startsWith("COUNT=")) {
       // COUNT=<count>\r\n
       getLogger().debug("Got line %s", line);

--- a/src/main/java/net/spy/memcached/protocol/ascii/CollectionCreateOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/CollectionCreateOperationImpl.java
@@ -85,6 +85,13 @@ public class CollectionCreateOperationImpl extends OperationImpl
       return;
     }
     /* ENABLE_REPLICATION end */
+    /* ENABLE_MIGRATION if */
+    if (line.startsWith("NOT_MY_KEY")) {
+      addRedirectSingleKeyOperation(line, key);
+      transitionState(OperationState.REDIRECT);
+      return;
+    }
+    /* ENABLE_MIGRATION end */
     getCallback().receivedStatus(matchStatus(line, CREATED, EXISTS, SERVER_ERROR));
     transitionState(OperationState.COMPLETE);
   }

--- a/src/main/java/net/spy/memcached/protocol/ascii/CollectionDeleteOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/CollectionDeleteOperationImpl.java
@@ -91,6 +91,13 @@ public class CollectionDeleteOperationImpl extends OperationImpl
       return;
     }
     /* ENABLE_REPLICATION end */
+    /* ENABLE_MIGRATION if */
+    if (line.startsWith("NOT_MY_KEY")) {
+      addRedirectSingleKeyOperation(line, key);
+      transitionState(OperationState.REDIRECT);
+      return;
+    }
+    /* ENABLE_MIGRATION end */
     OperationStatus status = matchStatus(line, DELETED, DELETED_DROPPED,
             NOT_FOUND, NOT_FOUND_ELEMENT, OUT_OF_RANGE, TYPE_MISMATCH,
             BKEY_MISMATCH);

--- a/src/main/java/net/spy/memcached/protocol/ascii/CollectionExistOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/CollectionExistOperationImpl.java
@@ -76,6 +76,13 @@ public class CollectionExistOperationImpl extends OperationImpl
   public void handleLine(String line) {
     assert getState() == OperationState.READING
             : "Read ``" + line + "'' when in " + getState() + " state";
+    /* ENABLE_MIGRATION if */
+    if (line.startsWith("NOT_MY_KEY")) {
+      addRedirectSingleKeyOperation(line, key);
+      transitionState(OperationState.REDIRECT);
+      return;
+    }
+    /* ENABLE_MIGRATION end */
     getCallback().receivedStatus(
             matchStatus(line, EXIST, NOT_EXIST, NOT_FOUND, NOT_FOUND,
                     TYPE_MISMATCH, UNREADABLE));

--- a/src/main/java/net/spy/memcached/protocol/ascii/CollectionGetOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/CollectionGetOperationImpl.java
@@ -108,7 +108,13 @@ public class CollectionGetOperationImpl extends OperationImpl
       return;
     }
     /* ENABLE_REPLICATION end */
-
+    /* ENABLE_MIGRATION if */
+    if (line.startsWith("NOT_MY_KEY")) {
+      addRedirectSingleKeyOperation(line, key);
+      transitionState(OperationState.REDIRECT);
+      return;
+    }
+    /* ENABLE_MIGRATION end */
     /*
       VALUE <flag> <count>\r\n
       <collection_data>\r\n

--- a/src/main/java/net/spy/memcached/protocol/ascii/CollectionInsertOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/CollectionInsertOperationImpl.java
@@ -105,6 +105,14 @@ public class CollectionInsertOperationImpl extends OperationImpl
       return;
     }
     /* ENABLE_REPLICATION end */
+    /* ENABLE_MIGRATION if */
+    if (line.startsWith("NOT_MY_KEY")) {
+      addRedirectSingleKeyOperation(line, key);
+      transitionState(OperationState.REDIRECT);
+      return;
+    }
+    /* ENABLE_MIGRATION end */
+
     getCallback().receivedStatus(
             matchStatus(line, STORED, REPLACED, CREATED_STORED, NOT_FOUND,
                     ELEMENT_EXISTS, OVERFLOWED, OUT_OF_RANGE,

--- a/src/main/java/net/spy/memcached/protocol/ascii/CollectionMutateOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/CollectionMutateOperationImpl.java
@@ -88,7 +88,13 @@ public class CollectionMutateOperationImpl extends OperationImpl implements
       return;
     }
     /* ENABLE_REPLICATION end */
-
+    /* ENABLE_MIGRATION if */
+    if (line.startsWith("NOT_MY_KEY")) {
+      addRedirectSingleKeyOperation(line, key);
+      transitionState(OperationState.REDIRECT);
+      return;
+    }
+    /* ENABLE_MIGRATION end */
     try {
       // <result value>\r\n
       Long.valueOf(line);

--- a/src/main/java/net/spy/memcached/protocol/ascii/CollectionPipedInsertOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/CollectionPipedInsertOperationImpl.java
@@ -102,7 +102,17 @@ public class CollectionPipedInsertOperationImpl extends OperationImpl
       return;
     }
     /* ENABLE_REPLICATION end */
-
+    /* ENABLE_MIGRATION if */
+    if (line.startsWith("NOT_MY_KEY")) {
+      addRedirectSingleKeyOperation(line, key);
+      insert.setRedirectIndex(index);
+      if (insert.getItemCount() == 1) {
+        insert.setNextOpIndex(0);
+        transitionState(OperationState.REDIRECT);
+      }
+      return;
+    }
+    /* ENABLE_MIGRATION end */
     if (insert.getItemCount() - insert.getNextOpIndex() == 1) {
       OperationStatus status = matchStatus(line, STORED, CREATED_STORED,
               NOT_FOUND, ELEMENT_EXISTS, OVERFLOWED, OUT_OF_RANGE,
@@ -125,6 +135,13 @@ public class CollectionPipedInsertOperationImpl extends OperationImpl
       END|PIPE_ERROR <error_string>\r\n
     */
     if (line.startsWith("END") || line.startsWith("PIPE_ERROR ")) {
+      /* ENABLE_MIGRATION if */
+      if (needRedirect()) {
+        insert.setNextOpIndex(0);
+        transitionState(OperationState.REDIRECT);
+        return;
+      }
+      /* ENABLE_MIGRATION end */
       cb.receivedStatus((successAll) ? END : FAILED_END);
       transitionState(OperationState.COMPLETE);
     } else if (line.startsWith("RESPONSE ")) {
@@ -154,6 +171,11 @@ public class CollectionPipedInsertOperationImpl extends OperationImpl
   public void initialize() {
     ByteBuffer buffer = insert.getAsciiCommand();
     setBuffer(buffer);
+    /* ENABLE_MIGRATION if */
+    if (redirectHandler != null) {
+      redirectHandler = null;
+    }
+    /* ENABLE_MIGRATION end */
 
     if (getLogger().isDebugEnabled()) {
       getLogger().debug("Request in ascii protocol: %s",

--- a/src/main/java/net/spy/memcached/protocol/ascii/CollectionUpdateOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/CollectionUpdateOperationImpl.java
@@ -95,6 +95,13 @@ public class CollectionUpdateOperationImpl extends OperationImpl implements
       return;
     }
     /* ENABLE_REPLICATION end */
+    /* ENABLE_MIGRATION if */
+    if (line.startsWith("NOT_MY_KEY")) {
+      addRedirectSingleKeyOperation(line, key);
+      transitionState(OperationState.REDIRECT);
+      return;
+    }
+    /* ENABLE_MIGRATION end */
     getCallback().receivedStatus(
             matchStatus(line, UPDATED, NOT_FOUND, NOT_FOUND_ELEMENT,
                     NOTHING_TO_UPDATE, TYPE_MISMATCH, BKEY_MISMATCH,

--- a/src/main/java/net/spy/memcached/protocol/ascii/DeleteOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/DeleteOperationImpl.java
@@ -64,6 +64,13 @@ final class DeleteOperationImpl extends OperationImpl
       return;
     }
     /* ENABLE_REPLICATION end */
+    /* ENABLE_MIGRATION if */
+    if (line.startsWith("NOT_MY_KEY")) {
+      addRedirectSingleKeyOperation(line, key);
+      transitionState(OperationState.REDIRECT);
+      return;
+    }
+    /* ENABLE_MIGRATION end */
     getCallback().receivedStatus(matchStatus(line, DELETED, NOT_FOUND));
     transitionState(OperationState.COMPLETE);
   }

--- a/src/main/java/net/spy/memcached/protocol/ascii/GetAttrOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/GetAttrOperationImpl.java
@@ -62,6 +62,13 @@ class GetAttrOperationImpl extends OperationImpl implements GetAttrOperation {
 
   @Override
   public void handleLine(String line) {
+    /* ENABLE_MIGRATION if */
+    if (line.startsWith("NOT_MY_KEY")) {
+      addRedirectSingleKeyOperation(line, key);
+      transitionState(OperationState.REDIRECT);
+      return;
+    }
+    /* ENABLE_MIGRATION end */
     if (line.startsWith("ATTR ")) {
       getLogger().debug("Got line %s", line);
 

--- a/src/main/java/net/spy/memcached/protocol/ascii/MutatorOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/MutatorOperationImpl.java
@@ -77,6 +77,13 @@ final class MutatorOperationImpl extends OperationImpl
       return;
     }
     /* ENABLE_REPLICATION end */
+    /* ENABLE_MIGRATION if */
+    if (line.startsWith("NOT_MY_KEY")) {
+      addRedirectSingleKeyOperation(line, key);
+      transitionState(OperationState.REDIRECT);
+      return;
+    }
+    /* ENABLE_MIGRATION end */
 
     OperationStatus status = null;
     try {

--- a/src/main/java/net/spy/memcached/protocol/ascii/OperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/OperationImpl.java
@@ -148,11 +148,11 @@ abstract class OperationImpl extends BaseOperationImpl implements Operation {
           }
         }
       }
-      /* ENABLE_REPLICATION if */
-      if (getState() == OperationState.MOVING) {
+      /* ENABLE_REPLICATION or ENABLE_MIGRATION if */
+      if (getState() == OperationState.MOVING || getState() == OperationState.REDIRECT) {
         break;
       }
-      /* ENABLE_REPLICATION end */
+      /* ENABLE_REPLICATION or ENABLE_MIGRATION end */
     }
   }
 

--- a/src/main/java/net/spy/memcached/protocol/ascii/SetAttrOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/SetAttrOperationImpl.java
@@ -77,6 +77,13 @@ class SetAttrOperationImpl extends OperationImpl
       return;
     }
     /* ENABLE_REPLICATION end */
+    /* ENABLE_MIGRATION if */
+    if (line.startsWith("NOT_MY_KEY")) {
+      addRedirectSingleKeyOperation(line, key);
+      transitionState(OperationState.REDIRECT);
+      return;
+    }
+    /* ENABLE_MIGRATION end */
     getCallback().receivedStatus(
             matchStatus(line, OK, NOT_FOUND, ATTR_ERROR_NOT_FOUND,
                     ATTR_ERROR_BAD_VALUE));

--- a/src/main/java/net/spy/memcached/protocol/binary/GetOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/binary/GetOperationImpl.java
@@ -91,4 +91,8 @@ class GetOperationImpl extends OperationImpl
     return true;
   }
 
+  @Override
+  public boolean isMGetOperation() {
+    return false;
+  }
 }

--- a/src/main/java/net/spy/memcached/protocol/binary/MultiGetOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/binary/MultiGetOperationImpl.java
@@ -146,4 +146,8 @@ class MultiGetOperationImpl extends OperationImpl implements GetOperation {
     return true;
   }
 
+  @Override
+  public boolean isMGetOperation() {
+    return false;
+  }
 }


### PR DESCRIPTION
Migration 기능을 개발하였습니다. 메인 동작 위주로 설명합니다.

MigrationMonitor 클래스
  - Migration 관련 ZK 디렉토리 감지 및 변경 이벤트를 처리하는 역할을 수행합니다. 클라이언트 구동 단계에서 CacheMonitor 이후에 생성됩니다.
  - 감지하는 ZK 디렉토리는 cloud_stat 디렉토리 내부에 있는 alter_list 디렉토리와 STATE znode 를 감지합니다.
    - alter_list 디렉토리 : joining or leaving 노드 전체 목록 확인
    - STATE znode : 데이터 이관 타입(JOIN/LEAVE)와 진행 상태 확인 
  - 확인한 위의 정보들은 IO Thread(MemcachedConnection)에 전달합니다.
  - 참고로, migration ZK read 후에 응용 요청 처리를 해야 하므로 CacheManger 에 migrationInitLatch 를 두었습니다.
    - migration 진행(PREPARED) 중에 클라이언트 구동된 경우 alter_list 읽은 후에 migrationInitLatch down
    - 그 외의 경우는 바로 migrationInitLatch down  

MemcachedConnection, ArcusKetamaLocator 클래스
  - ZK Thread 로부터 전달 받은 alter_list 목록, 데이터 이관 타입(type) 과 진행 상태(state)를 통해 다음의 작업을 수행합니다.
    - state 가 PREPARED 이면, 전체 alter_list 등록이 완료된 상태이므로 ArcusKetamaLocator 의 다음 Migration 준비 작업을 수행 후 state 를 PROGRESS 로 변경
        -  alter 노드 목록, exist 노드 목록, alter 노드의 hashring 구성, 데이터 이관 타입 설정
    - state 가 PROGRESS 이면, joining node 다운을 확인하여 제거합니다.
      - leaving node 다운이면, cachelist update 에서 확인이 가능하므로 이 곳에서 처리가 됩니다.
  - migration 도중에 existing node 다운되면 아래 작업을 수행합니다.
    - JOIN : auto join completion 수행
    - LEAVE : base hpoint 소유자 다운이면, auto leave abort 수행 

NOT_MY_KEY 처리
  - 클라이언트는 데이터 이관 진척 상태를 실시간으로 알지 못하기 때문에 Old Hashring 기준으로 담당 노드를 잘못 선택할 수 있습니다.
  - 따라서 Migration 동안에 Exporter 역할을 수행하는 캐시 서버는 자신이 담당하는 Key 인지 확인하고, 아니라면 아래 형식의 NOT_MY_KEY 를 응답합니다.  
     - `NOT_MY_KEY <spoint> <epoint> <owner>\r\n `
        - spoint, epoint : 데이터 이관의 시작과 완료 해시 포인트
        - owner : 요청한 key 의 담당 노드. pipe 연산의 경우는 owner 를 주지 않기 때문에 클라이언트가 직접 hashring 조회하여 담당 노드를 찾습니다.
  - 모든 연산 구현체(OperationImpl)의 응답 문자열 처리 메서드(handleLine()) 에서 NOT_MY_KEY 응답 검사를 추가하였습니다.
  - NOT_MY_KEY 응답을 받으면 single key 연산이면, RedirectHandlerSingleKey 객체를, multi key 연산이면, RedirectHandlerMultiKey 객체를 생성하여 저장해둡니다. 
  - 전체 응답을 받은 후에 redirectHandler 객체가 등록되어 있다면 연산의 상태를 REDIRECT 상태로 전이하여 재요청 작업을 진행하고, 등록되어 있지 않다면 기존대로 COMPLETE 상태로 전이하여 callback.complete() 호출하여 연산 처리 완료합니다. 
 
RedirectHandler 클래스
  - 연산 redirect 시에 필요한 정보를 저장해두고 redirect 시에 사용합니다. 
  - NOT_MY_KEY 응답을 파싱하여 얻은 spoint, epoint, owner 와 owner 별 redirect key 목록을 저장해둡니다.

재요청(Redirect) 작업
- 연산에 등록된 redirectHandler 를 얻어온 후에 데이터 이관 완료 범위(spoint ~ epoint)를 hashring 에 반영합니다.
- 연산을 재요청할 수 있는 상태로 초기화(Initialize)한 후에 그 연산을 Owner 노드의 writeQ에, owner 노드는 addedQueue 에 넣어두고  IO 스레드의 기존 연산 처리 동작(handleIO())에 의해 처리됩니다.
- multi key 의 경우는 owner 가 여러 개일 수 있으므로 owner 별로 별도의 연산으로 요청하기 위하여 기존 연산을 clone 하고, 모든 key 를 응답 받았을 때 연산 완료 처리할 수 있도록 MultiOperationCallback 등록해둡니다.

MultiOperationCallback 클래스
  - int remaining : 재요청을 통해 응답 받아야 하는 Key 개수. 0이면, 모든 Key에 대한 응답 받았으므로 originalCallback 호출해 연산 완료 처리
  - OperationCallback originalCallback : 응용이 호출한 연산 API 내에서 등록된 콜백(callback)


전체 구현을 같이 볼 필요가 있어서 한번의 PR 로 보냈는데, 리뷰에 부담이 되면 아래와 같이 PR 을 분리할 수 있을 것 같습니다.
- MigrationMonitor
- redirect 처리 코드들
- ArcusKetamaLocator
- ArcusReplKetamaLocator
