### PR TITLE
TEST: Set logger to Log4jLogger when running test.

### DIFF
--- a/src/test/java/net/spy/memcached/ClientBaseCase.java
+++ b/src/test/java/net/spy/memcached/ClientBaseCase.java
@@ -59,6 +59,8 @@ public abstract class ClientBaseCase extends TestCase {
   protected static boolean SHUTDOWN_AFTER_EACH_TEST = USE_ZK;
 
   static {
+    LoggerSetter.setLog4JLogger();
+
     System.out.println("---------------------------------------------");
     System.out.println("[ArcusClient initialization info.]");
     System.out.println("USE_ZK=" + USE_ZK);

--- a/src/test/manual/net/spy/memcached/LoggerSetter.java
+++ b/src/test/manual/net/spy/memcached/LoggerSetter.java
@@ -1,0 +1,32 @@
+package net.spy.memcached;
+
+import net.spy.memcached.compat.log.DefaultLogger;
+import net.spy.memcached.compat.log.Log4JLogger;
+import net.spy.memcached.compat.log.Logger;
+import net.spy.memcached.compat.log.SLF4JLogger;
+import net.spy.memcached.compat.log.SunLogger;
+
+public class LoggerSetter {
+  private LoggerSetter() {}
+
+  public static <T extends Logger> void setLogger(Class<T> logger) {
+    System.setProperty("net.spy.log.LoggerImpl", logger.getName());
+  }
+
+  public static void setDefaultLogger() {
+    setLogger(DefaultLogger.class);
+  }
+
+  public static void setLog4JLogger() {
+    setLogger(Log4JLogger.class);
+  }
+
+  public static void setSLF4JLogger() {
+    setLogger(SLF4JLogger.class);
+  }
+
+  public static void setSunLogger() {
+    setLogger(SunLogger.class);
+  }
+
+}

--- a/src/test/manual/net/spy/memcached/collection/BaseIntegrationTest.java
+++ b/src/test/manual/net/spy/memcached/collection/BaseIntegrationTest.java
@@ -27,6 +27,7 @@ import net.spy.memcached.ArcusClient;
 import net.spy.memcached.ConnectionFactoryBuilder;
 import net.spy.memcached.ConnectionObserver;
 
+import net.spy.memcached.LoggerSetter;
 import org.junit.Ignore;
 
 @Ignore
@@ -49,6 +50,8 @@ public class BaseIntegrationTest extends TestCase {
   protected ArcusClient mc = null;
 
   static {
+    LoggerSetter.setLog4JLogger();
+
     System.out.println("---------------------------------------------");
     System.out.println("[ArcusClient initialization info.]");
     System.out.println("\tUSE_ZK = " + USE_ZK);
@@ -67,8 +70,6 @@ public class BaseIntegrationTest extends TestCase {
   @Override
   protected void setUp() throws Exception {
     try {
-      System.setProperty("net.spy.log.LoggerImpl",
-              "net.spy.memcached.compat.log.Log4JLogger");
       System.setProperty("arcus.mbean", "true");
       if (USE_ZK) {
         openFromZK();


### PR DESCRIPTION
현재 구현으로 Logger 객체는 한 번 만들어진 이후에는 교체가 되지 않습니다. 테스트 코드를 수행할 때 original memcached 테스트 코드가 먼저 수행되는데, 이 때 Logger 설정이 존재하지 않아 DefaultLogger를 사용합니다. 이렇게 되면 arcus memcached 테스트 코드를 수행할 때도 DefaultLogger를 사용하게 됩니다. 
이러한 Logger 설정을 original memcached 테스트 코드와 arcus memcached 테스트 코드 모두 같은 Logger를 사용할 수 있도록 변경했습니다. 현 PR은 arcus memcached 테스트 코드에서 설정한 Log4JLogger를 사용하도록 해뒀으며 쉽게 다른 Logger로 교체(이미 만들어진 Logger의 교체가 아닌 최초에 만들 Logger 타입 교체)할 수 있도록 구현했습니다.