### PR TITLE
INTERNAL: Move key header decode from BTreeGetBulkImpl to BTreeGetBulkOperationImpl.

### DIFF
--- a/src/main/java/net/spy/memcached/collection/BTreeGetBulk.java
+++ b/src/main/java/net/spy/memcached/collection/BTreeGetBulk.java
@@ -38,10 +38,6 @@ public interface BTreeGetBulk<T> {
 
   public boolean keyHeaderReady(int spaceCount);
 
-  public String getKey();
-
-  public int getFlag();
-
   public Object getSubkey();
 
   public int getDataLength();
@@ -49,6 +45,4 @@ public interface BTreeGetBulk<T> {
   public byte[] getEFlag();
 
   public void decodeItemHeader(String itemHeader);
-
-  public void decodeKeyHeader(String keyHeader);
 }

--- a/src/main/java/net/spy/memcached/collection/BTreeGetBulkImpl.java
+++ b/src/main/java/net/spy/memcached/collection/BTreeGetBulkImpl.java
@@ -44,8 +44,6 @@ public abstract class BTreeGetBulkImpl<T> implements BTreeGetBulk<T> {
 
   protected Map<Integer, T> map;
 
-  protected String key;
-  protected int flag;
   protected Object subkey;
   protected int dataLength;
   protected byte[] eflag = null;
@@ -141,16 +139,6 @@ public abstract class BTreeGetBulkImpl<T> implements BTreeGetBulk<T> {
     }
   }
 
-  public void decodeKeyHeader(String keyHeader) {
-    // VALUE <key> <status> [<flags> <ecount>]
-    String[] splited = keyHeader.split(" ");
-    this.key = splited[1];
-
-    if (splited.length == 5) {
-      this.flag = Integer.parseInt(splited[3]);
-    }
-  }
-
   public String getCommand() {
     return command;
   }
@@ -161,14 +149,6 @@ public abstract class BTreeGetBulkImpl<T> implements BTreeGetBulk<T> {
 
   public boolean keyHeaderReady(int spaceCount) {
     return spaceCount == 3 || spaceCount == 5;
-  }
-
-  public String getKey() {
-    return key;
-  }
-
-  public int getFlag() {
-    return flag;
   }
 
   public int getDataLength() {


### PR DESCRIPTION
https://github.com/naver/arcus-java-client/pull/490 에서 논의된 내용입니다.

BTreeGetBulkOperationImpl에서 element count를 decode 하는 곳을 BTreeGetBulkImpl.decodeKeyHeader() 메소드로 옮겼습니다.
OperationStatus의 경우 matchStatus() 메소드가 필요한데, 이 메소드는 OperationImpl 클래스에 정의되어 BTreeGetBulkImpl 클래스에서 사용할 수 없었습니다. 그래서 status를 decode 하는 곳은 변경하지 않았습니다.