### PR TITLE
INTERNAL: separate usage of subkey and bkey/mkey

### DIFF
--- a/docs/07-btree-API.md
+++ b/docs/07-btree-API.md
@@ -712,8 +712,8 @@ Element의 값은 String 형의 숫자이어야 한다.
 CollectionFuture<Long> asyncBopIncr(String key, long bkey, int by)
 CollectionFuture<Long> asyncBopDecr(String key, long bkey, int by)
 
-CollectionFuture<Long> asyncBopIncr(String key, Byte[] bkey, int by)
-CollectionFuture<Long> asyncBopDecr(String key, Byte[] bkey, int by)
+CollectionFuture<Long> asyncBopIncr(String key, byte[] bkey, int by)
+CollectionFuture<Long> asyncBopDecr(String key, byte[] bkey, int by)
 
 CollectionFuture<Long> asyncBopIncr(String key, long bkey, int by, long initial, byte[] eFlag);
 CollectionFuture<Long> asyncBopDecr(String key, long bkey, int by, long initial, byte[] eFlag);

--- a/src/main/java/net/spy/memcached/ArcusClient.java
+++ b/src/main/java/net/spy/memcached/ArcusClient.java
@@ -673,10 +673,10 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
             latch.countDown();
           }
 
-          public void gotData(String key, int flags, String subkey, byte[] data) {
+          public void gotData(String key, int flags, String bkey, byte[] data) {
             assert key.equals(k) : "Wrong key returned";
-            long longSubkey = Long.parseLong(subkey);
-            map.put(longSubkey, new Element<T>(longSubkey,
+            long longBkey = Long.parseLong(bkey);
+            map.put(longBkey, new Element<T>(longBkey,
                             tc.decode(new CachedData(flags, data, tc.getMaxSize())),
                             collectionGet.getElementFlag()));
           }
@@ -739,9 +739,9 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
             latch.countDown();
           }
 
-          public void gotData(String key, int flags, String subkey, byte[] data) {
+          public void gotData(String key, int flags, String mkey, byte[] data) {
             assert key.equals(k) : "Wrong key returned";
-            map.put(subkey, tc.decode(new CachedData(flags, data, tc.getMaxSize())));
+            map.put(mkey, tc.decode(new CachedData(flags, data, tc.getMaxSize())));
           }
         });
     rv.setOperation(op);
@@ -3105,13 +3105,13 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
             latch.countDown();
           }
 
-          public void gotData(String key, int flags, String subkey, byte[] data) {
+          public void gotData(String key, int flags, String bkey, byte[] data) {
             assert key.equals(k) : "Wrong key returned";
-            byte[] bkey = BTreeUtil.hexStringToByteArrays(subkey);
-            Element<T> element = new Element<T>(bkey,
+            byte[] byteBkey = BTreeUtil.hexStringToByteArrays(bkey);
+            Element<T> element = new Element<T>(byteBkey,
                     tc.decode(new CachedData(flags, data, tc.getMaxSize())),
                     collectionGet.getElementFlag());
-            map.put(new ByteArrayBKey(bkey), element);
+            map.put(new ByteArrayBKey(byteBkey), element);
           }
         });
     rv.setOperation(op);
@@ -4349,9 +4349,9 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
         }
 
         @Override
-        public void gotElement(String key, int flags, Object subkey, byte[] eflag, byte[] data) {
+        public void gotElement(String key, int flags, Object bkey, byte[] eflag, byte[] data) {
           result.get(key).addElement(
-                  new BTreeElement<Long, T>((Long) subkey, eflag,
+                  new BTreeElement<Long, T>((Long) bkey, eflag,
                           tc.decode(new CachedData(flags, data, tc.getMaxSize()))));
         }
       });
@@ -4405,10 +4405,10 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
         }
 
         @Override
-        public void gotElement(String key, int flags, Object subkey, byte[] eflag, byte[] data) {
+        public void gotElement(String key, int flags, Object bkey, byte[] eflag, byte[] data) {
           result.get(key).addElement(
                   new BTreeElement<ByteArrayBKey, T>(
-                          new ByteArrayBKey((byte[]) subkey),
+                          new ByteArrayBKey((byte[]) bkey),
                           eflag, tc.decode(new CachedData(flags, data, tc.getMaxSize()))));
         }
       });

