### PR TITLE
INTERNAL: add omitted parameter methods - list/set/map

### DIFF
--- a/src/main/java/net/spy/memcached/ArcusClient.java
+++ b/src/main/java/net/spy/memcached/ArcusClient.java
@@ -1527,12 +1527,22 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
   }
 
   @Override
+  public CollectionFuture<Map<String, Object>> asyncMopGet(String key) {
+    return asyncMopGet(key, false, false);
+  }
+
+  @Override
   public CollectionFuture<Map<String, Object>> asyncMopGet(String key,
                                                            boolean withDelete,
                                                            boolean dropIfEmpty) {
     List<String> mkeyList = new ArrayList<String>();
     MapGet get = new MapGet(mkeyList, withDelete, dropIfEmpty);
     return asyncMopGet(key, get, collectionTranscoder);
+  }
+
+  @Override
+  public CollectionFuture<Map<String, Object>> asyncMopGet(String key, String mkey) {
+    return asyncMopGet(key, mkey, false, false);
   }
 
   @Override
@@ -1551,6 +1561,11 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
   }
 
   @Override
+  public CollectionFuture<Map<String, Object>> asyncMopGet(String key, List<String> mkeyList) {
+    return asyncMopGet(key, mkeyList, false, false);
+  }
+
+  @Override
   public CollectionFuture<Map<String, Object>> asyncMopGet(String key,
                                                            List<String> mkeyList,
                                                            boolean withDelete,
@@ -1566,12 +1581,22 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
   }
 
   @Override
+  public <T> CollectionFuture<Map<String, T>> asyncMopGet(String key, Transcoder<T> tc) {
+    return asyncMopGet(key, false, false, tc);
+  }
+
+  @Override
   public <T> CollectionFuture<Map<String, T>> asyncMopGet(String key,
                                                           boolean withDelete, boolean dropIfEmpty,
                                                           Transcoder<T> tc) {
     List<String> mkeyList = new ArrayList<String>();
     MapGet get = new MapGet(mkeyList, withDelete, dropIfEmpty);
     return asyncMopGet(key, get, tc);
+  }
+
+  @Override
+  public <T> CollectionFuture<Map<String, T>> asyncMopGet(String key, String mkey, Transcoder<T> tc) {
+    return asyncMopGet(key, mkey, false, false, tc);
   }
 
   @Override
@@ -1590,6 +1615,11 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
   }
 
   @Override
+  public <T> CollectionFuture<Map<String, T>> asyncMopGet(String key, List<String> mkeyList, Transcoder<T> tc) {
+    return asyncMopGet(key, mkeyList, false, false, tc);
+  }
+
+  @Override
   public <T> CollectionFuture<Map<String, T>> asyncMopGet(String key,
                                                           List<String> mkeyList,
                                                           boolean withDelete, boolean dropIfEmpty,
@@ -1605,10 +1635,20 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
   }
 
   @Override
+  public CollectionFuture<List<Object>> asyncLopGet(String key, int index) {
+    return asyncLopGet(key, index, false, false);
+  }
+
+  @Override
   public CollectionFuture<List<Object>> asyncLopGet(String key, int index,
                                                     boolean withDelete, boolean dropIfEmpty) {
     ListGet get = new ListGet(index, withDelete, dropIfEmpty);
     return asyncLopGet(key, get, collectionTranscoder);
+  }
+
+  @Override
+  public CollectionFuture<List<Object>> asyncLopGet(String key, int from, int to) {
+    return asyncLopGet(key, from, to, false, false);
   }
 
   @Override
@@ -1620,11 +1660,20 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
   }
 
   @Override
+  public <T> CollectionFuture<List<T>> asyncLopGet(String key, int index, Transcoder<T> tc) {
+    return asyncLopGet(key, index, false, false, tc);
+  }
+  @Override
   public <T> CollectionFuture<List<T>> asyncLopGet(String key, int index,
                                                    boolean withDelete, boolean dropIfEmpty,
                                                    Transcoder<T> tc) {
     ListGet get = new ListGet(index, withDelete, dropIfEmpty);
     return asyncLopGet(key, get, tc);
+  }
+
+  @Override
+  public <T> CollectionFuture<List<T>> asyncLopGet(String key, int from, int to, Transcoder<T> tc) {
+    return asyncLopGet(key, from, to, false, false, tc);
   }
 
   @Override
@@ -1637,10 +1686,20 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
   }
 
   @Override
