### PR TITLE
CLEANUP: changed method addAllOpToWriteQ() to addOpToWriteQ().

### DIFF
--- a/src/main/java/net/spy/memcached/MemcachedNode.java
+++ b/src/main/java/net/spy/memcached/MemcachedNode.java
@@ -23,7 +23,6 @@ import java.nio.ByteBuffer;
 import java.nio.channels.SelectionKey;
 import java.nio.channels.SocketChannel;
 import java.util.Collection;
-import java.util.concurrent.BlockingQueue;
 
 import net.spy.memcached.ops.Operation;
 
@@ -115,6 +114,13 @@ public interface MemcachedNode {
    * never be added to the queue, but this is not checked.
    */
   void addOpToInputQ(Operation op);
+
+  /**
+   * Add an operation to the write queue. It is used to process operation in prior to
+   * operations in input queue. For example, when the switchover occurs,
+   * the operation moved to the new master must be prioritized.
+   */
+  boolean addOpToWriteQ(Operation op);
 
   /**
    * Insert an operation to the beginning of the queue.
@@ -290,8 +296,6 @@ public interface MemcachedNode {
   void setReplicaGroup(MemcachedReplicaGroup g);
 
   MemcachedReplicaGroup getReplicaGroup();
-
-  int addAllOpToWriteQ(BlockingQueue<Operation> allOp);
 
   int moveOperations(final MemcachedNode toNode, boolean cancelNonIdempontent);
 

--- a/src/main/java/net/spy/memcached/MemcachedNodeROImpl.java
+++ b/src/main/java/net/spy/memcached/MemcachedNodeROImpl.java
@@ -23,7 +23,6 @@ import java.nio.ByteBuffer;
 import java.nio.channels.SelectionKey;
 import java.nio.channels.SocketChannel;
 import java.util.Collection;
-import java.util.concurrent.BlockingQueue;
 
 import net.spy.memcached.ops.Operation;
 
@@ -51,6 +50,10 @@ public class MemcachedNodeROImpl implements MemcachedNode {
   }
 
   public void addOpToInputQ(Operation op) {
+    throw new UnsupportedOperationException();
+  }
+
+  public boolean addOpToWriteQ(Operation op) {
     throw new UnsupportedOperationException();
   }
 
@@ -242,10 +245,6 @@ public class MemcachedNodeROImpl implements MemcachedNode {
   }
 
   public MemcachedReplicaGroup getReplicaGroup() {
-    throw new UnsupportedOperationException();
-  }
-
-  public int addAllOpToWriteQ(BlockingQueue<Operation> allOp) {
     throw new UnsupportedOperationException();
   }
 

--- a/src/test/java/net/spy/memcached/MockMemcachedNode.java
+++ b/src/test/java/net/spy/memcached/MockMemcachedNode.java
@@ -24,7 +24,6 @@ import java.nio.ByteBuffer;
 import java.nio.channels.SelectionKey;
 import java.nio.channels.SocketChannel;
 import java.util.Collection;
-import java.util.concurrent.BlockingQueue;
 
 import net.spy.memcached.ops.Operation;
 
@@ -106,6 +105,11 @@ public class MockMemcachedNode implements MemcachedNode {
 
   public void addOpToInputQ(Operation op) {
     // noop
+  }
+
+  public boolean addOpToWriteQ(Operation op) {
+    // noop
+    return false;
   }
 
   public void insertOp(Operation op) {
@@ -263,12 +267,6 @@ public class MockMemcachedNode implements MemcachedNode {
   public MemcachedReplicaGroup getReplicaGroup() {
     // noop
     return null;
-  }
-
-  @Override
-  public int addAllOpToWriteQ(BlockingQueue<Operation> allOp) {
-    // noop
-    return 0;
   }
 
   @Override


### PR DESCRIPTION
addAllOpToWriteQ() 메서드를 변경하였습니다. (https://github.com/naver/arcus-java-client/pull/473#discussion_r884135421)
기존 : int addAllOpToWriteQ(BlockingQueue<Operation> allOp) 
변경 : boolean addOpToWriteQ(Operation op)

메서드는 하나의 Operation 만을 writeQ 로 옮기는 작업을 수행하고,
기존 Operation 컬렉션의 경우는 외부에서 이터레이트하여 호출하도록 변경하였습니다.