### PR TITLE
INTERNAL: Replace parameter type of CollectionInsertBulkOperation.Callback.gotStatus() method from int to String.

### DIFF
--- a/src/main/java/net/spy/memcached/ArcusClient.java
+++ b/src/main/java/net/spy/memcached/ArcusClient.java
@@ -4070,13 +4070,13 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
                   latch.countDown();
                 }
 
-                public void gotStatus(Integer index, OperationStatus status) {
+                public void gotStatus(String key, OperationStatus status) {
                   if (!status.isSuccess()) {
                     if (status instanceof CollectionOperationStatus) {
-                      failedResult.put(insert.getKeyList().get(index),
+                      failedResult.put(key,
                               (CollectionOperationStatus) status);
                     } else {
-                      failedResult.put(insert.getKeyList().get(index),
+                      failedResult.put(key,
                               new CollectionOperationStatus(status));
                     }
                   }

--- a/src/main/java/net/spy/memcached/collection/CollectionBulkInsert.java
+++ b/src/main/java/net/spy/memcached/collection/CollectionBulkInsert.java
@@ -307,6 +307,10 @@ public abstract class CollectionBulkInsert<T> extends CollectionObject {
     }
   }
 
+  public String getKey(int index) {
+    return this.keyList.get(index);
+  }
+
   public List<String> getKeyList() {
     return this.keyList;
   }

--- a/src/main/java/net/spy/memcached/ops/CollectionBulkInsertOperation.java
+++ b/src/main/java/net/spy/memcached/ops/CollectionBulkInsertOperation.java
@@ -26,7 +26,7 @@ public interface CollectionBulkInsertOperation extends KeyedOperation {
   CollectionBulkInsert<?> getInsert();
 
   interface Callback extends OperationCallback {
-    void gotStatus(Integer index, OperationStatus status);
+    void gotStatus(String key, OperationStatus status);
   }
 
 }

--- a/src/main/java/net/spy/memcached/protocol/ascii/CollectionBulkInsertOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/CollectionBulkInsertOperationImpl.java
@@ -103,7 +103,7 @@ public class CollectionBulkInsertOperationImpl extends OperationImpl
       if (status.isSuccess()) {
         cb.receivedStatus((successAll) ? END : FAILED_END);
       } else {
-        cb.gotStatus(index, status);
+        cb.gotStatus(insert.getKey(index), status);
         cb.receivedStatus(FAILED_END);
       }
       transitionState(OperationState.COMPLETE);
@@ -136,7 +136,7 @@ public class CollectionBulkInsertOperationImpl extends OperationImpl
               TYPE_MISMATCH, BKEY_MISMATCH);
 
       if (!status.isSuccess()) {
-        cb.gotStatus(index, status);
+        cb.gotStatus(insert.getKey(index), status);
         successAll = false;
       }
 

--- a/src/test/manual/net/spy/memcached/MultibyteKeyTest.java
+++ b/src/test/manual/net/spy/memcached/MultibyteKeyTest.java
@@ -464,7 +464,7 @@ public class MultibyteKeyTest {
     CollectionBulkInsertOperation.Callback cbsCallback =
         new CollectionBulkInsertOperation.Callback() {
           @Override
-          public void gotStatus(Integer index, OperationStatus status) {
+          public void gotStatus(String key, OperationStatus status) {
           }
 
           @Override


### PR DESCRIPTION
https://github.com/naver/arcus-java-client/pull/486#discussion_r893425536

CollectionInsertBulkOperation.Callback.gotStatus() 메소드의 첫 인자를 int에서 String으로 변경하여 key를 간접적으로 불러오는 부분을 key를 매개변수로 직접 받아오도록 수정했습니다.