### PR TITLE
INTERNAL: Move Buffer.clear() method call.

### DIFF
--- a/src/main/java/net/spy/memcached/MemcachedConnection.java
+++ b/src/main/java/net/spy/memcached/MemcachedConnection.java
@@ -960,15 +960,14 @@ public final class MemcachedConnection extends SpyObject {
         /* ENABLE_REPLICATION end */
         }
       }
+      ((Buffer) rbuf).clear();
       /* ENABLE_REPLICATION if */
       if (currentOp != null && currentOp.getState() == OperationState.MOVING) {
-        ((Buffer) rbuf).clear();
         delayedSwitchoverGroups.remove(qa.getReplicaGroup());
         switchoverMemcachedReplGroup(qa, false);
         break;
       }
       /* ENABLE_REPLICATION end */
-      ((Buffer) rbuf).clear();
       read = channel.read(rbuf);
     }
     if (read < 0) {


### PR DESCRIPTION
`((Buffer) rbuf).clear();` 메소드 호출을 공통 로직으로 옮겼습니다.