### PR TITLE
CLEANUP: Comment the receivedStatus().

### DIFF
--- a/src/main/java/net/spy/memcached/ArcusClient.java
+++ b/src/main/java/net/spy/memcached/ArcusClient.java
@@ -4063,7 +4063,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
       Operation op = opFact.collectionBulkInsert(
               insert, new CollectionBulkInsertOperation.Callback() {
                 public void receivedStatus(OperationStatus status) {
-
+                  // Nothing to do here because the user MUST search the result Map instance.
                 }
 
                 public void complete() {
@@ -4257,6 +4257,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
       Operation op = opFact.bopGetBulk(getBulk, new BTreeGetBulkOperation.Callback() {
         @Override
         public void receivedStatus(OperationStatus status) {
+          // Nothing to do here because the user MUST search the result Map instance.
         }
 
         @Override

--- a/src/main/java/net/spy/memcached/MemcachedClient.java
+++ b/src/main/java/net/spy/memcached/MemcachedClient.java
@@ -1143,6 +1143,7 @@ public class MemcachedClient extends SpyThread
         if (!status.isSuccess()) {
           getLogger().warn("Unsuccessful get:  %s", status);
         }
+        // Nothing to do here because the user MUST search the result Map instance.
       }
 
       public void gotData(String k, int flags, byte[] data) {
@@ -1278,6 +1279,7 @@ public class MemcachedClient extends SpyThread
         if (!status.isSuccess()) {
           getLogger().warn("Unsuccessful gets:  %s", status);
         }
+        // Nothing to do here because the user MUST search the result Map instance.
       }
 
       public void gotData(String k, int flags, long cas, byte[] data) {


### PR DESCRIPTION
https://github.com/naver/arcus-java-client/pull/504#issuecomment-1157486255

기존 MultiOperationCallback.recievedStatus()의 구현은 originalCallback.receivedStatus()를 호출하지 않는 것이었습니다.
이를 SMGet의 migration 기능을 지원하기 위해 MultiOperationCallback.recievedStatus()의 구현을 originalCallback.receivedStatus()를 호출하도록 바꾸었습니다.
에러 원인은 Mock 객체로 만들어진 originalCallback을 통해 recievedStatus()를 호출하면 unexpected invocation 테스트 실패가 뜨는 것입니다.
MultiOperationCallback.recievedStatus()에서 originalCallback.receivedStatus()를 호출하지 않도록 바꾸고, MultiBTreeSortMergeGetOperationCallback.recievedStatus()에서만 originalCallback.receivedStatus()를 호출하도록 바꿨습니다.