### PR TITLE
INTERNAL: add omitted parameter method - asyncBopGet()

### DIFF
--- a/src/main/java/net/spy/memcached/ArcusClient.java
+++ b/src/main/java/net/spy/memcached/ArcusClient.java
@@ -1477,6 +1477,12 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
   }
 
   @Override
+  public CollectionFuture<Map<Long, Element<Object>>> asyncBopGet(String key, long bkey,
+                                                                  ElementFlagFilter eFlagFilter) {
+    return asyncBopGet(key, bkey, eFlagFilter, false, false);
+  }
+
+  @Override
   public CollectionFuture<Map<Long, Element<Object>>> asyncBopGet(String key,
                                                                   long bkey,
                                                                   ElementFlagFilter eFlagFilter,
@@ -1485,6 +1491,14 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
     BTreeUtil.validateBkey(bkey);
     BTreeGet get = new BTreeGet(bkey, withDelete, dropIfEmpty, eFlagFilter);
     return asyncBopGet(key, get, false, collectionTranscoder);
+  }
+
+  @Override
+  public CollectionFuture<Map<Long, Element<Object>>> asyncBopGet(String key,
+                                                                  long from, long to,
+                                                                  ElementFlagFilter eFlagFilter,
+                                                                  int offset, int count) {
+    return asyncBopGet(key, from, to, eFlagFilter, offset, count, false, false);
   }
 
   @Override
@@ -1504,12 +1518,29 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
   public <T> CollectionFuture<Map<Long, Element<T>>> asyncBopGet(String key,
                                                                  long bkey,
                                                                  ElementFlagFilter eFlagFilter,
+                                                                 Transcoder<T> tc) {
+    return asyncBopGet(key, bkey, eFlagFilter, false, false, tc);
+  }
+
+  @Override
+  public <T> CollectionFuture<Map<Long, Element<T>>> asyncBopGet(String key,
+                                                                 long bkey,
+                                                                 ElementFlagFilter eFlagFilter,
                                                                  boolean withDelete,
                                                                  boolean dropIfEmpty,
                                                                  Transcoder<T> tc) {
     BTreeUtil.validateBkey(bkey);
     BTreeGet get = new BTreeGet(bkey, withDelete, dropIfEmpty, eFlagFilter);
     return asyncBopGet(key, get, false, tc);
+  }
+
+  @Override
+  public <T> CollectionFuture<Map<Long, Element<T>>> asyncBopGet(String key,
+                                                                 long from, long to,
+                                                                 ElementFlagFilter eFlagFilter,
+                                                                 int offset, int count,
+                                                                 Transcoder<T> tc) {
+    return asyncBopGet(key, from, to, eFlagFilter, offset, count, false, false, tc);
   }
 
   @Override
@@ -3008,11 +3039,23 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
 
   @Override
   public CollectionFuture<Map<ByteArrayBKey, Element<Object>>> asyncBopGet(
+          String key, byte[] bkey, ElementFlagFilter eFlagFilter) {
+    return asyncBopGet(key, bkey, eFlagFilter, false, false);
+  }
+
+  @Override
+  public CollectionFuture<Map<ByteArrayBKey, Element<Object>>> asyncBopGet(
           String key, byte[] bkey, ElementFlagFilter eFlagFilter,
           boolean withDelete, boolean dropIfEmpty) {
     BTreeUtil.validateBkey(bkey);
     BTreeGet get = new BTreeGet(bkey, withDelete, dropIfEmpty, eFlagFilter);
     return asyncBopExtendedGet(key, get, false, collectionTranscoder);
+  }
+
+  @Override
+  public <T> CollectionFuture<Map<ByteArrayBKey, Element<T>>> asyncBopGet(
+          String key, byte[] bkey, ElementFlagFilter eFlagFilter, Transcoder<T> tc) {
+    return asyncBopGet(key, bkey, eFlagFilter, false, false, tc);
   }
 
   @Override
