### PR TITLE
INTERNAL: Change first parameter type of OperationFactory.cloneMultiOperation() from List<Intreger> to List<String>.

### DIFF
--- a/src/main/java/net/spy/memcached/OperationFactory.java
+++ b/src/main/java/net/spy/memcached/OperationFactory.java
@@ -364,7 +364,7 @@ public interface OperationFactory {
   MultiOperationCallback createMultiOperationCallback(KeyedOperation op, int count);
 
   Operation cloneMultiOperation(KeyedOperation op, MemcachedNode node,
-                                List<Integer> keyIndexes, MultiOperationCallback mcb);
+                                List<String> redirectKeys, MultiOperationCallback mcb);
   /**
    * Create operation for collection items.
    *

--- a/src/main/java/net/spy/memcached/ops/BaseOperationFactory.java
+++ b/src/main/java/net/spy/memcached/ops/BaseOperationFactory.java
@@ -131,22 +131,15 @@ public abstract class BaseOperationFactory implements OperationFactory {
 
   @Override
   public Operation cloneMultiOperation(KeyedOperation op, MemcachedNode node,
-                                       List<Integer> keyIndexes, MultiOperationCallback mcb) {
+                                       List<String> redirectKeys, MultiOperationCallback mcb) {
     assert !op.isCancelled() : "Attempted to clone a canceled op";
     assert !op.hasErrored() : "Attempted to clone an errored op";
-
-    List<String> originalKeys = (List<String>) op.getKeys();
-    List<String> redirectKeys = new ArrayList<String>();
-
-    for (Integer idx : keyIndexes) {
-      redirectKeys.add(originalKeys.get(idx));
-    }
 
     if (op instanceof GetOperation) {
       // If MemcachedNode supports this clone feature, it should support mget operation too.
       return mget(redirectKeys, (GetOperation.Callback) mcb);
     } else if (op instanceof GetsOperation) {
-      //If MemcachedNode supports this clone feature, it should support mgets operation too.
+      // If MemcachedNode supports this clone feature, it should support mgets operation too.
       return mgets(redirectKeys, (GetsOperation.Callback) mcb);
     } else if (op instanceof CollectionBulkInsertOperation) {
       final CollectionBulkInsert<?> insert = ((CollectionBulkInsertOperation) op).getInsert();


### PR DESCRIPTION
기존 구현은 key index를 받아 redirect 해야 할 key를 구했습니다.
바뀐 구현은 index를 받지 않고 redirect 해야 할 key를 바로 받습니다.