### PR TITLE
INTERNAL: Remove unnecessary constructors in BTreeGetBulkImpl.

### DIFF
--- a/src/main/java/net/spy/memcached/collection/BTreeGetBulkImpl.java
+++ b/src/main/java/net/spy/memcached/collection/BTreeGetBulkImpl.java
@@ -63,21 +63,6 @@ public abstract class BTreeGetBulkImpl<T> implements BTreeGetBulk<T> {
     this.count = count;
   }
 
-  protected BTreeGetBulkImpl(MemcachedNode node, List<String> keyList,
-                             long from, long to,
-                             ElementFlagFilter eFlagFilter, int offset,
-                             int count) {
-    this(node, keyList, from + ".." + to, from > to, eFlagFilter, offset, count);
-  }
-
-  protected BTreeGetBulkImpl(MemcachedNode node, List<String> keyList,
-                             byte[] from, byte[] to,
-                             ElementFlagFilter eFlagFilter, int offset,
-                             int count) {
-    this(node, keyList, BTreeUtil.toHex(from) + ".." + BTreeUtil.toHex(to),
-        BTreeUtil.compareByteArraysInLexOrder(from, to) > 0, eFlagFilter, offset, count);
-  }
-
   public void setKeySeparator(String keySeparator) {
     this.keySeparator = keySeparator;
   }

--- a/src/main/java/net/spy/memcached/collection/BTreeGetBulkWithByteTypeBkey.java
+++ b/src/main/java/net/spy/memcached/collection/BTreeGetBulkWithByteTypeBkey.java
@@ -27,7 +27,8 @@ public class BTreeGetBulkWithByteTypeBkey<T> extends BTreeGetBulkImpl<T> {
                                       byte[] from, byte[] to,
                                       ElementFlagFilter eFlagFilter,
                                       int offset, int count) {
-    super(node, keyList, from, to, eFlagFilter, offset, count);
+    super(node, keyList, BTreeUtil.toHex(from) + ".." + BTreeUtil.toHex(to),
+        BTreeUtil.compareByteArraysInLexOrder(from, to) > 0, eFlagFilter, offset, count);
   }
 
   public byte[] getSubkey() {

--- a/src/main/java/net/spy/memcached/collection/BTreeGetBulkWithLongTypeBkey.java
+++ b/src/main/java/net/spy/memcached/collection/BTreeGetBulkWithLongTypeBkey.java
@@ -27,7 +27,7 @@ public class BTreeGetBulkWithLongTypeBkey<T> extends BTreeGetBulkImpl<T> {
                                       long from, long to,
                                       ElementFlagFilter eFlagFilter,
                                       int offset, int count) {
-    super(node, keyList, from, to, eFlagFilter, offset, count);
+    super(node, keyList, from + ".." + to, from > to, eFlagFilter, offset, count);
   }
 
   public Long getSubkey() {


### PR DESCRIPTION
BTreeGetBulkImpl 클래스의 하위 클래스에서 사용되는 BTreeGetBulkImpl 클래스의 생성자가 불필요해 보여 제거했습니다.