@@ -3026,12 +3069,27 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
 
   @Override
   public CollectionFuture<Map<ByteArrayBKey, Element<Object>>> asyncBopGet(
-      String key, byte[] from, byte[] to, ElementFlagFilter eFlagFilter,
-      int offset, int count, boolean withDelete, boolean dropIfEmpty) {
+          String key, byte[] from, byte[] to, ElementFlagFilter eFlagFilter,
+          int offset, int count) {
+    return asyncBopGet(key, from, to, eFlagFilter, offset, count, false, false);
+  }
+
+  @Override
+  public CollectionFuture<Map<ByteArrayBKey, Element<Object>>> asyncBopGet(
+          String key, byte[] from, byte[] to, ElementFlagFilter eFlagFilter,
+          int offset, int count, boolean withDelete, boolean dropIfEmpty) {
     BTreeUtil.validateBkey(from, to);
     BTreeGet get = new BTreeGet(from, to, offset, count, withDelete, dropIfEmpty, eFlagFilter);
     boolean reverse = BTreeUtil.compareByteArraysInLexOrder(from, to) > 0;
     return asyncBopExtendedGet(key, get, reverse, collectionTranscoder);
+  }
+
+  @Override
+  public <T> CollectionFuture<Map<ByteArrayBKey, Element<T>>> asyncBopGet(
+          String key, byte[] from, byte[] to, ElementFlagFilter eFlagFilter, int offset,
+          int count, Transcoder<T> tc) {
+    return asyncBopGet(key, from, to, eFlagFilter, offset, count,
+            false, false, tc);
   }
 
   @Override

