### PR TITLE
CLEANUP: Remove unnecessary generic type in BTreeGetBulkOperation.Callback.

### DIFF
--- a/src/main/java/net/spy/memcached/ArcusClient.java
+++ b/src/main/java/net/spy/memcached/ArcusClient.java
@@ -4254,7 +4254,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
         new ConcurrentHashMap<String, BTreeGetResult<Long, T>>();
 
     for (BTreeGetBulk<T> getBulk : getBulkList) {
-      Operation op = opFact.bopGetBulk(getBulk, new BTreeGetBulkOperation.Callback<T>() {
+      Operation op = opFact.bopGetBulk(getBulk, new BTreeGetBulkOperation.Callback() {
         @Override
         public void receivedStatus(OperationStatus status) {
         }
@@ -4309,7 +4309,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
         new ConcurrentHashMap<String, BTreeGetResult<ByteArrayBKey, T>>();
 
     for (BTreeGetBulk<T> getBulk : getBulkList) {
-      Operation op = opFact.bopGetBulk(getBulk, new BTreeGetBulkOperation.Callback<T>() {
+      Operation op = opFact.bopGetBulk(getBulk, new BTreeGetBulkOperation.Callback() {
         @Override
         public void receivedStatus(OperationStatus status) {
         }

--- a/src/main/java/net/spy/memcached/OperationFactory.java
+++ b/src/main/java/net/spy/memcached/OperationFactory.java
@@ -479,7 +479,7 @@ public interface OperationFactory {
    * @param cb  the callback that will contain the results
    * @return a new BTreeGetBulkOperation
    */
-  BTreeGetBulkOperation bopGetBulk(BTreeGetBulk<?> get, BTreeGetBulkOperation.Callback<?> cb);
+  BTreeGetBulkOperation bopGetBulk(BTreeGetBulk<?> get, BTreeGetBulkOperation.Callback cb);
 
   /**
    * Get operation for b+tree items using positions.

--- a/src/main/java/net/spy/memcached/ops/BTreeGetBulkOperation.java
+++ b/src/main/java/net/spy/memcached/ops/BTreeGetBulkOperation.java
@@ -17,7 +17,7 @@
 package net.spy.memcached.ops;
 
 public interface BTreeGetBulkOperation extends KeyedOperation {
-  interface Callback<K> extends OperationCallback {
+  interface Callback extends OperationCallback {
     void gotElement(String key, int flags, Object subkey, byte[] eflag, byte[] data);
 
     void gotKey(String key, int elementCount, OperationStatus status);

--- a/src/main/java/net/spy/memcached/protocol/ascii/AsciiOperationFactory.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/AsciiOperationFactory.java
@@ -265,7 +265,7 @@ public class AsciiOperationFactory extends BaseOperationFactory {
 
   @Override
   public BTreeGetBulkOperation bopGetBulk(BTreeGetBulk<?> getBulk,
-                                          BTreeGetBulkOperation.Callback<?> cb) {
+                                          BTreeGetBulkOperation.Callback cb) {
     return new BTreeGetBulkOperationImpl(getBulk, cb);
   }
 

--- a/src/main/java/net/spy/memcached/protocol/ascii/BTreeGetBulkOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/BTreeGetBulkOperationImpl.java
@@ -104,7 +104,7 @@ public class BTreeGetBulkOperationImpl extends OperationImpl implements
         elementCount = Integer.parseInt(chunk[4]);
       }
 
-      BTreeGetBulkOperation.Callback<?> cb = ((BTreeGetBulkOperation.Callback<?>) getCallback());
+      BTreeGetBulkOperation.Callback cb = ((BTreeGetBulkOperation.Callback) getCallback());
       cb.gotKey(key, elementCount, status);
 
       if (elementCount > 0) {

--- a/src/main/java/net/spy/memcached/protocol/binary/BinaryOperationFactory.java
+++ b/src/main/java/net/spy/memcached/protocol/binary/BinaryOperationFactory.java
@@ -309,7 +309,7 @@ public class BinaryOperationFactory extends BaseOperationFactory {
 
   @Override
   public BTreeGetBulkOperation bopGetBulk(BTreeGetBulk<?> get,
-                                          BTreeGetBulkOperation.Callback<?> cb) {
+                                          BTreeGetBulkOperation.Callback cb) {
     throw new RuntimeException(
             "BTree get bulk operation is not supported in binary protocol yet.");
   }

--- a/src/test/manual/net/spy/memcached/MultibyteKeyTest.java
+++ b/src/test/manual/net/spy/memcached/MultibyteKeyTest.java
@@ -512,7 +512,7 @@ public class MultibyteKeyTest {
           new BTreeGetBulkWithLongTypeBkey<Integer>(null,
               keyList, 0L, 10L, ElementFlagFilter.DO_NOT_FILTER, 0, 0
           ),
-          new BTreeGetBulkOperation.Callback<Integer>() {
+          new BTreeGetBulkOperation.Callback() {
             @Override
             public void gotElement(String key, int flags, Object subkey,
                                    byte[] eflag, byte[] data) {


### PR DESCRIPTION
https://github.com/naver/arcus-java-client/pull/486#discussion_r898640644

BTreeGetBulkOperation.Callback에 불필요한 generic 선언을 제거했습니다.