### PR TITLE
FEATURE: Prepared the node locator for data migration.

### DIFF
--- a/src/main/java/net/spy/memcached/ArcusKetamaNodeLocator.java
+++ b/src/main/java/net/spy/memcached/ArcusKetamaNodeLocator.java
@@ -18,12 +18,15 @@
 package net.spy.memcached;
 
 import java.io.IOException;
+import java.net.SocketAddress;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.NavigableMap;
 import java.util.SortedMap;
 import java.util.TreeMap;
 import java.util.SortedSet;
@@ -38,6 +41,17 @@ public class ArcusKetamaNodeLocator extends SpyObject implements NodeLocator {
 
   private final TreeMap<Long, SortedSet<MemcachedNode>> ketamaNodes;
   private final Collection<MemcachedNode> allNodes;
+
+  /* ENABLE_MIGRATION if */
+  private TreeMap<Long, SortedSet<MemcachedNode>> ketamaAlterNodes;
+  private Collection<MemcachedNode> alterNodes;
+  private Collection<MemcachedNode> existNodes;
+
+  private MigrationType migrationType;
+  private Long migrationBasePoint;
+  private Long migrationLastPoint;
+  private boolean migrationInProgress;
+  /* ENABLE_MIGRATION end */
 
   private final HashAlgorithm hashAlg = HashAlgorithm.KETAMA_HASH;
   private final ArcusKetamaNodeLocatorConfiguration config;
@@ -54,6 +68,13 @@ public class ArcusKetamaNodeLocator extends SpyObject implements NodeLocator {
     allNodes = nodes;
     ketamaNodes = new TreeMap<Long, SortedSet<MemcachedNode>>();
     config = conf;
+
+    /* ENABLE_MIGRATION if */
+    existNodes = new HashSet<MemcachedNode>();
+    alterNodes = new HashSet<MemcachedNode>();
+    ketamaAlterNodes = new TreeMap<Long, SortedSet<MemcachedNode>>();
+    clearMigration();
+    /* ENABLE_MIGRATION end */
 
     int numReps = config.getNodeRepetitions();
     // Ketama does some special work with md5 where it reuses chunks.
@@ -72,11 +93,39 @@ public class ArcusKetamaNodeLocator extends SpyObject implements NodeLocator {
     ketamaNodes = smn;
     allNodes = an;
     config = conf;
+
+    /* ENABLE_MIGRATION if */
+    existNodes = new HashSet<MemcachedNode>();
+    alterNodes = new HashSet<MemcachedNode>();
+    ketamaAlterNodes = new TreeMap<Long, SortedSet<MemcachedNode>>();
+    clearMigration();
+    /* ENABLE_MIGRATION end */
   }
 
   public Collection<MemcachedNode> getAll() {
     return Collections.unmodifiableCollection(allNodes);
   }
+
+  /* ENABLE_MIGRATION if */
+  public Collection<MemcachedNode> getAlterAll() {
+    return Collections.unmodifiableCollection(alterNodes);
+  }
+
+  public MemcachedNode getAlterNode(SocketAddress sa) {
+    /* The alter node to attach must be found */
+    for (MemcachedNode node : alterNodes) {
+      if (sa.equals(node.getSocketAddress())) {
+        return node;
+      }
+    }
+    for (MemcachedNode node : allNodes) {
+      if (sa.equals(node.getSocketAddress())) {
+        return node;
+      }
+    }
+    return null;
+  }
+  /* ENABLE_MIGRATION end */
 
   public SortedMap<Long, SortedSet<MemcachedNode>> getKetamaNodes() {
     return Collections.unmodifiableSortedMap(ketamaNodes);
@@ -166,9 +215,40 @@ public class ArcusKetamaNodeLocator extends SpyObject implements NodeLocator {
         }
       }
     } finally {
+      /* ENABLE_MIGRATION if */
+      if (migrationInProgress && alterNodes.isEmpty()) {
+        getLogger().info("Migration " + migrationType + " has been finished.");
+        clearMigration();
+      }
+      /* ENABLE_MIGRATION end */
       lock.unlock();
     }
   }
