### PR TITLE
INTERNAL: Redirect to prepare migration.

### DIFF
--- a/src/main/java/net/spy/memcached/MemcachedConnection.java
+++ b/src/main/java/net/spy/memcached/MemcachedConnection.java
@@ -53,6 +53,7 @@ import net.spy.memcached.compat.SpyObject;
 import net.spy.memcached.compat.log.LoggerFactory;
 import net.spy.memcached.internal.ReconnDelay;
 import net.spy.memcached.ops.KeyedOperation;
+import net.spy.memcached.ops.MultiOperationCallback;
 import net.spy.memcached.ops.Operation;
 import net.spy.memcached.ops.OperationCallback;
 import net.spy.memcached.ops.OperationException;
@@ -968,6 +969,17 @@ public final class MemcachedConnection extends SpyObject {
         break;
       }
       /* ENABLE_REPLICATION end */
+      /* ENABLE_MIGRATION if */
+      if (currentOp != null && currentOp.getState() == OperationState.REDIRECT) {
+        ((Buffer) rbuf).clear();
+        qa.removeCurrentReadOp();
+        if (currentOp == qa.getCurrentWriteOp()) { /* partially written */
+          qa.removeCurrentWriteOp();
+        }
+        redirectOperation(currentOp);
+        break;
+      }
+      /* ENABLE_MIGRATION end */
       ((Buffer) rbuf).clear();
       read = channel.read(rbuf);
     }
@@ -988,6 +1000,100 @@ public final class MemcachedConnection extends SpyObject {
     }
     /* ENABLE_REPLICATION end */
   }
