### PR TITLE
INTERNAL: Inherit CollectionPipe class to SetPipedExist class to call same semantic method isNotPiped().

### DIFF
--- a/src/main/java/net/spy/memcached/collection/SetPipedExist.java
+++ b/src/main/java/net/spy/memcached/collection/SetPipedExist.java
@@ -26,37 +26,25 @@ import net.spy.memcached.CachedData;
 import net.spy.memcached.KeyUtil;
 import net.spy.memcached.transcoders.Transcoder;
 
-public class SetPipedExist<T> extends CollectionObject {
+public class SetPipedExist<T> extends CollectionPipe {
 
   public static final int MAX_PIPED_ITEM_COUNT = 500;
 
   private static final String COMMAND = "sop exist";
-  private static final String PIPE = "pipe";
 
   private final String key;
   private final List<T> values;
   private final Transcoder<T> tc;
-  private int itemCount;
-
-  protected int nextOpIndex = 0;
-
-  public void setNextOpIndex(int i) {
-    this.nextOpIndex = i;
-  }
 
   public List<T> getValues() {
     return this.values;
   }
 
-  public int getItemCount() {
-    return this.itemCount;
-  }
-
   public SetPipedExist(String key, List<T> values, Transcoder<T> tc) {
+    super(values.size());
     this.key = key;
     this.values = values;
     this.tc = tc;
-    this.itemCount = values.size();
   }
 
   public ByteBuffer getAsciiCommand() {
@@ -94,9 +82,5 @@ public class SetPipedExist<T> extends CollectionObject {
     ((Buffer) bb).flip();
 
     return bb;
-  }
-
-  public ByteBuffer getBinaryCommand() {
-    throw new RuntimeException("not supported in binary protocol yet.");
   }
 }

--- a/src/main/java/net/spy/memcached/protocol/ascii/CollectionPipedExistOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/CollectionPipedExistOperationImpl.java
@@ -79,7 +79,7 @@ public class CollectionPipedExistOperationImpl extends OperationImpl implements
     assert getState() == OperationState.READING : "Read ``" + line
             + "'' when in " + getState() + " state";
 
-    if (setPipedExist.getItemCount() == 1) {
+    if (setPipedExist.isNotPiped()) {
       OperationStatus status = matchStatus(line, EXIST, NOT_EXIST,
               NOT_FOUND, TYPE_MISMATCH, UNREADABLE);
       cb.gotStatus(index, status);


### PR DESCRIPTION
SetPipedExist 연산의 handleLine() 메소드에서 itemCount가 1인지 아닌지 비교하는 if문이 있는데, isNotPiped를 의미합니다.
isNotPiped() 메소드를 호출하기 위해 SetPipedExist 클래스에서 CollectionPipe 클래스를 상속하도록 수정했습니다.