--- a/src/main/java/net/spy/memcached/ArcusClientIF.java
+++ b/src/main/java/net/spy/memcached/ArcusClientIF.java
@@ -511,6 +511,18 @@ public interface ArcusClientIF {
    * @param key         key of a b+tree
    * @param bkey        bkey
    * @param eFlagFilter element flag filter
+   * @return a future that will hold the return value map of the fetch.
+   */
+  public CollectionFuture<Map<Long, Element<Object>>> asyncBopGet(String key,
+                                                                  long bkey,
+                                                                  ElementFlagFilter eFlagFilter);
+
+  /**
+   * Retrieves an item on given bkey in the b+tree.
+   *
+   * @param key         key of a b+tree
+   * @param bkey        bkey
+   * @param eFlagFilter element flag filter
    * @param withDelete  true to remove the returned item in the b+tree
    * @param dropIfEmpty true to remove the key when all elements are removed. false b+
    *                    tree will remain empty even if all the elements are removed
@@ -521,6 +533,28 @@ public interface ArcusClientIF {
                                                                   ElementFlagFilter eFlagFilter,
                                                                   boolean withDelete,
                                                                   boolean dropIfEmpty);
+
+  /**
+   * Retrieves count number of items in given bkey range(from..to)
+   * from offset in the b+tree.
+   * The returned map from the future should be sorted by the given range.
+   * <pre>{@code
+   *  from >= to : in descending order
+   *  from < to  : in ascending order
+   * }</pre>
+   *
+   * @param key         key of a b+tree
+   * @param from        the first bkey
+   * @param to          the last bkey
+   * @param eFlagFilter element flag filter
+   * @param offset      0-based offset
+   * @param count       number of returning values (0 to all)
+   * @return a future that will hold the return value map of the fetch
+   */
+  public CollectionFuture<Map<Long, Element<Object>>> asyncBopGet(String key,
+                                                                  long from, long to,
+                                                                  ElementFlagFilter eFlagFilter,
+                                                                  int offset, int count);
 
   /**
    * Retrieves count number of items in given bkey range(from..to)
@@ -556,6 +590,21 @@ public interface ArcusClientIF {
    * @param key         key of a b+tree
    * @param bkey        bkey
    * @param eFlagFilter element flag filter
+   * @param tc          a transcoder to decode returned values
+   * @return a future that will hold the return value map of the fetch.
+   */
+  public <T> CollectionFuture<Map<Long, Element<T>>> asyncBopGet(String key,
+                                                                 long bkey,
+                                                                 ElementFlagFilter eFlagFilter,
+                                                                 Transcoder<T> tc);
+
+  /**
+   * Retrieves an item on given bkey in the b+tree.
+   *
+   * @param <T>         the expected class of the value
+   * @param key         key of a b+tree
+   * @param bkey        bkey
+   * @param eFlagFilter element flag filter
    * @param withDelete  true to remove the returned item in the b+tree
    * @param dropIfEmpty true to remove the key when all elements are removed.
    *                    false b+ tree will remain empty even if all the elements are removed
@@ -567,6 +616,31 @@ public interface ArcusClientIF {
                                                                  ElementFlagFilter eFlagFilter,
                                                                  boolean withDelete,
                                                                  boolean dropIfEmpty,
+                                                                 Transcoder<T> tc);
+
+  /**
+   * Retrieves count number of items in given bkey range(from..to)
+   * from offset in the b+tree.
+   * The returned map from the future should be sorted by the given range.
+   * <pre>{@code
+   *  from >= to : in descending order
+   *  from < to  : in ascending order
+   * }</pre>
+   *
+   * @param <T>         the expected class of the value
+   * @param key         key of a b+tree
+   * @param from        the first bkey
+   * @param to          the last bkey
+   * @param eFlagFilter element flag filter
+   * @param offset      0-based offset
+   * @param count       number of returning values (0 to all)
+   * @param tc          a transcoder to decode returned values
+   * @return a future that will hold the return value map of the fetch
+   */
+  public <T> CollectionFuture<Map<Long, Element<T>>> asyncBopGet(String key,
+                                                                 long from, long to,
+                                                                 ElementFlagFilter eFlagFilter,
+                                                                 int offset, int count,
                                                                  Transcoder<T> tc);
 
   /**
@@ -1549,57 +1623,6 @@ public interface ArcusClientIF {
                                                       Transcoder<T> tc);
 
   /**
-   * Retrieves count number of items in given bkey range(from..to)
-   * from offset in the b+tree.
-   * The returned map from the future should be sorted by the given range.
-   * <pre>{@code
-   *  from >= to : in descending order
-   *  from < to  : in ascending order
-   * }</pre>
-   *
-   * @param key         key of a b+tree
-   * @param from        the first bkey
-   * @param to          the last bkey
-   * @param eFlagFilter element flag filter
-   * @param offset      0-based offset
-   * @param count       number of returning values (0 to all)
-   * @param withDelete  true to remove the returned item in the b+tree
-   * @param dropIfEmpty false to remove the key when all elements are removed.
-   *                    true b+ tree will remain empty even if all the elements are removed
-   * @return a future that will hold the return value map of the fetch
-   */
-  public CollectionFuture<Map<ByteArrayBKey, Element<Object>>> asyncBopGet(
-          String key, byte[] from, byte[] to, ElementFlagFilter eFlagFilter, int offset,
-          int count, boolean withDelete, boolean dropIfEmpty);
-
-  /**
-   * Retrieves count number of items in given bkey range(from..to)
-   * from offset in the b+tree.
-   * The returned map from the future should be sorted by the given range.
-   * <pre>{@code
-   *  from >= to : in descending order
-   *  from < to  : in ascending order
-   * }</pre>
-   *
-   * @param <T>         the expected class of the value
-   * @param key         key of a b+tree
-   * @param from        the first bkey
-   * @param to          the last bkey
-   * @param eFlagFilter element flag filter
-   * @param offset      0-based offset
-   * @param count       number of returning values (0 to all)
-   * @param withDelete  true to remove the returned item in the b+tree
-   * @param dropIfEmpty false to remove the key when all elements are removed.
-   *                    true b+ tree will remain empty even if all the elements are removed
-   * @param tc          transcoder to decode value
-   * @return a future that will hold the return value map of the fetch
-   */
-  public <T> CollectionFuture<Map<ByteArrayBKey, Element<T>>> asyncBopGet(
-          String key, byte[] from, byte[] to, ElementFlagFilter eFlagFilter, int offset,
-          int count, boolean withDelete, boolean dropIfEmpty,
-          Transcoder<T> tc);
-
-  /**
    * Update or insert an element.
    *
    * Element that matched both key and bkey criteria will updated. If element
@@ -1748,6 +1771,18 @@ public interface ArcusClientIF {
    * @param key         key of a b+tree
    * @param bkey        bkey of an element
    * @param eFlagFilter element flag filter
+   * @return a future that will hold the return value map of the fetch
+   */
+  public CollectionFuture<Map<ByteArrayBKey, Element<Object>>> asyncBopGet(
+          String key, byte[] bkey,
+          ElementFlagFilter eFlagFilter);
+
+  /**
+   * Retrieves count number of items in given bkey in the b+tree.
+   *
+   * @param key         key of a b+tree
+   * @param bkey        bkey of an element
+   * @param eFlagFilter element flag filter
    * @param withDelete  true to remove the returned item in the b+tree
    * @param dropIfEmpty false to remove the key when all elements are removed. true b+
    *                    tree will remain empty even if all the elements are removed
@@ -1756,6 +1791,20 @@ public interface ArcusClientIF {
   public CollectionFuture<Map<ByteArrayBKey, Element<Object>>> asyncBopGet(
           String key, byte[] bkey,
           ElementFlagFilter eFlagFilter, boolean withDelete, boolean dropIfEmpty);
+
+  /**
+   * Retrieves count number of items in given bkey in the b+tree.
+   *
+   * @param <T>         the expected class of the value
+   * @param key         key of a b+tree
+   * @param bkey        bkey of an element
+   * @param eFlagFilter element flag filter
+   * @param tc          transcoder to decode value
+   * @return a future that will hold the return value map of the fetch
+   */
+  public <T> CollectionFuture<Map<ByteArrayBKey, Element<T>>> asyncBopGet(
+          String key, byte[] bkey,
+          ElementFlagFilter eFlagFilter, Transcoder<T> tc);
 
   /**
    * Retrieves count number of items in given bkey in the b+tree.
@@ -1773,6 +1822,101 @@ public interface ArcusClientIF {
   public <T> CollectionFuture<Map<ByteArrayBKey, Element<T>>> asyncBopGet(
           String key, byte[] bkey,
           ElementFlagFilter eFlagFilter, boolean withDelete, boolean dropIfEmpty, Transcoder<T> tc);
+
+  /**
+   * Retrieves count number of items in given bkey range(from..to)
+   * from offset in the b+tree.
+   * The returned map from the future should be sorted by the given range.
+   * <pre>{@code
+   *  from >= to : in descending order
+   *  from < to  : in ascending order
+   * }</pre>
+   *
+   * @param key         key of a b+tree
+   * @param from        the first bkey
+   * @param to          the last bkey
+   * @param eFlagFilter element flag filter
+   * @param offset      0-based offset
+   * @param count       number of returning values (0 to all)
+   * @return a future that will hold the return value map of the fetch
+   */
+  public CollectionFuture<Map<ByteArrayBKey, Element<Object>>> asyncBopGet(
+          String key, byte[] from, byte[] to, ElementFlagFilter eFlagFilter, int offset,
+          int count);
+
+  /**
+   * Retrieves count number of items in given bkey range(from..to)
+   * from offset in the b+tree.
+   * The returned map from the future should be sorted by the given range.
+   * <pre>{@code
+   *  from >= to : in descending order
+   *  from < to  : in ascending order
+   * }</pre>
+   *
+   * @param key         key of a b+tree
+   * @param from        the first bkey
+   * @param to          the last bkey
+   * @param eFlagFilter element flag filter
+   * @param offset      0-based offset
+   * @param count       number of returning values (0 to all)
+   * @param withDelete  true to remove the returned item in the b+tree
+   * @param dropIfEmpty false to remove the key when all elements are removed.
+   *                    true b+ tree will remain empty even if all the elements are removed
+   * @return a future that will hold the return value map of the fetch
+   */
+  public CollectionFuture<Map<ByteArrayBKey, Element<Object>>> asyncBopGet(
+          String key, byte[] from, byte[] to, ElementFlagFilter eFlagFilter, int offset,
+          int count, boolean withDelete, boolean dropIfEmpty);
+
+  /**
+   * Retrieves count number of items in given bkey range(from..to)
+   * from offset in the b+tree.
+   * The returned map from the future should be sorted by the given range.
+   * <pre>{@code
+   *  from >= to : in descending order
+   *  from < to  : in ascending order
+   * }</pre>
+   *
+   * @param <T>         the expected class of the value
+   * @param key         key of a b+tree
+   * @param from        the first bkey
+   * @param to          the last bkey
+   * @param eFlagFilter element flag filter
+   * @param offset      0-based offset
+   * @param count       number of returning values (0 to all)
+   * @param tc          transcoder to decode value
+   * @return a future that will hold the return value map of the fetch
+   */
+  public <T> CollectionFuture<Map<ByteArrayBKey, Element<T>>> asyncBopGet(
+          String key, byte[] from, byte[] to, ElementFlagFilter eFlagFilter, int offset,
+          int count, Transcoder<T> tc);
+
+  /**
+   * Retrieves count number of items in given bkey range(from..to)
+   * from offset in the b+tree.
+   * The returned map from the future should be sorted by the given range.
+   * <pre>{@code
+   *  from >= to : in descending order
+   *  from < to  : in ascending order
+   * }</pre>
+   *
+   * @param <T>         the expected class of the value
+   * @param key         key of a b+tree
+   * @param from        the first bkey
+   * @param to          the last bkey
+   * @param eFlagFilter element flag filter
+   * @param offset      0-based offset
+   * @param count       number of returning values (0 to all)
+   * @param withDelete  true to remove the returned item in the b+tree
+   * @param dropIfEmpty false to remove the key when all elements are removed.
+   *                    true b+ tree will remain empty even if all the elements are removed
+   * @param tc          transcoder to decode value
+   * @return a future that will hold the return value map of the fetch
+   */
+  public <T> CollectionFuture<Map<ByteArrayBKey, Element<T>>> asyncBopGet(
+          String key, byte[] from, byte[] to, ElementFlagFilter eFlagFilter, int offset,
+          int count, boolean withDelete, boolean dropIfEmpty,
+          Transcoder<T> tc);
 
   /**
    * Get elements that matched both filter and bkey range criteria from

--- a/src/main/java/net/spy/memcached/ArcusClientPool.java
+++ b/src/main/java/net/spy/memcached/ArcusClientPool.java
@@ -659,11 +659,27 @@ public class ArcusClientPool implements MemcachedClientIF, ArcusClientIF {
   @Override
   public CollectionFuture<Map<Long, Element<Object>>> asyncBopGet(String key,
                                                                   long bkey,
+                                                                  ElementFlagFilter eFlagFilter) {
+    return this.getClient().asyncBopGet(key, bkey, eFlagFilter);
+  }
+
+  @Override
+  public CollectionFuture<Map<Long, Element<Object>>> asyncBopGet(String key,
+                                                                  long bkey,
                                                                   ElementFlagFilter eFlagFilter,
                                                                   boolean withDelete,
                                                                   boolean dropIfEmpty) {
     return this.getClient().asyncBopGet(key, bkey, eFlagFilter, withDelete,
             dropIfEmpty);
+  }
+
+  @Override
+  public CollectionFuture<Map<Long, Element<Object>>> asyncBopGet(String key,
+                                                                  long from, long to,
+                                                                  ElementFlagFilter eFlagFilter,
+                                                                  int offset, int count) {
+    return this.getClient().asyncBopGet(key, from, to, eFlagFilter, offset,
+            count);
   }
 
   @Override
@@ -678,13 +694,32 @@ public class ArcusClientPool implements MemcachedClientIF, ArcusClientIF {
   }
 
   @Override
-  public <T> CollectionFuture<Map<Long, Element<T>>> asyncBopGet(String key, long bkey,
+  public <T> CollectionFuture<Map<Long, Element<T>>> asyncBopGet(String key,
+                                                                 long bkey,
+                                                                 ElementFlagFilter eFlagFilter,
+                                                                 Transcoder<T> tc) {
+    return this.getClient().asyncBopGet(key, bkey, eFlagFilter, tc);
+  }
+
+  @Override
+  public <T> CollectionFuture<Map<Long, Element<T>>> asyncBopGet(String key,
+                                                                 long bkey,
                                                                  ElementFlagFilter eFlagFilter,
                                                                  boolean withDelete,
                                                                  boolean dropIfEmpty,
                                                                  Transcoder<T> tc) {
     return this.getClient().asyncBopGet(key, bkey, eFlagFilter, withDelete,
             dropIfEmpty, tc);
+  }
+
+  @Override
+  public <T> CollectionFuture<Map<Long, Element<T>>> asyncBopGet(String key,
+                                                                 long from, long to,
+                                                                 ElementFlagFilter eFlagFilter,
+                                                                 int offset, int count,
+                                                                 Transcoder<T> tc) {
+    return this.getClient().asyncBopGet(key, from, to, eFlagFilter, offset,
+            count, tc);
   }
 
   @Override
@@ -1121,23 +1156,6 @@ public class ArcusClientPool implements MemcachedClientIF, ArcusClientIF {
   }
 
   @Override
-  public CollectionFuture<Map<ByteArrayBKey, Element<Object>>> asyncBopGet(
-          String key, byte[] from, byte[] to, ElementFlagFilter eFlagFilter,
-          int offset, int count, boolean withDelete, boolean dropIfEmpty) {
-    return this.getClient().asyncBopGet(key, from, to, eFlagFilter, offset,
-            count, withDelete, dropIfEmpty);
-  }
-
-  @Override
-  public <T> CollectionFuture<Map<ByteArrayBKey, Element<T>>> asyncBopGet(
-          String key, byte[] from, byte[] to, ElementFlagFilter eFlagFilter,
-          int offset, int count, boolean withDelete, boolean dropIfEmpty,
-          Transcoder<T> tc) {
-    return this.getClient().asyncBopGet(key, from, to, eFlagFilter, offset,
-            count, withDelete, dropIfEmpty, tc);
-  }
-
-  @Override
   public CollectionFuture<Boolean> asyncBopDelete(String key, byte[] from,
                                                   byte[] to, ElementFlagFilter eFlagFilter,
                                                   int count,
@@ -1274,10 +1292,38 @@ public class ArcusClientPool implements MemcachedClientIF, ArcusClientIF {
 
   @Override
   public CollectionFuture<Map<ByteArrayBKey, Element<Object>>> asyncBopGet(
+          String key, byte[] bkey, ElementFlagFilter eFlagFilter) {
+    return this.getClient().asyncBopGet(key, bkey, eFlagFilter);
+  }
+
+  @Override
+  public CollectionFuture<Map<ByteArrayBKey, Element<Object>>> asyncBopGet(
           String key, byte[] bkey, ElementFlagFilter eFlagFilter,
           boolean withDelete, boolean dropIfEmpty) {
     return this.getClient().asyncBopGet(key, bkey, eFlagFilter, withDelete,
             dropIfEmpty);
+  }
+
+  @Override
+  public CollectionFuture<Map<ByteArrayBKey, Element<Object>>> asyncBopGet(
+          String key, byte[] from, byte[] to, ElementFlagFilter eFlagFilter,
+          int offset, int count) {
+    return this.getClient().asyncBopGet(key, from, to, eFlagFilter, offset,
+            count);
+  }
+
+  @Override
+  public CollectionFuture<Map<ByteArrayBKey, Element<Object>>> asyncBopGet(
+          String key, byte[] from, byte[] to, ElementFlagFilter eFlagFilter,
+          int offset, int count, boolean withDelete, boolean dropIfEmpty) {
+    return this.getClient().asyncBopGet(key, from, to, eFlagFilter, offset,
+            count, withDelete, dropIfEmpty);
+  }
+
+  @Override
+  public <T> CollectionFuture<Map<ByteArrayBKey, Element<T>>> asyncBopGet(
+          String key, byte[] bkey, ElementFlagFilter eFlagFilter, Transcoder<T> tc) {
+    return this.getClient().asyncBopGet(key, bkey, eFlagFilter, tc);
   }
 
   @Override
@@ -1286,6 +1332,23 @@ public class ArcusClientPool implements MemcachedClientIF, ArcusClientIF {
           boolean withDelete, boolean dropIfEmpty, Transcoder<T> tc) {
     return this.getClient().asyncBopGet(key, bkey, eFlagFilter, withDelete,
             dropIfEmpty, tc);
+  }
+
+  @Override
+  public <T> CollectionFuture<Map<ByteArrayBKey, Element<T>>> asyncBopGet(
+          String key, byte[] from, byte[] to, ElementFlagFilter eFlagFilter,
+          int offset, int count, Transcoder<T> tc) {
+    return this.getClient().asyncBopGet(key, from, to, eFlagFilter, offset,
+            count, tc);
+  }
+
+  @Override
+  public <T> CollectionFuture<Map<ByteArrayBKey, Element<T>>> asyncBopGet(
+          String key, byte[] from, byte[] to, ElementFlagFilter eFlagFilter,
+          int offset, int count, boolean withDelete, boolean dropIfEmpty,
+          Transcoder<T> tc) {
+    return this.getClient().asyncBopGet(key, from, to, eFlagFilter, offset,
+            count, withDelete, dropIfEmpty, tc);
   }
 
   @Override

--- a/src/test/manual/net/spy/memcached/collection/btree/BopOverflowActionTest.java
+++ b/src/test/manual/net/spy/memcached/collection/btree/BopOverflowActionTest.java
@@ -64,7 +64,7 @@ public class BopOverflowActionTest extends BaseIntegrationTest {
 
       Map<Long, Element<Object>> result = mc.asyncBopGet(key, 0,
               maxcount + 1000, ElementFlagFilter.DO_NOT_FILTER, 0,
-              maxcount + 1000, false, false).get(10000,
+              maxcount + 1000).get(10000,
               TimeUnit.MILLISECONDS);
       assertEquals(maxcount, result.size());
       assertTrue(mc.asyncBopDelete(key, 0, 20000,


### PR DESCRIPTION
#439 
- withDelete, dropIfEmpty 인자만 생략한 asyngBopGet() API를 제공합니다.
- byte array형식의 bkey를 사용하는 API들을 일관성 있게 위치 조정하였습니다.