+  public CollectionFuture<Set<Object>> asyncSopGet(String key, int count) {
+    return asyncSopGet(key, count, false, false);
+  }
+
+  @Override
   public CollectionFuture<Set<Object>> asyncSopGet(String key, int count,
                                                    boolean withDelete, boolean dropIfEmpty) {
     SetGet get = new SetGet(count, withDelete, dropIfEmpty);
     return asyncSopGet(key, get, collectionTranscoder);
+  }
+
+  @Override
+  public <T> CollectionFuture<Set<T>> asyncSopGet(String key, int count, Transcoder<T> tc) {
+    return asyncSopGet(key, count, false, false, tc);
   }
 
   @Override

--- a/src/main/java/net/spy/memcached/ArcusClientIF.java
+++ b/src/main/java/net/spy/memcached/ArcusClientIF.java
@@ -603,6 +603,14 @@ public interface ArcusClientIF {
    * Retrieves all items from the map
    *
    * @param key         key of a map
+   * @return a future that will hold the return value map of the fetch
+   */
+  public CollectionFuture<Map<String, Object>> asyncMopGet(String key);
+
+  /**
+   * Retrieves all items from the map
+   *
+   * @param key         key of a map
    * @param withDelete  true to remove the returned item in the map
    * @param dropIfEmpty true to remove the key when all elements are removed.
    *                    false map will remain empty even if all the elements are removed
@@ -610,6 +618,15 @@ public interface ArcusClientIF {
    */
   public CollectionFuture<Map<String, Object>> asyncMopGet(String key,
                                                            boolean withDelete, boolean dropIfEmpty);
+
+  /**
+   * Retrieves an item on given mkey in the map.
+   *
+   * @param key         key of a map
+   * @param mkey        mkey of a map
+   * @return a future that will hold the return value map of the fetch
+   */
+  public CollectionFuture<Map<String, Object>> asyncMopGet(String key, String mkey);
 
   /**
    * Retrieves an item on given mkey in the map.
@@ -629,6 +646,15 @@ public interface ArcusClientIF {
    *
    * @param key         key of a map
    * @param mkeyList    mkeyList
+   * @return a future that will hold the return value map of the fetch.
+   */
+  public CollectionFuture<Map<String, Object>> asyncMopGet(String key, List<String> mkeyList);
+
+  /**
+   * Retrieves items on given mkey list in the map.
+   *
+   * @param key         key of a map
+   * @param mkeyList    mkeyList
    * @param withDelete  true to remove the returned item in the map
    * @param dropIfEmpty true to remove the key when all elements are removed.
    *                    false map will remain empty even if all the elements are removed
@@ -636,6 +662,17 @@ public interface ArcusClientIF {
    */
   public CollectionFuture<Map<String, Object>> asyncMopGet(String key, List<String> mkeyList,
                                                            boolean withDelete, boolean dropIfEmpty);
+
+  /**
+   * Retrieves all items from the map
+   *
+   * @param <T>         the expected class of the value
+   * @param key         key of a map
+   * @param tc          a transcoder to decode returned values
+   * @return a future that will hold the return value map of the fetch
+   */
+  public <T> CollectionFuture<Map<String, T>> asyncMopGet(String key,
+                                                          Transcoder<T> tc);
 
   /**
    * Retrieves all items from the map
@@ -650,6 +687,18 @@ public interface ArcusClientIF {
    */
   public <T> CollectionFuture<Map<String, T>> asyncMopGet(String key,
                                                           boolean withDelete, boolean dropIfEmpty,
+                                                          Transcoder<T> tc);
+
+  /**
+   * Retrieves an item on given mkey in the map.
+   *
+   * @param <T>         the expected class of the value
+   * @param key         key of a map
+   * @param mkey        mkey of a map
+   * @param tc          a transcoder to decode returned values
+   * @return a future that will hold the return value map of the fetch
+   */
+  public <T> CollectionFuture<Map<String, T>> asyncMopGet(String key, String mkey,
                                                           Transcoder<T> tc);
 
   /**
@@ -674,6 +723,18 @@ public interface ArcusClientIF {
    * @param <T>         the expected class of the value
    * @param key         key of a map
    * @param mkeyList    mkeyList
+   * @param tc          a transcoder to decode returned values
+   * @return a future that will hold the return value map of the fetch.
+   */
+  public <T> CollectionFuture<Map<String, T>> asyncMopGet(String key, List<String> mkeyList,
+                                                          Transcoder<T> tc);
+
+  /**
+   * Retrieves items on given mkey list in the map.
+   *
+   * @param <T>         the expected class of the value
+   * @param key         key of a map
+   * @param mkeyList    mkeyList
    * @param withDelete  true to remove the returned item in the map
    * @param dropIfEmpty true to remove the key when all elements are removed.
    *                    false map will remain empty even if all the elements are removed
@@ -689,6 +750,15 @@ public interface ArcusClientIF {
    *
    * @param key         key of a list
    * @param index       list index
+   * @return a future that will hold the return value list of the fetch
+   */
+  public CollectionFuture<List<Object>> asyncLopGet(String key, int index);
+
+  /**
+   * Retrieves an item on given index in the list.
+   *
+   * @param key         key of a list
+   * @param index       list index
    * @param withDelete  true to remove the returned item in the list
    * @param dropIfEmpty true to remove the key when all elements are removed.
    *                    false list will remain empty even if all the elements are removed
@@ -696,6 +766,17 @@ public interface ArcusClientIF {
    */
   public CollectionFuture<List<Object>> asyncLopGet(String key, int index,
                                                     boolean withDelete, boolean dropIfEmpty);
+
+  /**
+   * Retrieves items on given index range(from..to) in the list.
+   *
+   * @param key         key of a list
+   * @param from        the first index to delete
+   * @param to          the last index to delete
+   * @return a future that will hold the return value list of the fetch
+   */
+  public CollectionFuture<List<Object>> asyncLopGet(String key,
+                                                    int from, int to);
 
   /**
    * Retrieves items on given index range(from..to) in the list.
@@ -718,6 +799,18 @@ public interface ArcusClientIF {
    * @param <T>         the expected class of the value
    * @param key         key of a list
    * @param index       list index
+   * @param tc          a tranacoder to decode returned value
+   * @return a future that will hold the return value list of the fetch
+   */
+  public <T> CollectionFuture<List<T>> asyncLopGet(String key, int index,
+                                                   Transcoder<T> tc);
+
+  /**
+   * Retrieves an item on given index in the list.
+   *
+   * @param <T>         the expected class of the value
+   * @param key         key of a list
+   * @param index       list index
    * @param withDelete  true to remove the returned item in the list
    * @param dropIfEmpty true to remove the key when all elements are removed.
    *                    false list will remain empty even if all the elements are removed
@@ -726,6 +819,20 @@ public interface ArcusClientIF {
    */
   public <T> CollectionFuture<List<T>> asyncLopGet(String key, int index,
                                                    boolean withDelete, boolean dropIfEmpty,
+                                                   Transcoder<T> tc);
+
+  /**
+   * Retrieves items on given index range(from..to) in the list. (Arcus 1.6 and above)
+   *
+   * @param <T>         the expected class of the value
+   * @param key         key of a list
+   * @param from        the first index to delete
+   * @param to          the last index to delete
+   * @param tc          a transcoder to decode the returned values
+   * @return a future that will hold the return value list of the fetch
+   */
+  public <T> CollectionFuture<List<T>> asyncLopGet(String key,
+                                                   int from, int to,
                                                    Transcoder<T> tc);
 
   /**
@@ -751,6 +858,15 @@ public interface ArcusClientIF {
    *
    * @param key         key of a set
    * @param count       number of items to fetch
+   * @return a future that will hold the return value set of the fetch
+   */
+  public CollectionFuture<Set<Object>> asyncSopGet(String key, int count);
+
+  /**
+   * Retrieves count number of random items in the set.
+   *
+   * @param key         key of a set
+   * @param count       number of items to fetch
    * @param withDelete  true to remove the returned item in the set
    * @param dropIfEmpty true to remove the key when all elements are removed.
    *                    false set will remain empty even if all the elements are removed
@@ -758,6 +874,18 @@ public interface ArcusClientIF {
    */
   public CollectionFuture<Set<Object>> asyncSopGet(String key, int count,
                                                    boolean withDelete, boolean dropIfEmpty);
+
+  /**
+   * Retrieves count number of random items in the set.
+   *
+   * @param <T>         the expected class of the value
+   * @param key         key of a set
+   * @param count       number of items to fetch
+   * @param tc          a tranacoder to decode returned value
+   * @return a future that will hold the return value set of the fetch
+   */
+  public <T> CollectionFuture<Set<T>> asyncSopGet(String key, int count,
+                                                  Transcoder<T> tc);
 
   /**
    * Retrieves count number of random items in the set.

--- a/src/main/java/net/spy/memcached/ArcusClientPool.java
+++ b/src/main/java/net/spy/memcached/ArcusClientPool.java
@@ -700,10 +700,8 @@ public class ArcusClientPool implements MemcachedClientIF, ArcusClientIF {
   }
 
   @Override
-  public CollectionFuture<Map<String, Object>> asyncMopGet(String key, List<String> mkeyList,
-                                                           boolean withDelete,
-                                                           boolean dropIfEmpty) {
-    return this.getClient().asyncMopGet(key, mkeyList, withDelete, dropIfEmpty);
+  public CollectionFuture<Map<String, Object>> asyncMopGet(String key) {
+    return this.getClient().asyncMopGet(key);
   }
 
   @Override
@@ -714,6 +712,11 @@ public class ArcusClientPool implements MemcachedClientIF, ArcusClientIF {
   }
 
   @Override
+  public CollectionFuture<Map<String, Object>> asyncMopGet(String key, String mkey) {
+    return this.getClient().asyncMopGet(key, mkey);
+  }
+
+  @Override
   public CollectionFuture<Map<String, Object>> asyncMopGet(String key, String mkey,
                                                            boolean withDelete,
                                                            boolean dropIfEmpty) {
@@ -721,11 +724,20 @@ public class ArcusClientPool implements MemcachedClientIF, ArcusClientIF {
   }
 
   @Override
-  public <T> CollectionFuture<Map<String, T>> asyncMopGet(String key, List<String> mkeyList,
-                                                          boolean withDelete,
-                                                          boolean dropIfEmpty,
-                                                          Transcoder<T> tc) {
-    return this.getClient().asyncMopGet(key, mkeyList, withDelete, dropIfEmpty, tc);
+  public CollectionFuture<Map<String, Object>> asyncMopGet(String key, List<String> mkeyList) {
+    return this.getClient().asyncMopGet(key, mkeyList);
+  }
+
+  @Override
+  public CollectionFuture<Map<String, Object>> asyncMopGet(String key, List<String> mkeyList,
+                                                           boolean withDelete,
+                                                           boolean dropIfEmpty) {
+    return this.getClient().asyncMopGet(key, mkeyList, withDelete, dropIfEmpty);
+  }
+
+  @Override
+  public <T> CollectionFuture<Map<String, T>> asyncMopGet(String key, Transcoder<T> tc) {
+    return this.getClient().asyncMopGet(key, tc);
   }
 
   @Override
@@ -738,10 +750,36 @@ public class ArcusClientPool implements MemcachedClientIF, ArcusClientIF {
 
   @Override
   public <T> CollectionFuture<Map<String, T>> asyncMopGet(String key, String mkey,
+                                                          Transcoder<T> tc) {
+    return this.getClient().asyncMopGet(key, mkey, tc);
+  }
+
+  @Override
+  public <T> CollectionFuture<Map<String, T>> asyncMopGet(String key, String mkey,
                                                           boolean withDelete,
                                                           boolean dropIfEmpty,
                                                           Transcoder<T> tc) {
     return this.getClient().asyncMopGet(key, mkey, withDelete, dropIfEmpty, tc);
+  }
+
+  @Override
+  public <T> CollectionFuture<Map<String, T>> asyncMopGet(String key, List<String> mkeyList,
+                                                          Transcoder<T> tc) {
+    return this.getClient().asyncMopGet(key, mkeyList, tc);
+  }
+
+  @Override
+  public <T> CollectionFuture<Map<String, T>> asyncMopGet(String key, List<String> mkeyList,
+                                                          boolean withDelete,
+                                                          boolean dropIfEmpty,
+                                                          Transcoder<T> tc) {
+    return this.getClient().asyncMopGet(key, mkeyList, withDelete, dropIfEmpty, tc);
+  }
+
+  @Override
+  public CollectionFuture<List<Object>> asyncLopGet(String key, int index) {
+    return this.getClient()
+            .asyncLopGet(key, index);
   }
 
   @Override
@@ -750,6 +788,11 @@ public class ArcusClientPool implements MemcachedClientIF, ArcusClientIF {
                                                     boolean dropIfEmpty) {
     return this.getClient()
             .asyncLopGet(key, index, withDelete, dropIfEmpty);
+  }
+
+  @Override
+  public CollectionFuture<List<Object>> asyncLopGet(String key, int from, int to) {
+    return this.getClient().asyncLopGet(key, from, to);
   }
 
   @Override
@@ -762,12 +805,22 @@ public class ArcusClientPool implements MemcachedClientIF, ArcusClientIF {
   }
 
   @Override
+  public <T> CollectionFuture<List<T>> asyncLopGet(String key, int index, Transcoder<T> tc) {
+    return this.getClient().asyncLopGet(key, index, tc);
+  }
+
+  @Override
   public <T> CollectionFuture<List<T>> asyncLopGet(String key, int index,
                                                    boolean withDelete,
                                                    boolean dropIfEmpty,
                                                    Transcoder<T> tc) {
     return this.getClient().asyncLopGet(key, index, withDelete,
             dropIfEmpty, tc);
+  }
+
+  @Override
+  public <T> CollectionFuture<List<T>> asyncLopGet(String key, int from, int to, Transcoder<T> tc) {
+    return this.getClient().asyncLopGet(key, from, to, tc);
   }
 
   @Override
@@ -781,12 +834,23 @@ public class ArcusClientPool implements MemcachedClientIF, ArcusClientIF {
   }
 
   @Override
+  public CollectionFuture<Set<Object>> asyncSopGet(String key, int count) {
+    return this.getClient()
+            .asyncSopGet(key, count);
+  }
+
+  @Override
   public CollectionFuture<Set<Object>> asyncSopGet(String key,
                                                    int count,
                                                    boolean withDelete,
                                                    boolean dropIfEmpty) {
     return this.getClient()
             .asyncSopGet(key, count, withDelete, dropIfEmpty);
+  }
+
+  @Override
+  public <T> CollectionFuture<Set<T>> asyncSopGet(String key, int count, Transcoder<T> tc) {
+    return this.getClient().asyncSopGet(key, count, tc);
   }
 
   @Override

--- a/src/test/manual/net/spy/memcached/collection/list/LopGetTest.java
+++ b/src/test/manual/net/spy/memcached/collection/list/LopGetTest.java
@@ -100,4 +100,17 @@ public class LopGetTest extends BaseIntegrationTest {
     assertNull(rlist);
   }
 
+  public void testLopGet_simple() throws Exception {
+    CollectionAttributes attrs = null;
+
+    // get all elements
+    List<Object> list = mc.asyncLopGet(key, 0, 9).get(1000,
+            TimeUnit.MILLISECONDS);
+
+    assertEquals(list.size(), 9);
+
+    // get count of the list and compare with count of items after using get method
+    attrs = mc.asyncGetAttr(key).get(1000, TimeUnit.MILLISECONDS);
+    assertEquals(9, attrs.getCount().intValue());
+  }
 }

--- a/src/test/manual/net/spy/memcached/collection/map/MopGetTest.java
+++ b/src/test/manual/net/spy/memcached/collection/map/MopGetTest.java
@@ -114,4 +114,23 @@ public class MopGetTest extends BaseIntegrationTest {
             TimeUnit.MILLISECONDS);
     assertNull(rmap);
   }
+
+  public void testMopGet_simple() throws Exception {
+    CollectionAttributes attrs = null;
+
+    List<String> mKeyList = new ArrayList<String>();
+    for (int i = 0; i <= 9; i++) {
+      mKeyList.add(String.valueOf(i));
+    }
+
+    // get all elements
+    Map<String, Object> list = mc.asyncMopGet(key, mKeyList).get(1000,
+            TimeUnit.MILLISECONDS);
+
+    assertEquals(list.size(), 9);
+
+    // get count of the map and compare with count of items after using get method
+    attrs = mc.asyncGetAttr(key).get(1000, TimeUnit.MILLISECONDS);
+    assertEquals(9, attrs.getCount().intValue());
+  }
 }

--- a/src/test/manual/net/spy/memcached/emptycollection/GetWithDropSetTest.java
+++ b/src/test/manual/net/spy/memcached/emptycollection/GetWithDropSetTest.java
@@ -105,4 +105,27 @@ public class GetWithDropSetTest extends BaseIntegrationTest {
       Assert.fail(e.getMessage());
     }
   }
+
+  public void testGetWithoutDeleteAndDropOptions() {
+    try {
+      // check attr
+      assertEquals(new Long(1), mc.asyncGetAttr(KEY).get()
+              .getCount());
+
+      //get value
+      assertTrue(mc.asyncSopGet(KEY, 10).get()
+              .contains(VALUE));
+
+      // check exists
+      assertEquals(new Long(1), mc.asyncGetAttr(KEY).get()
+              .getCount());
+
+      // get value again
+      assertTrue(mc.asyncSopGet(KEY, 10).get()
+              .contains(VALUE));
+    } catch (Exception e) {
+      e.printStackTrace();
+      fail(e.getMessage());
+    }
+  }
 }


### PR DESCRIPTION
#439

- 생략가능한 인자를 제외한 list/set/map API를 구현하였습니다.
- asyncLopGet, asyncSopGet, asyncMopGet 메소드에서 withDelete, dropIfEmpty 인자를 명시하지 않아도 동작합니다.
- unit test 완료하였습니다.