### PR TITLE
DOC: Replace "\t" to "    ".

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,10 @@ This is a fork of [spymemcached][spymemcached] with the following modifications
 to support Arcus memcached cloud.
 
 - Collection data types
-	- List: A doubly-linked list.
-	- Set: An unordered set of unique data.
-	- Map: An unordered set of <field, value>.
-	- B+Tree: A B+Tree structure similar to sorted map.
+    - List: A doubly-linked list.
+    - Set: An unordered set of unique data.
+    - Map: An unordered set of <field, value>.
+    - B+Tree: A B+Tree structure similar to sorted map.
 - ZooKeeper based clustering
 
 [spymemcached]: https://code.google.com/p/spymemcached/ "spymemcached"
@@ -25,11 +25,11 @@ To use it, add the following dependency to your pom.xml.
 
 ```xml
 <dependencies>
-	<dependency>
-		<groupId>com.navercorp.arcus</groupId>
-		<artifactId>arcus-java-client</artifactId>
-		<version>1.13.3</version>
-	</dependency>
+    <dependency>
+        <groupId>com.navercorp.arcus</groupId>
+        <artifactId>arcus-java-client</artifactId>
+        <version>1.13.3</version>
+    </dependency>
 </dependencies>
 ```
 

--- a/docs/05-set-API.md
+++ b/docs/05-set-API.md
@@ -60,23 +60,23 @@ String key = "Sample:EmptySet";
 CollectionFuture<Boolean> future = null;
 CollectionAttributes attribute = new CollectionAttributes();
 try {
-	future = client.asyncSopCreate(key, ElementValueType.OTHERS,
-			attribute); // (1)
+    future = client.asyncSopCreate(key, ElementValueType.OTHERS,
+            attribute); // (1)
 } catch (IllegalStateException e) {
-	// handle exception
+    // handle exception
 }
 if (future == null)
