### PR TITLE
CLEANUP: use constructor chaining on BTreeGetBulkImpl and BTreeBulkIn…

### DIFF
--- a/src/main/java/net/spy/memcached/collection/BTreeGetBulkImpl.java
+++ b/src/main/java/net/spy/memcached/collection/BTreeGetBulkImpl.java
@@ -37,10 +37,10 @@ public abstract class BTreeGetBulkImpl<T> implements BTreeGetBulk<T> {
 
   protected List<String> keyList;
   protected String range;
+  protected boolean reverse;
   protected ElementFlagFilter eFlagFilter;
   protected int offset = -1;
   protected int count;
-  protected boolean reverse;
 
   protected Map<Integer, T> map;
 
@@ -51,42 +51,31 @@ public abstract class BTreeGetBulkImpl<T> implements BTreeGetBulk<T> {
   protected byte[] eflag = null;
 
   protected BTreeGetBulkImpl(MemcachedNode node, List<String> keyList,
-                             byte[] from, byte[] to,
+                             String range, boolean reverse,
                              ElementFlagFilter eFlagFilter, int offset,
                              int count) {
     this.node = node;
     this.keyList = keyList;
-    this.range = BTreeUtil.toHex(from) + ".." + BTreeUtil.toHex(to);
+    this.range = range;
+    this.reverse = reverse;
     this.eFlagFilter = eFlagFilter;
     this.offset = offset;
     this.count = count;
-    this.reverse = BTreeUtil.compareByteArraysInLexOrder(from, to) > 0;
   }
 
   protected BTreeGetBulkImpl(MemcachedNode node, List<String> keyList,
                              long from, long to,
                              ElementFlagFilter eFlagFilter, int offset,
                              int count) {
-    this.node = node;
-    this.keyList = keyList;
-    this.range = String.valueOf(from) + ".." + String.valueOf(to);
-    this.eFlagFilter = eFlagFilter;
-    this.offset = offset;
-    this.count = count;
-    this.reverse = (from > to);
+    this(node, keyList, from + ".." + to, from > to, eFlagFilter, offset, count);
   }
 
   protected BTreeGetBulkImpl(MemcachedNode node, List<String> keyList,
-                             long bkey,
+                             byte[] from, byte[] to,
                              ElementFlagFilter eFlagFilter, int offset,
                              int count) {
-    this.node = node;
-    this.keyList = keyList;
-    this.range = String.valueOf(bkey);
-    this.eFlagFilter = eFlagFilter;
-    this.offset = offset;
-    this.count = count;
-    this.reverse = false;
+    this(node, keyList, BTreeUtil.toHex(from) + ".." + BTreeUtil.toHex(to),
+        BTreeUtil.compareByteArraysInLexOrder(from, to) > 0, eFlagFilter, offset, count);
   }
 
   public void setKeySeparator(String keySeparator) {

--- a/src/main/java/net/spy/memcached/collection/CollectionBulkInsert.java
+++ b/src/main/java/net/spy/memcached/collection/CollectionBulkInsert.java
@@ -73,14 +73,14 @@ public abstract class CollectionBulkInsert<T> extends CollectionObject {
     private final String eflag;
 
     public BTreeBulkInsert(MemcachedNode node, List<String> keyList, String bkey,
-                           byte[] eflag, T value, CollectionAttributes attr, Transcoder<T> tc) {
+                           String eflag, T value, CollectionAttributes attr, Transcoder<T> tc) {
       if (attr != null) { /* item creation option */
         CollectionCreate.checkOverflowAction(CollectionType.btree, attr.getOverflowAction());
       }
       this.node = node;
       this.keyList = keyList;
       this.bkey = bkey;
-      this.eflag = BTreeUtil.toHex(eflag);
+      this.eflag = eflag;
       this.value = value;
       this.attribute = attr;
       this.tc = tc;
@@ -90,12 +90,12 @@ public abstract class CollectionBulkInsert<T> extends CollectionObject {
 
     public BTreeBulkInsert(MemcachedNode node, List<String> keyList, Long bkey,
                            byte[] eflag, T value, CollectionAttributes attr, Transcoder<T> tc) {
-      this(node, keyList, String.valueOf(bkey), eflag, value, attr, tc);
+      this(node, keyList, String.valueOf(bkey), BTreeUtil.toHex(eflag), value, attr, tc);
     }
 
     public BTreeBulkInsert(MemcachedNode node, List<String> keyList, byte[] bkey,
                            byte[] eflag, T value, CollectionAttributes attr, Transcoder<T> tc) {
-      this(node, keyList, BTreeUtil.toHex(bkey), eflag, value, attr, tc);
+      this(node, keyList, BTreeUtil.toHex(bkey), BTreeUtil.toHex(eflag), value, attr, tc);
     }
 
     public ByteBuffer getAsciiCommand() {


### PR DESCRIPTION
BTreeGetBulkImpl 와 BTreeBulkInsert 의 생성자를 체이닝 방식으로 호출하도록 수정하였습니다.
내부에서 변환하면, 외부에서 생성자 호출 코드가 간결 및 변환을 신경쓰지 않아도 되므로 이 방식이 나아보입니다.