### PR TITLE
FIX: Add eflag field in SMGetElement class.

### DIFF
--- a/src/main/java/net/spy/memcached/ArcusClient.java
+++ b/src/main/java/net/spy/memcached/ArcusClient.java
@@ -2354,17 +2354,17 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
         }
 
         @Override
-        public void gotData(String key, Object subkey, int flags, byte[] data) {
+        public void gotData(String key, Object subkey, int flags, byte[] eflag, byte[] data) {
           if (stopCollect.get()) {
             return;
           }
 
           if (subkey instanceof Long) {
-            eachResult.add(new SMGetElement<T>(key, (Long) subkey, tc.decode(
-                new CachedData(flags, data, tc.getMaxSize()))));
+            eachResult.add(new SMGetElement<T>(key, (Long) subkey, eflag,
+                tc.decode(new CachedData(flags, data, tc.getMaxSize()))));
           } else if (subkey instanceof byte[]) {
-            eachResult.add(new SMGetElement<T>(key, (byte[]) subkey, tc.decode(
-                new CachedData(flags, data, tc.getMaxSize()))));
+            eachResult.add(new SMGetElement<T>(key, (byte[]) subkey, eflag,
+                tc.decode(new CachedData(flags, data, tc.getMaxSize()))));
           }
         }
 
@@ -2615,17 +2615,17 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
         }
 
         @Override