-	return;
+    return;
 try {
-	Boolean result = future.get(1000L, TimeUnit.MILLISECONDS); // (2)
-	System.out.println(result);
-	System.out.println(future.getOperationStatus().getResponse()); // (3)
+    Boolean result = future.get(1000L, TimeUnit.MILLISECONDS); // (2)
+    System.out.println(result);
+    System.out.println(future.getOperationStatus().getResponse()); // (3)
 } catch (TimeoutException e) {
-	future.cancel(true);
+    future.cancel(true);
 } catch (InterruptedException e) {
-	future.cancel(true);
+    future.cancel(true);
 } catch (ExecutionException e) {
-	future.cancel(true);
+    future.cancel(true);
 }
 ```
 

--- a/docs/07-btree-API.md
+++ b/docs/07-btree-API.md
@@ -90,9 +90,9 @@ eflag filter 조건에서 compare/bitwise 연산이 수행될 eflag의 전체/�
 
 compare 연산자                                | 설명
 --------------------------------------------- | ----
-ElementFlagFilter.CompOperands.Equal	      | 일치
-ElementFlagFilter.CompOperands.NotEqual	      | 일치하지 않음
-ElementFlagFilter.CompOperands.LessThan	      | 작은 것
+ElementFlagFilter.CompOperands.Equal          | 일치
+ElementFlagFilter.CompOperands.NotEqual          | 일치하지 않음
+ElementFlagFilter.CompOperands.LessThan          | 작은 것
 ElementFlagFilter.CompOperands.LessOrEqual    | 작거나 같은 것
 ElementFlagFilter.CompOperands.GreaterThan    | 큰 것
 ElementFlagFilter.CompOperands.GreaterOrEqual | 크거나 같은 것
@@ -101,9 +101,9 @@ ElementFlagFilter.CompOperands.GreaterOrEqual | 크거나 같은 것
 
 | bitwise 연산자                              | 설명
 |-------------------------------------------- | ----
-ElementFlagFilter.BitwiseOperands.AND	      | AND 연산
-ElementFlagFilter.BitwiseOperands.OR	      | OR 연산
-ElementFlagFilter.BitwiseOperands.XOR	      | XOR 연산
+ElementFlagFilter.BitwiseOperands.AND          | AND 연산
+ElementFlagFilter.BitwiseOperands.OR          | OR 연산
+ElementFlagFilter.BitwiseOperands.XOR          | XOR 연산
 
 ### ElementFlagFilter 메소드
 
@@ -441,38 +441,38 @@ private String key = "BopStoreAndGetTest";
 private long[] longBkeys = { 10L, 11L, 12L, 13L, 14L, 15L, 16L, 17L, 18L };
 
 public void testInsertAndGetTrimmedLongBKey() throws Exception {
-	// insert test data
-	CollectionAttributes attrs = new CollectionAttributes();
-	attrs.setMaxCount(10);
-	attrs.setOverflowAction(CollectionOverflowAction.smallest_trim);
-	for (long each : longBkeys) {
-		mc.asyncBopInsert(key, each, null, "val", attrs).get();
-	}
+    // insert test data
+    CollectionAttributes attrs = new CollectionAttributes();
+    attrs.setMaxCount(10);
+    attrs.setOverflowAction(CollectionOverflowAction.smallest_trim);
+    for (long each : longBkeys) {
+        mc.asyncBopInsert(key, each, null, "val", attrs).get();
+    }
 
-	// cause an overflow
-	assertTrue(mc.asyncBopInsert(key, 1000, null, "val", null).get());
-	
-	// expecting that bkey 10 was trimmed out and the first bkey is 11 
-	Map<Integer, Element<Object>> posMap = mc.asyncBopGetByPosition(key, BTreeOrder.ASC, 0).get();
-	assertNotNull(posMap);
-	assertNotNull(posMap.get(0)); // the first element
-	assertEquals(11L, posMap.get(0).getLongBkey());
+    // cause an overflow
+    assertTrue(mc.asyncBopInsert(key, 1000, null, "val", null).get());
+    
+    // expecting that bkey 10 was trimmed out and the first bkey is 11 
+    Map<Integer, Element<Object>> posMap = mc.asyncBopGetByPosition(key, BTreeOrder.ASC, 0).get();
+    assertNotNull(posMap);
+    assertNotNull(posMap.get(0)); // the first element
+    assertEquals(11L, posMap.get(0).getLongBkey());
 
-	// then cause an overflow again and get a trimmed object
-	// it would be a bkey(11)
-	BTreeStoreAndGetFuture<Boolean, Object> f = mc.asyncBopInsertAndGetTrimmed(key, 2000, null, "val", null);
-	boolean succeeded = f.get();
-	Element<Object> element = f.getElement();
-	assertTrue(succeeded);
-	assertNotNull(element);
-	assertEquals(11L, element.getLongBkey());
-	System.out.println("The insertion was succeeded and an element " + f.getElement() + " was trimmed out");
-	
-	// finally check the first bkey which is expected to be 12 
-	posMap = mc.asyncBopGetByPosition(key, BTreeOrder.ASC, 0).get();
-	assertNotNull(posMap);
-	assertNotNull(posMap.get(0)); // the first element
-	assertEquals(12L, posMap.get(0).getLongBkey());
+    // then cause an overflow again and get a trimmed object
+    // it would be a bkey(11)
+    BTreeStoreAndGetFuture<Boolean, Object> f = mc.asyncBopInsertAndGetTrimmed(key, 2000, null, "val", null);
+    boolean succeeded = f.get();
+    Element<Object> element = f.getElement();
+    assertTrue(succeeded);
+    assertNotNull(element);
+    assertEquals(11L, element.getLongBkey());
+    System.out.println("The insertion was succeeded and an element " + f.getElement() + " was trimmed out");
+    
+    // finally check the first bkey which is expected to be 12 
+    posMap = mc.asyncBopGetByPosition(key, BTreeOrder.ASC, 0).get();
+    assertNotNull(posMap);
+    assertNotNull(posMap.get(0)); // the first element
+    assertEquals(12L, posMap.get(0).getLongBkey());
 }
 ```
 
@@ -1104,7 +1104,7 @@ null                         | CollectionResponse.UNREADABLE           | 해당 
 
 BTreeGetResult.getElements()로 조회한 BTreeElement 객체로부터 개별 element의 bkey, eflag, value를 조회할 수 있다.
 
-BTreeElement 객체의 Method  | 자료형	          | 설명
+BTreeElement 객체의 Method  | 자료형              | 설명
 --------------------------- | -----------------| ----
 getBkey()                   | long 또는 byte[]  | element의 bkey
 getEFlag()                  | byte[]           | element flag
