### PR TITLE
FEATURE: Prepared the node locator for data migration

### DIFF
--- a/src/main/java/net/spy/memcached/ArcusKetamaNodeLocator.java
+++ b/src/main/java/net/spy/memcached/ArcusKetamaNodeLocator.java
@@ -18,12 +18,15 @@
 package net.spy.memcached;
 
 import java.io.IOException;
+import java.net.SocketAddress;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.NavigableMap;
 import java.util.SortedMap;
 import java.util.TreeMap;
 import java.util.SortedSet;
@@ -38,6 +41,17 @@ public class ArcusKetamaNodeLocator extends SpyObject implements NodeLocator {
 
   private final TreeMap<Long, SortedSet<MemcachedNode>> ketamaNodes;
   private final Collection<MemcachedNode> allNodes;
+
+  /* ENABLE_MIGRATION if */
+  private TreeMap<Long, SortedSet<MemcachedNode>> ketamaAlterNodes;
+  private Collection<MemcachedNode> alterNodes;
+  private Collection<MemcachedNode> existNodes;
+
+  private MigrationType migrationType;
+  private Long migrationBasePoint;
+  private Long migrationLastPoint;
+  private boolean migrationInProgress;
+  /* ENABLE_MIGRATION end */
 
   private final HashAlgorithm hashAlg = HashAlgorithm.KETAMA_HASH;
   private final ArcusKetamaNodeLocatorConfiguration config;
@@ -54,6 +68,13 @@ public class ArcusKetamaNodeLocator extends SpyObject implements NodeLocator {
     allNodes = nodes;
     ketamaNodes = new TreeMap<Long, SortedSet<MemcachedNode>>();
     config = conf;
+
+    /* ENABLE_MIGRATION if */
+    existNodes = new HashSet<MemcachedNode>();
+    alterNodes = new HashSet<MemcachedNode>();
+    ketamaAlterNodes = new TreeMap<Long, SortedSet<MemcachedNode>>();
+    clearMigration();
+    /* ENABLE_MIGRATION end */
 
     int numReps = config.getNodeRepetitions();
     // Ketama does some special work with md5 where it reuses chunks.
@@ -72,11 +93,34 @@ public class ArcusKetamaNodeLocator extends SpyObject implements NodeLocator {
     ketamaNodes = smn;
     allNodes = an;
     config = conf;
+
+    /* ENABLE_MIGRATION if */
+    existNodes = new HashSet<MemcachedNode>();
+    alterNodes = new HashSet<MemcachedNode>();
+    ketamaAlterNodes = new TreeMap<Long, SortedSet<MemcachedNode>>();
+    clearMigration();
+    /* ENABLE_MIGRATION end */
   }
 
   public Collection<MemcachedNode> getAll() {
     return Collections.unmodifiableCollection(allNodes);
   }
+
+  /* ENABLE_MIGRATION if */
+  public Collection<MemcachedNode> getAlterAll() {
+    return Collections.unmodifiableCollection(alterNodes);
+  }
+
+  public MemcachedNode getAlterNode(SocketAddress sa) {
+    /* The alter node to attach must be found */
+    for (MemcachedNode node : alterNodes) {
+      if (sa.equals(node.getSocketAddress())) {
+        return node;
+      }
+    }
+    return null;
+  }
+  /* ENABLE_MIGRATION end */
 
   public SortedMap<Long, SortedSet<MemcachedNode>> getKetamaNodes() {
     return Collections.unmodifiableSortedMap(ketamaNodes);
@@ -166,6 +210,12 @@ public class ArcusKetamaNodeLocator extends SpyObject implements NodeLocator {
         }
       }
     } finally {
+      /* ENABLE_MIGRATION if */
+      if (migrationInProgress && alterNodes.isEmpty()) {
+        getLogger().info("Migration " + migrationType + " has been finished.");
+        clearMigration();
+      }
+      /* ENABLE_MIGRATION end */
       lock.unlock();
     }
   }