-        public void gotData(String key, Object subkey, int flags, byte[] data) {
+        public void gotData(String key, Object subkey, int flags, byte[] eflag, byte[] data) {
           if (stopCollect.get()) {
             return;
           }
 
           if (subkey instanceof Long) {
-            eachResult.add(new SMGetElement<T>(key, (Long) subkey, tc.decode(
-                new CachedData(flags, data, tc.getMaxSize()))));
+            eachResult.add(new SMGetElement<T>(key, (Long) subkey, eflag,
+                tc.decode(new CachedData(flags, data, tc.getMaxSize()))));
           } else if (subkey instanceof byte[]) {
-            eachResult.add(new SMGetElement<T>(key, (byte[]) subkey, tc.decode(
-                new CachedData(flags, data, tc.getMaxSize()))));
+            eachResult.add(new SMGetElement<T>(key, (byte[]) subkey, eflag,
+                tc.decode(new CachedData(flags, data, tc.getMaxSize()))));
           }
         }
 

--- a/src/main/java/net/spy/memcached/collection/BTreeSMGet.java
+++ b/src/main/java/net/spy/memcached/collection/BTreeSMGet.java
@@ -48,7 +48,7 @@ public interface BTreeSMGet<T> {
 
   public boolean isReverse();
 
-  public boolean hasEflag();
+  public byte[] getEflag();
 
   public void decodeItemHeader(String itemHeader);
 }

--- a/src/main/java/net/spy/memcached/collection/BTreeSMGetImpl.java
+++ b/src/main/java/net/spy/memcached/collection/BTreeSMGetImpl.java
@@ -149,8 +149,8 @@ public abstract class BTreeSMGetImpl<T> implements BTreeSMGet<T> {
     return reverse;
   }
 
-  public boolean hasEflag() {
-    return eflag != null;
+  public byte[] getEflag() {
+    return eflag;
   }
 
   public void decodeItemHeader(String itemHeader) {

--- a/src/main/java/net/spy/memcached/collection/SMGetElement.java
+++ b/src/main/java/net/spy/memcached/collection/SMGetElement.java
@@ -17,26 +17,35 @@
  */
 package net.spy.memcached.collection;
 
+import net.spy.memcached.util.BTreeUtil;
+
 public class SMGetElement<T> implements Comparable<SMGetElement<T>> {
 
-  private String key;
-  private BKeyObject bKeyObject;
-  private T value;
+  private final String key;
+  private final BKeyObject bKeyObject;
+  private final byte[] eflag;
+  private final T value;
 
-  public SMGetElement(String key, long bkey, T value) {
+  public SMGetElement(String key, long bkey, byte[] eflag, T value) {
     this.key = key;
     this.bKeyObject = new BKeyObject(bkey);
+    this.eflag = eflag;
     this.value = value;
   }
 
-  public SMGetElement(String key, byte[] bkey, T value) {
+  public SMGetElement(String key, byte[] bkey, byte[] eflag, T value) {
     this.key = key;
     this.bKeyObject = new BKeyObject(bkey);
+    this.eflag = eflag;
     this.value = value;
   }
 
   @Override
   public String toString() {
+    if (eflag != null) {
+      return "SMGetElement {KEY:" + key + ", BKEY:" + bKeyObject
+          + ", EFLAG: " + BTreeUtil.toHex(eflag) +  ", VALUE:" + value + "}";
+    }
     return "SMGetElement {KEY:" + key + ", BKEY:" + bKeyObject + ", VALUE:" + value + "}";
   }
 
@@ -83,6 +92,10 @@ public class SMGetElement<T> implements Comparable<SMGetElement<T>> {
 
   public BKeyObject getBkeyObject() {
     return bKeyObject;
+  }
+
+  public byte[] getEflag() {
+    return eflag;
   }
 
   public T getValue() {

--- a/src/main/java/net/spy/memcached/ops/BTreeSortMergeGetOperation.java
+++ b/src/main/java/net/spy/memcached/ops/BTreeSortMergeGetOperation.java
@@ -18,7 +18,7 @@ package net.spy.memcached.ops;
 
 public interface BTreeSortMergeGetOperation extends KeyedOperation {
   interface Callback extends OperationCallback {
-    void gotData(String key, Object subkey, int flags, byte[] data);
+    void gotData(String key, Object subkey, int flags, byte[] eflag, byte[] data);
 
     void gotMissedKey(String key, OperationStatus cause);
 

--- a/src/main/java/net/spy/memcached/ops/BTreeSortMergeGetOperationOld.java
+++ b/src/main/java/net/spy/memcached/ops/BTreeSortMergeGetOperationOld.java
@@ -18,7 +18,7 @@ package net.spy.memcached.ops;
 
 public interface BTreeSortMergeGetOperationOld extends KeyedOperation {
   interface Callback extends OperationCallback {
-    void gotData(String key, Object subkey, int flags, byte[] data);
+    void gotData(String key, Object subkey, int flags, byte[] eflag, byte[] data);
 
     void gotMissedKey(byte[] data);
   }

--- a/src/main/java/net/spy/memcached/protocol/ascii/BTreeSortMergeGetOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/BTreeSortMergeGetOperationImpl.java
@@ -256,7 +256,7 @@ public class BTreeSortMergeGetOperationImpl extends OperationImpl implements
 
     if (lookingFor == '\0' && readOffset == data.length && count < lineCount) {
       BTreeSortMergeGetOperation.Callback cb = (BTreeSortMergeGetOperation.Callback) getCallback();
-      cb.gotData(smGet.getKey(), smGet.getSubkey(), smGet.getFlags(), data);
+      cb.gotData(smGet.getKey(), smGet.getSubkey(), smGet.getFlags(), smGet.getEflag(), data);
       lookingFor = '\r';
     }
 

--- a/src/main/java/net/spy/memcached/protocol/ascii/BTreeSortMergeGetOperationOldImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/BTreeSortMergeGetOperationOldImpl.java
@@ -219,7 +219,7 @@ public class BTreeSortMergeGetOperationOldImpl extends OperationImpl implements
     if (lookingFor == '\0' && readOffset == data.length) {
       BTreeSortMergeGetOperationOld.Callback cb =
           (BTreeSortMergeGetOperationOld.Callback) getCallback();
-      cb.gotData(smGet.getKey(), smGet.getSubkey(), smGet.getFlags(), data);
+      cb.gotData(smGet.getKey(), smGet.getSubkey(), smGet.getFlags(), smGet.getEflag(), data);
       lookingFor = '\r';
     }
 

--- a/src/test/manual/net/spy/memcached/MultibyteKeyTest.java
+++ b/src/test/manual/net/spy/memcached/MultibyteKeyTest.java
@@ -285,7 +285,7 @@ public class MultibyteKeyTest {
               keyList, 0L, 100L, ElementFlagFilter.DO_NOT_FILTER, 0, SMGetMode.UNIQUE),
           new BTreeSortMergeGetOperation.Callback() {
             @Override
-            public void gotData(String key, Object subkey, int flags, byte[] data) {
+            public void gotData(String key, Object subkey, int flags, byte[] eflag, byte[] data) {
             }
 
             @Override
@@ -317,7 +317,7 @@ public class MultibyteKeyTest {
               keyList, 0L, 100L, ElementFlagFilter.DO_NOT_FILTER, 0, 0),
           new BTreeSortMergeGetOperationOld.Callback() {
             @Override
-            public void gotData(String key, Object subkey, int flags, byte[] data) {
+            public void gotData(String key, Object subkey, int flags, byte[] eflag, byte[] data) {
             }
 
             @Override

--- a/src/test/manual/net/spy/memcached/collection/btree/SMGetElementTest.java
+++ b/src/test/manual/net/spy/memcached/collection/btree/SMGetElementTest.java
@@ -4,6 +4,7 @@ import net.spy.memcached.collection.SMGetElement;
 import org.junit.Test;
 import org.junit.function.ThrowingRunnable;
 
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
@@ -12,17 +13,19 @@ public class SMGetElementTest {
 
   private static final String KEY = "test";
   private static final String VALUE = "testValue";
+  private static final byte[] EFLAG = {1, 8, 16, 32, 64};
 
   @Test
   public void createWithLongBkey() {
     //given
     long bkey = 1;
 
-    final SMGetElement<String> element = new SMGetElement<String>(KEY, bkey, VALUE);
+    final SMGetElement<String> element = new SMGetElement<String>(KEY, bkey, EFLAG, VALUE);
 
     //when, then
     assertEquals(KEY, element.getKey());
     assertEquals(bkey, element.getBkey());
+    assertArrayEquals(EFLAG, element.getEflag());
     assertThrows(IllegalStateException.class, new ThrowingRunnable() {
       @Override
       public void run() throws Throwable {
@@ -37,11 +40,12 @@ public class SMGetElementTest {
     //given
     byte[] bkey = {0x34};
 
-    final SMGetElement<String> element = new SMGetElement<String>(KEY, bkey, VALUE);
+    final SMGetElement<String> element = new SMGetElement<String>(KEY, bkey, EFLAG, VALUE);
 
     //when, then
     assertEquals(KEY, element.getKey());
     assertEquals(bkey, element.getByteBkey());
+    assertArrayEquals(EFLAG, element.getEflag());
     assertThrows(IllegalStateException.class, new ThrowingRunnable() {
       @Override
       public void run() throws Throwable {
@@ -56,8 +60,8 @@ public class SMGetElementTest {
     //given
     long bkey = 2;
 
-    SMGetElement<String> element = new SMGetElement<String>(KEY, bkey, VALUE);
-    SMGetElement<String> anotherElement = new SMGetElement<String>(KEY, bkey, VALUE);
+    SMGetElement<String> element = new SMGetElement<String>(KEY, bkey, EFLAG, VALUE);
+    SMGetElement<String> anotherElement = new SMGetElement<String>(KEY, bkey, EFLAG, VALUE);
 
     //when, then
     assertEquals(0, element.compareTo(anotherElement));
@@ -69,8 +73,8 @@ public class SMGetElementTest {
     long bkey = 2;
     long anotherBkey = 1;
 
-    SMGetElement<String> element = new SMGetElement<String>(KEY, bkey, VALUE);
-    SMGetElement<String> anotherElement = new SMGetElement<String>(KEY, anotherBkey, VALUE);
+    SMGetElement<String> element = new SMGetElement<String>(KEY, bkey, EFLAG, VALUE);
+    SMGetElement<String> anotherElement = new SMGetElement<String>(KEY, anotherBkey, EFLAG, VALUE);
 
     //when, then
     assertTrue(element.compareBkeyTo(anotherElement) > 0);


### PR DESCRIPTION
https://github.com/jam2in/arcus-works/issues/341

smget 연산 수행 시 eflag 정보를 가져오지만 연산의 결과가 되는 SMGetElement 객체에는 저장하지 않던 점을 수정했습니다.