### PR TITLE
INTERNAL: Existing migration logic - redirect.

### DIFF
--- a/src/main/java/net/spy/memcached/AddrUtil.java
+++ b/src/main/java/net/spy/memcached/AddrUtil.java
@@ -52,4 +52,8 @@ public final class AddrUtil {
     assert !addrs.isEmpty() : "No addrs found";
     return addrs;
   }
+
+  public static InetSocketAddress getAddress(String s) {
+    return getAddresses(s).get(0);
+  }
 }

--- a/src/main/java/net/spy/memcached/ArcusKetamaNodeLocator.java
+++ b/src/main/java/net/spy/memcached/ArcusKetamaNodeLocator.java
@@ -111,6 +111,10 @@ public class ArcusKetamaNodeLocator extends SpyObject implements NodeLocator {
     return Collections.unmodifiableCollection(alterNodes);
   }
 
+  public Collection<MemcachedNode> getExistAll() {
+    return Collections.unmodifiableCollection(existNodes);
+  }
+
   public MemcachedNode getAlterNode(SocketAddress sa) {
     /* The alter node to attach must be found */
     for (MemcachedNode node : alterNodes) {
@@ -609,7 +613,7 @@ public class ArcusKetamaNodeLocator extends SpyObject implements NodeLocator {
     getLogger().info("Applied LEAVE range. spoint=" + spoint + ", epoint=" + epoint);
   }
 
-  public void updateMigration(Long spoint, Long epoint) {
+  public boolean updateMigration(Long spoint, Long epoint) {
     if (migrationInProgress && needToMigrateRange(spoint, epoint)) {
       if (migrationType == MigrationType.JOIN) {
         migrateJoinRange(spoint, epoint);
@@ -617,6 +621,7 @@ public class ArcusKetamaNodeLocator extends SpyObject implements NodeLocator {
         migrateLeaveRange(spoint, epoint);
       }
     }
+    return true;
   }
   /* ENABLE_MIGRATION end */
 

--- a/src/main/java/net/spy/memcached/ArcusReplKetamaNodeLocator.java
+++ b/src/main/java/net/spy/memcached/ArcusReplKetamaNodeLocator.java
@@ -133,6 +133,19 @@ public class ArcusReplKetamaNodeLocator extends SpyObject implements NodeLocator
     return Collections.unmodifiableCollection(alterNodes);
   }
 
+  public Collection<MemcachedNode> getExistAll() {
+    return new ArrayList<MemcachedNode>();
+  }
+
+  public Map<String, MemcachedReplicaGroup> getAlterGroups() {
+    return Collections.unmodifiableMap(alterGroups);
+  }
+
+  public Map<String, MemcachedReplicaGroup> getExistGroups() {
+    return Collections.unmodifiableMap(existGroups);
+  }
+  /* ENABLE_MIGRATION end */
+
   public MemcachedNode getAlterNode(SocketAddress sa) {
     /* The alter node to attach should be found */
     for (MemcachedNode node : alterNodes) {
@@ -767,7 +780,7 @@ public class ArcusReplKetamaNodeLocator extends SpyObject implements NodeLocator
     getLogger().info("Applied LEAVE range. spoint=" + spoint + ", epoint=" + epoint);
   }
 
-  public void updateMigration(Long spoint, Long epoint) {
+  public boolean updateMigration(Long spoint, Long epoint) {
     if (migrationInProgress && needToMigrateRange(spoint, epoint)) {
       if (migrationType == MigrationType.JOIN) {
         migrateJoinRange(spoint, epoint);
@@ -775,6 +788,7 @@ public class ArcusReplKetamaNodeLocator extends SpyObject implements NodeLocator
         migrateLeaveRange(spoint, epoint);
       }
     }
+    return true;
   }
   /* ENABLE_MIGRATION end */
 

--- a/src/main/java/net/spy/memcached/ArrayModNodeLocator.java
+++ b/src/main/java/net/spy/memcached/ArrayModNodeLocator.java
@@ -81,6 +81,10 @@ public final class ArrayModNodeLocator implements NodeLocator {
     return new ArrayList<MemcachedNode>();
   }
 
+  public Collection<MemcachedNode> getExistAll() {
+    return new ArrayList<MemcachedNode>();
+  }
+
   public MemcachedNode getAlterNode(SocketAddress sa) {
     return null;
   }
@@ -94,7 +98,7 @@ public final class ArrayModNodeLocator implements NodeLocator {
     throw new UnsupportedOperationException("prepareMigration not supported");
   }
 
-  public void updateMigration(Long spoint, Long epoint) {
+  public boolean updateMigration(Long spoint, Long epoint) {
     throw new UnsupportedOperationException("updateMigration not supported");
   }
   /* ENABLE_MIGRATION end */

--- a/src/main/java/net/spy/memcached/KetamaNodeLocator.java
+++ b/src/main/java/net/spy/memcached/KetamaNodeLocator.java
@@ -157,6 +157,10 @@ public final class KetamaNodeLocator extends SpyObject implements NodeLocator {
     return new ArrayList<MemcachedNode>();
   }
 
+  public Collection<MemcachedNode> getExistAll() {
+    return new ArrayList<MemcachedNode>();
+  }
+
   public MemcachedNode getAlterNode(SocketAddress sa) {
     return null;
   }
@@ -170,7 +174,7 @@ public final class KetamaNodeLocator extends SpyObject implements NodeLocator {
     throw new UnsupportedOperationException("prepareMigration not supported");
   }
 
-  public void updateMigration(Long spoint, Long epoint) {
+  public boolean updateMigration(Long spoint, Long epoint) {
     throw new UnsupportedOperationException("updateMigration not supported");
   }
   /* ENABLE_MIGRATION end */

--- a/src/main/java/net/spy/memcached/NodeLocator.java
+++ b/src/main/java/net/spy/memcached/NodeLocator.java
@@ -65,6 +65,11 @@ public interface NodeLocator {
   Collection<MemcachedNode> getAlterAll();
 
   /**
+   * Get all exist memcached nodes.
+   */
+  Collection<MemcachedNode> getExistAll();
+
+  /**
    * Get an alter memcached node which contains the given socket address.
    */
   MemcachedNode getAlterNode(SocketAddress sa);
@@ -83,6 +88,6 @@ public interface NodeLocator {
   /**
    * Update(or reflect) the migratoin range in ketama hash ring.
    */
-  void updateMigration(Long spoint, Long epoint);
+  boolean updateMigration(Long spoint, Long epoint);
   /* ENABLE_MIGRATION end */
 }

--- a/src/main/java/net/spy/memcached/RedirectHandler.java
+++ b/src/main/java/net/spy/memcached/RedirectHandler.java
@@ -1,0 +1,147 @@
+/*
+ * arcus-java-client : Arcus Java client
+ * Copyright 2022 JaM2in Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.spy.memcached;
+
+import net.spy.memcached.ops.OperationStatus;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public abstract class RedirectHandler {
+
+  private Long spoint;
+  private Long epoint;
+  private OperationStatus operationStatus;
+
+  public abstract void addRedirectKey(String response, String key, Integer keyIndex);
+
+  protected String parseRedirectResponse(String response) {
+    /* response format : NOT_MY_KEY <spoint> <epoint> <owner_name> */
+    String[] tokens = response.split(" ");
+    assert tokens.length >= 3;
+    spoint = Long.valueOf(tokens[1]);
+    epoint = Long.valueOf(tokens[2]);
+    return tokens.length == 3 ? null : tokens[3]; /* no owner in pipe response */
+  }
+
+  public final Long getMigrationBasePoint() {
+    return spoint;
+  }
+
+  public final Long getMigrationEndPoint() {
+    return epoint;
+  }
+
+  public final void setOperationStatus(OperationStatus operationStatus) {
+    this.operationStatus = operationStatus;
+  }
+
+  public final OperationStatus getOperationStatus() {
+    return operationStatus;
+  }
+
+  public static class RedirectHandlerSingleKey extends RedirectHandler {
+
+    private String key;
+    private String owner;
+
+    @Override
+    public void addRedirectKey(String response, String key, Integer keyIndex) {
+      this.key = key;
+      this.owner = parseRedirectResponse(response);
+    }
+
+    public String getOwner() {
+      return owner;
+    }
+
+    public String getKey() {
+      return key;
+    }
+  }
+
+  public static class RedirectHandlerMultiKey extends RedirectHandler {
+
+    private List<String> keys;
+    private List<Integer> keyIndexes;
+    private Map<String, ArrayList<Integer>> keyIndexesByOwner;
+
+    @Override
+    public void addRedirectKey(String response, String key, Integer keyIndex) {
+      String owner = parseRedirectResponse(response);
+      if (owner == null) {
+        if (keys == null) {
+          keys = new ArrayList<String>();
+          keyIndexes = new ArrayList<Integer>();
+        }
+        keys.add(key);
+        keyIndexes.add(keyIndex);
+      } else {
+        if (keyIndexesByOwner == null) {
+          keyIndexesByOwner = new HashMap<String, ArrayList<Integer>>();
+        }
+        ArrayList<Integer> keyIndexes = keyIndexesByOwner.get(owner);
+        if (keyIndexes == null) {
+          keyIndexes = new ArrayList<Integer>();
+          keyIndexesByOwner.put(owner, keyIndexes);
+        }
+        keyIndexes.add(keyIndex);
+      }
+    }
+
+    public Map<MemcachedNode, ArrayList<Integer>> groupRedirectKeysWithOwner(
+            MemcachedConnection conn) {
+      Map<MemcachedNode, ArrayList<Integer>> keyIndexesByNode =
+          new HashMap<MemcachedNode, ArrayList<Integer>>();
+      for (Map.Entry<String, ArrayList<Integer>> entry : keyIndexesByOwner.entrySet()) {
+        MemcachedNode node = conn.getOwnerNodeByName(entry.getKey());
+        if (node == null) {
+          return null;
+        }
+        keyIndexesByNode.put(node, entry.getValue());
+      }
+      return keyIndexesByNode;
+    }
+
+    public Map<MemcachedNode, ArrayList<Integer>> groupRedirectKeysWithoutOwner(
+            MemcachedConnection conn) {
+      Map<MemcachedNode, ArrayList<Integer>> keyIndexesByNode =
+          new HashMap<MemcachedNode, ArrayList<Integer>>();
+      for (int i = 0; i < keys.size(); i++) {
+        MemcachedNode node = conn.findNodeByKey(keys.get(i));
+        if (node == null) {
+          return null;
+        }
+        ArrayList<Integer> keyIndexes = keyIndexesByNode.get(node);
+        if (keyIndexes == null) {
+          keyIndexes = new ArrayList<Integer>();
+          keyIndexesByNode.put(node, keyIndexes);
+        }
+        keyIndexes.add(this.keyIndexes.get(i));
+      }
+      return keyIndexesByNode;
+    }
+
+    public Map<MemcachedNode, ArrayList<Integer>> groupRedirectKeys(
+            MemcachedConnection conn) {
+      return keyIndexesByOwner == null ?
+              groupRedirectKeysWithoutOwner(conn) : groupRedirectKeysWithOwner(conn);
+    }
+  }
+}

--- a/src/main/java/net/spy/memcached/collection/CollectionPipedInsert.java
+++ b/src/main/java/net/spy/memcached/collection/CollectionPipedInsert.java
@@ -40,7 +40,9 @@ public abstract class CollectionPipedInsert<T> extends CollectionObject {
   protected CollectionAttributes attribute;
 
   protected int nextOpIndex = 0;
-
+  /* ENABLE_MIGRATION if */
+  protected int redirectIndex = 0;
+  /* ENABLE_MIGRATION end */
   /**
    * set next index of operation
    * that will be processed after when operation moved by switchover
@@ -52,6 +54,12 @@ public abstract class CollectionPipedInsert<T> extends CollectionObject {
   public int getNextOpIndex() {
     return nextOpIndex;
   }
+
+  /* ENABLE_MIGRATION if */
+  public void setRedirectIndex(int i) {
+    this.redirectIndex = i;
+  }
+  /* ENABLE_MIGRATION end */
 
   public abstract ByteBuffer getAsciiCommand();
 
@@ -104,7 +112,7 @@ public abstract class CollectionPipedInsert<T> extends CollectionObject {
       int eSize = encodedList.size();
       String createOption = attribute != null ?
           CollectionCreate.makeCreateClause(attribute, cd.getFlags()) : "";
-      for (int i = this.nextOpIndex; i < eSize; i++) {
+      for (int i = nextOpIndex > 0 ? nextOpIndex : redirectIndex; i < eSize; i++) {
         byte[] each = encodedList.get(i);
         setArguments(bb, COMMAND, key, index, each.length,
                      createOption, (i < eSize - 1) ? PIPE : "");
@@ -168,7 +176,7 @@ public abstract class CollectionPipedInsert<T> extends CollectionObject {
       int eSize = encodedList.size();
       String createOption = attribute != null ?
           CollectionCreate.makeCreateClause(attribute, cd.getFlags()) : "";
-      for (int i = this.nextOpIndex; i < eSize; i++) {
+      for (int i = nextOpIndex > 0 ? nextOpIndex : redirectIndex; i < eSize; i++) {
         byte[] each = encodedList.get(i);
         setArguments(bb, COMMAND, key, each.length,
                      createOption, (i < eSize - 1) ? PIPE : "");
@@ -234,7 +242,7 @@ public abstract class CollectionPipedInsert<T> extends CollectionObject {
       List<Long> keyList = new ArrayList<Long>(map.keySet());
       String createOption = attribute != null ?
           CollectionCreate.makeCreateClause(attribute, cd.getFlags()) : "";
-      for (i = this.nextOpIndex; i < keySize; i++) {
+      for (i = nextOpIndex > 0 ? nextOpIndex : redirectIndex; i < keySize; i++) {
         Long bkey = keyList.get(i);
         byte[] value = decodedList.get(i);
         setArguments(bb, COMMAND, key, bkey, value.length,
@@ -303,7 +311,7 @@ public abstract class CollectionPipedInsert<T> extends CollectionObject {
       int eSize = elements.size();
       String createOption = attribute != null ?
           CollectionCreate.makeCreateClause(attribute, cd.getFlags()) : "";
-      for (i = this.nextOpIndex; i < eSize; i++) {
+      for (i = nextOpIndex > 0 ? nextOpIndex : redirectIndex; i < eSize; i++) {
         Element<T> element = elements.get(i);
         byte[] value = decodedList.get(i);
         setArguments(bb, COMMAND, key,
@@ -372,7 +380,7 @@ public abstract class CollectionPipedInsert<T> extends CollectionObject {
       List<String> keyList = new ArrayList<String>(map.keySet());
       String createOption = attribute != null ?
           CollectionCreate.makeCreateClause(attribute, cd.getFlags()) : "";
-      for (i = this.nextOpIndex; i < mkeySize; i++) {
+      for (i = nextOpIndex > 0 ? nextOpIndex : redirectIndex; i < mkeySize; i++) {
         String mkey = keyList.get(i);
         byte[] value = encodedList.get(i);
         setArguments(bb, COMMAND, key, mkey, value.length,

--- a/src/main/java/net/spy/memcached/collection/CollectionPipedUpdate.java
+++ b/src/main/java/net/spy/memcached/collection/CollectionPipedUpdate.java
@@ -36,6 +36,9 @@ public abstract class CollectionPipedUpdate<T> extends CollectionObject {
   protected Transcoder<T> tc;
   protected int itemCount;
   protected int nextOpIndex = 0;
+  /* ENABLE_MIGRATION if */
+  protected int redirectIndex = 0;
+  /* ENABLE_MIGRATION end */
 
   /**
    * set next index of operation
@@ -48,6 +51,12 @@ public abstract class CollectionPipedUpdate<T> extends CollectionObject {
   public int getNextOpIndex() {
     return nextOpIndex;
   }
+
+  /* ENABLE_MIGRATION if */
+  public void setRedirectIndex(int i) {
+    this.redirectIndex = i;
+  }
+  /* ENABLE_MIGRATION end */
 
   public abstract ByteBuffer getAsciiCommand();
 
@@ -110,7 +119,8 @@ public abstract class CollectionPipedUpdate<T> extends CollectionObject {
       ByteBuffer bb = ByteBuffer.allocate(capacity);
 
       int eSize = elements.size();
-      for (i = this.nextOpIndex; i < eSize; i++) {
+      int index = nextOpIndex > 0 ? nextOpIndex : redirectIndex;
+      for (i = index; i < eSize; i++) {
         Element<T> element = elements.get(i);
         value = decodedList.get(i);
         eflagUpdate = element.getElementFlagUpdate();
@@ -195,7 +205,8 @@ public abstract class CollectionPipedUpdate<T> extends CollectionObject {
       // create ascii operation string
       int mkeySize = elements.keySet().size();
       List<String> keyList = new ArrayList<String>(elements.keySet());
-      for (i = this.nextOpIndex; i < mkeySize; i++) {
+      int index = nextOpIndex > 0 ? nextOpIndex : redirectIndex;
+      for (i = index; i < mkeySize; i++) {
         String mkey = keyList.get(i);
         value = encodedList.get(i);
         b = new StringBuilder();

--- a/src/main/java/net/spy/memcached/collection/SetPipedExist.java
+++ b/src/main/java/net/spy/memcached/collection/SetPipedExist.java
@@ -38,6 +38,14 @@ public class SetPipedExist<T> extends CollectionObject {
   private final Transcoder<T> tc;
   private int itemCount;
 
+  /* ENABLE_MIGRATION if */
+  protected int redirectIndex = 0;
+
+  public void setRedirectIndex(int i) {
+    this.redirectIndex = i;
+  }
+  /* ENABLE_MIGRATION end */
+
   public List<T> getValues() {
     return this.values;
   }
@@ -76,7 +84,7 @@ public class SetPipedExist<T> extends CollectionObject {
 
     // create ascii operation string
     int eSize = encodedList.size();
-    for (int i = 0; i < eSize; i++) {
+    for (int i = redirectIndex; i < eSize; i++) {
       byte[] each = encodedList.get(i);
 
       setArguments(bb, COMMAND, key, each.length,

--- a/src/main/java/net/spy/memcached/ops/Operation.java
+++ b/src/main/java/net/spy/memcached/ops/Operation.java
@@ -21,6 +21,7 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 
 import net.spy.memcached.MemcachedNode;
+import net.spy.memcached.RedirectHandler;
 
 
 /**
@@ -129,6 +130,10 @@ public interface Operation {
   boolean isPipeOperation();
 
   boolean isIdempotentOperation();
+
+  /* ENABLE_MIGRATION if */
+  RedirectHandler getRedirectHandler();
+  /* ENABLE_MIGRATION end */
 
   APIType getAPIType();
 }

--- a/src/main/java/net/spy/memcached/ops/OperationState.java
+++ b/src/main/java/net/spy/memcached/ops/OperationState.java
@@ -40,6 +40,13 @@ public enum OperationState {
   /**
    * State indicating this operation will be moved by switchover or failover
    */
-  MOVING
+  MOVING,
   /* ENABLE_REPLICATION end */
+
+  /* ENABLE_MIGRATION if */
+  /**
+   * State indicating this operation will be redirected by migration
+   */
+  REDIRECT
+  /* ENABLE_MIGRATION end */
 }

--- a/src/main/java/net/spy/memcached/protocol/BaseOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/BaseOperationImpl.java
@@ -23,6 +23,7 @@ import java.nio.ByteBuffer;
 
 import net.spy.memcached.MemcachedNode;
 import net.spy.memcached.MemcachedReplicaGroup;
+import net.spy.memcached.RedirectHandler;
 import net.spy.memcached.compat.SpyObject;
 import net.spy.memcached.ops.CancelledOperationStatus;
 import net.spy.memcached.ops.OperationException;
@@ -57,6 +58,10 @@ public abstract class BaseOperationImpl extends SpyObject {
   /* ENABLE_REPLICATION if */
   private boolean moved = false;
   /* ENABLE_REPLICATION end */
+
+  /* ENABLE_MIGRATION if */
+  protected RedirectHandler redirectHandler;
+  /* ENABLE_MIGRATION end */
 
   public BaseOperationImpl() {
     super();
@@ -150,6 +155,34 @@ public abstract class BaseOperationImpl extends SpyObject {
     transitionState(OperationState.MOVING);
   }
   /* ENABLE_REPLICATION end */
+
+  /* ENABLE_MIGRATION if */
+  public final RedirectHandler getRedirectHandler() {
+    return redirectHandler;
+  }
+
+  protected final void addRedirectSingleKeyOperation(String response, String key) {
+    if (redirectHandler == null) {
+      redirectHandler = new RedirectHandler.RedirectHandlerSingleKey();
+    }
+    redirectHandler.addRedirectKey(response, key, null);
+  }
+
+  protected final void addRedirectMultiKeyOperation(String response, String key, Integer keyIndex) {
+    if (redirectHandler == null) {
+      redirectHandler = new RedirectHandler.RedirectHandlerMultiKey();
+    }
+    redirectHandler.addRedirectKey(response, key, keyIndex);
+  }
+
+  protected final void setPreviousOperationStatus(OperationStatus operationStatus) {
+    redirectHandler.setOperationStatus(operationStatus);
+  }
+
+  protected final boolean needRedirect() {
+    return redirectHandler != null;
+  }
+  /* ENABLE_MIGRATION end */
 
   public final ByteBuffer getBuffer() {
     return cmd;

--- a/src/main/java/net/spy/memcached/protocol/ascii/BTreeFindPositionOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/BTreeFindPositionOperationImpl.java
@@ -80,6 +80,14 @@ public class BTreeFindPositionOperationImpl extends OperationImpl implements
 
     Integer position = null;
 
+    /* ENABLE_MIGRATION if */
+    if (line.startsWith("NOT_MY_KEY")) {
+      addRedirectSingleKeyOperation(line, key);
+      transitionState(OperationState.REDIRECT);
+      return;
+    }
+    /* ENABLE_MIGRATION end */
+
     if (line.startsWith("POSITION=")) {
       String[] stuff = line.split("=");
       assert stuff.length == 2;

--- a/src/main/java/net/spy/memcached/protocol/ascii/BTreeFindPositionWithGetOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/BTreeFindPositionWithGetOperationImpl.java
@@ -88,6 +88,14 @@ public class BTreeFindPositionWithGetOperationImpl extends OperationImpl impleme
   public void handleLine(String line) {
     getLogger().debug("Got line %s", line);
 
+    /* ENABLE_MIGRATION if */
+    if (line.startsWith("NOT_MY_KEY")) {
+      addRedirectSingleKeyOperation(line, key);
+      transitionState(OperationState.REDIRECT);
+      return;
+    }
+    /* ENABLE_MIGRATION end */
+
     /*
       VALUE <position> <flags> <count> <index>\r\n
       <bkey> [<eflag>] <bytes> <data>\r\n

--- a/src/main/java/net/spy/memcached/protocol/ascii/BTreeGetByPositionOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/BTreeGetByPositionOperationImpl.java
@@ -85,6 +85,14 @@ public class BTreeGetByPositionOperationImpl extends OperationImpl implements
   public void handleLine(String line) {
     getLogger().debug("Got line %s", line);
 
+    /* ENABLE_MIGRATION if */
+    if (line.startsWith("NOT_MY_KEY")) {
+      addRedirectSingleKeyOperation(line, key);
+      transitionState(OperationState.REDIRECT);
+      return;
+    }
+    /* ENABLE_MIGRATION end */
+
     /*
       VALUE <flags> <count>\r\n
       <bkey> [<eflag>] <bytes> <data>\r\n

--- a/src/main/java/net/spy/memcached/protocol/ascii/BTreeInsertAndGetOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/BTreeInsertAndGetOperationImpl.java
@@ -122,7 +122,13 @@ public class BTreeInsertAndGetOperationImpl extends OperationImpl implements
       return;
     }
     /* ENABLE_REPLICATION end */
-
+    /* ENABLE_MIGRATION if */
+    if (line.startsWith("NOT_MY_KEY")) {
+      addRedirectSingleKeyOperation(line, key);
+      transitionState(OperationState.REDIRECT);
+      return;
+    }
+    /* ENABLE_MIGRATION end */
     /*
       VALUE <flags> <count>\r\n
       <bkey> [<eflag>] <bytes> <data>\r\n

--- a/src/main/java/net/spy/memcached/protocol/ascii/BaseGetOpImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/BaseGetOpImpl.java
@@ -19,6 +19,7 @@ package net.spy.memcached.protocol.ascii;
 
 import java.nio.Buffer;
 import java.nio.ByteBuffer;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Iterator;
 
@@ -46,6 +47,9 @@ abstract class BaseGetOpImpl extends OperationImpl {
   private byte[] data = null;
   private int readOffset = 0;
   private byte lookingFor = '\0';
+  /* ENABLE_MIGRATION if */
+  private int keyIndex = 0;
+  /* ENABLE_MIGRATION end */
 
   public BaseGetOpImpl(String c,
                        OperationCallback cb, Collection<String> k) {
@@ -66,6 +70,12 @@ abstract class BaseGetOpImpl extends OperationImpl {
   public final void handleLine(String line) {
     if (line.equals("END")) {
       getLogger().debug("Get complete!");
+      /* ENABLE_MIGRATION if */
+      if (needRedirect()) {
+        transitionState(OperationState.REDIRECT);
+        return;
+      }
+      /* ENABLE_MIGRATION end */
       getCallback().receivedStatus(END);
       transitionState(OperationState.COMPLETE);
       data = null;
@@ -82,6 +92,12 @@ abstract class BaseGetOpImpl extends OperationImpl {
       readOffset = 0;
       getLogger().debug("Set read type to data");
       setReadType(OperationReadType.DATA);
+      /* ENABLE_MIGRATION if */
+      keyIndex++;
+    } else if (line.startsWith("NOT_MY_KEY")) {
+      addRedirectMultiKeyOperation(line, ((ArrayList<String>) keys).get(keyIndex), keyIndex);
+      keyIndex++;
+      /* ENABLE_MIGRATION end */
     } else {
       assert false : "Unknown line type: " + line;
     }
@@ -159,6 +175,12 @@ abstract class BaseGetOpImpl extends OperationImpl {
     ByteBuffer b;
 
     String keysString = generateKeysString();
+    /* ENABLE_MIGRATION if */
+    keyIndex = 0;
+    if (redirectHandler != null) {
+      redirectHandler = null;
+    }
+    /* ENABLE_MIGRATION end */
 
     if (cmd.equals("get") || cmd.equals("gets")) {
       // make command string, for example,

--- a/src/main/java/net/spy/memcached/protocol/ascii/BaseStoreOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/BaseStoreOperationImpl.java
@@ -70,6 +70,13 @@ abstract class BaseStoreOperationImpl extends OperationImpl {
       return;
     }
     /* ENABLE_REPLICATION end */
+    /* ENABLE_MIGRATION if */
+    if (line.startsWith("NOT_MY_KEY")) {
+      addRedirectSingleKeyOperation(line, key);
+      transitionState(OperationState.REDIRECT);
+      return;
+    }
+    /* ENABLE_MIGRATION end */
     getCallback().receivedStatus(matchStatus(line, STORED, NOT_FOUND, EXISTS));
     transitionState(OperationState.COMPLETE);
   }

--- a/src/main/java/net/spy/memcached/protocol/ascii/CASOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/CASOperationImpl.java
@@ -79,6 +79,13 @@ class CASOperationImpl extends OperationImpl implements CASOperation {
       return;
     }
     /* ENABLE_REPLICATION end */
+    /* ENABLE_MIGRATION if */
+    if (line.startsWith("NOT_MY_KEY")) {
+      addRedirectSingleKeyOperation(line, key);
+      transitionState(OperationState.REDIRECT);
+      return;
+    }
+    /* ENABLE_MIGRATION end */
     getCallback().receivedStatus(matchStatus(line, STORED, NOT_FOUND, EXISTS));
     transitionState(OperationState.COMPLETE);
   }

--- a/src/main/java/net/spy/memcached/protocol/ascii/CollectionCountOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/CollectionCountOperationImpl.java
@@ -69,6 +69,13 @@ public class CollectionCountOperationImpl extends OperationImpl implements
   }
 
   public void handleLine(String line) {
+    /* ENABLE_MIGRATION if */
+    if (line.startsWith("NOT_MY_KEY")) {
+      addRedirectSingleKeyOperation(line, key);
+      transitionState(OperationState.REDIRECT);
+      return;
+    }
+    /* ENABLE_MIGRATION end */
     if (line.startsWith("COUNT=")) {
       // COUNT=<count>\r\n
       getLogger().debug("Got line %s", line);

--- a/src/main/java/net/spy/memcached/protocol/ascii/CollectionCreateOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/CollectionCreateOperationImpl.java
@@ -85,6 +85,13 @@ public class CollectionCreateOperationImpl extends OperationImpl
       return;
     }
     /* ENABLE_REPLICATION end */
+    /* ENABLE_MIGRATION if */
+    if (line.startsWith("NOT_MY_KEY")) {
+      addRedirectSingleKeyOperation(line, key);
+      transitionState(OperationState.REDIRECT);
+      return;
+    }
+    /* ENABLE_MIGRATION end */
     getCallback().receivedStatus(matchStatus(line, CREATED, EXISTS, SERVER_ERROR));
     transitionState(OperationState.COMPLETE);
   }

--- a/src/main/java/net/spy/memcached/protocol/ascii/CollectionDeleteOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/CollectionDeleteOperationImpl.java
@@ -91,6 +91,13 @@ public class CollectionDeleteOperationImpl extends OperationImpl
       return;
     }
     /* ENABLE_REPLICATION end */
+    /* ENABLE_MIGRATION if */
+    if (line.startsWith("NOT_MY_KEY")) {
+      addRedirectSingleKeyOperation(line, key);
+      transitionState(OperationState.REDIRECT);
+      return;
+    }
+    /* ENABLE_MIGRATION end */
     OperationStatus status = matchStatus(line, DELETED, DELETED_DROPPED,
             NOT_FOUND, NOT_FOUND_ELEMENT, OUT_OF_RANGE, TYPE_MISMATCH,
             BKEY_MISMATCH);

--- a/src/main/java/net/spy/memcached/protocol/ascii/CollectionExistOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/CollectionExistOperationImpl.java
@@ -76,6 +76,13 @@ public class CollectionExistOperationImpl extends OperationImpl
   public void handleLine(String line) {
     assert getState() == OperationState.READING
             : "Read ``" + line + "'' when in " + getState() + " state";
+    /* ENABLE_MIGRATION if */
+    if (line.startsWith("NOT_MY_KEY")) {
+      addRedirectSingleKeyOperation(line, key);
+      transitionState(OperationState.REDIRECT);
+      return;
+    }
+    /* ENABLE_MIGRATION end */
     getCallback().receivedStatus(
             matchStatus(line, EXIST, NOT_EXIST, NOT_FOUND, NOT_FOUND,
                     TYPE_MISMATCH, UNREADABLE));

--- a/src/main/java/net/spy/memcached/protocol/ascii/CollectionGetOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/CollectionGetOperationImpl.java
@@ -108,7 +108,13 @@ public class CollectionGetOperationImpl extends OperationImpl
       return;
     }
     /* ENABLE_REPLICATION end */
-
+    /* ENABLE_MIGRATION if */
+    if (line.startsWith("NOT_MY_KEY")) {
+      addRedirectSingleKeyOperation(line, key);
+      transitionState(OperationState.REDIRECT);
+      return;
+    }
+    /* ENABLE_MIGRATION end */
     /*
       VALUE <flag> <count>\r\n
       <collection_data>\r\n

--- a/src/main/java/net/spy/memcached/protocol/ascii/CollectionInsertOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/CollectionInsertOperationImpl.java
@@ -105,6 +105,14 @@ public class CollectionInsertOperationImpl extends OperationImpl
       return;
     }
     /* ENABLE_REPLICATION end */
+    /* ENABLE_MIGRATION if */
+    if (line.startsWith("NOT_MY_KEY")) {
+      addRedirectSingleKeyOperation(line, key);
+      transitionState(OperationState.REDIRECT);
+      return;
+    }
+    /* ENABLE_MIGRATION end */
+
     getCallback().receivedStatus(
             matchStatus(line, STORED, REPLACED, CREATED_STORED, NOT_FOUND,
                     ELEMENT_EXISTS, OVERFLOWED, OUT_OF_RANGE,

--- a/src/main/java/net/spy/memcached/protocol/ascii/CollectionMutateOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/CollectionMutateOperationImpl.java
@@ -88,7 +88,13 @@ public class CollectionMutateOperationImpl extends OperationImpl implements
       return;
     }
     /* ENABLE_REPLICATION end */
-
+    /* ENABLE_MIGRATION if */
+    if (line.startsWith("NOT_MY_KEY")) {
+      addRedirectSingleKeyOperation(line, key);
+      transitionState(OperationState.REDIRECT);
+      return;
+    }
+    /* ENABLE_MIGRATION end */
     try {
       // <result value>\r\n
       Long.valueOf(line);

--- a/src/main/java/net/spy/memcached/protocol/ascii/CollectionPipedUpdateOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/CollectionPipedUpdateOperationImpl.java
@@ -98,7 +98,17 @@ public class CollectionPipedUpdateOperationImpl extends OperationImpl implements
       return;
     }
     /* ENABLE_REPLICATION end */
-
+    /* ENABLE_MIGRATION if */
+    if (line.startsWith("NOT_MY_KEY")) {
+      addRedirectSingleKeyOperation(line, key);
+      update.setRedirectIndex(index);
+      if (update.getItemCount() == 1) {
+        update.setNextOpIndex(0);
+        transitionState(OperationState.REDIRECT);
+      }
+      return;
+    }
+    /* ENABLE_MIGRATION end */
     if (update.getItemCount() - update.getNextOpIndex() == 1) {
       OperationStatus status = matchStatus(line, UPDATED, NOT_FOUND,
               NOT_FOUND_ELEMENT, NOTHING_TO_UPDATE, TYPE_MISMATCH,
@@ -121,6 +131,12 @@ public class CollectionPipedUpdateOperationImpl extends OperationImpl implements
       END|PIPE_ERROR <error_string>\r\n
     */
     if (line.startsWith("END") || line.startsWith("PIPE_ERROR ")) {
+      /* ENABLE_MIGRATION if */
+      if (needRedirect()) {
+        transitionState(OperationState.REDIRECT);
+        return;
+      }
+      /* ENABLE_MIGRATION end */
       cb.receivedStatus((successAll) ? END : FAILED_END);
       transitionState(OperationState.COMPLETE);
     } else if (line.startsWith("RESPONSE ")) {
@@ -150,6 +166,11 @@ public class CollectionPipedUpdateOperationImpl extends OperationImpl implements
   public void initialize() {
     ByteBuffer buffer = update.getAsciiCommand();
     setBuffer(buffer);
+    /* ENABLE_MIGRATION if */
+    if (redirectHandler != null) {
+      redirectHandler = null;
+    }
+    /* ENABLE_MIGRATION end */
 
     if (getLogger().isDebugEnabled()) {
       getLogger().debug(

--- a/src/main/java/net/spy/memcached/protocol/ascii/CollectionUpdateOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/CollectionUpdateOperationImpl.java
@@ -95,6 +95,13 @@ public class CollectionUpdateOperationImpl extends OperationImpl implements
       return;
     }
     /* ENABLE_REPLICATION end */
+    /* ENABLE_MIGRATION if */
+    if (line.startsWith("NOT_MY_KEY")) {
+      addRedirectSingleKeyOperation(line, key);
+      transitionState(OperationState.REDIRECT);
+      return;
+    }
+    /* ENABLE_MIGRATION end */
     getCallback().receivedStatus(
             matchStatus(line, UPDATED, NOT_FOUND, NOT_FOUND_ELEMENT,
                     NOTHING_TO_UPDATE, TYPE_MISMATCH, BKEY_MISMATCH,

--- a/src/main/java/net/spy/memcached/protocol/ascii/DeleteOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/DeleteOperationImpl.java
@@ -64,6 +64,13 @@ final class DeleteOperationImpl extends OperationImpl
       return;
     }
     /* ENABLE_REPLICATION end */
+    /* ENABLE_MIGRATION if */
+    if (line.startsWith("NOT_MY_KEY")) {
+      addRedirectSingleKeyOperation(line, key);
+      transitionState(OperationState.REDIRECT);
+      return;
+    }
+    /* ENABLE_MIGRATION end */
     getCallback().receivedStatus(matchStatus(line, DELETED, NOT_FOUND));
     transitionState(OperationState.COMPLETE);
   }

--- a/src/main/java/net/spy/memcached/protocol/ascii/GetAttrOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/GetAttrOperationImpl.java
@@ -62,6 +62,13 @@ class GetAttrOperationImpl extends OperationImpl implements GetAttrOperation {
 
   @Override
   public void handleLine(String line) {
+    /* ENABLE_MIGRATION if */
+    if (line.startsWith("NOT_MY_KEY")) {
+      addRedirectSingleKeyOperation(line, key);
+      transitionState(OperationState.REDIRECT);
+      return;
+    }
+    /* ENABLE_MIGRATION end */
     if (line.startsWith("ATTR ")) {
       getLogger().debug("Got line %s", line);
 

--- a/src/main/java/net/spy/memcached/protocol/ascii/MutatorOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/MutatorOperationImpl.java
@@ -77,6 +77,13 @@ final class MutatorOperationImpl extends OperationImpl
       return;
     }
     /* ENABLE_REPLICATION end */
+    /* ENABLE_MIGRATION if */
+    if (line.startsWith("NOT_MY_KEY")) {
+      addRedirectSingleKeyOperation(line, key);
+      transitionState(OperationState.REDIRECT);
+      return;
+    }
+    /* ENABLE_MIGRATION end */
 
     OperationStatus status = null;
     try {

--- a/src/main/java/net/spy/memcached/protocol/ascii/SetAttrOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/SetAttrOperationImpl.java
@@ -77,6 +77,13 @@ class SetAttrOperationImpl extends OperationImpl
       return;
     }
     /* ENABLE_REPLICATION end */
+    /* ENABLE_MIGRATION if */
+    if (line.startsWith("NOT_MY_KEY")) {
+      addRedirectSingleKeyOperation(line, key);
+      transitionState(OperationState.REDIRECT);
+      return;
+    }
+    /* ENABLE_MIGRATION end */
     getCallback().receivedStatus(
             matchStatus(line, OK, NOT_FOUND, ATTR_ERROR_NOT_FOUND,
                     ATTR_ERROR_BAD_VALUE));


### PR DESCRIPTION
기존 로직의 redirect 입니다. 변경된 clone operations, locator 구현에 맞춰 일부 수정했습니다.

# 논의할 사항
- Locator.updateMigration() 메소드의 반환 타입과 구현
    - 기존 로직은 반환 타입이 boolean으로 되어 있습니다. 다만 항상 true를 반환하게 되어 있습니다. 
    - 호출하는 쪽에서는 Locator.updateMigration() 메소드가 false를 반환하는 경우 hashring update failure로 판단하고 있습니다.
    - Locator.updateMigration() 메소드에서 성공, 실패 여부를 구분하여 반환하도록 수정하는 작업이 필요한지 논의해야 할 것 같습니다.
 - Locator.getExistAll() 메소드의 구현
    - existNodes 필드가 존재하는 ArcusKetamaNodeLocator 클래스의 경우 그냥 반환하면 되지만, ArcusReplNodeLocator의 경우 해당 필드가 존재하지 않습니다.
    - KetamaLocator.getAlterAll() 메소드의 구현을 참고하여 ArcusReplNodeLocator.getExistAll() 메소드를 구현해 놓았습니다.
    - Replication 기능을 사용한다면 ArcusReplNodeLocator.getExistAll() 메소드는 실제로 호출되는 경우는 없습니다.
    - 따라서 빈 내용의 Collection을 반환할 것인지, UnsupportedExpcetion을 발생시킬 것인지 논의해야 할 것 같습니다.