### PR TITLE
INTERNAL: Prepare NodeLocator to redirect in migration.

### DIFF
--- a/src/main/java/net/spy/memcached/AddrUtil.java
+++ b/src/main/java/net/spy/memcached/AddrUtil.java
@@ -52,4 +52,8 @@ public final class AddrUtil {
     assert !addrs.isEmpty() : "No addrs found";
     return addrs;
   }
+
+  public static InetSocketAddress getAddress(String s) {
+    return getAddresses(s).get(0);
+  }
 }

--- a/src/main/java/net/spy/memcached/ArcusKetamaNodeLocator.java
+++ b/src/main/java/net/spy/memcached/ArcusKetamaNodeLocator.java
@@ -18,6 +18,7 @@
 package net.spy.memcached;
 
 import java.io.IOException;
+import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -116,6 +117,24 @@ public class ArcusKetamaNodeLocator extends SpyObject implements NodeLocator {
     for (MemcachedNode node : alterNodes) {
       if (sa.equals(node.getSocketAddress())) {
         return node;
+      }
+    }
+    return null;
+  }
+
+  public MemcachedNode getOwnerNode(String owner, MigrationType mgType) {
+    InetSocketAddress ownerAddress = AddrUtil.getAddress(owner);
+    if (mgType == MigrationType.JOIN) {
+      for (MemcachedNode node : alterNodes) {
+        if (node.getSocketAddress().equals(ownerAddress)) {
+          return node;
+        }
+      }
+    } else { /* MigrationType.LEAVE */
+      for (MemcachedNode node : existNodes) {
+        if (node.getSocketAddress().equals(ownerAddress)) {
+          return node;
+        }
       }
     }
     return null;

--- a/src/main/java/net/spy/memcached/ArcusReplKetamaNodeLocator.java
+++ b/src/main/java/net/spy/memcached/ArcusReplKetamaNodeLocator.java
@@ -143,6 +143,19 @@ public class ArcusReplKetamaNodeLocator extends SpyObject implements NodeLocator
     /* If a slave node has started during migration, it may not exist */ 
     return null;
   }
+
+  public MemcachedNode getOwnerNode(String owner, MigrationType mgType) {
+    MemcachedReplicaGroup group;
+    if (mgType == MigrationType.JOIN) {
+      group = alterGroups.get(owner);
+    } else { /* MigrationType.LEAVE */
+      group = existGroups.get(owner);
+    }
+    if (group != null) {
+      return group.getMasterNode();
+    }
+    return null;
+  }
   /* ENABLE_MIGRATION end */
 
   public Collection<MemcachedNode> getMasterNodes() {

--- a/src/main/java/net/spy/memcached/ArrayModNodeLocator.java
+++ b/src/main/java/net/spy/memcached/ArrayModNodeLocator.java
@@ -85,6 +85,10 @@ public final class ArrayModNodeLocator implements NodeLocator {
     return null;
   }
 
+  public MemcachedNode getOwnerNode(String owner, MigrationType mgType) {
+    return null;
+  }
+
   public void updateAlter(Collection<MemcachedNode> toAttach,
                           Collection<MemcachedNode> toDelete) {
     throw new UnsupportedOperationException("updateAlter not supported");

--- a/src/main/java/net/spy/memcached/KetamaNodeLocator.java
+++ b/src/main/java/net/spy/memcached/KetamaNodeLocator.java
@@ -161,6 +161,10 @@ public final class KetamaNodeLocator extends SpyObject implements NodeLocator {
     return null;
   }
 
+  public MemcachedNode getOwnerNode(String owner, MigrationType mgType) {
+    return null;
+  }
+
   public void updateAlter(Collection<MemcachedNode> toAttach,
                           Collection<MemcachedNode> toDelete) {
     throw new UnsupportedOperationException("updateAlter not supported");

--- a/src/main/java/net/spy/memcached/NodeLocator.java
+++ b/src/main/java/net/spy/memcached/NodeLocator.java
@@ -70,6 +70,13 @@ public interface NodeLocator {
   MemcachedNode getAlterNode(SocketAddress sa);
 
   /**
+   * Get an owner node by owner name.
+   * @return OwnerNode is a importer. Importer by migration type
+   * JOIN : joining node, LEAVE : existing node.
+   */
+  MemcachedNode getOwnerNode(String owner, MigrationType mgType);
+
+  /**
    * Remove the alter nodes which have failed down.
    */
   void updateAlter(Collection<MemcachedNode> toAttach,


### PR DESCRIPTION
NodeLocator에 NOT_MY_KEY 응답의 owner MemcachedNode를 찾는 기능을 추가했습니다.