### PR TITLE
INTERNAL: Prepare SetPipedExist to redirect in migration.

### DIFF
--- a/src/main/java/net/spy/memcached/collection/SetPipedExist.java
+++ b/src/main/java/net/spy/memcached/collection/SetPipedExist.java
@@ -38,6 +38,12 @@ public class SetPipedExist<T> extends CollectionObject {
   private final Transcoder<T> tc;
   private int itemCount;
 
+  protected int nextOpIndex = 0;
+
+  public void setNextOpIndex(int i) {
+    this.nextOpIndex = i;
+  }
+
   public List<T> getValues() {
     return this.values;
   }
@@ -76,7 +82,7 @@ public class SetPipedExist<T> extends CollectionObject {
 
     // create ascii operation string
     int eSize = encodedList.size();
-    for (int i = 0; i < eSize; i++) {
+    for (int i = this.nextOpIndex; i < eSize; i++) {
       byte[] each = encodedList.get(i);
 
       setArguments(bb, COMMAND, key, each.length,


### PR DESCRIPTION
SetPipedExist 연산이 중간에 중단되었을 때 중단된 지점부터 다시 수행할 수 있도록 수정했습니다.