+
+  /* ENABLE_MIGRATION if */
+  /* There is a possibility that NOT_MY_KEY will be received
+   * regardless of migration in the future. (to solve old hashring problem by zookeeper disconnect)
+   */
+  private void redirectOperation(Operation op) {
+    if (getLogger().isDebugEnabled()) {
+      getLogger().debug("Redirect Operation. op=" + op);
+    }
+    /* Get RedirectHandler */
+    RedirectHandler rh = op.getAndClearRedirectHandler();
+    if (rh == null) {
+      /* Probably code bug */
+      op.cancel("Redirect failure. RedirectHandler is not registered.");
+      return;
+    }
+
+    /* Hashring update by migration */
+    locator.updateMigration(rh.getMigrationBasePoint(), rh.getMigrationEndPoint());
+
+    /* Redirect operation */
+    boolean success;
+    if (rh instanceof RedirectHandler.RedirectHandlerSingleKey) {
+      success = redirectSingleKeyOperation((RedirectHandler.RedirectHandlerSingleKey) rh, op);
+    } else {
+      success = redirectMultiKeyOperation((RedirectHandler.RedirectHandlerMultiKey) rh, op);
+    }
+    if (success) {
+      Selector s = selector.wakeup();
+      assert s == selector : "Wakeup returned the wrong selector.";
+    }
+  }
+
+  private boolean redirectSingleKeyOperation(
+      RedirectHandler.RedirectHandlerSingleKey redirectHandler, Operation op) {
+    String owner = redirectHandler.getOwner();
+    MemcachedNode ownerNode;
+    if (owner != null) {
+      ownerNode = findNodeByOwner(owner);
+    } else { /* single key pipe operation */
+      ownerNode = findNodeByKey(redirectHandler.getKey()); /* hashring lookup */
+    }
+    if (ownerNode == null) {
+      op.cancel("Redirect failure. No node.");
+      return false;
+    }
+    if ((!ownerNode.isActive() && !ownerNode.isFirstConnecting())) {
+      op.cancel("Redirect failure. Inactive node.");
+      return false;
+    }
+    ownerNode.addOpToWriteQ(op);
+    addedQueue.offer(ownerNode);
+    return true;
+  }
+
+  private boolean redirectMultiKeyOperation(RedirectHandler.RedirectHandlerMultiKey redirectHandler,
+                                           Operation op) {
+    Map<MemcachedNode, List<String>> ownerToKeys = redirectHandler.groupRedirectKeys(this);
+    if (ownerToKeys == null) {
+      op.cancel("Redirect failure. No ownerToKeys.");
+      return false;
+    }
+
+    MemcachedNode ownerNode;
+    Map<MemcachedNode, Operation> ops = new HashMap<MemcachedNode, Operation>();
+    MultiOperationCallback mcb = opFactory.createMultiOperationCallback(
+        (KeyedOperation) op, ownerToKeys.size());
+    for (Map.Entry<MemcachedNode, List<String>> entry : ownerToKeys.entrySet()) {
+      ownerNode = entry.getKey();
+      if (ownerNode == null) {
+        getLogger().warn("Redirect failure. No node.");
+        continue;
+      }
+      if ((!ownerNode.isActive() && !ownerNode.isFirstConnecting())) {
+        getLogger().warn("Redirect failure. Inactive node: %s",
+            ownerNode.getNodeName());
+        continue;
+      }
+      ops.put(ownerNode,
+          opFactory.cloneMultiOperation(
+              (KeyedOperation) op, ownerNode, entry.getValue(), mcb));
+    }
+    for (Map.Entry<MemcachedNode, Operation> entry : ops.entrySet()) {
+      ownerNode = entry.getKey();
+      ownerNode.addOpToWriteQ(entry.getValue());
+      addedQueue.offer(ownerNode);
+    }
+    return true;
+  }
+
+  public MemcachedNode findNodeByOwner(String owner) {
+    return locator.getOwnerNode(owner, mgType);
+  }
+  /* ENABLE_MIGRATION end */
 
   // Make a debug string out of the given buffer's values
   static String dbgBuffer(ByteBuffer b, int size) {

--- a/src/main/java/net/spy/memcached/RedirectHandler.java
+++ b/src/main/java/net/spy/memcached/RedirectHandler.java
@@ -1,0 +1,135 @@
+/*
+ * arcus-java-client : Arcus Java client
+ * Copyright 2022 JaM2in Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/* ENABLE_MIGRATION if */
+package net.spy.memcached;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public abstract class RedirectHandler {
+
+  private Long spoint;
+  private Long epoint;
+
+  public abstract void addRedirectKey(String response, String key);
+
+  protected String parseRedirectResponse(String response) {
+    /* response format : NOT_MY_KEY <spoint> <epoint> <owner_name> */
+    String[] tokens = response.split(" ");
+    assert tokens.length >= 3;
+    spoint = Long.valueOf(tokens[1]);
+    epoint = Long.valueOf(tokens[2]);
+    return tokens.length == 3 ? null : tokens[3]; /* no owner in pipe response */
+  }
+
+  public final Long getMigrationBasePoint() {
+    return spoint;
+  }
+
+  public final Long getMigrationEndPoint() {
+    return epoint;
+  }
+
+  public static class RedirectHandlerSingleKey extends RedirectHandler {
+
+    private String key;
+    private String owner;
+
+    @Override
+    public void addRedirectKey(String response, String key) {
+      this.key = key;
+      this.owner = parseRedirectResponse(response);
+    }
+
+    public String getOwner() {
+      return owner;
+    }
+
+    public String getKey() {
+      return key;
+    }
+  }
+
+  public static class RedirectHandlerMultiKey extends RedirectHandler {
+
+    private List<String> keysWithoutOwner;
+    private Map<String, List<String>> keysByOwner;
+
+    @Override
+    public void addRedirectKey(String response, String key) {
+      String owner = parseRedirectResponse(response);
+      if (owner == null) {
+        if (keysWithoutOwner == null) {
+          keysWithoutOwner = new ArrayList<String>();
+        }
+        keysWithoutOwner.add(key);
+      } else {
+        if (keysByOwner == null) {
+          keysByOwner = new HashMap<String, List<String>>();
+        }
+        List<String> keys = keysByOwner.get(owner);
+        if (keys == null) {
+          keys = new ArrayList<String>();
+          keysByOwner.put(owner, keys);
+        }
+        keys.add(key);
+      }
+    }
+
+    private Map<MemcachedNode, List<String>> groupRedirectKeysWithOwner(
+            MemcachedConnection conn) {
+      Map<MemcachedNode, List<String>> keysByNode =
+          new HashMap<MemcachedNode, List<String>>();
+      for (Map.Entry<String, List<String>> entry : keysByOwner.entrySet()) {
+        MemcachedNode node = conn.findNodeByOwner(entry.getKey());
+        if (node == null) {
+          return null;
+        }
+        keysByNode.put(node, entry.getValue());
+      }
+      return keysByNode;
+    }
+
+    private Map<MemcachedNode, List<String>> groupRedirectKeysWithoutOwner(
+            MemcachedConnection conn) {
+      Map<MemcachedNode, List<String>> keysByNode =
+          new HashMap<MemcachedNode, List<String>>();
+      for (String key : keysWithoutOwner) {
+        MemcachedNode node = conn.findNodeByKey(key);
+        if (node == null) {
+          return null;
+        }
+        List<String> keys = keysByNode.get(node);
+        if (keys == null) {
+          keys = new ArrayList<String>();
+          keysByNode.put(node, keys);
+        }
+        keys.add(key);
+      }
+      return keysByNode;
+    }
+
+    public Map<MemcachedNode, List<String>> groupRedirectKeys(
+            MemcachedConnection conn) {
+      return keysByOwner == null ?
+              groupRedirectKeysWithoutOwner(conn) : groupRedirectKeysWithOwner(conn);
+    }
+  }
+}
+/* ENABLE_MIGRATION end */

--- a/src/main/java/net/spy/memcached/ops/Operation.java
+++ b/src/main/java/net/spy/memcached/ops/Operation.java
@@ -21,6 +21,7 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 
 import net.spy.memcached.MemcachedNode;
+import net.spy.memcached.RedirectHandler;
 
 
 /**
@@ -129,6 +130,10 @@ public interface Operation {
   boolean isPipeOperation();
 
   boolean isIdempotentOperation();
+
+  /* ENABLE_MIGRATION if */
+  RedirectHandler getAndClearRedirectHandler();
+  /* ENABLE_MIGRATION end */
 
   APIType getAPIType();
 }

