### PR TITLE
FIX: get operation can be bulk operation if having multi key.

### DIFF
--- a/src/main/java/net/spy/memcached/ArcusClient.java
+++ b/src/main/java/net/spy/memcached/ArcusClient.java
@@ -4060,7 +4060,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
     final CountDownLatch latch = new CountDownLatch(insertList.size());
 
     for (final CollectionBulkInsert<T> insert : insertList) {
-      Operation op = opFact.collectionBulkInsert(insert.getKeyList(),
+      Operation op = opFact.collectionBulkInsert(
               insert, new CollectionBulkInsertOperation.Callback() {
                 public void receivedStatus(OperationStatus status) {
 

--- a/src/main/java/net/spy/memcached/OperationFactory.java
+++ b/src/main/java/net/spy/memcached/OperationFactory.java
@@ -17,7 +17,6 @@
 package net.spy.memcached;
 
 import java.util.Collection;
-import java.util.List;
 import java.util.Map;
 
 import javax.security.auth.callback.CallbackHandler;
@@ -466,13 +465,11 @@ public interface OperationFactory {
   /**
    * Bulk insert operation for collection items.
    *
-   * @param key    collection item's key
    * @param insert operation parameters (element values, and so on)
    * @param cb     the status callback
    * @return a new CollectionBulkInsertOperation
    */
-  CollectionBulkInsertOperation collectionBulkInsert(List<String> key,
-                                                     CollectionBulkInsert<?> insert,
+  CollectionBulkInsertOperation collectionBulkInsert(CollectionBulkInsert<?> insert,
                                                      OperationCallback cb);
 
   /**

--- a/src/main/java/net/spy/memcached/TimedOutMessageFactory.java
+++ b/src/main/java/net/spy/memcached/TimedOutMessageFactory.java
@@ -1,7 +1,6 @@
 package net.spy.memcached;
 
 import net.spy.memcached.ops.Operation;
-import net.spy.memcached.ops.GetOperation;
 import net.spy.memcached.ops.StoreOperation;
 import net.spy.memcached.ops.DeleteOperation;
 
@@ -33,15 +32,10 @@ public final class TimedOutMessageFactory {
   /**
    * check bulk operation or not
    * @param op operation
-   * @param ops number of operation (used in GetOpeartion, StoreOperationImpl, DeleteOperationImpl)
+   * @param ops number of operation (used in StoreOperationImpl, DeleteOperationImpl)
    */
   private static boolean isBulkOperation(Operation op, Collection<Operation> ops) {
-    if (op instanceof GetOperation) {
-      GetOperation gop = (GetOperation) op;
-      return gop.getKeys().size() > 1;
-    } else if (op instanceof StoreOperation) {
-      return ops.size() > 1;
-    } else if (op instanceof DeleteOperation) {
+    if (op instanceof StoreOperation || op instanceof DeleteOperation) {
       return ops.size() > 1;
     }
     return op.isBulkOperation();

--- a/src/main/java/net/spy/memcached/protocol/ascii/AsciiOperationFactory.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/AsciiOperationFactory.java
@@ -17,7 +17,6 @@
 package net.spy.memcached.protocol.ascii;
 
 import java.util.Collection;
-import java.util.List;
 import java.util.Map;
 
 import javax.security.auth.callback.CallbackHandler;
@@ -259,10 +258,9 @@ public class AsciiOperationFactory extends BaseOperationFactory {
   }
 
   @Override
-  public CollectionBulkInsertOperation collectionBulkInsert(List<String> key,
-                                                            CollectionBulkInsert<?> insert,
+  public CollectionBulkInsertOperation collectionBulkInsert(CollectionBulkInsert<?> insert,
                                                             OperationCallback cb) {
-    return new CollectionBulkInsertOperationImpl(key, insert, cb);
+    return new CollectionBulkInsertOperationImpl(insert, cb);
   }
 
   @Override

--- a/src/main/java/net/spy/memcached/protocol/ascii/BaseGetOpImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/BaseGetOpImpl.java
@@ -218,7 +218,7 @@ abstract class BaseGetOpImpl extends OperationImpl {
 
   @Override
   public boolean isBulkOperation() {
-    return false;
+    return keys.size() > 1;
   }
 
   @Override

--- a/src/main/java/net/spy/memcached/protocol/ascii/CollectionBulkInsertOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/CollectionBulkInsertOperationImpl.java
@@ -19,8 +19,6 @@ package net.spy.memcached.protocol.ascii;
 
 import java.nio.ByteBuffer;
 import java.util.Collection;
-import java.util.Collections;
-import java.util.List;
 
 import net.spy.memcached.collection.CollectionBulkInsert;
 import net.spy.memcached.collection.CollectionResponse;
@@ -63,7 +61,6 @@ public class CollectionBulkInsertOperationImpl extends OperationImpl
   private static final OperationStatus BKEY_MISMATCH = new CollectionOperationStatus(
           false, "BKEY_MISMATCH", CollectionResponse.BKEY_MISMATCH);
 
-  protected final String key;
   protected final CollectionBulkInsert<?> insert;
   protected final CollectionBulkInsertOperation.Callback cb;
 
@@ -71,10 +68,8 @@ public class CollectionBulkInsertOperationImpl extends OperationImpl
   protected int index = 0;
   protected boolean successAll = true;
 
-  public CollectionBulkInsertOperationImpl(List<String> keyList,
-                                           CollectionBulkInsert<?> insert, OperationCallback cb) {
+  public CollectionBulkInsertOperationImpl(CollectionBulkInsert<?> insert, OperationCallback cb) {
     super(cb);
-    this.key = keyList.get(0);
     this.insert = insert;
     this.cb = (Callback) cb;
     if (this.insert instanceof CollectionBulkInsert.ListBulkInsert) {
@@ -166,7 +161,7 @@ public class CollectionBulkInsertOperationImpl extends OperationImpl
   }
 
   public Collection<String> getKeys() {
-    return Collections.singleton(key);
+    return insert.getKeyList();
   }
 
   public CollectionBulkInsert<?> getInsert() {

--- a/src/main/java/net/spy/memcached/protocol/ascii/MGetOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/MGetOperationImpl.java
@@ -17,14 +17,4 @@ public class MGetOperationImpl extends BaseGetOpImpl implements GetOperation {
     super(CMD, c, new HashSet<String>(k));
     setAPIType(APIType.MGET);
   }
-
-  @Override
-  public boolean isBulkOperation() {
-    return true;
-  }
-
-  @Override
-  public boolean isPipeOperation() {
-    return false;
-  }
 }

--- a/src/main/java/net/spy/memcached/protocol/binary/BinaryOperationFactory.java
+++ b/src/main/java/net/spy/memcached/protocol/binary/BinaryOperationFactory.java
@@ -17,7 +17,6 @@
 package net.spy.memcached.protocol.binary;
 
 import java.util.Collection;
-import java.util.List;
 import java.util.Map;
 
 import javax.security.auth.callback.CallbackHandler;
@@ -302,9 +301,8 @@ public class BinaryOperationFactory extends BaseOperationFactory {
   }
 
   @Override
-  public CollectionBulkInsertOperation collectionBulkInsert(
-          List<String> key, CollectionBulkInsert<?> insert,
-          OperationCallback cb) {
+  public CollectionBulkInsertOperation collectionBulkInsert(CollectionBulkInsert<?> insert,
+                                                            OperationCallback cb) {
     throw new RuntimeException(
             "Collection piped insert2 operation is not supported in binary protocol yet.");
   }

--- a/src/test/manual/net/spy/memcached/MultibyteKeyTest.java
+++ b/src/test/manual/net/spy/memcached/MultibyteKeyTest.java
@@ -480,7 +480,7 @@ public class MultibyteKeyTest {
         1L, new byte[]{0, 0}, new Random().nextInt(),
         new CollectionAttributes(), new IntegerTranscoder());
     try {
-      opFact.collectionBulkInsert(insert.getKeyList(), insert, cbsCallback).initialize();
+      opFact.collectionBulkInsert(insert, cbsCallback).initialize();
     } catch (java.nio.BufferOverflowException e) {
       Assert.fail();
     }
@@ -490,7 +490,7 @@ public class MultibyteKeyTest {
         new IntegerTranscoder());
 
     try {
-      opFact.collectionBulkInsert(insert.getKeyList(), insert, cbsCallback).initialize();
+      opFact.collectionBulkInsert(insert, cbsCallback).initialize();
     } catch (java.nio.BufferOverflowException e) {
       Assert.fail();
     }
@@ -499,7 +499,7 @@ public class MultibyteKeyTest {
         new Random().nextInt(), new CollectionAttributes(),
         new IntegerTranscoder());
     try {
-      opFact.collectionBulkInsert(insert.getKeyList(), insert, cbsCallback).initialize();
+      opFact.collectionBulkInsert(insert, cbsCallback).initialize();
     } catch (java.nio.BufferOverflowException e) {
       Assert.fail();
     }


### PR DESCRIPTION
다음을 수정하였습니다.
- BaseGetOpImpl 의 isBulkOperation() 는 key 개수가 2개 이상이면 true, 아니면 false 리턴.
  - TimedOutMessage 생성 시에는 key 개수로 bulk operation 인지를 확인하고 있음. 이와 같은 로직이 맞다고 봄.

```java
public final class TimedOutMessageFactory {

...
  private static boolean isBulkOperation(Operation op, Collection<Operation> ops) {
    if (op instanceof GetOperation) {
      GetOperation gop = (GetOperation) op;
      return gop.getKeys().size() > 1;
    } else if (op instanceof StoreOperation) {
      return ops.size() > 1;
    } else if (op instanceof DeleteOperation) {
      return ops.size() > 1;
    }
    return op.isBulkOperation();
  }
}
```
- CollectionBulkInsertOperationImpl 의 key field 는 keylist 를 갖도록 수정.
  - multi key & single value 를 요청하므로 keylist 를 갖고,
  - CollectionPipedInsertOperationImpl 처럼 single key & multi value 를 요청하는 연산에서는 single key 를 갖는 것이 맞아보임.
 
```java
public class CollectionPipedInsertOperationImpl extends OperationImpl
        implements CollectionPipedInsertOperation {
...
  protected final String key;
  protected final CollectionPipedInsert<?> insert;
  protected final CollectionPipedInsertOperation.Callback cb;

  protected int count;
  protected int index = 0;
  protected boolean successAll = true;

  public CollectionPipedInsertOperationImpl(String key,
                                            CollectionPipedInsert<?> insert, OperationCallback cb) {
    super(cb);
    this.key = key;
    this.insert = insert;
    this.cb = (Callback) cb;
...
  }
```

local test 통과 확인하였습니다. 