### PR TITLE
CLEANUP: Simplified code in CollectionBulkInsertOperation.handleLine() when operation is not piped.

### DIFF
--- a/src/main/java/net/spy/memcached/protocol/ascii/CollectionBulkInsertOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/CollectionBulkInsertOperationImpl.java
@@ -100,12 +100,11 @@ public class CollectionBulkInsertOperationImpl extends OperationImpl
       OperationStatus status = matchStatus(line, STORED, CREATED_STORED,
               NOT_FOUND, ELEMENT_EXISTS, OVERFLOWED, OUT_OF_RANGE,
               TYPE_MISMATCH, BKEY_MISMATCH);
-      if (status.isSuccess()) {
-        cb.receivedStatus((successAll) ? END : FAILED_END);
-      } else {
+      if (!status.isSuccess()) {
         cb.gotStatus(insert.getKey(index), status);
-        cb.receivedStatus(FAILED_END);
+        successAll = false;
       }
+      cb.receivedStatus((successAll) ? END : FAILED_END);
       transitionState(OperationState.COMPLETE);
       return;
     }


### PR DESCRIPTION
```java
      if (status.isSuccess()) {
        cb.receivedStatus((successAll) ? END : FAILED_END);
      } else {
        cb.gotStatus(insert.getKey(index), status);
        cb.receivedStatus(FAILED_END);
      }
```

if문과 else문 모두 callback.receivedStatus() 메소드를 호출하는데, 아래와 같이 if문에 무관하게 메소드를 1회 호출하도록 변경했습니다.

```java
      if (!status.isSuccess()) {
        cb.gotStatus(insert.getKey(index), status);
        successAll = false;
      }
      cb.receivedStatus((successAll) ? END : FAILED_END);
```