@@ -1340,37 +1340,37 @@ String key = "BopFindPositionTest";
 long[] longBkeys = { 10L, 11L, 12L, 13L, 14L, 15L, 16L, 17L, 18L, 19L };
 
 public void testLongBKeyAsc() throws Exception {
-	// insert
-	CollectionAttributes attrs = new CollectionAttributes();
-	for (long each : longBkeys) {
-		arcusClient.asyncBopInsert(key, each, null, "val", attrs).get();
-	}
-	
-	// bop position
-	for (int i=0; i<longBkeys.length; i++) {
-		CollectionFuture<Integer> f = arcusClient.asyncBopFindPosition(key, longBkeys[i], BTreeOrder.ASC);
-		Integer position = f.get();
-		assertNotNull(position);
-		assertEquals(CollectionResponse.OK, f.getOperationStatus().getResponse());
-		assertEquals(i, position.intValue());
-	}
+    // insert
+    CollectionAttributes attrs = new CollectionAttributes();
+    for (long each : longBkeys) {
+        arcusClient.asyncBopInsert(key, each, null, "val", attrs).get();
+    }
+    
+    // bop position
+    for (int i=0; i<longBkeys.length; i++) {
+        CollectionFuture<Integer> f = arcusClient.asyncBopFindPosition(key, longBkeys[i], BTreeOrder.ASC);
+        Integer position = f.get();
+        assertNotNull(position);
+        assertEquals(CollectionResponse.OK, f.getOperationStatus().getResponse());
+        assertEquals(i, position.intValue());
+    }
 }
 
 public void testLongBKeyDesc() throws Exception {
-	// insert
-	CollectionAttributes attrs = new CollectionAttributes();
-	for (long each : longBkeys) {
-		arcusClient.asyncBopInsert(key, each, null, "val", attrs).get();
-	}
-	
-	// bop position
-	for (int i=0; i<longBkeys.length; i++) {
-		CollectionFuture<Integer> f = arcusClient.asyncBopFindPosition(key, longBkeys[i], BTreeOrder.DESC);
-		Integer position = f.get();
-		assertNotNull(position);
-		assertEquals(CollectionResponse.OK, f.getOperationStatus().getResponse());
-		assertEquals("invalid position", longBkeys.length-i-1, position.intValue());
-	}
+    // insert
+    CollectionAttributes attrs = new CollectionAttributes();
+    for (long each : longBkeys) {
+        arcusClient.asyncBopInsert(key, each, null, "val", attrs).get();
+    }
+    
+    // bop position
+    for (int i=0; i<longBkeys.length; i++) {
+        CollectionFuture<Integer> f = arcusClient.asyncBopFindPosition(key, longBkeys[i], BTreeOrder.DESC);
+        Integer position = f.get();
+        assertNotNull(position);
+        assertEquals(CollectionResponse.OK, f.getOperationStatus().getResponse());
+        assertEquals("invalid position", longBkeys.length-i-1, position.intValue());
+    }
 }
 ```
 
@@ -1408,30 +1408,30 @@ String key = "BopGetByPositionTest";
 long[] longBkeys = { 10L, 11L, 12L, 13L, 14L, 15L, 16L, 17L, 18L, 19L };
 
 public void testLongBKeyMultiple() throws Exception {
-	// 10개의 테스트 데이터를 insert 한다.
-	CollectionAttributes attrs = new CollectionAttributes();
-	for (long each : longBkeys) {
-		arcusClient.asyncBopInsert(key, each, null, "val", attrs).get();
-	}
-	
-	// 테스트 : 5 부터 8 위치의 엘리먼트를 조회한다.
-	int posFrom = 5;
-	int posTo = 8;
-	CollectionFuture<Map<Integer, Element<Object>>> f = arcusClient
-			.asyncBopGetByPosition(key, BTreeOrder.ASC, posFrom, posTo);
-	Map<Integer, Element<Object>> result = f.get(1000,
-			TimeUnit.MILLISECONDS);
+    // 10개의 테스트 데이터를 insert 한다.
+    CollectionAttributes attrs = new CollectionAttributes();
+    for (long each : longBkeys) {
+        arcusClient.asyncBopInsert(key, each, null, "val", attrs).get();
+    }
+    
+    // 테스트 : 5 부터 8 위치의 엘리먼트를 조회한다.
+    int posFrom = 5;
+    int posTo = 8;
+    CollectionFuture<Map<Integer, Element<Object>>> f = arcusClient
+            .asyncBopGetByPosition(key, BTreeOrder.ASC, posFrom, posTo);
+    Map<Integer, Element<Object>> result = f.get(1000,
+            TimeUnit.MILLISECONDS);
 
-	assertEquals(4, result.size());
-	assertEquals(CollectionResponse.END, f.getOperationStatus().getResponse());
+    assertEquals(4, result.size());
+    assertEquals(CollectionResponse.END, f.getOperationStatus().getResponse());
 
-	int count = 0;
-	for (Entry<Integer, Element<Object>> each : result.entrySet()) {
-		int currPos = posFrom + count++;
-		assertEquals("invalid index", currPos, each.getKey().intValue());
-		assertEquals("invalid bkey", longBkeys[currPos], each.getValue().getLongBkey());
-		assertEquals("invalid value", "val", each.getValue().getValue());
-	}
+    int count = 0;
+    for (Entry<Integer, Element<Object>> each : result.entrySet()) {
+        int currPos = posFrom + count++;
+        assertEquals("invalid index", currPos, each.getKey().intValue());
+        assertEquals("invalid bkey", longBkeys[currPos], each.getValue().getLongBkey());
+        assertEquals("invalid value", "val", each.getValue().getValue());
+    }
 }
 ```
 

