### PR TITLE
INTERNAL: Remove duplicated logic in concrete classes that extends BTreeGetBulkImpl.

### DIFF
--- a/src/main/java/net/spy/memcached/collection/BTreeGetBulkImpl.java
+++ b/src/main/java/net/spy/memcached/collection/BTreeGetBulkImpl.java
@@ -125,6 +125,32 @@ public abstract class BTreeGetBulkImpl<T> implements BTreeGetBulk<T> {
     return str;
   }
 
+  public void decodeItemHeader(String itemHeader) {
+    String[] splited = itemHeader.split(" ");
+
+    if (splited.length == 3) {
+      // ELEMENT <bkey> <bytes>
+      this.subkey = decodeSubkey(splited[1]);
+      this.dataLength = Integer.parseInt(splited[2]);
+      this.eflag = null;
+    } else if (splited.length == 4) {
+      // ELEMENT <bkey> <eflag> <bytes>
+      this.subkey = decodeSubkey(splited[1]);
+      this.eflag = BTreeUtil.hexStringToByteArrays(splited[2].substring(2));
+      this.dataLength = Integer.parseInt(splited[3]);
+    }
+  }
+
+  public void decodeKeyHeader(String keyHeader) {
+    // VALUE <key> <status> [<flags> <ecount>]
+    String[] splited = keyHeader.split(" ");
+    this.key = splited[1];
+
+    if (splited.length == 5) {
+      this.flag = Integer.parseInt(splited[3]);
+    }
+  }
+
   public String getCommand() {
     return command;
   }
@@ -152,4 +178,6 @@ public abstract class BTreeGetBulkImpl<T> implements BTreeGetBulk<T> {
   public byte[] getEFlag() {
     return eflag;
   }
+
+  protected abstract Object decodeSubkey(String subkey);
 }

--- a/src/main/java/net/spy/memcached/collection/BTreeGetBulkWithByteTypeBkey.java
+++ b/src/main/java/net/spy/memcached/collection/BTreeGetBulkWithByteTypeBkey.java
@@ -35,28 +35,7 @@ public class BTreeGetBulkWithByteTypeBkey<T> extends BTreeGetBulkImpl<T> {
     return (byte[]) subkey;
   }
 
-  public void decodeItemHeader(String itemHeader) {
-    String[] splited = itemHeader.split(" ");
-
-    if (splited.length == 3) {
-      // ELEMENT <bkey> <bytes>
-      this.subkey = BTreeUtil.hexStringToByteArrays(splited[1].substring(2));
-      this.dataLength = Integer.parseInt(splited[2]);
-      this.eflag = null;
-    } else if (splited.length == 4) {
-      // ELEMENT <bkey> <eflag> <bytes>
-      this.subkey = BTreeUtil.hexStringToByteArrays(splited[1].substring(2));
-      this.eflag = BTreeUtil.hexStringToByteArrays(splited[2].substring(2));
-      this.dataLength = Integer.parseInt(splited[3]);
-    }
-  }
-
-  @Override
-  public void decodeKeyHeader(String keyHeader) {
-    String[] splited = keyHeader.split(" ");
-    this.key = splited[1];
-    if (splited.length == 5) {
-      this.flag = Integer.valueOf(splited[3]);
-    }
+  protected Object decodeSubkey(String subkey) {
+    return BTreeUtil.hexStringToByteArrays(subkey.substring(2));
   }
 }

--- a/src/main/java/net/spy/memcached/collection/BTreeGetBulkWithLongTypeBkey.java
+++ b/src/main/java/net/spy/memcached/collection/BTreeGetBulkWithLongTypeBkey.java
@@ -19,7 +19,6 @@ package net.spy.memcached.collection;
 import java.util.List;
 
 import net.spy.memcached.MemcachedNode;
-import net.spy.memcached.util.BTreeUtil;
 
 public class BTreeGetBulkWithLongTypeBkey<T> extends BTreeGetBulkImpl<T> {
 
@@ -34,29 +33,7 @@ public class BTreeGetBulkWithLongTypeBkey<T> extends BTreeGetBulkImpl<T> {
     return (Long) subkey;
   }
 
-  public void decodeItemHeader(String itemHeader) {
-    String[] splited = itemHeader.split(" ");
-
-    if (splited.length == 3) {
-      // ELEMENT <bkey> <bytes>
-      this.subkey = Long.parseLong(splited[1]);
-      this.dataLength = Integer.parseInt(splited[2]);
-      this.eflag = null;
-    } else if (splited.length == 4) {
-      // ELEMENT <bkey> <eflag> <bytes>
-      this.subkey = Long.parseLong(splited[1]);
-      this.eflag = BTreeUtil.hexStringToByteArrays(splited[2].substring(2));
-      this.dataLength = Integer.parseInt(splited[3]);
-    }
+  protected Object decodeSubkey(String subkey) {
+    return Long.parseLong(subkey);
   }
-
-  @Override
-  public void decodeKeyHeader(String keyHeader) {
-    String[] splited = keyHeader.split(" ");
-    this.key = splited[1];
-    if (splited.length == 5) {
-      this.flag = Integer.valueOf(splited[3]);
-    }
-  }
-
 }


### PR DESCRIPTION
BTreeGetBulkImpl 클래스를 상속받는 두 클래스, BTreeGetBulkWithByteTypeBkey 클래스와 BTreeGetBulkWithLongTypeBkey 클래스에 중복되는 로직이 있어서 BTreeGetBulkImpl 클래스로 로직을 옮겼습니다.
- decodeKeyHeader() 메소드의 경우 두 concrete 클래스에 완전히 동일한 로직으로 있어서 그대로 BTreeGetBulkImpl 클래스로 옮겼습니다.
- decodeItemHeader() 메소드의 경우 완전히 동일하진 않지만 매우 유사한 로직으로 있어서 서로 다른 부분만 abstract 메소드로 각 concrete 클래스에서 구현하도록 하고 동일한 부분은 BTreeGetBulkImpl 클래스로 옮겼습니다.