+
+  /* ENABLE_MIGRATION if */
+  public void updateAlter(Collection<MemcachedNode> toDelete) {
+    assert migrationType == MigrationType.JOIN;
+    lock.lock();
+    try {
+      // Remove the failed or left alter nodes.
+      for (MemcachedNode node : toDelete) {
+        alterNodes.remove(node);
+        removeHashOfAlter(node);
+        try {
+          node.closeChannel();
+        } catch (IOException e) {
+          getLogger().error("Failed to closeChannel the node : " + node);
+        }
+      }
+    } finally {
+      if (alterNodes.isEmpty()) {
+        getLogger().info("Migration " + migrationType + " has been finished.");
+        clearMigration();
+      }
+      lock.unlock();
+    }
+  }
+  /* ENABLE_MIGRATION end */
 
   private Long getKetamaHashPoint(byte[] digest, int h) {
     return ((long) (digest[3 + h * 4] & 0xFF) << 24)
@@ -178,7 +258,17 @@ public class ArcusKetamaNodeLocator extends SpyObject implements NodeLocator {
   }
 
   private void insertHash(MemcachedNode node) {
+    /* ENABLE_MIGRATION if */
+    if (migrationInProgress) {
+      assert migrationType == MigrationType.JOIN;
+      alterNodes.remove(node);
+      insertHashOfJOIN(node); // joining => joined
+      return;
+    }
+    /* ENABLE_MIGRATION end */
+
     config.insertNode(node);
+
     // Ketama does some special work with md5 where it reuses chunks.
     for (int i = 0; i < config.getNodeRepetitions() / 4; i++) {
       byte[] digest = HashAlgorithm.computeMd5(config.getKeyForNode(node, i));
@@ -195,6 +285,29 @@ public class ArcusKetamaNodeLocator extends SpyObject implements NodeLocator {
   }
 
   private void removeHash(MemcachedNode node) {
+    /* ENABLE_MIGRATION if */
+    boolean callAutoLeaveAbort = false;
+    if (migrationInProgress) {
+      if (alterNodes.remove(node)) {
+        /* A leaving node is down or has left */
+        assert migrationType == MigrationType.LEAVE;
+        removeHashOfAlter(node);
+        return;
+      }
+      if (existNodes.remove(node)) {
+        /* An existing node is down */
+        if (migrationType == MigrationType.JOIN) {
+          automaticJoinCompletion(node);
+        } else {
+          callAutoLeaveAbort = true;
+        }
+      } else {
+        /* A joined node is down : do nothing */
+      }
+      /* go downward */
+    }
+    /* ENABLE_MIGRATION end */
+
     // Ketama does some special work with md5 where it reuses chunks.
     for (int i = 0; i < config.getNodeRepetitions() / 4; i++) {
       byte[] digest = HashAlgorithm.computeMd5(config.getKeyForNode(node, i));
@@ -209,7 +322,307 @@ public class ArcusKetamaNodeLocator extends SpyObject implements NodeLocator {
       }
     }
     config.removeNode(node);
+
+    /* ENABLE_MIGRATION if */
+    if (callAutoLeaveAbort) {
+      automaticLeaveAbort(node);
+    }
+    /* ENABLE_MIGRATION end */
   }
+
+  /* ENABLE_MIGRATION if */
+  /* Insert the joining hash points into ketamaAlterNodes */
+  private void prepareHashOfJOIN(MemcachedNode node) {
+    config.insertNode(node); // register the node in config
+
+    for (int i = 0; i < config.getNodeRepetitions() / 4; i++) {
+      byte[] digest = HashAlgorithm.computeMd5(config.getKeyForNode(node, i));
+      for (int h = 0; h < 4; h++) {
+        Long k = getKetamaHashPoint(digest, h);
+        SortedSet<MemcachedNode> nodeSet = ketamaAlterNodes.get(k);
+        if (nodeSet == null) {
+          nodeSet = new TreeSet<MemcachedNode>(config.new NodeNameComparator());
+          ketamaAlterNodes.put(k, nodeSet);
+        }
+        nodeSet.add(node);
+      }
+    }
+  }
+
+  /* Insert the joining hash points into ketamaNodes. */
+  private void insertHashOfJOIN(MemcachedNode node) {
+    config.insertNode(node); // register the node in config
+
+    for (int i = 0; i < config.getNodeRepetitions() / 4; i++) {
+      byte[] digest = HashAlgorithm.computeMd5(config.getKeyForNode(node, i));
+      for (int h = 0; h < 4; h++) {
+        Long k = getKetamaHashPoint(digest, h);
+        SortedSet<MemcachedNode> alterSet = ketamaAlterNodes.get(k);
+        if (alterSet != null && alterSet.remove(node)) {
+          if (alterSet.size() == 0) {
+            ketamaAlterNodes.remove(k);
+          }
+          SortedSet<MemcachedNode> existSet = ketamaNodes.get(k);
+          if (existSet == null) {
+            existSet = new TreeSet<MemcachedNode>(config.new NodeNameComparator());
+            ketamaNodes.put(k, existSet);
+          }
+          existSet.add(node); // joining => joined
+        } else {
+          // The hash points have already been inserted.
+        }
+      }
+    }
+  }
+
+  /* Remove all hash points of the alter node */
+  private void removeHashOfAlter(MemcachedNode node) {
+    // The alter hpoints can be in both ketamaAlterNodes and ketamaNodes.
+    for (int i = 0; i < config.getNodeRepetitions() / 4; i++) {
+      byte[] digest = HashAlgorithm.computeMd5(config.getKeyForNode(node, i));
+      for (int h = 0; h < 4; h++) {
+        Long k = getKetamaHashPoint(digest, h);
+        SortedSet<MemcachedNode> nodeSet = ketamaAlterNodes.get(k);
+        if (nodeSet != null && nodeSet.remove(node)) {
+          if (nodeSet.isEmpty()) {
+            ketamaAlterNodes.remove(k);
+          }
+        } else {
+          nodeSet = ketamaNodes.get(k);
+          assert nodeSet != null;
+          boolean removed = nodeSet.remove(node);
+          if (nodeSet.isEmpty()) {
+            ketamaNodes.remove(k);
+          }
+          assert removed;
+        }
+      }
+    }
+    config.removeNode(node); // unregister the node in config
+  }
+
+  /* Move an alter hash range from ketamaAlterNodes to ketamaNodes */
+  private void moveAlterHashRangeFromAlterToExist(Long spoint, boolean sInclusive,
+                                                  Long epoint, boolean eInclusive) {
+    NavigableMap<Long, SortedSet<MemcachedNode>> moveRange
+        = ketamaAlterNodes.subMap(spoint, sInclusive, epoint, eInclusive);
+
+    List<Long> removeList = new ArrayList<Long>();
+    for (Map.Entry<Long, SortedSet<MemcachedNode>> entry : moveRange.entrySet()) {
+      SortedSet<MemcachedNode> nodeSet = ketamaNodes.get(entry.getKey());
+      if (nodeSet == null) {
+        nodeSet = new TreeSet<MemcachedNode>(config.new NodeNameComparator());
+        ketamaNodes.put(entry.getKey(), nodeSet);
+      }
+      nodeSet.addAll(entry.getValue());
+      removeList.add(entry.getKey());
+    }
+    for (Long key : removeList) {
+      ketamaAlterNodes.remove(key);
+    }
+  }
+
+  /* Move an alter hash range from ketamaNode to ketamaAlterNodes */
+  private void moveAlterHashRangeFromExistToAlter(Long spoint, boolean sInclusive,
+                                                  Long epoint, boolean eInclusive) {
+    NavigableMap<Long, SortedSet<MemcachedNode>> moveRange
+        = ketamaNodes.subMap(spoint, sInclusive, epoint, eInclusive);
+
+    List<Long> removeList = new ArrayList<Long>();
+    for (Map.Entry<Long, SortedSet<MemcachedNode>> entry : moveRange.entrySet()) {
+      Iterator<MemcachedNode> nodeIter = entry.getValue().iterator();
+      while (nodeIter.hasNext()) {
+        MemcachedNode node = nodeIter.next();
+        if (alterNodes.contains(node)) {
+          nodeIter.remove(); // leaving => leaved
+          SortedSet<MemcachedNode> alterSet = ketamaAlterNodes.get(entry.getKey());
+          if (alterSet == null) {
+            alterSet = new TreeSet<MemcachedNode>(config.new NodeNameComparator());
+            ketamaAlterNodes.put(entry.getKey(), alterSet); // for auto leave abort
+          }
+          alterSet.add(node);
+        }
+      }
+      if (entry.getValue().isEmpty()) {
+        removeList.add(entry.getKey());
+      }
+    }
+    for (Long key : removeList) {
+      ketamaNodes.remove(key);
+    }
+  }
+
+  private void insertAlterHashRange(Long spoint, Long epoint, boolean inclusive) {
+    if (spoint < epoint) {
+      moveAlterHashRangeFromAlterToExist(spoint, inclusive, epoint, true);
+    } else {
+      moveAlterHashRangeFromAlterToExist(spoint, inclusive, 0xFFFFFFFFL, true);
+      moveAlterHashRangeFromAlterToExist(0L, true, epoint, true);
+    }
+  }
+
+  private void removeAlterHashRange(Long spoint, Long epoint, boolean inclusive) {
+    if (spoint < epoint) {
+      moveAlterHashRangeFromExistToAlter(spoint, inclusive, epoint, true);
+    } else {
+      moveAlterHashRangeFromExistToAlter(0L, true, epoint, true);
+      moveAlterHashRangeFromExistToAlter(spoint, inclusive, 0xFFFFFFFFL, true);
+    }
+  }
+
+  private void automaticJoinCompletion(MemcachedNode mine) {
+    getLogger().info("Started automatic join completion. node=" + mine.getNodeName());
+    for (int i = 0; i < config.getNodeRepetitions() / 4; i++) {
+      byte[] digest = HashAlgorithm.computeMd5(config.getKeyForNode(mine, i));
+      for (int h = 0; h < 4; h++) {
+        Long currPoint = getKetamaHashPoint(digest, h);
+        SortedSet<MemcachedNode> existSet = ketamaNodes.get(currPoint);
+        assert existSet != null && existSet.size() > 0;
+        if (existSet.size() == 1 || existSet.first() == mine) { // visible (FIXME)
+          Long prevPoint = ketamaNodes.lowerKey(currPoint);
+          insertAlterHashRange(prevPoint, currPoint, true); // inclusive: true
+        }
+      }
+    }
+    getLogger().info("Completed automatic join completion. node=" + mine.getNodeName());
+  }
+
+  private Long findMigrationBasePointLEAVE() {
+    Long key = ketamaNodes.lastKey();
+    while (key != null) {
+      for (MemcachedNode node : ketamaNodes.get(key)) {
+        if (existNodes.contains(node)) {
+          break;
+        }
+      }
+      key = ketamaNodes.lowerKey(key);
+    }
+    assert key != null;
+    return key;
+  }
+
+  private void automaticLeaveAbort(MemcachedNode mine) {
+    if (migrationBasePoint != -1L && existNodes.size() > 0) {
+      Long newBasePoint = findMigrationBasePointLEAVE();
+      if (newBasePoint == migrationBasePoint) {
+        return; // nothing to abort
+      }
+
+      getLogger().info("Started automatic leave abort. node=" + mine.getNodeName());
+      /* abort (newBasePoint ~ migrationBasePoint) leaved hpoints */
+      insertAlterHashRange(newBasePoint, migrationBasePoint, true); // inclusive: true
+      migrationBasePoint = newBasePoint;
+      if (migrationBasePoint == migrationLastPoint) {
+        migrationBasePoint = -1L;
+        migrationLastPoint = -1L;
+      }
+      getLogger().info("Completed automatic leave abort. node=" + mine.getNodeName());
+    }
+  }
+
+  private void clearMigration() {
+    existNodes.clear();
+    alterNodes.clear();
+    ketamaAlterNodes.clear();
+    migrationBasePoint = -1L;
+    migrationLastPoint = -1L;
+    migrationType = MigrationType.UNKNOWN;
+    migrationInProgress = false;
+  }
+
+  public void prepareMigration(Collection<MemcachedNode> toAlter, MigrationType type) {
+    getLogger().info("Prepare ketama info for migration. type=" + type);
+    assert type != MigrationType.UNKNOWN;
+
+    clearMigration();
+    migrationType = type;
+    migrationInProgress = true;
+
+    /* prepare alterNodes, ketamaAlterNodes and existNodes */
+    if (type == MigrationType.JOIN) {
+      for (MemcachedNode node : toAlter) {
+        alterNodes.add(node);
+        prepareHashOfJOIN(node);
+      }
+      for (MemcachedNode node : allNodes) {
+        existNodes.add(node);
+      }
+    } else { // MigrationType.LEAVE
+      for (MemcachedNode node : toAlter) {
+        alterNodes.add(node);
+      }
+      for (MemcachedNode node : allNodes) {
+        if (!alterNodes.contains(node)) {
+          existNodes.add(node);
+        }
+      }
+    }
+  }
+
+  /* check migrationLastPoint belongs to the (spoint, epoint) range. */
+  private boolean needToMigrateRange(Long spoint, Long epoint) {
+    if (spoint != 0 || epoint != 0) { // Valid migration range
+      if (migrationLastPoint == -1) {
+        return true;
+      }
+      if (spoint == epoint) { // full range
+        return spoint != migrationLastPoint;
+      }
+      if (spoint < epoint) {
+        if (spoint < migrationLastPoint && migrationLastPoint < epoint) {
+          return true;
+        }
+      } else { // spoint > epoint
+        if (spoint < migrationLastPoint || migrationLastPoint < epoint) {
+          return true;
+        }
+      }
+    }
+    return false;
+  }
+
+  private void migrateJoinRange(Long spoint, Long epoint) {
+    lock.lock();
+    try {
+      if (migrationLastPoint == -1) {
+        migrationBasePoint = spoint;
+      } else {
+        spoint = migrationLastPoint;
+      }
+      insertAlterHashRange(spoint, epoint, false); // inclusive: false
+      migrationLastPoint = epoint;
+    } finally {
+      lock.unlock();
+    }
+    getLogger().info("Applied JOIN range. spoint=" + spoint + ", epoint=" + epoint);
+  }
+
+  private void migrateLeaveRange(Long spoint, Long epoint) {
+    lock.lock();
+    try {
+      if (migrationLastPoint == -1) {
+        migrationBasePoint = epoint;
+      } else {
+        epoint = migrationLastPoint;
+      }
+      removeAlterHashRange(spoint, epoint, false); // inclusive: false
+      migrationLastPoint = spoint;
+    } finally {
+      lock.unlock();
+    }
+    getLogger().info("Applied LEAVE range. spoint=" + spoint + ", epoint=" + epoint);
+  }
+
+  public void updateMigration(Long spoint, Long epoint) {
+    if (migrationInProgress && needToMigrateRange(spoint, epoint)) {
+      if (migrationType == MigrationType.JOIN) {
+        migrateJoinRange(spoint, epoint);
+      } else {
+        migrateLeaveRange(spoint, epoint);
+      }
+    }
+  }
+  /* ENABLE_MIGRATION end */
 
   class KetamaIterator implements Iterator<MemcachedNode> {
 

--- a/src/main/java/net/spy/memcached/ArcusKetamaNodeLocator.java
+++ b/src/main/java/net/spy/memcached/ArcusKetamaNodeLocator.java
@@ -118,11 +118,6 @@ public class ArcusKetamaNodeLocator extends SpyObject implements NodeLocator {
         return node;
       }
     }
-    for (MemcachedNode node : allNodes) {
-      if (sa.equals(node.getSocketAddress())) {
-        return node;
-      }
-    }
     return null;
   }
   /* ENABLE_MIGRATION end */

--- a/src/main/java/net/spy/memcached/ArcusReplKetamaNodeLocator.java
+++ b/src/main/java/net/spy/memcached/ArcusReplKetamaNodeLocator.java
@@ -290,6 +290,7 @@ public class ArcusReplKetamaNodeLocator extends SpyObject implements NodeLocator
   /* ENABLE_MIGRATION if */
   public void updateAlter(Collection<MemcachedNode> toDelete) {
     assert migrationType == MigrationType.JOIN;
+    lock.lock();
     try {
       // Remove the failed or left alter nodes.
       for (MemcachedNode node : toDelete) {

--- a/src/main/java/net/spy/memcached/ArcusReplKetamaNodeLocator.java
+++ b/src/main/java/net/spy/memcached/ArcusReplKetamaNodeLocator.java
@@ -140,11 +140,6 @@ public class ArcusReplKetamaNodeLocator extends SpyObject implements NodeLocator
         return node;
       }
     }
-    for (MemcachedNode node : allNodes) {
-      if (sa.equals(node.getSocketAddress())) {
-        return node;
-      }
-    }
     return null;
   }
   /* ENABLE_MIGRATION end */

--- a/src/main/java/net/spy/memcached/ArcusReplKetamaNodeLocator.java
+++ b/src/main/java/net/spy/memcached/ArcusReplKetamaNodeLocator.java
@@ -134,12 +134,13 @@ public class ArcusReplKetamaNodeLocator extends SpyObject implements NodeLocator
   }
 
   public MemcachedNode getAlterNode(SocketAddress sa) {
-    /* The alter node to attach must be found */
+    /* The alter node to attach should be found */
     for (MemcachedNode node : alterNodes) {
       if (sa.equals(node.getSocketAddress())) {
         return node;
       }
     }
+    /* If a slave node has started during migration, it may not exist */ 
     return null;
   }
   /* ENABLE_MIGRATION end */

--- a/src/main/java/net/spy/memcached/ArrayModNodeLocator.java
+++ b/src/main/java/net/spy/memcached/ArrayModNodeLocator.java
@@ -16,6 +16,8 @@
  */
 package net.spy.memcached;
 
+import java.net.SocketAddress;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Iterator;
@@ -73,6 +75,30 @@ public final class ArrayModNodeLocator implements NodeLocator {
   public void update(Collection<MemcachedNode> toAttach, Collection<MemcachedNode> toDelete) {
     throw new UnsupportedOperationException("update not supported");
   }
+
+  /* ENABLE_MIGRATION if */
+  public Collection<MemcachedNode> getAlterAll() {
+    return new ArrayList<MemcachedNode>();
+  }
+
+  public MemcachedNode getAlterNode(SocketAddress sa) {
+    return null;
+  }
+
+  public void updateAlter(Collection<MemcachedNode> toDelete) {
+    throw new UnsupportedOperationException("updateAlter not supported");
+  }
+
+  @Override
+  public void prepareMigration(Collection<MemcachedNode> toAlter, MigrationType type) {
+    throw new UnsupportedOperationException("prepareMigration not supported");
+  }
+
+  @Override
+  public void updateMigration(Long spoint, Long epoint) {
+    throw new UnsupportedOperationException("updateMigration not supported");
+  }
+  /* ENABLE_MIGRATION end */
 
   private int getServerForKey(String key) {
     int rv = (int) (hashAlg.hash(key) % nodes.length);

--- a/src/main/java/net/spy/memcached/KetamaNodeLocator.java
+++ b/src/main/java/net/spy/memcached/KetamaNodeLocator.java
@@ -16,6 +16,7 @@
  */
 package net.spy.memcached;
 
+import java.net.SocketAddress;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -150,6 +151,30 @@ public final class KetamaNodeLocator extends SpyObject implements NodeLocator {
   public SortedMap<Long, MemcachedNode> getKetamaNodes() {
     return Collections.unmodifiableSortedMap(ketamaNodes);
   }
+
+  /* ENABLE_MIGRATION if */
+  public Collection<MemcachedNode> getAlterAll() {
+    return new ArrayList<MemcachedNode>();
+  }
+
+  public MemcachedNode getAlterNode(SocketAddress sa) {
+    return null;
+  }
+
+  public void updateAlter(Collection<MemcachedNode> toDelete) {
+    throw new UnsupportedOperationException("updateAlter not supported");
+  }
+
+  @Override
+  public void prepareMigration(Collection<MemcachedNode> toAlter, MigrationType type) {
+    throw new UnsupportedOperationException("prepareMigration not supported");
+  }
+
+  @Override
+  public void updateMigration(Long spoint, Long epoint) {
+    throw new UnsupportedOperationException("updateMigration not supported");
+  }
+  /* ENABLE_MIGRATION end */
 
   class KetamaIterator implements Iterator<MemcachedNode> {
 

--- a/src/main/java/net/spy/memcached/MemcachedConnection.java
+++ b/src/main/java/net/spy/memcached/MemcachedConnection.java
@@ -600,9 +600,7 @@ public final class MemcachedConnection extends SpyObject {
     if (mgType == MigrationType.JOIN) {
       /* Only joining nodes can be attached */
       MemcachedNode node = locator.getAlterNode(sa);
-      if (node != null) {
-        return node;
-      }
+      return node;
     }
     /* ENABLE_MIGRATION end */
     return makeMemcachedNode(connName, sa);

--- a/src/main/java/net/spy/memcached/MemcachedConnection.java
+++ b/src/main/java/net/spy/memcached/MemcachedConnection.java
@@ -102,7 +102,7 @@ public final class MemcachedConnection extends SpyObject {
   private final Set<MemcachedNode> nodesNeedVersionOp = new HashSet<MemcachedNode>();
 
   /* ENABLE_MIGRATION if */
-  private boolean arcusMigrEnabled;
+  private boolean arcusMigrEnabled = false;
   private MigrationType mgType = MigrationType.UNKNOWN;
   private MigrationState mgState = MigrationState.UNKNOWN;
   /* ENABLE_MIGRATION end */

--- a/src/main/java/net/spy/memcached/MemcachedConnection.java
+++ b/src/main/java/net/spy/memcached/MemcachedConnection.java
@@ -600,7 +600,9 @@ public final class MemcachedConnection extends SpyObject {
     if (mgType == MigrationType.JOIN) {
       /* Only joining nodes can be attached */
       MemcachedNode node = locator.getAlterNode(sa);
-      return node;
+      if (node != null) {
+        return node;
+      }
     }
     /* ENABLE_MIGRATION end */
     return makeMemcachedNode(connName, sa);

--- a/src/main/java/net/spy/memcached/MemcachedConnection.java
+++ b/src/main/java/net/spy/memcached/MemcachedConnection.java
@@ -91,12 +91,21 @@ public final class MemcachedConnection extends SpyObject {
   // reconnectQueue contains the attachments that need to be reconnected
   private final ReconnectQueue reconnectQueue;
   private final BlockingQueue<String> nodesChangeQueue = new LinkedBlockingQueue<String>();
+  /* ENABLE_MIGRATION if */
+  private final BlockingQueue<String> alterNodesChangeQueue = new LinkedBlockingQueue<String>();
+  /* ENABLE_MIGRATION end */
 
   private final OperationFactory opFactory;
   private final ConnectionFactory connFactory;
   private final Collection<ConnectionObserver> connObservers =
           new ConcurrentLinkedQueue<ConnectionObserver>();
   private final Set<MemcachedNode> nodesNeedVersionOp = new HashSet<MemcachedNode>();
+
+  /* ENABLE_MIGRATION if */
+  private boolean arcusMigrEnabled;
+  private MigrationType mgType = MigrationType.UNKNOWN;
+  private MigrationState mgState = MigrationState.UNKNOWN;
+  /* ENABLE_MIGRATION end */
 
   /* ENABLE_REPLICATION if */
   private static final long DELAYED_SWITCHOVER_TIMEOUT_MILLISECONDS = 50;
@@ -152,6 +161,17 @@ public final class MemcachedConnection extends SpyObject {
     return arcusReplEnabled;
   }
   /* ENABLE_REPLICATION end */
+
+  /* ENABLE_MIGRATION if */
+  void setArcusMigrEnabled(boolean b) {
+    arcusMigrEnabled = b;
+  }
+
+  void setMigrationTypeAndState(MigrationType type, MigrationState state) {
+    this.mgType = type;
+    this.mgState = state;
+  }
+  /* ENABLE_MIGRATION end */
 
   private boolean selectorsMakeSense() {
     for (MemcachedNode qa : locator.getAll()) {
@@ -282,6 +302,11 @@ public final class MemcachedConnection extends SpyObject {
 
     // Deal with the memcached server group that's been added by CacheManager.
     handleNodesChangeQueue();
+    /* ENABLE_MIGRATION if */
+    if (arcusMigrEnabled) {
+      handleAlterNodesChangeQueue();
+    }
+    /* ENABLE_MIGRATION if */
 
     if (!reconnectQueue.isEmpty()) {
       attemptReconnects();
@@ -571,6 +596,15 @@ public final class MemcachedConnection extends SpyObject {
   /* ENABLE_REPLICATION end */
 
   private MemcachedNode attachMemcachedNode(SocketAddress sa) throws IOException {
+    /* ENABLE_MIGRATION if */
+    if (mgType == MigrationType.JOIN) {
+      /* Only joining nodes can be attached */
+      MemcachedNode node = locator.getAlterNode(sa);
+      if (node != null) {
+        return node;
+      }
+    }
+    /* ENABLE_MIGRATION end */
     return makeMemcachedNode(connName, sa);
   }
 
@@ -656,6 +690,80 @@ public final class MemcachedConnection extends SpyObject {
       updateConnections(AddrUtil.getAddresses(addrs));
     }
   }
+
+  /* ENABLE_MIGRATION if */
+  /* Called by CacheManger to add the alter memcached server group. */
+  public void putAlterNodesChangeQueue(String addrs) {
+    alterNodesChangeQueue.offer(addrs);
+    selector.wakeup();
+  }
+
+  /* Handle the alter memcached server group that's been added by CacheManager. */
+  private void handleAlterNodesChangeQueue() throws IOException {
+    if (!alterNodesChangeQueue.isEmpty()) {
+      String addrs = alterNodesChangeQueue.poll();
+      if (mgState == MigrationState.PREPARED) {
+        /* prepare connections of alter nodes */
+        prepareAlterConnections(convertToSocketAddresses(addrs));
+        mgState = MigrationState.PROGRESS;
+      } else if (mgState == MigrationState.PROGRESS) {
+        /* check joining node down */
+        if (mgType == MigrationType.JOIN) {
+          updateAlterConnections(convertToSocketAddresses(addrs));
+        }
+      }
+      if (addrs.isEmpty()) { // end of migration
+        this.mgType = MigrationType.UNKNOWN;
+        this.mgState = MigrationState.UNKNOWN;
+      }
+    }
+  }
+
+  private List<InetSocketAddress> convertToSocketAddresses(String s) {
+    /* ENABLE_REPLICATION if */
+    if (arcusReplEnabled) {
+      return ArcusReplNodeAddress.getAddresses(s);
+    }
+    /* ENABLE_REPLICATION end */
+    return AddrUtil.getAddresses(s);
+  }
+
+  private void prepareAlterConnections(List<InetSocketAddress> addrs) throws IOException {
+    getLogger().info("Prepare connection of alter nodes. addrs=" + addrs);
+    List<MemcachedNode> alterNodes = new ArrayList<MemcachedNode>();
+    if (mgType == MigrationType.JOIN) {
+      for (SocketAddress sa : addrs) {
+        alterNodes.add(makeMemcachedNode(connName, sa));
+      }
+    } else { /* MigrationType.LEAVE */
+      for (MemcachedNode node : locator.getAll()) {
+        if (addrs.contains(node.getSocketAddress())) {
+          alterNodes.add(node);
+        }
+      }
+    }
+    locator.prepareMigration(alterNodes, mgType);
+  }
+
+  private void updateAlterConnections(List<InetSocketAddress> addrs) throws IOException {
+    List<MemcachedNode> removeNodes = new ArrayList<MemcachedNode>();
+
+    for (MemcachedNode node : locator.getAlterAll()) {
+      if (addrs.contains(node.getSocketAddress())) {
+        addrs.remove(node.getSocketAddress());
+      } else {
+        removeNodes.add(node);
+      }
+    }
+    assert addrs.isEmpty() == true;
+
+    // Update the hash.
+    locator.updateAlter(removeNodes);
+
+    // Remove the unavailable nodes.
+    handleNodesToRemove(removeNodes);
+  }
+  /* ENABLE_MIGRATION end */
 
   // Handle the memcached server group that need delayed switchover.
   private void handleDelayedSwitchover() {

--- a/src/main/java/net/spy/memcached/MigrationState.java
+++ b/src/main/java/net/spy/memcached/MigrationState.java
@@ -1,0 +1,9 @@
+package net.spy.memcached;
+
+public enum MigrationState {
+  UNKNOWN,
+  BEGIN,
+  PREPARED,
+  PROGRESS,
+  DONE
+}

--- a/src/main/java/net/spy/memcached/MigrationType.java
+++ b/src/main/java/net/spy/memcached/MigrationType.java
@@ -1,0 +1,7 @@
+package net.spy.memcached;
+
+public enum MigrationType {
+  UNKNOWN,
+  JOIN,
+  LEAVE
+}

--- a/src/main/java/net/spy/memcached/NodeLocator.java
+++ b/src/main/java/net/spy/memcached/NodeLocator.java
@@ -16,6 +16,7 @@
  */
 package net.spy.memcached;
 
+import java.net.SocketAddress;
 import java.util.Collection;
 import java.util.Iterator;
 
@@ -56,4 +57,31 @@ public interface NodeLocator {
    * only available in ArcusKetamaNodeLocator.
    */
   void update(Collection<MemcachedNode> toAttach, Collection<MemcachedNode> toDelete);
+
+  /* ENABLE_MIGRATION if */
+  /**
+   * Get all alter memcached nodes.
+   */
+  Collection<MemcachedNode> getAlterAll();
+
+  /**
+   * Get an alter memcached node which contains the given socket address.
+   */
+  MemcachedNode getAlterNode(SocketAddress sa);
+
+  /**
+   * Remove the alter nodes which have failed down.
+   */
+  void updateAlter(Collection<MemcachedNode> toDelete);
+
+  /**
+   * Prepare migration with alter nodes and migration type.
+   */
+  void prepareMigration(Collection<MemcachedNode> toAlter, MigrationType type);
+
+  /**
+   * Update(or reflect) the migratoin range in ketama hash ring.
+   */
+  void updateMigration(Long spoint, Long epoint);
+  /* ENABLE_MIGRATION end */
 }


### PR DESCRIPTION
Migration 위한 node locator 준비 작업의 PR 입니다.

아래 메소드를 추가 제공하도록 확장 되었습니다.

```java
  /**
   * Get all alter memcached nodes.
   */
  Collection<MemcachedNode> getAlterAll();

  /**
   * Get an alter memcached node which contains the given socket address.
   */
  MemcachedNode getAlterNode(SocketAddress sa);

  /**
   * Remove the alter nodes which have failed down.
   */
  void updateAlter(Collection<MemcachedNode> toDelete);

  /**
   * Prepare migration with alter nodes and migration type.
   */
  void prepareMigration(Collection<MemcachedNode> toAlter, MigrationType type);

  /**
   * Update(or reflect) the migratoin range in ketama hash ring.
   */
  void updateMigration(Long spoint, Long epoint);
```