--- a/src/main/java/net/spy/memcached/ops/OperationState.java
+++ b/src/main/java/net/spy/memcached/ops/OperationState.java
@@ -40,6 +40,13 @@ public enum OperationState {
   /**
    * State indicating this operation will be moved by switchover or failover
    */
-  MOVING
+  MOVING,
   /* ENABLE_REPLICATION end */
+
+  /* ENABLE_MIGRATION if */
+  /**
+   * State indicating this operation will be redirected by migration
+   */
+  REDIRECT
+  /* ENABLE_MIGRATION end */
 }

--- a/src/main/java/net/spy/memcached/protocol/BaseOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/BaseOperationImpl.java
@@ -23,6 +23,7 @@ import java.nio.ByteBuffer;
 
 import net.spy.memcached.MemcachedNode;
 import net.spy.memcached.MemcachedReplicaGroup;
+import net.spy.memcached.RedirectHandler;
 import net.spy.memcached.compat.SpyObject;
 import net.spy.memcached.ops.CancelledOperationStatus;
 import net.spy.memcached.ops.OperationException;
@@ -57,6 +58,10 @@ public abstract class BaseOperationImpl extends SpyObject {
   /* ENABLE_REPLICATION if */
   private boolean moved = false;
   /* ENABLE_REPLICATION end */
+
+  /* ENABLE_MIGRATION if */
+  private RedirectHandler redirectHandler = null;
+  /* ENABLE_MIGRATION end */
 
   public BaseOperationImpl() {
     super();
@@ -150,6 +155,33 @@ public abstract class BaseOperationImpl extends SpyObject {
     transitionState(OperationState.MOVING);
   }
   /* ENABLE_REPLICATION end */
+
+  /* ENABLE_MIGRATION if */
+  public final RedirectHandler getAndClearRedirectHandler() {
+    RedirectHandler redirectHandler = this.redirectHandler;
+    this.redirectHandler = null;
+
+    return redirectHandler;
+  }
+
+  protected final void addRedirectSingleKeyOperation(String response, String key) {
+    if (redirectHandler == null) {
+      redirectHandler = new RedirectHandler.RedirectHandlerSingleKey();
+    }
+    redirectHandler.addRedirectKey(response, key);
+  }
+
+  protected final void addRedirectMultiKeyOperation(String response, String key) {
+    if (redirectHandler == null) {
+      redirectHandler = new RedirectHandler.RedirectHandlerMultiKey();
+    }
+    redirectHandler.addRedirectKey(response, key);
+  }
+
+  protected final boolean needRedirect() {
+    return redirectHandler != null;
+  }
+  /* ENABLE_MIGRATION end */
 
   public final ByteBuffer getBuffer() {
     return cmd;

--- a/src/main/java/net/spy/memcached/protocol/ascii/BTreeFindPositionOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/BTreeFindPositionOperationImpl.java
@@ -80,6 +80,14 @@ public class BTreeFindPositionOperationImpl extends OperationImpl implements
 
     Integer position = null;
 
+    /* ENABLE_MIGRATION if */
+    if (hasNotMyKey(line)) {
+      addRedirectSingleKeyOperation(line, key);
+      transitionState(OperationState.REDIRECT);
+      return;
+    }
+    /* ENABLE_MIGRATION end */
+
     if (line.startsWith("POSITION=")) {
       String[] stuff = line.split("=");
       assert stuff.length == 2;

--- a/src/main/java/net/spy/memcached/protocol/ascii/BTreeFindPositionWithGetOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/BTreeFindPositionWithGetOperationImpl.java
@@ -88,6 +88,14 @@ public class BTreeFindPositionWithGetOperationImpl extends OperationImpl impleme
   public void handleLine(String line) {
     getLogger().debug("Got line %s", line);
 
+    /* ENABLE_MIGRATION if */
+    if (hasNotMyKey(line)) {
+      addRedirectSingleKeyOperation(line, key);
+      transitionState(OperationState.REDIRECT);
+      return;
+    }
+    /* ENABLE_MIGRATION end */
+
     /*
       VALUE <position> <flags> <count> <index>\r\n
       <bkey> [<eflag>] <bytes> <data>\r\n

--- a/src/main/java/net/spy/memcached/protocol/ascii/BTreeGetBulkOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/BTreeGetBulkOperationImpl.java
@@ -94,6 +94,14 @@ public class BTreeGetBulkOperationImpl extends OperationImpl implements
     */
     if (line.startsWith("VALUE ")) {
       String[] chunk = line.split(" ");
+
+      /* ENABLE_MIGRATION if */
+      if (hasNotMyKey(chunk[2])) {
+        addRedirectMultiKeyOperation(getNotMyKey(line), chunk[1]);
+        return;
+      }
+      /* ENABLE_MIGRATION end */
+
       OperationStatus status = matchStatus(chunk[2], OK, TRIMMED, NOT_FOUND,
           NOT_FOUND_ELEMENT, OUT_OF_RANGE, TYPE_MISMATCH, BKEY_MISMATCH,
           UNREADABLE);
@@ -114,6 +122,12 @@ public class BTreeGetBulkOperationImpl extends OperationImpl implements
       OperationStatus status = matchStatus(line, END);
 
       getLogger().debug(status);
+      /* ENABLE_MIGRATION if */
+      if (needRedirect()) {
+        transitionState(OperationState.REDIRECT);
+        return;
+      }
+      /* ENABLE_MIGRATION end */
       getCallback().receivedStatus(status);
 
       transitionState(OperationState.COMPLETE);

--- a/src/main/java/net/spy/memcached/protocol/ascii/BTreeGetByPositionOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/BTreeGetByPositionOperationImpl.java
@@ -85,6 +85,14 @@ public class BTreeGetByPositionOperationImpl extends OperationImpl implements
   public void handleLine(String line) {
     getLogger().debug("Got line %s", line);
 
+    /* ENABLE_MIGRATION if */
+    if (hasNotMyKey(line)) {
+      addRedirectSingleKeyOperation(line, key);
+      transitionState(OperationState.REDIRECT);
+      return;
+    }
+    /* ENABLE_MIGRATION end */
+
     /*
       VALUE <flags> <count>\r\n
       <bkey> [<eflag>] <bytes> <data>\r\n

--- a/src/main/java/net/spy/memcached/protocol/ascii/BTreeInsertAndGetOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/BTreeInsertAndGetOperationImpl.java
@@ -122,7 +122,13 @@ public class BTreeInsertAndGetOperationImpl extends OperationImpl implements
       return;
     }
     /* ENABLE_REPLICATION end */
-
+    /* ENABLE_MIGRATION if */
+    if (hasNotMyKey(line)) {
+      addRedirectSingleKeyOperation(line, key);
+      transitionState(OperationState.REDIRECT);
+      return;
+    }
+    /* ENABLE_MIGRATION end */
     /*
       VALUE <flags> <count>\r\n
       <bkey> [<eflag>] <bytes> <data>\r\n

--- a/src/main/java/net/spy/memcached/protocol/ascii/BaseStoreOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/BaseStoreOperationImpl.java
@@ -70,6 +70,13 @@ abstract class BaseStoreOperationImpl extends OperationImpl {
       return;
     }
     /* ENABLE_REPLICATION end */
+    /* ENABLE_MIGRATION if */
+    if (hasNotMyKey(line)) {
+      addRedirectSingleKeyOperation(line, key);
+      transitionState(OperationState.REDIRECT);
+      return;
+    }
+    /* ENABLE_MIGRATION end */
     getCallback().receivedStatus(matchStatus(line, STORED, NOT_FOUND, EXISTS));
     transitionState(OperationState.COMPLETE);
   }

--- a/src/main/java/net/spy/memcached/protocol/ascii/CASOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/CASOperationImpl.java
@@ -79,6 +79,13 @@ class CASOperationImpl extends OperationImpl implements CASOperation {
       return;
     }
     /* ENABLE_REPLICATION end */
+    /* ENABLE_MIGRATION if */
+    if (hasNotMyKey(line)) {
+      addRedirectSingleKeyOperation(line, key);
+      transitionState(OperationState.REDIRECT);
+      return;
+    }
+    /* ENABLE_MIGRATION end */
     getCallback().receivedStatus(matchStatus(line, STORED, NOT_FOUND, EXISTS));
     transitionState(OperationState.COMPLETE);
   }

--- a/src/main/java/net/spy/memcached/protocol/ascii/CollectionCountOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/CollectionCountOperationImpl.java
@@ -69,6 +69,13 @@ public class CollectionCountOperationImpl extends OperationImpl implements
   }
 
   public void handleLine(String line) {
+    /* ENABLE_MIGRATION if */
+    if (hasNotMyKey(line)) {
+      addRedirectSingleKeyOperation(line, key);
+      transitionState(OperationState.REDIRECT);
+      return;
+    }
+    /* ENABLE_MIGRATION end */
     if (line.startsWith("COUNT=")) {
       // COUNT=<count>\r\n
       getLogger().debug("Got line %s", line);

--- a/src/main/java/net/spy/memcached/protocol/ascii/CollectionCreateOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/CollectionCreateOperationImpl.java
@@ -85,6 +85,13 @@ public class CollectionCreateOperationImpl extends OperationImpl
       return;
     }
     /* ENABLE_REPLICATION end */
+    /* ENABLE_MIGRATION if */
+    if (hasNotMyKey(line)) {
+      addRedirectSingleKeyOperation(line, key);
+      transitionState(OperationState.REDIRECT);
+      return;
+    }
+    /* ENABLE_MIGRATION end */
     getCallback().receivedStatus(matchStatus(line, CREATED, EXISTS, SERVER_ERROR));
     transitionState(OperationState.COMPLETE);
   }

--- a/src/main/java/net/spy/memcached/protocol/ascii/CollectionDeleteOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/CollectionDeleteOperationImpl.java
@@ -91,6 +91,13 @@ public class CollectionDeleteOperationImpl extends OperationImpl
       return;
     }
     /* ENABLE_REPLICATION end */
+    /* ENABLE_MIGRATION if */
+    if (hasNotMyKey(line)) {
+      addRedirectSingleKeyOperation(line, key);
+      transitionState(OperationState.REDIRECT);
+      return;
+    }
+    /* ENABLE_MIGRATION end */
     OperationStatus status = matchStatus(line, DELETED, DELETED_DROPPED,
             NOT_FOUND, NOT_FOUND_ELEMENT, OUT_OF_RANGE, TYPE_MISMATCH,
             BKEY_MISMATCH);

--- a/src/main/java/net/spy/memcached/protocol/ascii/CollectionExistOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/CollectionExistOperationImpl.java
@@ -76,6 +76,13 @@ public class CollectionExistOperationImpl extends OperationImpl
   public void handleLine(String line) {
     assert getState() == OperationState.READING
             : "Read ``" + line + "'' when in " + getState() + " state";
+    /* ENABLE_MIGRATION if */
+    if (hasNotMyKey(line)) {
+      addRedirectSingleKeyOperation(line, key);
+      transitionState(OperationState.REDIRECT);
+      return;
+    }
+    /* ENABLE_MIGRATION end */
     getCallback().receivedStatus(
             matchStatus(line, EXIST, NOT_EXIST, NOT_FOUND, NOT_FOUND,
                     TYPE_MISMATCH, UNREADABLE));

--- a/src/main/java/net/spy/memcached/protocol/ascii/CollectionGetOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/CollectionGetOperationImpl.java
@@ -108,7 +108,13 @@ public class CollectionGetOperationImpl extends OperationImpl
       return;
     }
     /* ENABLE_REPLICATION end */
-
+    /* ENABLE_MIGRATION if */
+    if (hasNotMyKey(line)) {
+      addRedirectSingleKeyOperation(line, key);
+      transitionState(OperationState.REDIRECT);
+      return;
+    }
+    /* ENABLE_MIGRATION end */
     /*
       VALUE <flag> <count>\r\n
       <collection_data>\r\n

--- a/src/main/java/net/spy/memcached/protocol/ascii/CollectionInsertOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/CollectionInsertOperationImpl.java
@@ -105,6 +105,14 @@ public class CollectionInsertOperationImpl extends OperationImpl
       return;
     }
     /* ENABLE_REPLICATION end */
+    /* ENABLE_MIGRATION if */
+    if (hasNotMyKey(line)) {
+      addRedirectSingleKeyOperation(line, key);
+      transitionState(OperationState.REDIRECT);
+      return;
+    }
+    /* ENABLE_MIGRATION end */
+
     getCallback().receivedStatus(
             matchStatus(line, STORED, REPLACED, CREATED_STORED, NOT_FOUND,
                     ELEMENT_EXISTS, OVERFLOWED, OUT_OF_RANGE,

--- a/src/main/java/net/spy/memcached/protocol/ascii/CollectionMutateOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/CollectionMutateOperationImpl.java
@@ -88,7 +88,13 @@ public class CollectionMutateOperationImpl extends OperationImpl implements
       return;
     }
     /* ENABLE_REPLICATION end */
-
+    /* ENABLE_MIGRATION if */
+    if (hasNotMyKey(line)) {
+      addRedirectSingleKeyOperation(line, key);
+      transitionState(OperationState.REDIRECT);
+      return;
+    }
+    /* ENABLE_MIGRATION end */
     try {
       // <result value>\r\n
       Long.valueOf(line);

--- a/src/main/java/net/spy/memcached/protocol/ascii/CollectionUpdateOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/CollectionUpdateOperationImpl.java
@@ -95,6 +95,13 @@ public class CollectionUpdateOperationImpl extends OperationImpl implements
       return;
     }
     /* ENABLE_REPLICATION end */
+    /* ENABLE_MIGRATION if */
+    if (hasNotMyKey(line)) {
+      addRedirectSingleKeyOperation(line, key);
+      transitionState(OperationState.REDIRECT);
+      return;
+    }
+    /* ENABLE_MIGRATION end */
     getCallback().receivedStatus(
             matchStatus(line, UPDATED, NOT_FOUND, NOT_FOUND_ELEMENT,
                     NOTHING_TO_UPDATE, TYPE_MISMATCH, BKEY_MISMATCH,

--- a/src/main/java/net/spy/memcached/protocol/ascii/DeleteOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/DeleteOperationImpl.java
@@ -64,6 +64,13 @@ final class DeleteOperationImpl extends OperationImpl
       return;
     }
     /* ENABLE_REPLICATION end */
+    /* ENABLE_MIGRATION if */
+    if (hasNotMyKey(line)) {
+      addRedirectSingleKeyOperation(line, key);
+      transitionState(OperationState.REDIRECT);
+      return;
+    }
+    /* ENABLE_MIGRATION end */
     getCallback().receivedStatus(matchStatus(line, DELETED, NOT_FOUND));
     transitionState(OperationState.COMPLETE);
   }

--- a/src/main/java/net/spy/memcached/protocol/ascii/GetAttrOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/GetAttrOperationImpl.java
@@ -62,6 +62,13 @@ class GetAttrOperationImpl extends OperationImpl implements GetAttrOperation {
 
   @Override
   public void handleLine(String line) {
+    /* ENABLE_MIGRATION if */
+    if (hasNotMyKey(line)) {
+      addRedirectSingleKeyOperation(line, key);
+      transitionState(OperationState.REDIRECT);
+      return;
+    }
+    /* ENABLE_MIGRATION end */
     if (line.startsWith("ATTR ")) {
       getLogger().debug("Got line %s", line);
 

--- a/src/main/java/net/spy/memcached/protocol/ascii/MutatorOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/MutatorOperationImpl.java
@@ -77,6 +77,13 @@ final class MutatorOperationImpl extends OperationImpl
       return;
     }
     /* ENABLE_REPLICATION end */
+    /* ENABLE_MIGRATION if */
+    if (hasNotMyKey(line)) {
+      addRedirectSingleKeyOperation(line, key);
+      transitionState(OperationState.REDIRECT);
+      return;
+    }
+    /* ENABLE_MIGRATION end */
 
     OperationStatus status = null;
     try {

--- a/src/main/java/net/spy/memcached/protocol/ascii/OperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/OperationImpl.java
@@ -153,6 +153,11 @@ abstract class OperationImpl extends BaseOperationImpl implements Operation {
         break;
       }
       /* ENABLE_REPLICATION end */
+      /* ENABLE_MIGRATION if */
+      if (getState() == OperationState.REDIRECT) {
+        break;
+      }
+      /* ENABLE_MIGRATION end */
     }
   }
 
@@ -161,4 +166,14 @@ abstract class OperationImpl extends BaseOperationImpl implements Operation {
   protected boolean hasSwitchedOver(String line) {
     return line.startsWith("SWITCHOVER") || line.startsWith("REPL_SLAVE");
   }
+
+  /* ENABLE_MIGRATION if */
+  protected boolean hasNotMyKey(String line) {
+    return line.startsWith("NOT_MY_KEY");
+  }
+
+  protected String getNotMyKey(String line) {
+    return line.substring(line.indexOf("NOT_MY_KEY"));
+  }
+  /* ENABLE_MIGRATION end */
 }

--- a/src/main/java/net/spy/memcached/protocol/ascii/SetAttrOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/SetAttrOperationImpl.java
@@ -77,6 +77,13 @@ class SetAttrOperationImpl extends OperationImpl
       return;
     }
     /* ENABLE_REPLICATION end */
+    /* ENABLE_MIGRATION if */
+    if (hasNotMyKey(line)) {
+      addRedirectSingleKeyOperation(line, key);
+      transitionState(OperationState.REDIRECT);
+      return;
+    }
+    /* ENABLE_MIGRATION end */
     getCallback().receivedStatus(
             matchStatus(line, OK, NOT_FOUND, ATTR_ERROR_NOT_FOUND,
                     ATTR_ERROR_BAD_VALUE));


### PR DESCRIPTION
기존 redirect 로직을 수정한 redirect 로직입니다. 수정 사항은 다음과 같습니다.
1. https://github.com/naver/arcus-java-client/pull/523 의 리뷰 내용을 반영했습니다.
2. NOT_MY_KEY 응답 탐지를 BaseOperationImpl 클래스에 메소드로 만들어 중복된 코드를 줄였습니다.
3. BaseOperationImpl 클래스에 resetRedirect() 메소드를 만들고 호출하고 있는데, 이는 single key operation이 redirect 될 때는 clone 하지 않고 initialize() 메소드를 호출하여 재사용하기 때문에 만든 메소드입니다. BaseOperationImpl.needRedirect() 메소드는 redirectHandler의 null 여부를 통해 redirect를 해야 하는지 아닌지 판별하는데, single key operation이 재사용 될 때 `redirectHandler = null`을 수행하지 않으면 needRedirect() 메소드가 오동작 하게 됩니다. 그래서 resetRedirect() 메소드를 만들어서 사용했습니다.