--- a/src/main/java/net/spy/memcached/ArcusClientIF.java
+++ b/src/main/java/net/spy/memcached/ArcusClientIF.java
@@ -1911,92 +1911,92 @@ public interface ArcusClientIF {
    * Increment the element's value in b+tree.
    *
    * @param key    b+tree item's key
-   * @param subkey element's key
+   * @param bkey element's key
    * @param by     increment amount
    * @return future holding the incremented value
    */
-  public CollectionFuture<Long> asyncBopIncr(String key, long subkey, int by);
+  public CollectionFuture<Long> asyncBopIncr(String key, long bkey, int by);
 
   /**
    * Increment the element's value in b+tree.
    *
    * @param key    b+tree item's key
-   * @param subkey element's key (byte-array type key)
+   * @param bkey element's key (byte-array type key)
    * @param by     increment amount
    * @return future holding the incremented value
    */
-  public CollectionFuture<Long> asyncBopIncr(String key, byte[] subkey, int by);
+  public CollectionFuture<Long> asyncBopIncr(String key, byte[] bkey, int by);
 
   /**
    * Increment the element's value in b+tree.
    *
    * @param key     b+tree item's key
-   * @param subkey  element's key (byte-array type key)
+   * @param bkey  element's key (byte-array type key)
    * @param by      increment amount
    * @param initial optional element's initial value
    * @param eFlag   optional element flag
    * @return future holding the incremented value
    */
-  public CollectionFuture<Long> asyncBopIncr(String key, long subkey,
+  public CollectionFuture<Long> asyncBopIncr(String key, long bkey,
                                              int by, long initial, byte[] eFlag);
 
   /**
    * Increment the element's value in b+tree.
    *
    * @param key     b+tree item's key
-   * @param subkey  element's key (byte-array type key)
+   * @param bkey  element's key (byte-array type key)
    * @param by      increment amount
    * @param initial optional element's initial value
    * @param eFlag   optional element flag
    * @return future holding the incremented value
    */
-  public CollectionFuture<Long> asyncBopIncr(String key, byte[] subkey,
+  public CollectionFuture<Long> asyncBopIncr(String key, byte[] bkey,
                                              int by, long initial, byte[] eFlag);
 
   /**
    * Decrement the element's value in b+tree.
    *
    * @param key    b+tree item's key
-   * @param subkey element's key
+   * @param bkey element's key
    * @param by     decrement amount
    * @return future holding the decremented value
    */
-  public CollectionFuture<Long> asyncBopDecr(String key, long subkey, int by);
+  public CollectionFuture<Long> asyncBopDecr(String key, long bkey, int by);
 
   /**
    * Decrement the element's value in b+tree.
    *
    * @param key    b+tree item's key
-   * @param subkey element's key (byte-array type key)
+   * @param bkey element's key (byte-array type key)
    * @param by     decrement amount
    * @return future holding the decremented value
    */
-  public CollectionFuture<Long> asyncBopDecr(String key, byte[] subkey, int by);
+  public CollectionFuture<Long> asyncBopDecr(String key, byte[] bkey, int by);
 
   /**
    * Decrement the element's value in b+tree.
    *
    * @param key     b+tree item's key
-   * @param subkey  element's key (byte-array type key)
+   * @param bkey  element's key (byte-array type key)
    * @param by      decrement amount
    * @param initial optional element's initial value
    * @param eFlag   optional element flag
    * @return future holding the decremented value
    */
-  public CollectionFuture<Long> asyncBopDecr(String key, long subkey,
+  public CollectionFuture<Long> asyncBopDecr(String key, long bkey,
                                              int by, long initial, byte[] eFlag);
 
   /**
    * Decrement the element's value in b+tree.
    *
    * @param key     b+tree item's key
-   * @param subkey  element's key (byte-array type key)
+   * @param bkey  element's key (byte-array type key)
    * @param by      decrement amount
    * @param initial optional element's initial value
    * @param eFlag   optional element flag
    * @return future holding the decremented value
    */
-  public CollectionFuture<Long> asyncBopDecr(String key, byte[] subkey,
+  public CollectionFuture<Long> asyncBopDecr(String key, byte[] bkey,
                                              int by, long initial, byte[] eFlag);
 
   /**


### PR DESCRIPTION
#521 
- CollectionAsync...와 같이 여러 Collection과 관련된 메소드는 `subkey` 용어를 사용합니다.
- AsyncBopIncr, AsyncMopGet과 같이 하나의 Collection과 관련된 메소드는 각 Collection에서 사용되는 키(`bkey`, `mkey`)를 용어로 사용합니다.
- 문서는 수정할 것이 크게 없어 오타 수정만 하였습니다.