### PR TITLE
TEST: Set log level to DEBUG temporarily to dig CI failure issue.

### DIFF
--- a/src/test/manual/net/spy/memcached/collection/btree/BopOverflowActionTest.java
+++ b/src/test/manual/net/spy/memcached/collection/btree/BopOverflowActionTest.java
@@ -30,6 +30,8 @@ import net.spy.memcached.collection.CollectionOverflowAction;
 import net.spy.memcached.collection.Element;
 import net.spy.memcached.collection.ElementFlagFilter;
 import net.spy.memcached.collection.ElementValueType;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.core.config.Configurator;
 
 public class BopOverflowActionTest extends BaseIntegrationTest {
 
@@ -157,8 +159,15 @@ public class BopOverflowActionTest extends BaseIntegrationTest {
 
     // Insert more than maxcount
     for (int i = 1; i <= maxcount + 10; i++) {
+      /*
+       * Set log level to DEBUG temporarily to dig issue below.
+       * https://github.com/naver/arcus-java-client/issues/534
+       * Remove Configurator.setRootLevel() and this comment when issue have resolved.
+       */
+      Configurator.setRootLevel(Level.TRACE);
       assertTrue(mc.asyncBopInsert(key, i, null, "item" + i, null).get(
               1000, TimeUnit.MILLISECONDS));
+      Configurator.setRootLevel(Level.INFO);
     }
 
     Map<Long, Element<Object>> result = mc.asyncBopGet(key, 0,


### PR DESCRIPTION
https://github.com/naver/arcus-java-client/issues/534

위 이슈를 해결하기 위해 Test가 실패하는 부분에 일시적으로 로그 레벨을 DEBUG로 두었다가 Test가 실패하는 부분을 벗어나면 다시 INFO로 되돌립니다.