### PR TITLE
INTERNAL: Change the order of parameter subkey and flags.

### DIFF
--- a/src/main/java/net/spy/memcached/ArcusClient.java
+++ b/src/main/java/net/spy/memcached/ArcusClient.java
@@ -2354,7 +2354,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
         }
 
         @Override
-        public void gotData(String key, Object subkey, int flags, byte[] eflag, byte[] data) {
+        public void gotData(String key, int flags, Object subkey, byte[] eflag, byte[] data) {
           if (stopCollect.get()) {
             return;
           }
@@ -2615,7 +2615,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
         }
 
         @Override
-        public void gotData(String key, Object subkey, int flags, byte[] eflag, byte[] data) {
+        public void gotData(String key, int flags, Object subkey, byte[] eflag, byte[] data) {
           if (stopCollect.get()) {
             return;
           }
@@ -4275,7 +4275,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
         }
 
         @Override
-        public void gotElement(String key, Object subkey, int flags, byte[] eflag, byte[] data) {
+        public void gotElement(String key, int flags, Object subkey, byte[] eflag, byte[] data) {
           result.get(key).addElement(
                   new BTreeElement<Long, T>((Long) subkey, eflag,
                           tc.decode(new CachedData(flags, data, tc.getMaxSize()))));
@@ -4331,7 +4331,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
         }
 
         @Override
-        public void gotElement(String key, Object subkey, int flags, byte[] eflag, byte[] data) {
+        public void gotElement(String key, int flags, Object subkey, byte[] eflag, byte[] data) {
           result.get(key).addElement(
                   new BTreeElement<ByteArrayBKey, T>(
                           new ByteArrayBKey((byte[]) subkey),

--- a/src/main/java/net/spy/memcached/ops/BTreeGetBulkOperation.java
+++ b/src/main/java/net/spy/memcached/ops/BTreeGetBulkOperation.java
@@ -18,7 +18,7 @@ package net.spy.memcached.ops;
 
 public interface BTreeGetBulkOperation extends KeyedOperation {
   interface Callback<K> extends OperationCallback {
-    void gotElement(String key, Object subkey, int flags, byte[] eflag, byte[] data);
+    void gotElement(String key, int flags, Object subkey, byte[] eflag, byte[] data);
 
     void gotKey(String key, int elementCount, OperationStatus status);
   }

--- a/src/main/java/net/spy/memcached/ops/BTreeSortMergeGetOperation.java
+++ b/src/main/java/net/spy/memcached/ops/BTreeSortMergeGetOperation.java
@@ -18,7 +18,7 @@ package net.spy.memcached.ops;
 
 public interface BTreeSortMergeGetOperation extends KeyedOperation {
   interface Callback extends OperationCallback {
-    void gotData(String key, Object subkey, int flags, byte[] eflag, byte[] data);
+    void gotData(String key, int flags, Object subkey, byte[] eflag, byte[] data);
 
     void gotMissedKey(String key, OperationStatus cause);
 

--- a/src/main/java/net/spy/memcached/ops/BTreeSortMergeGetOperationOld.java
+++ b/src/main/java/net/spy/memcached/ops/BTreeSortMergeGetOperationOld.java
@@ -18,7 +18,7 @@ package net.spy.memcached.ops;
 
 public interface BTreeSortMergeGetOperationOld extends KeyedOperation {
   interface Callback extends OperationCallback {
-    void gotData(String key, Object subkey, int flags, byte[] eflag, byte[] data);
+    void gotData(String key, int flags, Object subkey, byte[] eflag, byte[] data);
 
     void gotMissedKey(byte[] data);
   }

--- a/src/main/java/net/spy/memcached/protocol/ascii/BTreeGetBulkOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/BTreeGetBulkOperationImpl.java
@@ -179,7 +179,7 @@ public class BTreeGetBulkOperationImpl extends OperationImpl implements
     if (lookingFor == '\0' && readOffset == data.length) {
       BTreeGetBulkOperation.Callback cb = (BTreeGetBulkOperation.Callback) getCallback();
       cb.gotElement(
-          key, getBulk.getSubkey(), flags, getBulk.getEFlag(), data);
+          key, flags, getBulk.getSubkey(), getBulk.getEFlag(), data);
       lookingFor = '\r';
     }
 

--- a/src/main/java/net/spy/memcached/protocol/ascii/BTreeSortMergeGetOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/BTreeSortMergeGetOperationImpl.java
@@ -256,7 +256,7 @@ public class BTreeSortMergeGetOperationImpl extends OperationImpl implements
 
     if (lookingFor == '\0' && readOffset == data.length && count < lineCount) {
       BTreeSortMergeGetOperation.Callback cb = (BTreeSortMergeGetOperation.Callback) getCallback();
-      cb.gotData(smGet.getKey(), smGet.getSubkey(), smGet.getFlags(), smGet.getEflag(), data);
+      cb.gotData(smGet.getKey(), smGet.getFlags(), smGet.getSubkey(), smGet.getEflag(), data);
       lookingFor = '\r';
     }
 

--- a/src/main/java/net/spy/memcached/protocol/ascii/BTreeSortMergeGetOperationOldImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/BTreeSortMergeGetOperationOldImpl.java
@@ -219,7 +219,7 @@ public class BTreeSortMergeGetOperationOldImpl extends OperationImpl implements
     if (lookingFor == '\0' && readOffset == data.length) {
       BTreeSortMergeGetOperationOld.Callback cb =
           (BTreeSortMergeGetOperationOld.Callback) getCallback();
-      cb.gotData(smGet.getKey(), smGet.getSubkey(), smGet.getFlags(), smGet.getEflag(), data);
+      cb.gotData(smGet.getKey(), smGet.getFlags(), smGet.getSubkey(), smGet.getEflag(), data);
       lookingFor = '\r';
     }
 

--- a/src/test/manual/net/spy/memcached/MultibyteKeyTest.java
+++ b/src/test/manual/net/spy/memcached/MultibyteKeyTest.java
@@ -285,7 +285,7 @@ public class MultibyteKeyTest {
               keyList, 0L, 100L, ElementFlagFilter.DO_NOT_FILTER, 0, SMGetMode.UNIQUE),
           new BTreeSortMergeGetOperation.Callback() {
             @Override
-            public void gotData(String key, Object subkey, int flags, byte[] eflag, byte[] data) {
+            public void gotData(String key, int flags, Object subkey, byte[] eflag, byte[] data) {
             }
 
             @Override
@@ -317,7 +317,7 @@ public class MultibyteKeyTest {
               keyList, 0L, 100L, ElementFlagFilter.DO_NOT_FILTER, 0, 0),
           new BTreeSortMergeGetOperationOld.Callback() {
             @Override
-            public void gotData(String key, Object subkey, int flags, byte[] eflag, byte[] data) {
+            public void gotData(String key, int flags, Object subkey, byte[] eflag, byte[] data) {
             }
 
             @Override
@@ -514,8 +514,8 @@ public class MultibyteKeyTest {
           ),
           new BTreeGetBulkOperation.Callback<Integer>() {
             @Override
-            public void gotElement(String key, Object subkey,
-                                   int flags, byte[] eflag, byte[] data) {
+            public void gotElement(String key, int flags, Object subkey,
+                                   byte[] eflag, byte[] data) {
             }
 
             @Override


### PR DESCRIPTION
https://github.com/naver/arcus-java-client/pull/496#discussion_r897527021

Bop Get Bulk와 smget 연산의 callback에서 매개변수 순서가 `key, subkey, flags, eflag, data`인 것을 `key, flags, subkey, eflag, data`로 변경했습니다.