--- a/docs/10-log-message.md
+++ b/docs/10-log-message.md
@@ -115,12 +115,12 @@ net.spy.memcached.internal.CheckedOperationTimeoutException: GET operation timed
 | ------------------------------------------- | ----------------------------------------------------- |
 | GET operation timed out (>300 MILLISECONDS )| Timeout 값이 300ms로 지정되어있고 GET 요청의 결과를 받기까지 300ms 이상 걸려서 timeout되었다.|
 | Failing node: /127.0.0.1:11211              | 해당 요청은 127.0.0.1:11211 에서 수행한다. 
-| [WRITING]	                                  | 해당 요청은 socket write를 위해 대기 중이다. 
-| [READING]	                                  | 해당 요청은 서버로 전달되었고 결과가 돌아오기를 기다리거나, 결과 값을 읽어 들이는 중이다. 
-| #iq	                                        | 해당 ARCUS node Input queue에서 대기중인 요청 수 
-| #Wops	                                      | Writing 상태에 있는 요청 수 
-| #Rops	                                      | Reading 상태에 있는 요청 수 
-| #CT	                                        | Continuous timeout, 해당 arcus node에서 연속적으로 발생한 timeout 횟수, 이 값이 connection factory builder로 지정되는 timeout threshold값을 넘어서면 클라이언트는 해당 서버와의 연결을 끊고 다시 연결한다. 
+| [WRITING]                                      | 해당 요청은 socket write를 위해 대기 중이다. 
+| [READING]                                      | 해당 요청은 서버로 전달되었고 결과가 돌아오기를 기다리거나, 결과 값을 읽어 들이는 중이다. 
+| #iq                                            | 해당 ARCUS node Input queue에서 대기중인 요청 수 
+| #Wops                                          | Writing 상태에 있는 요청 수 
+| #Rops                                          | Reading 상태에 있는 요청 수 
+| #CT                                            | Continuous timeout, 해당 arcus node에서 연속적으로 발생한 timeout 횟수, 이 값이 connection factory builder로 지정되는 timeout threshold값을 넘어서면 클라이언트는 해당 서버와의 연결을 끊고 다시 연결한다. 
 
 즉, 해석해 보자면 ARCUS node 127.0.0.1:11211에 대해 요청을 보냈는데 300ms이내에 결과값을 돌려줄 수 없어 실패했다는 의미이다.
 가장 많이 발생할 수 있는 메시지로 원인 또한 매우 다양하다. 원인을 나열해 보자면 다음과 같다.


### PR DESCRIPTION
https://github.com/jam2in/arcus-works/issues/338 이슈 작업을 위해 document 수정 중 일부 indent가 "\t"로 되어 있는 것을 확인했습니다. Markdown viewer에 따라 출력이 일관적이지 않을 수 있어서 .md 파일에 한하여 "\t"를 "    "(space 4개)로 바꿨습니다.