### PR TITLE
CLEANUP: Refactored BTreeGetBulkImpl and BTreeSMGetImpl.

### DIFF
--- a/src/main/java/net/spy/memcached/collection/BTreeGetBulkImpl.java
+++ b/src/main/java/net/spy/memcached/collection/BTreeGetBulkImpl.java
@@ -17,7 +17,6 @@
 package net.spy.memcached.collection;
 
 import java.util.List;
-import java.util.Map;
 
 import net.spy.memcached.KeyUtil;
 import net.spy.memcached.MemcachedNode;
@@ -27,35 +26,28 @@ public abstract class BTreeGetBulkImpl<T> implements BTreeGetBulk<T> {
 
   private static final String command = "bop mget";
 
-  private MemcachedNode node;
+  private final MemcachedNode node;
+  private String str;
 
   private String keySeparator;
   private String spaceSeparatedKeys;
 
-  protected String str;
-  protected int lenKeys;
-
-  protected List<String> keyList;
-  protected String range;
-  protected boolean reverse;
-  protected ElementFlagFilter eFlagFilter;
-  protected int offset = -1;
-  protected int count;
-
-  protected Map<Integer, T> map;
+  private final List<String> keyList;
+  private final String range;
+  private final ElementFlagFilter eFlagFilter;
+  private final int offset;
+  private final int count;
 
   protected Object subkey;
-  protected int dataLength;
-  protected byte[] eflag = null;
+  private int dataLength;
+  private byte[] eflag = null;
 
   protected BTreeGetBulkImpl(MemcachedNode node, List<String> keyList,
-                             String range, boolean reverse,
-                             ElementFlagFilter eFlagFilter, int offset,
-                             int count) {
+                             String range, ElementFlagFilter eFlagFilter,
+                             int offset, int count) {
     this.node = node;
     this.keyList = keyList;
     this.range = range;
-    this.reverse = reverse;
     this.eFlagFilter = eFlagFilter;
     this.offset = offset;
     this.count = count;

--- a/src/main/java/net/spy/memcached/collection/BTreeGetBulkWithByteTypeBkey.java
+++ b/src/main/java/net/spy/memcached/collection/BTreeGetBulkWithByteTypeBkey.java
@@ -28,7 +28,7 @@ public class BTreeGetBulkWithByteTypeBkey<T> extends BTreeGetBulkImpl<T> {
                                       ElementFlagFilter eFlagFilter,
                                       int offset, int count) {
     super(node, keyList, BTreeUtil.toHex(from) + ".." + BTreeUtil.toHex(to),
-        BTreeUtil.compareByteArraysInLexOrder(from, to) > 0, eFlagFilter, offset, count);
+        eFlagFilter, offset, count);
   }
 
   public byte[] getSubkey() {

--- a/src/main/java/net/spy/memcached/collection/BTreeGetBulkWithLongTypeBkey.java
+++ b/src/main/java/net/spy/memcached/collection/BTreeGetBulkWithLongTypeBkey.java
@@ -26,7 +26,7 @@ public class BTreeGetBulkWithLongTypeBkey<T> extends BTreeGetBulkImpl<T> {
                                       long from, long to,
                                       ElementFlagFilter eFlagFilter,
                                       int offset, int count) {
-    super(node, keyList, from + ".." + to, from > to, eFlagFilter, offset, count);
+    super(node, keyList, from + ".." + to, eFlagFilter, offset, count);
   }
 
   public Long getSubkey() {

--- a/src/main/java/net/spy/memcached/collection/BTreeSMGet.java
+++ b/src/main/java/net/spy/memcached/collection/BTreeSMGet.java
@@ -46,8 +46,6 @@ public interface BTreeSMGet<T> {
 
   public int getDataLength();
 
-  public boolean isReverse();
-
   public byte[] getEflag();
 
   public void decodeItemHeader(String itemHeader);

--- a/src/main/java/net/spy/memcached/collection/BTreeSMGetImpl.java
+++ b/src/main/java/net/spy/memcached/collection/BTreeSMGetImpl.java
@@ -27,49 +27,50 @@ public abstract class BTreeSMGetImpl<T> implements BTreeSMGet<T> {
   private static final String command = "bop smget";
 
   private final MemcachedNode node;
-  protected String str;
+  private String str;
 
   private String keySeparator;
   private String spaceSeparatedKeys;
 
-  protected List<String> keyList;
-  protected String range;
-  protected boolean reverse;
-  protected ElementFlagFilter eFlagFilter;
-  protected int offset = -1;
-  protected int count;
-  protected SMGetMode smgetMode = null;
+  private final List<String> keyList;
+  private final String range;
+  private final ElementFlagFilter eFlagFilter;
+  private final int offset;
+  private final int count;
+  private final SMGetMode smgetMode;
 
-  protected String key;
-  protected int flags;
+  private String key;
+  private int flags;
   protected Object subkey;
-  protected int dataLength;
-  protected byte[] eflag = null;
+  private int dataLength;
+  private byte[] eflag = null;
 
   public BTreeSMGetImpl(MemcachedNode node, List<String> keyList,
-                        String range, boolean reverse,
+                        String range,
                         ElementFlagFilter eFlagFilter, int count,
                         SMGetMode smgetMode) {
-    this.node = node;
-    this.keyList = keyList;
-    this.range = range;
-    this.reverse = reverse;
-    this.eFlagFilter = eFlagFilter;
-    this.count = count;
-    this.smgetMode = smgetMode;
+    this(node, keyList, range, eFlagFilter, -1, count, smgetMode);
   }
 
   public BTreeSMGetImpl(MemcachedNode node, List<String> keyList,
-                        String range, boolean reverse,
+                        String range,
                         ElementFlagFilter eFlagFilter,
                         int offset, int count) {
+    this(node, keyList, range, eFlagFilter, offset, count, null);
+  }
+
+  private BTreeSMGetImpl(MemcachedNode node, List<String> keyList,
+                         String range,
+                         ElementFlagFilter eFlagFilter,
+                         int offset, int count,
+                         SMGetMode smgetMode) {
     this.node = node;
     this.keyList = keyList;
     this.range = range;
-    this.reverse = reverse;
     this.eFlagFilter = eFlagFilter;
     this.offset = offset;
     this.count = count;
+    this.smgetMode = smgetMode;
   }
 
   public void setKeySeparator(String keySeparator) {
@@ -143,10 +144,6 @@ public abstract class BTreeSMGetImpl<T> implements BTreeSMGet<T> {
 
   public int getDataLength() {
     return dataLength;
-  }
-
-  public boolean isReverse() {
-    return reverse;
   }
 
   public byte[] getEflag() {

--- a/src/main/java/net/spy/memcached/collection/BTreeSMGetWithByteTypeBkey.java
+++ b/src/main/java/net/spy/memcached/collection/BTreeSMGetWithByteTypeBkey.java
@@ -28,7 +28,7 @@ public class BTreeSMGetWithByteTypeBkey<T> extends BTreeSMGetImpl<T> {
                                     ElementFlagFilter eFlagFilter, int count,
                                     SMGetMode smgetMode) {
     super(node, keyList, BTreeUtil.toHex(from) + ".." + BTreeUtil.toHex(to),
-        (BTreeUtil.compareByteArraysInLexOrder(from, to) > 0), eFlagFilter, count, smgetMode);
+        eFlagFilter, count, smgetMode);
   }
 
   @Override

--- a/src/main/java/net/spy/memcached/collection/BTreeSMGetWithByteTypeBkeyOld.java
+++ b/src/main/java/net/spy/memcached/collection/BTreeSMGetWithByteTypeBkeyOld.java
@@ -29,7 +29,7 @@ public class BTreeSMGetWithByteTypeBkeyOld<T> extends BTreeSMGetImpl<T> {
                                        ElementFlagFilter eFlagFilter,
                                        int offset, int count) {
     super(node, keyList, BTreeUtil.toHex(from) + ".." + BTreeUtil.toHex(to),
-        (BTreeUtil.compareByteArraysInLexOrder(from, to) > 0), eFlagFilter, offset, count);
+        eFlagFilter, offset, count);
   }
 
   @Override

--- a/src/main/java/net/spy/memcached/collection/BTreeSMGetWithLongTypeBkey.java
+++ b/src/main/java/net/spy/memcached/collection/BTreeSMGetWithLongTypeBkey.java
@@ -26,7 +26,7 @@ public class BTreeSMGetWithLongTypeBkey<T> extends BTreeSMGetImpl<T> {
                                     long from, long to,
                                     ElementFlagFilter eFlagFilter, int count,
                                     SMGetMode smgetMode) {
-    super(node, keyList, from + ".." + to, (from > to), eFlagFilter, count, smgetMode);
+    super(node, keyList, from + ".." + to, eFlagFilter, count, smgetMode);
   }
 
   @Override

--- a/src/main/java/net/spy/memcached/collection/BTreeSMGetWithLongTypeBkeyOld.java
+++ b/src/main/java/net/spy/memcached/collection/BTreeSMGetWithLongTypeBkeyOld.java
@@ -27,7 +27,7 @@ public class BTreeSMGetWithLongTypeBkeyOld<T> extends BTreeSMGetImpl<T> {
                                        long from, long to,
                                        ElementFlagFilter eFlagFilter,
                                        int offset, int count) {
-    super(node, keyList, from + ".." + to, (from > to), eFlagFilter, offset, count);
+    super(node, keyList, from + ".." + to, eFlagFilter, offset, count);
   }
 
   @Override


### PR DESCRIPTION
https://github.com/naver/arcus-java-client/pull/486#pullrequestreview-1008422907

BTreeGetBulkImpl 클래스와 BTreeSMGetImpl 클래스에서 변하지 않는 필드들을 final로 선언하고 사용되지 않는 필드는 제거했습니다.