### PR TITLE
FIX: Add apt-get update command before apt-get install.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,8 @@ jobs:
         virtualenv -p /usr/bin/python2.7 venv
         
         source venv/bin/activate
+    - name: Update apt-get
+      run: sudo apt-get update
     - name: Install ARCUS Dependencies
       run: sudo apt-get install -qq build-essential autoconf automake libtool libcppunit-dev python-setuptools python-dev ant
     - name: Cache Maven Dependencies


### PR DESCRIPTION
https://github.com/naver/arcus-java-client/issues/514

위 이슈 관련하여 apt-get update 명령어를 수행하여 old version package 대신 latest version package를 설치하도록 했습니다.