@@ -178,7 +228,19 @@ public class ArcusKetamaNodeLocator extends SpyObject implements NodeLocator {
   }
 
   private void insertHash(MemcachedNode node) {
+    /* ENABLE_MIGRATION if */
+    if (migrationInProgress) {
+      if (alterNodes.contains(node)) {
+        alterNodes.remove(node);
+        insertHashOfJOIN(node); // joining => joined
+        return;
+      }
+      // How to handle the new node ? go downward (FIXME)
+    }
+    /* ENABLE_MIGRATION end */
+
     config.insertNode(node);
+
     // Ketama does some special work with md5 where it reuses chunks.
     for (int i = 0; i < config.getNodeRepetitions() / 4; i++) {
       byte[] digest = HashAlgorithm.computeMd5(config.getKeyForNode(node, i));
@@ -195,6 +257,29 @@ public class ArcusKetamaNodeLocator extends SpyObject implements NodeLocator {
   }
 
   private void removeHash(MemcachedNode node) {
+    /* ENABLE_MIGRATION if */
+    boolean callAutoLeaveAbort = false;
+    if (migrationInProgress) {
+      if (alterNodes.remove(node)) {
+        /* A leaving node is down or has left */
+        assert migrationType == MigrationType.LEAVE;
+        removeHashOfAlter(node);
+        return;
+      }
+      if (existNodes.remove(node)) {
+        /* An existing node is down */
+        if (migrationType == MigrationType.JOIN) {
+          automaticJoinCompletion(node);
+        } else {
+          callAutoLeaveAbort = true;
+        }
+      } else {
+        /* A joined node is down : do nothing */
+      }
+      /* go downward */
+    }
+    /* ENABLE_MIGRATION end */
+
     // Ketama does some special work with md5 where it reuses chunks.
     for (int i = 0; i < config.getNodeRepetitions() / 4; i++) {
       byte[] digest = HashAlgorithm.computeMd5(config.getKeyForNode(node, i));
@@ -209,7 +294,331 @@ public class ArcusKetamaNodeLocator extends SpyObject implements NodeLocator {
       }
     }
     config.removeNode(node);
+
+    /* ENABLE_MIGRATION if */
+    if (callAutoLeaveAbort) {
+      automaticLeaveAbort(node);
+    }
+    /* ENABLE_MIGRATION end */
   }
+
+  /* ENABLE_MIGRATION if */
+  /* Insert the joining hash points into ketamaAlterNodes */
+  private void prepareHashOfJOIN(MemcachedNode node) {
+    config.insertNode(node); // register the node in config
+
+    for (int i = 0; i < config.getNodeRepetitions() / 4; i++) {
+      byte[] digest = HashAlgorithm.computeMd5(config.getKeyForNode(node, i));
+      for (int h = 0; h < 4; h++) {
+        Long k = getKetamaHashPoint(digest, h);
+        SortedSet<MemcachedNode> nodeSet = ketamaAlterNodes.get(k);
+        if (nodeSet == null) {
+          nodeSet = new TreeSet<MemcachedNode>(config.new NodeNameComparator());
+          ketamaAlterNodes.put(k, nodeSet);
+        }
+        nodeSet.add(node);
+      }
+    }
+  }
+
+  /* Insert the joining hash points into ketamaNodes. */
+  private void insertHashOfJOIN(MemcachedNode node) {
+    config.insertNode(node); // register the node in config
+
+    for (int i = 0; i < config.getNodeRepetitions() / 4; i++) {
+      byte[] digest = HashAlgorithm.computeMd5(config.getKeyForNode(node, i));
+      for (int h = 0; h < 4; h++) {
+        Long k = getKetamaHashPoint(digest, h);
+        SortedSet<MemcachedNode> alterSet = ketamaAlterNodes.get(k);
+        if (alterSet != null && alterSet.remove(node)) {
+          if (alterSet.size() == 0) {
+            ketamaAlterNodes.remove(k);
+          }
+          SortedSet<MemcachedNode> existSet = ketamaNodes.get(k);
+          if (existSet == null) {
+            existSet = new TreeSet<MemcachedNode>(config.new NodeNameComparator());
+            ketamaNodes.put(k, existSet);
+          }
+          existSet.add(node); // joining => joined
+        } else {
+          // The hash points have already been inserted.
+        }
+      }
+    }
+  }
+
+  /* Remove all hash points of the alter node */
+  private void removeHashOfAlter(MemcachedNode node) {
+    // The alter hpoints can be in both ketamaAlterNodes and ketamaNodes.
+    for (int i = 0; i < config.getNodeRepetitions() / 4; i++) {
+      byte[] digest = HashAlgorithm.computeMd5(config.getKeyForNode(node, i));
+      for (int h = 0; h < 4; h++) {
+        Long k = getKetamaHashPoint(digest, h);
+        SortedSet<MemcachedNode> nodeSet = ketamaAlterNodes.get(k);
+        if (nodeSet != null && nodeSet.remove(node)) {
+          if (nodeSet.isEmpty()) {
+            ketamaAlterNodes.remove(k);
+          }
+        } else {
+          nodeSet = ketamaNodes.get(k);
+          assert nodeSet != null;
+          boolean removed = nodeSet.remove(node);
+          if (nodeSet.isEmpty()) {
+            ketamaNodes.remove(k);
+          }
+          assert removed;
+        }
+      }
+    }
+    config.removeNode(node); // unregister the node in config
+  }
+
+  /* Move an alter hash range from ketamaAlterNodes to ketamaNodes */
+  private void moveAlterHashRangeFromAlterToExist(Long spoint, boolean sInclusive,
+                                                  Long epoint, boolean eInclusive) {
+    NavigableMap<Long, SortedSet<MemcachedNode>> moveRange
+        = ketamaAlterNodes.subMap(spoint, sInclusive, epoint, eInclusive);
+
+    List<Long> removeList = new ArrayList<Long>();
+    for (Map.Entry<Long, SortedSet<MemcachedNode>> entry : moveRange.entrySet()) {
+      SortedSet<MemcachedNode> nodeSet = ketamaNodes.get(entry.getKey());
+      if (nodeSet == null) {
+        nodeSet = new TreeSet<MemcachedNode>(config.new NodeNameComparator());
+        ketamaNodes.put(entry.getKey(), nodeSet);
+      }
+      nodeSet.addAll(entry.getValue());
+      removeList.add(entry.getKey());
+    }
+    for (Long key : removeList) {
+      ketamaAlterNodes.remove(key);
+    }
+  }
+
+  /* Move an alter hash range from ketamaNode to ketamaAlterNodes */
+  private void moveAlterHashRangeFromExistToAlter(Long spoint, boolean sInclusive,
+                                                  Long epoint, boolean eInclusive) {
+    NavigableMap<Long, SortedSet<MemcachedNode>> moveRange
+        = ketamaNodes.subMap(spoint, sInclusive, epoint, eInclusive);
+
+    List<Long> removeList = new ArrayList<Long>();
+    for (Map.Entry<Long, SortedSet<MemcachedNode>> entry : moveRange.entrySet()) {
+      Iterator<MemcachedNode> nodeIter = entry.getValue().iterator();
+      while (nodeIter.hasNext()) {
+        MemcachedNode node = nodeIter.next();
+        if (alterNodes.contains(node)) {
+          nodeIter.remove(); // leaving => leaved
+          SortedSet<MemcachedNode> alterSet = ketamaAlterNodes.get(entry.getKey());
+          if (alterSet == null) {
+            alterSet = new TreeSet<MemcachedNode>(config.new NodeNameComparator());
+            ketamaAlterNodes.put(entry.getKey(), alterSet); // for auto leave abort
+          }
+          alterSet.add(node);
+        }
+      }
+      if (entry.getValue().isEmpty()) {
+        removeList.add(entry.getKey());
+      }
+    }
+    for (Long key : removeList) {
+      ketamaNodes.remove(key);
+    }
+  }
+
+  private void insertAlterHashRange(Long spoint, Long epoint, boolean inclusive) {
+    if (spoint < epoint) {
+      moveAlterHashRangeFromAlterToExist(spoint, inclusive, epoint, true);
+    } else {
+      moveAlterHashRangeFromAlterToExist(spoint, inclusive, 0xFFFFFFFFL, true);
+      moveAlterHashRangeFromAlterToExist(0L, true, epoint, true);
+    }
+  }
+
+  private void removeAlterHashRange(Long spoint, Long epoint, boolean inclusive) {
+    if (spoint < epoint) {
+      moveAlterHashRangeFromExistToAlter(spoint, inclusive, epoint, true);
+    } else {
+      moveAlterHashRangeFromExistToAlter(0L, true, epoint, true);
+      moveAlterHashRangeFromExistToAlter(spoint, inclusive, 0xFFFFFFFFL, true);
+    }
+  }
+
+  private void automaticJoinCompletion(MemcachedNode mine) {
+    getLogger().info("Started automatic join completion. node=" + mine.getNodeName());
+    for (int i = 0; i < config.getNodeRepetitions() / 4; i++) {
+      byte[] digest = HashAlgorithm.computeMd5(config.getKeyForNode(mine, i));
+      for (int h = 0; h < 4; h++) {
+        Long currPoint = getKetamaHashPoint(digest, h);
+        SortedSet<MemcachedNode> existSet = ketamaNodes.get(currPoint);
+        assert existSet != null && existSet.size() > 0;
+        if (existSet.size() == 1 || existSet.first() == mine) { // visible (FIXME)
+          Long prevPoint = ketamaNodes.lowerKey(currPoint);
+          insertAlterHashRange(prevPoint, currPoint, true); // inclusive: true
+        }
+      }
+    }
+    getLogger().info("Completed automatic join completion. node=" + mine.getNodeName());
+  }
+
+  private Long findMigrationBasePointLEAVE() {
+    Long key = ketamaNodes.lastKey();
+    while (key != null) {
+      for (MemcachedNode node : ketamaNodes.get(key)) {
+        if (existNodes.contains(node)) {
+          break;
+        }
+      }
+      key = ketamaNodes.lowerKey(key);
+    }
+    assert key != null;
+    return key;
+  }
+
+  private void automaticLeaveAbort(MemcachedNode mine) {
+    if (migrationBasePoint != -1L && existNodes.size() > 0) {
+      Long newBasePoint = findMigrationBasePointLEAVE();
+      if (newBasePoint == migrationBasePoint) {
+        return; // nothing to abort
+      }
+
+      getLogger().info("Started automatic leave abort. node=" + mine.getNodeName());
+      /* abort (newBasePoint ~ migrationBasePoint) leaved hpoints */
+      insertAlterHashRange(newBasePoint, migrationBasePoint, true); // inclusive: true
+      migrationBasePoint = newBasePoint;
+      if (migrationBasePoint == migrationLastPoint) {
+        migrationBasePoint = -1L;
+        migrationLastPoint = -1L;
+      }
+      getLogger().info("Completed automatic leave abort. node=" + mine.getNodeName());
+    }
+  }
+
+  public void updateAlter(Collection<MemcachedNode> toAttach,
+                          Collection<MemcachedNode> toDelete) {
+    assert toAttach.isEmpty() == true;
+    lock.lock();
+    try {
+      // Remove the failed or left alter nodes.
+      for (MemcachedNode node : toDelete) {
+        alterNodes.remove(node);
+        removeHashOfAlter(node);
+        try {
+          node.closeChannel();
+        } catch (IOException e) {
+          getLogger().error("Failed to closeChannel the node : " + node);
+        }
+      }
+    } finally {
+      if (alterNodes.isEmpty()) {
+        getLogger().info("Migration " + migrationType + " has been finished.");
+        clearMigration();
+      }
+      lock.unlock();
+    }
+  }
+
+  private void clearMigration() {
+    existNodes.clear();
+    alterNodes.clear();
+    ketamaAlterNodes.clear();
+    migrationBasePoint = -1L;
+    migrationLastPoint = -1L;
+    migrationType = MigrationType.UNKNOWN;
+    migrationInProgress = false;
+  }
+
+  public void prepareMigration(Collection<MemcachedNode> toAlter, MigrationType type) {
+    getLogger().info("Prepare ketama info for migration. type=" + type);
+    assert type != MigrationType.UNKNOWN;
+
+    clearMigration();
+    migrationType = type;
+    migrationInProgress = true;
+
+    /* prepare alterNodes, ketamaAlterNodes and existNodes */
+    if (type == MigrationType.JOIN) {
+      for (MemcachedNode node : toAlter) {
+        alterNodes.add(node);
+        prepareHashOfJOIN(node);
+      }
+      for (MemcachedNode node : allNodes) {
+        existNodes.add(node);
+      }
+    } else { // MigrationType.LEAVE
+      for (MemcachedNode node : toAlter) {
+        alterNodes.add(node);
+      }
+      for (MemcachedNode node : allNodes) {
+        if (!alterNodes.contains(node)) {
+          existNodes.add(node);
+        }
+      }
+    }
+  }
+
+  /* check migrationLastPoint belongs to the (spoint, epoint) range. */
+  private boolean needToMigrateRange(Long spoint, Long epoint) {
+    if (spoint != 0 || epoint != 0) { // Valid migration range
+      if (migrationLastPoint == -1) {
+        return true;
+      }
+      if (spoint == epoint) { // full range
+        return spoint != migrationLastPoint;
+      }
+      if (spoint < epoint) {
+        if (spoint < migrationLastPoint && migrationLastPoint < epoint) {
+          return true;
+        }
+      } else { // spoint > epoint
+        if (spoint < migrationLastPoint || migrationLastPoint < epoint) {
+          return true;
+        }
+      }
+    }
+    return false;
+  }
+
+  private void migrateJoinRange(Long spoint, Long epoint) {
+    lock.lock();
+    try {
+      if (migrationLastPoint == -1) {
+        migrationBasePoint = spoint;
+      } else {
+        spoint = migrationLastPoint;
+      }
+      insertAlterHashRange(spoint, epoint, false); // inclusive: false
+      migrationLastPoint = epoint;
+    } finally {
+      lock.unlock();
+    }
+    getLogger().info("Applied JOIN range. spoint=" + spoint + ", epoint=" + epoint);
+  }
+
+  private void migrateLeaveRange(Long spoint, Long epoint) {
+    lock.lock();
+    try {
+      if (migrationLastPoint == -1) {
+        migrationBasePoint = epoint;
+      } else {
+        epoint = migrationLastPoint;
+      }
+      removeAlterHashRange(spoint, epoint, false); // inclusive: false
+      migrationLastPoint = spoint;
+    } finally {
+      lock.unlock();
+    }
+    getLogger().info("Applied LEAVE range. spoint=" + spoint + ", epoint=" + epoint);
+  }
+
+  public void updateMigration(Long spoint, Long epoint) {
+    if (migrationInProgress && needToMigrateRange(spoint, epoint)) {
+      if (migrationType == MigrationType.JOIN) {
+        migrateJoinRange(spoint, epoint);
+      } else {
+        migrateLeaveRange(spoint, epoint);
+      }
+    }
+  }
+  /* ENABLE_MIGRATION end */
 
   class KetamaIterator implements Iterator<MemcachedNode> {
 

--- a/src/main/java/net/spy/memcached/ArcusReplKetamaNodeLocator.java
+++ b/src/main/java/net/spy/memcached/ArcusReplKetamaNodeLocator.java
@@ -19,6 +19,7 @@
 package net.spy.memcached;
 
 import java.io.IOException;
+import java.net.SocketAddress;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -27,6 +28,7 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.NavigableMap;
 import java.util.TreeMap;
 import java.util.SortedSet;
 import java.util.TreeSet;
@@ -42,6 +44,18 @@ public class ArcusReplKetamaNodeLocator extends SpyObject implements NodeLocator
   private final HashMap<String, MemcachedReplicaGroup> allGroups;
   private final Collection<MemcachedNode> allNodes;
 
+  /* ENABLE_MIGRATION if */
+  private TreeMap<Long, SortedSet<MemcachedReplicaGroup>> ketamaAlterGroups;
+  private HashMap<String, MemcachedReplicaGroup> alterGroups;
+  private HashMap<String, MemcachedReplicaGroup> existGroups;
+  private HashSet<MemcachedNode> alterNodes;
+
+  private MigrationType migrationType;
+  private Long migrationBasePoint;
+  private Long migrationLastPoint;
+  private boolean migrationInProgress;
+  /* ENABLE_MIGRATION end */
+
   private final Collection<MemcachedReplicaGroup> toDeleteGroups;
   private final HashAlgorithm hashAlg = HashAlgorithm.KETAMA_HASH;
   private final ArcusReplKetamaNodeLocatorConfiguration config
@@ -54,6 +68,14 @@ public class ArcusReplKetamaNodeLocator extends SpyObject implements NodeLocator
     allNodes = nodes;
     ketamaGroups = new TreeMap<Long, SortedSet<MemcachedReplicaGroup>>();
     allGroups = new HashMap<String, MemcachedReplicaGroup>();
+
+    /* ENABLE_MIGRATION if */
+    alterNodes = new HashSet<MemcachedNode>();
+    ketamaAlterGroups = new TreeMap<Long, SortedSet<MemcachedReplicaGroup>>();
+    alterGroups = new HashMap<String, MemcachedReplicaGroup>();
+    existGroups = new HashMap<String, MemcachedReplicaGroup>();
+    clearMigration();
+    /* ENABLE_MIGRATION end */
 
     // create all memcached replica group
     for (MemcachedNode node : nodes) {
@@ -88,6 +110,14 @@ public class ArcusReplKetamaNodeLocator extends SpyObject implements NodeLocator
     allGroups = ag;
     allNodes = an;
     toDeleteGroups = new HashSet<MemcachedReplicaGroup>();
+
+    /* ENABLE_MIGRATION if */
+    alterNodes = new HashSet<MemcachedNode>();
+    ketamaAlterGroups = new TreeMap<Long, SortedSet<MemcachedReplicaGroup>>();
+    alterGroups = new HashMap<String, MemcachedReplicaGroup>();
+    existGroups = new HashMap<String, MemcachedReplicaGroup>();
+    clearMigration();
+    /* ENABLE_MIGRATION end */
   }
 
   public Collection<MemcachedNode> getAll() {
@@ -97,6 +127,23 @@ public class ArcusReplKetamaNodeLocator extends SpyObject implements NodeLocator
   public Map<String, MemcachedReplicaGroup> getAllGroups() {
     return Collections.unmodifiableMap(allGroups);
   }
+
+  /* ENABLE_MIGRATION if */
+  public Collection<MemcachedNode> getAlterAll() {
+    return Collections.unmodifiableCollection(alterNodes);
+  }
+
+  public MemcachedNode getAlterNode(SocketAddress sa) {
+    /* The alter node to attach should be found */
+    for (MemcachedNode node : alterNodes) {
+      if (sa.equals(node.getSocketAddress())) {
+        return node;
+      }
+    }
+    /* If a slave node has started during migration, it may not exist */ 
+    return null;
+  }
+  /* ENABLE_MIGRATION end */
 
   public Collection<MemcachedNode> getMasterNodes() {
     List<MemcachedNode> masterNodes = new ArrayList<MemcachedNode>(allGroups.size());
@@ -230,6 +277,12 @@ public class ArcusReplKetamaNodeLocator extends SpyObject implements NodeLocator
       }
       toDeleteGroups.clear();
     } finally {
+      /* ENABLE_MIGRATION if */
+      if (migrationInProgress && alterNodes.isEmpty()) {
+        getLogger().info("Migration " + migrationType + " has been finished.");
+        clearMigration();
+      }
+      /* ENABLE_MIGRATION end */
       lock.unlock();
     }
   }
@@ -241,6 +294,22 @@ public class ArcusReplKetamaNodeLocator extends SpyObject implements NodeLocator
   }
 
   private void insertNodeIntoGroup(MemcachedNode node) {
+    /* ENABLE_MIGRATION if */
+    if (migrationInProgress) {
+      if (alterNodes.contains(node)) {
+        alterNodes.remove(node);
+        MemcachedReplicaGroup mrg;
+        mrg = alterGroups.get(MemcachedReplicaGroup.getGroupNameFromNode(node));
+        if (mrg != null) {
+          allGroups.put(mrg.getGroupName(), mrg);
+          insertHash(mrg);
+        }
+        return;
+      }
+      // How to handle the new node ? go downward (FIXME)
+    }
+    /* ENABLE_MIGRATION end */
+
     MemcachedReplicaGroup mrg;
     mrg = allGroups.get(MemcachedReplicaGroup.getGroupNameFromNode(node));
     if (mrg == null) {
@@ -257,6 +326,13 @@ public class ArcusReplKetamaNodeLocator extends SpyObject implements NodeLocator
   }
 
   private void removeNodeFromGroup(MemcachedNode node) {
+    /* ENABLE_MIGRATION if */
+    if (migrationInProgress) {
+      alterNodes.remove(node);
+      /* go downward */
+    }
+    /* ENABLE_MIGRATION end */
+
     MemcachedReplicaGroup mrg;
     mrg = allGroups.get(MemcachedReplicaGroup.getGroupNameFromNode(node));
     mrg.deleteMemcachedNode(node);
@@ -273,6 +349,15 @@ public class ArcusReplKetamaNodeLocator extends SpyObject implements NodeLocator
   }
 
   private void insertHash(MemcachedReplicaGroup group) {
+    /* ENABLE_MIGRATION if */
+    if (migrationInProgress) {
+      assert migrationType == MigrationType.JOIN;
+      alterGroups.remove(group.getGroupName());
+      insertHashOfJOIN(group); // joining => joined
+      return;
+    }
+    /* ENABLE_MIGRATION end */
+
     // Ketama does some special work with md5 where it reuses chunks.
     for (int i = 0; i < config.getNodeRepetitions() / 4; i++) {
       byte[] digest = HashAlgorithm.computeMd5(config.getKeyForGroup(group, i));
@@ -290,6 +375,29 @@ public class ArcusReplKetamaNodeLocator extends SpyObject implements NodeLocator
   }
 
   private void removeHash(MemcachedReplicaGroup group) {
+    /* ENABLE_MIGRATION if */
+    boolean callAutoLeaveAbort = false;
+    if (migrationInProgress) {
+      if (alterGroups.remove(group.getGroupName()) != null) {
+        /* A leaving group is down or has left */
+        assert migrationType == MigrationType.LEAVE;
+        removeHashOfAlter(group);
+        return;
+      }
+      if (existGroups.remove(group.getGroupName()) != null) {
+        /* An existing group is down */
+        if (migrationType == MigrationType.JOIN) {
+          automaticJoinCompletion(group);
+        } else {
+          callAutoLeaveAbort = true;
+        }
+      } else {
+        /* A joined group is down : do nothing */
+      }
+      /* go downward */
+    }
+    /* ENABLE_MIGRATION end */
+
     // Ketama does some special work with md5 where it reuses chunks.
     for (int i = 0; i < config.getNodeRepetitions() / 4; i++) {
       byte[] digest = HashAlgorithm.computeMd5(config.getKeyForGroup(group, i));
@@ -302,7 +410,373 @@ public class ArcusReplKetamaNodeLocator extends SpyObject implements NodeLocator
         }
       }
     }
+
+    /* ENABLE_MIGRATION if */
+    if (callAutoLeaveAbort) {
+      automaticLeaveAbort(group);
+    }
+    /* ENABLE_MIGRATION end */
   }
+
+  /* ENABLE_MIGRATION if */
+  /* Insert the joining hash points into ketamaAlterGroups */
+  private void prepareHashOfJOIN(MemcachedReplicaGroup group) {
+    // Ketama does some special work with md5 where it reuses chunks.
+    for (int i = 0; i < config.getNodeRepetitions() / 4; i++) {
+      byte[] digest = HashAlgorithm.computeMd5(config.getKeyForGroup(group, i));
+      for (int h = 0; h < 4; h++) {
+        Long k = getKetamaHashPoint(digest, h);
+        SortedSet<MemcachedReplicaGroup> nodeSet = ketamaAlterGroups.get(k);
+        if (nodeSet == null) {
+          nodeSet = new TreeSet<MemcachedReplicaGroup>(
+              new ArcusReplKetamaNodeLocatorConfiguration.MemcachedReplicaGroupComparator());
+          ketamaAlterGroups.put(k, nodeSet);
+        }
+        nodeSet.add(group);
+      }
+    }
+  }
+
+  /* Insert the joining hash points into ketamaGroups */
+  private void insertHashOfJOIN(MemcachedReplicaGroup group) {
+    for (int i = 0; i < config.getNodeRepetitions() / 4; i++) {
+      byte[] digest = HashAlgorithm.computeMd5(config.getKeyForGroup(group, i));
+      for (int h = 0; h < 4; h++) {
+        Long k = getKetamaHashPoint(digest, h);
+        SortedSet<MemcachedReplicaGroup> alterSet = ketamaAlterGroups.get(k);
+        if (alterSet != null && alterSet.remove(group)) {
+          if (alterSet.size() == 0) {
+            ketamaAlterGroups.remove(k);
+          }
+          SortedSet<MemcachedReplicaGroup> existSet = ketamaGroups.get(k);
+          if (existSet == null) {
+            existSet = new TreeSet<MemcachedReplicaGroup>(
+                new ArcusReplKetamaNodeLocatorConfiguration.MemcachedReplicaGroupComparator());
+            ketamaGroups.put(k, existSet);
+          }
+          existSet.add(group); // joining => joined
+        } else {
+          // The hash point has already been inserted.
+        }
+      }
+    }
+  }
+
+  /* Remove all hash points of the alter group */
+  private void removeHashOfAlter(MemcachedReplicaGroup group) {
+    // The alter hpoints can be in both ketamaAlterGroups and ketamaGroups.
+    for (int i = 0; i < config.getNodeRepetitions() / 4; i++) {
+      byte[] digest = HashAlgorithm.computeMd5(config.getKeyForGroup(group, i));
+      for (int h = 0; h < 4; h++) {
+        Long k = getKetamaHashPoint(digest, h);
+        SortedSet<MemcachedReplicaGroup> groupSet = ketamaAlterGroups.get(k);
+        if (groupSet != null && groupSet.remove(group)) {
+          if (groupSet.isEmpty()) {
+            ketamaAlterGroups.remove(k);
+          }
+        } else {
+          groupSet = ketamaGroups.get(k);
+          assert groupSet != null;
+          boolean removed = groupSet.remove(group);
+          if (groupSet.isEmpty()) {
+            ketamaGroups.remove(k);
+          }
+          assert removed;
+        }
+      }
+    }
+  }
+
+  /* Move an alter hash range from ketamaAlterNodes to ketamaNodes */
+  private void moveAlterHashRangeFromAlterToExist(Long spoint, boolean sInclusive,
+                                                  Long epoint, boolean eInclusive) {
+    NavigableMap<Long, SortedSet<MemcachedReplicaGroup>> moveRange
+        = ketamaAlterGroups.subMap(spoint, sInclusive, epoint, eInclusive);
+
+    List<Long> removeList = new ArrayList<Long>();
+    for (Map.Entry<Long, SortedSet<MemcachedReplicaGroup>> entry : moveRange.entrySet()) {
+      SortedSet<MemcachedReplicaGroup> groupSet = ketamaGroups.get(entry.getKey());
+      if (groupSet == null) {
+        groupSet = new TreeSet<MemcachedReplicaGroup>(
+            new ArcusReplKetamaNodeLocatorConfiguration.MemcachedReplicaGroupComparator());
+        ketamaGroups.put(entry.getKey(), groupSet);
+      }
+      groupSet.addAll(entry.getValue());
+      removeList.add(entry.getKey());
+    }
+    for (Long key : removeList) {
+      ketamaAlterGroups.remove(key);
+    }
+  }
+
+  /* Move an alter hash range from ketamaNode to ketamaAlterNodes */
+  private void moveAlterHashRangeFromExistToAlter(Long spoint, boolean sInclusive,
+                                             Long epoint, boolean eInclusive) {
+    NavigableMap<Long, SortedSet<MemcachedReplicaGroup>> moveRange
+        = ketamaGroups.subMap(spoint, sInclusive, epoint, eInclusive);
+
+    List<Long> removeList = new ArrayList<Long>();
+    for (Map.Entry<Long, SortedSet<MemcachedReplicaGroup>> entry : moveRange.entrySet()) {
+      Iterator<MemcachedReplicaGroup> groupIter = entry.getValue().iterator();
+      while (groupIter.hasNext()) {
+        MemcachedReplicaGroup group = groupIter.next();
+        if (alterGroups.containsKey(group.getGroupName())) {
+          groupIter.remove(); // leaving => leaved
+          SortedSet<MemcachedReplicaGroup> alterSet = ketamaAlterGroups.get(entry.getKey());
+          if (alterSet == null) {
+            alterSet = new TreeSet<MemcachedReplicaGroup>(
+                new ArcusReplKetamaNodeLocatorConfiguration.MemcachedReplicaGroupComparator());
+            ketamaAlterGroups.put(entry.getKey(), alterSet); // for auto leave abort
+          }
+          alterSet.add(group);
+        }
+      }
+      if (entry.getValue().isEmpty()) {
+        removeList.add(entry.getKey());
+      }
+    }
+    for (Long key : removeList) {
+      ketamaGroups.remove(key);
+    }
+  }
+
+  private void insertAlterHashRange(Long spoint, Long epoint, boolean inclusive) {
+    if (spoint < epoint) {
+      moveAlterHashRangeFromAlterToExist(spoint, inclusive, epoint, true);
+    } else {
+      moveAlterHashRangeFromAlterToExist(spoint, inclusive, 0xFFFFFFFFL, true);
+      moveAlterHashRangeFromAlterToExist(0L, true, epoint, true);
+    }
+  }
+
+  private void removeAlterHashRange(Long spoint, Long epoint, boolean inclusive) {
+    if (spoint < epoint) {
+      moveAlterHashRangeFromExistToAlter(spoint, inclusive, epoint, true);
+    } else {
+      moveAlterHashRangeFromExistToAlter(0L, true, epoint, true);
+      moveAlterHashRangeFromExistToAlter(spoint, inclusive, 0xFFFFFFFFL, true);
+    }
+  }
+
+  private void automaticJoinCompletion(MemcachedReplicaGroup mine) {
+    getLogger().info("Started automatic join completion. group=" + mine.getGroupName());
+    for (int i = 0; i < config.getNodeRepetitions() / 4; i++) {
+      byte[] digest = HashAlgorithm.computeMd5(config.getKeyForGroup(mine, i));
+      for (int h = 0; h < 4; h++) {
+        Long currPoint = getKetamaHashPoint(digest, h);
+        SortedSet<MemcachedReplicaGroup> existSet = ketamaGroups.get(currPoint);
+        assert existSet != null && existSet.size() > 0;
+        if (existSet.size() == 1 || existSet.first() == mine) { // visible (FIXME)
+          Long prevPoint = ketamaGroups.lowerKey(currPoint);
+          insertAlterHashRange(prevPoint, currPoint, true); // inclusive: true
+        }
+      }
+    }
+    getLogger().info("Completed automatic join completion. group=" + mine.getGroupName());
+  }
+
+  private Long findMigrationBasePointLEAVE() {
+    Long key = ketamaGroups.lastKey();
+    while (key != null) {
+      for (MemcachedReplicaGroup group : ketamaGroups.get(key)) {
+        if (existGroups.containsKey(group.getGroupName())) {
+          break;
+        }
+      }
+      key = ketamaGroups.lowerKey(key);
+    }
+    assert key != null;
+    return key;
+  }
+
+  private void automaticLeaveAbort(MemcachedReplicaGroup mine) {
+    if (migrationBasePoint != -1L && existGroups.size() > 0) {
+      Long newBasePoint = findMigrationBasePointLEAVE();
+      if (newBasePoint == migrationBasePoint) {
+        return; // nothing to abort
+      }
+
+      getLogger().info("Started automatic leave abort. group=" + mine.getGroupName());
+      /* abort (newBasePoint ~ migrationBasePoint) leaved hpoints */
+      insertAlterHashRange(newBasePoint, migrationBasePoint, true); // inclusive: true
+      migrationBasePoint = newBasePoint;
+      if (migrationBasePoint == migrationLastPoint) {
+        migrationBasePoint = -1L;
+        migrationLastPoint = -1L;
+      }
+      getLogger().info("Completed automatic leave abort. group=" + mine.getGroupName());
+    }
+  }
+
+  public void updateAlter(Collection<MemcachedNode> toAttach,
+                          Collection<MemcachedNode> toDelete) {
+    lock.lock();
+    try {
+      // Add the alter nodes with slave role */
+      for (MemcachedNode node : toAttach) {
+        String groupName = MemcachedReplicaGroup.getGroupNameFromNode(node);
+        MemcachedReplicaGroup mrg = alterGroups.get(groupName);
+        if (mrg == null) {
+          mrg = allGroups.get(groupName);
+        }
+        if (mrg == null) { // close the unknown alter node (FIXME) */
+          try {
+            node.closeChannel();
+          } catch (IOException e) {
+            getLogger().error("Failed to closeChannel the node : " + node);
+          }
+        } else {
+          mrg.setMemcachedNode(node);
+          alterNodes.add(node);
+        }
+      }
+      // Remove the failed or left alter nodes.
+      for (MemcachedNode node : toDelete) {
+        if (alterNodes.remove(node)) {
+          MemcachedReplicaGroup mrg;
+          mrg = alterGroups.get(MemcachedReplicaGroup.getGroupNameFromNode(node));
+          if (mrg != null) {
+            mrg.deleteMemcachedNode(node);
+            if (mrg.isEmptyGroup()) {
+              removeHashOfAlter(mrg);
+            }
+          }
+        }
+        try {
+          node.closeChannel();
+        } catch (IOException e) {
+          getLogger().error("Failed to closeChannel the node : " + node);
+        }
+      }
+    } finally {
+      if (alterNodes.isEmpty()) {
+        getLogger().info("Migration " + migrationType + " has been finished.");
+        clearMigration();
+      }
+      lock.unlock();
+    }
+  }
+
+  private void clearMigration() {
+    alterNodes.clear();
+    alterGroups.clear();
+    existGroups.clear();
+    ketamaAlterGroups.clear();
+    migrationBasePoint = -1L;
+    migrationLastPoint = -1L;
+    migrationType = MigrationType.UNKNOWN;
+    migrationInProgress = false;
+  }
+
+  public void prepareMigration(Collection<MemcachedNode> toAlter, MigrationType type) {
+    getLogger().info("Prepare ketama info for migration. type=" + type);
+    assert type != MigrationType.UNKNOWN;
+
+    clearMigration();
+    migrationType = type;
+    migrationInProgress = true;
+
+    MemcachedReplicaGroup mrg;
+    if (type == MigrationType.JOIN) {
+      for (MemcachedNode node : toAlter) {
+        alterNodes.add(node);
+        String groupName = MemcachedReplicaGroup.getGroupNameFromNode(node);
+        mrg = alterGroups.get(groupName);
+        if (mrg == null) {
+          mrg = new MemcachedReplicaGroupImpl(node);
+          alterGroups.put(groupName, mrg);
+          prepareHashOfJOIN(mrg);
+        } else {
+          mrg.setMemcachedNode(node);
+        }
+      }
+      for (String groupName : allGroups.keySet()) {
+        mrg = allGroups.get(groupName);
+        existGroups.put(groupName, mrg);
+      }
+    } else { // MigrationType.LEAVE
+      for (MemcachedNode node : toAlter) {
+        alterNodes.add(node);
+        String groupName = MemcachedReplicaGroup.getGroupNameFromNode(node);
+        mrg = alterGroups.get(groupName);
+        if (mrg == null) {
+          mrg = allGroups.get(groupName);
+          alterGroups.put(groupName, mrg);
+        }
+      }
+      for (String groupName : allGroups.keySet()) {
+        if (!alterGroups.containsKey(groupName)) {
+          mrg = allGroups.get(groupName);
+          existGroups.put(groupName, mrg);
+        }
+      }
+    }
+  }
+
+  /* check migrationLastPoint belongs to the (spoint, epoint) range. */
+  private boolean needToMigrateRange(Long spoint, Long epoint) {
+    if (spoint != 0 || epoint != 0) { // Valid migration range
+      if (migrationLastPoint == -1) {
+        return true;
+      }
+      if (spoint == epoint) { // full range
+        return spoint != migrationLastPoint;
+      }
+      if (spoint < epoint) {
+        if (spoint < migrationLastPoint && migrationLastPoint < epoint) {
+          return true;
+        }
+      } else { // spoint > epoint
+        if (spoint < migrationLastPoint || migrationLastPoint < epoint) {
+          return true;
+        }
+      }
+    }
+    return false;
+  }
+
+  private void migrateJoinRange(Long spoint, Long epoint) {
+    lock.lock();
+    try {
+      if (migrationLastPoint == -1) {
+        migrationBasePoint = spoint;
+      } else {
+        spoint = migrationLastPoint;
+      }
+      insertAlterHashRange(spoint, epoint, false); // inclusive: false
+      migrationLastPoint = epoint;
+    } finally {
+      lock.unlock();
+    }
+    getLogger().info("Applied JOIN range. spoint=" + spoint + ", epoint=" + epoint);
+  }
+
+  private void migrateLeaveRange(Long spoint, Long epoint) {
+    lock.lock();
+    try {
+      if (migrationLastPoint == -1) {
+        migrationBasePoint = epoint;
+      } else {
+        epoint = migrationLastPoint;
+      }
+      removeAlterHashRange(spoint, epoint, false); // inclusive: false
+      migrationLastPoint = spoint;
+    } finally {
+      lock.unlock();
+    }
+    getLogger().info("Applied LEAVE range. spoint=" + spoint + ", epoint=" + epoint);
+  }
+
+  public void updateMigration(Long spoint, Long epoint) {
+    if (migrationInProgress && needToMigrateRange(spoint, epoint)) {
+      if (migrationType == MigrationType.JOIN) {
+        migrateJoinRange(spoint, epoint);
+      } else {
+        migrateLeaveRange(spoint, epoint);
+      }
+    }
+  }
+  /* ENABLE_MIGRATION end */
 
   private class ReplKetamaIterator implements Iterator<MemcachedNode> {
     private final String key;

--- a/src/main/java/net/spy/memcached/ArrayModNodeLocator.java
+++ b/src/main/java/net/spy/memcached/ArrayModNodeLocator.java
@@ -16,6 +16,8 @@
  */
 package net.spy.memcached;
 
+import java.net.SocketAddress;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Iterator;
@@ -73,6 +75,29 @@ public final class ArrayModNodeLocator implements NodeLocator {
   public void update(Collection<MemcachedNode> toAttach, Collection<MemcachedNode> toDelete) {
     throw new UnsupportedOperationException("update not supported");
   }
+
+  /* ENABLE_MIGRATION if */
+  public Collection<MemcachedNode> getAlterAll() {
+    return new ArrayList<MemcachedNode>();
+  }
+
+  public MemcachedNode getAlterNode(SocketAddress sa) {
+    return null;
+  }
+
+  public void updateAlter(Collection<MemcachedNode> toAttach,
+                          Collection<MemcachedNode> toDelete) {
+    throw new UnsupportedOperationException("updateAlter not supported");
+  }
+
+  public void prepareMigration(Collection<MemcachedNode> toAlter, MigrationType type) {
+    throw new UnsupportedOperationException("prepareMigration not supported");
+  }
+
+  public void updateMigration(Long spoint, Long epoint) {
+    throw new UnsupportedOperationException("updateMigration not supported");
+  }
+  /* ENABLE_MIGRATION end */
 
   private int getServerForKey(String key) {
     int rv = (int) (hashAlg.hash(key) % nodes.length);

--- a/src/main/java/net/spy/memcached/KetamaNodeLocator.java
+++ b/src/main/java/net/spy/memcached/KetamaNodeLocator.java
@@ -16,6 +16,7 @@
  */
 package net.spy.memcached;
 
+import java.net.SocketAddress;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -150,6 +151,29 @@ public final class KetamaNodeLocator extends SpyObject implements NodeLocator {
   public SortedMap<Long, MemcachedNode> getKetamaNodes() {
     return Collections.unmodifiableSortedMap(ketamaNodes);
   }
+
+  /* ENABLE_MIGRATION if */
+  public Collection<MemcachedNode> getAlterAll() {
+    return new ArrayList<MemcachedNode>();
+  }
+
+  public MemcachedNode getAlterNode(SocketAddress sa) {
+    return null;
+  }
+
+  public void updateAlter(Collection<MemcachedNode> toAttach,
+                          Collection<MemcachedNode> toDelete) {
+    throw new UnsupportedOperationException("updateAlter not supported");
+  }
+
+  public void prepareMigration(Collection<MemcachedNode> toAlter, MigrationType type) {
+    throw new UnsupportedOperationException("prepareMigration not supported");
+  }
+
+  public void updateMigration(Long spoint, Long epoint) {
+    throw new UnsupportedOperationException("updateMigration not supported");
+  }
+  /* ENABLE_MIGRATION end */
 
   class KetamaIterator implements Iterator<MemcachedNode> {
 

--- a/src/main/java/net/spy/memcached/MigrationState.java
+++ b/src/main/java/net/spy/memcached/MigrationState.java
@@ -1,0 +1,9 @@
+package net.spy.memcached;
+
+public enum MigrationState {
+  UNKNOWN,
+  BEGIN,
+  PREPARED,
+  PROGRESS,
+  DONE
+}

--- a/src/main/java/net/spy/memcached/MigrationType.java
+++ b/src/main/java/net/spy/memcached/MigrationType.java
@@ -1,0 +1,7 @@
+package net.spy.memcached;
+
+public enum MigrationType {
+  UNKNOWN,
+  JOIN,
+  LEAVE
+}

--- a/src/main/java/net/spy/memcached/NodeLocator.java
+++ b/src/main/java/net/spy/memcached/NodeLocator.java
@@ -16,6 +16,7 @@
  */
 package net.spy.memcached;
 
+import java.net.SocketAddress;
 import java.util.Collection;
 import java.util.Iterator;
 
@@ -56,4 +57,32 @@ public interface NodeLocator {
    * only available in ArcusKetamaNodeLocator.
    */
   void update(Collection<MemcachedNode> toAttach, Collection<MemcachedNode> toDelete);
+
+  /* ENABLE_MIGRATION if */
+  /**
+   * Get all alter memcached nodes.
+   */
+  Collection<MemcachedNode> getAlterAll();
+
+  /**
+   * Get an alter memcached node which contains the given socket address.
+   */
+  MemcachedNode getAlterNode(SocketAddress sa);
+
+  /**
+   * Remove the alter nodes which have failed down.
+   */
+  void updateAlter(Collection<MemcachedNode> toAttach,
+                   Collection<MemcachedNode> toDelete);
+
+  /**
+   * Prepare migration with alter nodes and migration type.
+   */
+  void prepareMigration(Collection<MemcachedNode> toAlter, MigrationType type);
+
+  /**
+   * Update(or reflect) the migratoin range in ketama hash ring.
+   */
+  void updateMigration(Long spoint, Long epoint);
+  /* ENABLE_MIGRATION end */
 }


### PR DESCRIPTION
Migration 위한 node locator 준비 작업의 PR 입니다.

아래 메소드를 추가 제공하도록 확장 되었습니다.

```java
  /**
   * Get all alter memcached nodes.
   */
  Collection<MemcachedNode> getAlterAll();

  /**
   * Get an alter memcached node which contains the given socket address.
   */
  MemcachedNode getAlterNode(SocketAddress sa);

  /**
   * Remove the alter nodes which have failed down.
   */
  void updateAlter(Collection<MemcachedNode> toDelete);

  /**
   * Prepare migration with alter nodes and migration type.
   */
  void prepareMigration(Collection<MemcachedNode> toAlter, MigrationType type);

  /**
   * Update(or reflect) the migratoin range in ketama hash ring.
   */
  void updateMigration(Long spoint, Long epoint);
```