### PR TITLE
FIX: Remove compile warnings.

### DIFF
--- a/docs/arcus-java-client-getting-started.md
+++ b/docs/arcus-java-client-getting-started.md
@@ -109,7 +109,7 @@ $ mvn eclipse:eclipse // 이클립스 IDE를 사용하는 경우 실행하여 �
 // HelloArcusTest.java
 package com.navercorp.arcus;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 
 import org.junit.Before;
 import org.junit.Test;

--- a/pom.xml
+++ b/pom.xml
@@ -129,6 +129,14 @@
                     <debug>true</debug>
                     <optimize>true</optimize>
                     <encoding>utf-8</encoding>
+                    <showDeprecation>true</showDeprecation>
+                    <showWarnings>true</showWarnings>
+                    <compilerArgs>
+                        <arg>-Xlint:all</arg>
+                        <arg>-Xlint:-options</arg> <!-- For warning about old java version 6. -->
+                        <arg>-Xlint:-processing</arg> <!-- For meaningless warning about annotations -->
+                        <arg>-Werror</arg>
+                    </compilerArgs>
                 </configuration>
             </plugin>
             <plugin>

--- a/src/main/java/net/spy/memcached/ArcusClient.java
+++ b/src/main/java/net/spy/memcached/ArcusClient.java
@@ -1854,7 +1854,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
               cstatus = new CollectionOperationStatus(status);
             }
             if (cstatus.isSuccess()) {
-              rv.set(new Integer(cstatus.getMessage()),
+              rv.set(Integer.valueOf(cstatus.getMessage()),
                       new CollectionOperationStatus(new OperationStatus(true, "END")));
               return;
             }
@@ -4564,7 +4564,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
           public void receivedStatus(OperationStatus status) {
             if (status.isSuccess()) {
               try {
-                rv.set(new Long(status.getMessage()),
+                rv.set(Long.valueOf(status.getMessage()),
                         new CollectionOperationStatus(new OperationStatus(true, "END")));
               } catch (NumberFormatException e) {
                 rv.set(null, new CollectionOperationStatus(

--- a/src/main/java/net/spy/memcached/BulkService.java
+++ b/src/main/java/net/spy/memcached/BulkService.java
@@ -124,7 +124,7 @@ class BulkService extends SpyObject {
 
     protected final int keyCount;
 
-    public BulkWorker(Collection keys, long timeout, ArcusClient[] clientList) {
+    public BulkWorker(Collection<?> keys, long timeout, ArcusClient[] clientList) {
       this.future = new ArrayList<Future<Boolean>>(keys.size());
       this.operationTimeout = timeout;
       this.clientList = clientList;

--- a/src/main/java/net/spy/memcached/transcoders/CollectionTranscoder.java
+++ b/src/main/java/net/spy/memcached/transcoders/CollectionTranscoder.java
@@ -83,25 +83,25 @@ public class CollectionTranscoder extends SerializingTranscoder implements
     } else if (flags != 0 && data != null) {
       switch (flags) {
         case SPECIAL_BOOLEAN:
-          rv = Boolean.valueOf(tu.decodeBoolean(data));
+          rv = tu.decodeBoolean(data);
           break;
         case SPECIAL_INT:
-          rv = new Integer(tu.decodeInt(data));
+          rv = tu.decodeInt(data);
           break;
         case SPECIAL_LONG:
-          rv = new Long(tu.decodeLong(data));
+          rv = tu.decodeLong(data);
           break;
         case SPECIAL_DATE:
           rv = new Date(tu.decodeLong(data));
           break;
         case SPECIAL_BYTE:
-          rv = new Byte(tu.decodeByte(data));
+          rv = tu.decodeByte(data);
           break;
         case SPECIAL_FLOAT:
-          rv = new Float(Float.intBitsToFloat(tu.decodeInt(data)));
+          rv = Float.intBitsToFloat(tu.decodeInt(data));
           break;
         case SPECIAL_DOUBLE:
-          rv = new Double(Double.longBitsToDouble(tu.decodeLong(data)));
+          rv = Double.longBitsToDouble(tu.decodeLong(data));
           break;
         case SPECIAL_BYTEARRAY:
           rv = data;

--- a/src/main/java/net/spy/memcached/transcoders/SerializingTranscoder.java
+++ b/src/main/java/net/spy/memcached/transcoders/SerializingTranscoder.java
@@ -80,25 +80,25 @@ public class SerializingTranscoder extends BaseSerializingTranscoder
     } else if (flags != 0 && data != null) {
       switch (flags) {
         case SPECIAL_BOOLEAN:
-          rv = Boolean.valueOf(tu.decodeBoolean(data));
+          rv = tu.decodeBoolean(data);
           break;
         case SPECIAL_INT:
-          rv = new Integer(tu.decodeInt(data));
+          rv = tu.decodeInt(data);
           break;
         case SPECIAL_LONG:
-          rv = new Long(tu.decodeLong(data));
+          rv = tu.decodeLong(data);
           break;
         case SPECIAL_DATE:
           rv = new Date(tu.decodeLong(data));
           break;
         case SPECIAL_BYTE:
-          rv = new Byte(tu.decodeByte(data));
+          rv = tu.decodeByte(data);
           break;
         case SPECIAL_FLOAT:
-          rv = new Float(Float.intBitsToFloat(tu.decodeInt(data)));
+          rv = Float.intBitsToFloat(tu.decodeInt(data));
           break;
         case SPECIAL_DOUBLE:
-          rv = new Double(Double.longBitsToDouble(tu.decodeLong(data)));
+          rv = Double.longBitsToDouble(tu.decodeLong(data));
           break;
         case SPECIAL_BYTEARRAY:
           rv = data;

--- a/src/main/java/net/spy/memcached/transcoders/WhalinTranscoder.java
+++ b/src/main/java/net/spy/memcached/transcoders/WhalinTranscoder.java
@@ -60,28 +60,28 @@ public class WhalinTranscoder extends BaseSerializingTranscoder
       int f = d.getFlags() & ~COMPRESSED;
       switch (f) {
         case SPECIAL_BOOLEAN:
-          rv = Boolean.valueOf(this.decodeBoolean(data));
+          rv = this.decodeBoolean(data);
           break;
         case SPECIAL_INT:
-          rv = new Integer(tu.decodeInt(data));
+          rv = tu.decodeInt(data);
           break;
         case SPECIAL_SHORT:
-          rv = new Short((short) tu.decodeInt(data));
+          rv = (short) tu.decodeInt(data);
           break;
         case SPECIAL_LONG:
-          rv = new Long(tu.decodeLong(data));
+          rv = tu.decodeLong(data);
           break;
         case SPECIAL_DATE:
           rv = new Date(tu.decodeLong(data));
           break;
         case SPECIAL_BYTE:
-          rv = new Byte(tu.decodeByte(data));
+          rv = tu.decodeByte(data);
           break;
         case SPECIAL_FLOAT:
-          rv = new Float(Float.intBitsToFloat(tu.decodeInt(data)));
+          rv = Float.intBitsToFloat(tu.decodeInt(data));
           break;
         case SPECIAL_DOUBLE:
-          rv = new Double(Double.longBitsToDouble(tu.decodeLong(data)));
+          rv = Double.longBitsToDouble(tu.decodeLong(data));
           break;
         case SPECIAL_BYTEARRAY:
           rv = data;

--- a/src/test/java/net/spy/memcached/ArcusTimeoutMessageTest.java
+++ b/src/test/java/net/spy/memcached/ArcusTimeoutMessageTest.java
@@ -39,8 +39,8 @@ import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.internal.runners.JUnit4ClassRunner;
 import org.junit.runner.RunWith;
+import org.junit.runners.BlockJUnit4ClassRunner;
 
 import java.io.IOException;
 import java.net.InetSocketAddress;
@@ -56,7 +56,7 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
-@RunWith(JUnit4ClassRunner.class)
+@RunWith(BlockJUnit4ClassRunner.class)
 public class ArcusTimeoutMessageTest extends TestCase {
   private ArcusClient mc = null;
 
@@ -163,7 +163,6 @@ public class ArcusTimeoutMessageTest extends TestCase {
   @Test
   public void storeWithoutBulkMessage() {
     String key = "KEY";
-    int keySize = 100;
     String value = "value";
 
     OperationFuture<Boolean> f
@@ -185,7 +184,6 @@ public class ArcusTimeoutMessageTest extends TestCase {
   public void setBulkWithBulkMessage() {
     String key = "KEY";
     int keySize = 100;
-    String value = "value";
 
     Map<String, Object> map = new HashMap<String, Object>();
 
@@ -193,6 +191,7 @@ public class ArcusTimeoutMessageTest extends TestCase {
       map.put(key + i, i);
     }
 
+    @SuppressWarnings("deprecation")
     Future<Map<String, CollectionOperationStatus>> f = mc.asyncSetBulk(map, 30);
 
     try {
@@ -211,7 +210,6 @@ public class ArcusTimeoutMessageTest extends TestCase {
   public void setBulkWithoutBulkMessage() {
     String key = "KEY";
     int keySize = 1;
-    String value = "value";
 
     Map<String, Object> map = new HashMap<String, Object>();
 
@@ -219,6 +217,7 @@ public class ArcusTimeoutMessageTest extends TestCase {
       map.put(key + i, i);
     }
 
+    @SuppressWarnings("deprecation")
     Future<Map<String, CollectionOperationStatus>> f = mc.asyncSetBulk(map, 30);
 
     try {
@@ -359,9 +358,7 @@ public class ArcusTimeoutMessageTest extends TestCase {
     String key = "key";
     int valueCount = 500;
     Object[] valueList = new Object[valueCount];
-    for (int i = 0; i < valueList.length; i++) {
-      valueList[i] = "MyValue";
-    }
+    Arrays.fill(valueList, "MyValue");
 
     // SET
     Future<Map<Integer, CollectionOperationStatus>> f = mc.asyncLopPipedInsertBulk(

--- a/src/test/java/net/spy/memcached/ArcusTimeoutTest.java
+++ b/src/test/java/net/spy/memcached/ArcusTimeoutTest.java
@@ -30,7 +30,7 @@ import net.spy.memcached.ops.OperationStatus;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.internal.runners.JUnit4ClassRunner;
+import org.junit.runners.BlockJUnit4ClassRunner;
 import org.junit.runner.RunWith;
 
 import java.io.IOException;
@@ -44,7 +44,7 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
-@RunWith(JUnit4ClassRunner.class)
+@RunWith(BlockJUnit4ClassRunner.class)
 public class ArcusTimeoutTest extends TestCase {
   private ArcusClient mc = null;
 
@@ -100,9 +100,9 @@ public class ArcusTimeoutTest extends TestCase {
       keys[i] = "MyKey" + i;
     }
 
-    String value = "MyValue";
+    @SuppressWarnings("deprecation")
     Future<Map<String, CollectionOperationStatus>> future = mc.asyncSetBulk(
-            Arrays.asList(keys), 60, value);
+            Arrays.asList(keys), 60, "MyValue");
     future.get(1L, TimeUnit.MILLISECONDS);
   }
 
@@ -116,10 +116,9 @@ public class ArcusTimeoutTest extends TestCase {
       keys[i] = "MyKey" + i;
     }
 
-    String value = "MyValue";
-
+    @SuppressWarnings("deprecation")
     Future<Map<String, CollectionOperationStatus>> future = mc.asyncSetBulk(
-            Arrays.asList(keys), 60, value);
+            Arrays.asList(keys), 60, "MyValue");
     future.get(1L, TimeUnit.MILLISECONDS);
   }
 
@@ -186,9 +185,7 @@ public class ArcusTimeoutTest extends TestCase {
           throws InterruptedException, ExecutionException, TimeoutException {
     int valueCount = 500;
     Object[] valueList = new Object[valueCount];
-    for (int i = 0; i < valueList.length; i++) {
-      valueList[i] = "MyValue";
-    }
+    Arrays.fill(valueList, "MyValue");
 
     // SET
     Future<Map<Integer, CollectionOperationStatus>> future = mc.asyncLopPipedInsertBulk(

--- a/src/test/java/net/spy/memcached/ConsistentHashingTest.java
+++ b/src/test/java/net/spy/memcached/ConsistentHashingTest.java
@@ -29,7 +29,7 @@ public class ConsistentHashingTest extends TestCase {
    * Simulate dropping from (totalNodes) to (totalNodes-1).
    * Ensure hashing is consistent between the the two scenarios.
    *
-   * @param totalNodes
+   * @param totalNodes totalNodes
    */
   private void runThisManyNodes(final int totalNodes) {
     final String[] stringNodes = generateAddresses(totalNodes);
@@ -95,14 +95,14 @@ public class ConsistentHashingTest extends TestCase {
     String port = ":11211 ";
     int last = (int) ((now % 100) + 3);
 
-    StringBuffer prefix = new StringBuffer();
+    StringBuilder prefix = new StringBuilder();
     prefix.append(first);
     prefix.append(".");
     prefix.append(second);
     prefix.append(".1.");
 
     // Don't protect the possible range too much, as we are our own client.
-    StringBuffer buf = new StringBuffer();
+    StringBuilder buf = new StringBuilder();
     for (int ix = 0; ix < maxSize - 1; ix++) {
       buf.append(prefix);
       buf.append(last + ix);

--- a/src/test/java/net/spy/memcached/ObserverTest.java
+++ b/src/test/java/net/spy/memcached/ObserverTest.java
@@ -10,7 +10,7 @@ import net.spy.memcached.compat.SpyObject;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.internal.runners.JUnit4ClassRunner;
+import org.junit.runners.BlockJUnit4ClassRunner;
 import org.junit.runner.RunWith;
 
 import static org.junit.Assume.assumeTrue;
@@ -18,7 +18,7 @@ import static org.junit.Assume.assumeTrue;
 /**
  * Test observer hooks.
  */
-@RunWith(JUnit4ClassRunner.class)
+@RunWith(BlockJUnit4ClassRunner.class)
 public class ObserverTest extends ClientBaseCase {
 
   @Before

--- a/src/test/manual/net/spy/memcached/ArcusClientConnectTest.java
+++ b/src/test/manual/net/spy/memcached/ArcusClientConnectTest.java
@@ -20,12 +20,12 @@ import junit.framework.TestCase;
 import net.spy.memcached.collection.BaseIntegrationTest;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.internal.runners.JUnit4ClassRunner;
+import org.junit.runners.BlockJUnit4ClassRunner;
 import org.junit.runner.RunWith;
 
 import static org.junit.Assume.assumeTrue;
 
-@RunWith(JUnit4ClassRunner.class)
+@RunWith(BlockJUnit4ClassRunner.class)
 public class ArcusClientConnectTest extends TestCase {
 
   @Before

--- a/src/test/manual/net/spy/memcached/ArcusClientFrontCacheTest.java
+++ b/src/test/manual/net/spy/memcached/ArcusClientFrontCacheTest.java
@@ -16,17 +16,17 @@
  */
 package net.spy.memcached;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import junit.framework.TestCase;
 import net.spy.memcached.collection.BaseIntegrationTest;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.internal.runners.JUnit4ClassRunner;
+import org.junit.runners.BlockJUnit4ClassRunner;
 import org.junit.runner.RunWith;
 
 import static org.junit.Assume.assumeTrue;
 
-@RunWith(JUnit4ClassRunner.class)
+@RunWith(BlockJUnit4ClassRunner.class)
 public class ArcusClientFrontCacheTest extends TestCase {
 
   @Before

--- a/src/test/manual/net/spy/memcached/ArcusClientPoolShutdownTest.java
+++ b/src/test/manual/net/spy/memcached/ArcusClientPoolShutdownTest.java
@@ -19,7 +19,7 @@ package net.spy.memcached;
 import java.util.ArrayList;
 import java.util.List;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import junit.framework.TestCase;
 import net.spy.memcached.collection.BaseIntegrationTest;
 

--- a/src/test/manual/net/spy/memcached/ArcusClientShutdownTest.java
+++ b/src/test/manual/net/spy/memcached/ArcusClientShutdownTest.java
@@ -19,7 +19,7 @@ package net.spy.memcached;
 import java.util.ArrayList;
 import java.util.List;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import junit.framework.TestCase;
 import net.spy.memcached.collection.BaseIntegrationTest;
 

--- a/src/test/manual/net/spy/memcached/LoggerSetter.java
+++ b/src/test/manual/net/spy/memcached/LoggerSetter.java
@@ -6,7 +6,7 @@ import net.spy.memcached.compat.log.Logger;
 import net.spy.memcached.compat.log.SLF4JLogger;
 import net.spy.memcached.compat.log.SunLogger;
 
-public class LoggerSetter {
+public final class LoggerSetter {
   private LoggerSetter() {}
 
   public static <T extends Logger> void setLogger(Class<T> logger) {

--- a/src/test/manual/net/spy/memcached/LongKeyTest/BaseLongKeyTest.java
+++ b/src/test/manual/net/spy/memcached/LongKeyTest/BaseLongKeyTest.java
@@ -1,6 +1,6 @@
 package net.spy.memcached.LongKeyTest;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import net.spy.memcached.collection.BTreeGetResult;
 import net.spy.memcached.collection.BaseIntegrationTest;
 import net.spy.memcached.collection.CollectionAttributes;
@@ -21,23 +21,24 @@ import java.util.Map;
 
 public class BaseLongKeyTest extends BaseIntegrationTest {
 
-  private int keySize = 200;
-  private char[] chars = "abcdefghijklmnopqrstuvwxyz".toCharArray();
-  private final List<String> keys = new ArrayList<String>() {
-    {
-      int defaultKeyLenght = 4000 - 10; // MAX_KEY_LENGTH - key index string length
-      for (int i = 0; i < keySize; i++) {
-        StringBuilder sb = new StringBuilder();
-        Random random = new Random();
-        for (int j = 0; j < defaultKeyLenght; j++) {
-          char c = chars[random.nextInt(chars.length)];
-          sb.append(c);
-        }
-        sb.append(i);
-        add(sb.toString());
+  private final int keySize = 200;
+  private final List<String> keys = new ArrayList<String>();
+
+  public BaseLongKeyTest() {
+    int defaultKeyLenght = 4000 - 10; // MAX_KEY_LENGTH - key index string length
+    char[] chars = "abcdefghijklmnopqrstuvwxyz".toCharArray();
+
+    for (int i = 0; i < keySize; i++) {
+      StringBuilder sb = new StringBuilder();
+      Random random = new Random();
+      for (int j = 0; j < defaultKeyLenght; j++) {
+        char c = chars[random.nextInt(chars.length)];
+        sb.append(c);
       }
+      sb.append(i);
+      keys.add(sb.toString());
     }
-  };
+  }
 
   public void testKV_Long() throws Exception {
     // KV Set

--- a/src/test/manual/net/spy/memcached/MultibyteKeyTest.java
+++ b/src/test/manual/net/spy/memcached/MultibyteKeyTest.java
@@ -16,7 +16,7 @@
  */
 package net.spy.memcached;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import net.spy.memcached.collection.Attributes;
 import net.spy.memcached.collection.BKeyObject;
 import net.spy.memcached.collection.BTreeCount;

--- a/src/test/manual/net/spy/memcached/btreesmget/ByteArrayBKeySMGetErrorTest.java
+++ b/src/test/manual/net/spy/memcached/btreesmget/ByteArrayBKeySMGetErrorTest.java
@@ -21,7 +21,7 @@ import java.util.List;
 import java.util.Random;
 import java.util.concurrent.TimeUnit;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import net.spy.memcached.collection.BaseIntegrationTest;
 import net.spy.memcached.collection.CollectionAttributes;
 import net.spy.memcached.collection.CollectionOverflowAction;

--- a/src/test/manual/net/spy/memcached/btreesmget/ByteArrayBKeySMGetIrregularEflagTest.java
+++ b/src/test/manual/net/spy/memcached/btreesmget/ByteArrayBKeySMGetIrregularEflagTest.java
@@ -20,7 +20,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import net.spy.memcached.collection.BaseIntegrationTest;
 import net.spy.memcached.collection.CollectionAttributes;
 import net.spy.memcached.collection.ElementFlagFilter;

--- a/src/test/manual/net/spy/memcached/btreesmget/ByteArrayBKeySMGetTest.java
+++ b/src/test/manual/net/spy/memcached/btreesmget/ByteArrayBKeySMGetTest.java
@@ -23,7 +23,7 @@ import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import net.spy.memcached.collection.BaseIntegrationTest;
 import net.spy.memcached.collection.CollectionAttributes;
 import net.spy.memcached.collection.ElementFlagFilter;

--- a/src/test/manual/net/spy/memcached/btreesmget/SMGetErrorTest.java
+++ b/src/test/manual/net/spy/memcached/btreesmget/SMGetErrorTest.java
@@ -22,7 +22,7 @@ import java.util.Map;
 import java.util.Random;
 import java.util.concurrent.TimeUnit;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import net.spy.memcached.collection.BaseIntegrationTest;
 import net.spy.memcached.collection.CollectionAttributes;
 import net.spy.memcached.collection.CollectionOverflowAction;

--- a/src/test/manual/net/spy/memcached/btreesmget/SMGetTest.java
+++ b/src/test/manual/net/spy/memcached/btreesmget/SMGetTest.java
@@ -23,7 +23,7 @@ import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import net.spy.memcached.collection.BaseIntegrationTest;
 import net.spy.memcached.collection.CollectionAttributes;
 import net.spy.memcached.collection.ElementFlagFilter;

--- a/src/test/manual/net/spy/memcached/btreesmget/SMGetWithCombinationEflagTest.java
+++ b/src/test/manual/net/spy/memcached/btreesmget/SMGetWithCombinationEflagTest.java
@@ -22,7 +22,7 @@ import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import net.spy.memcached.collection.BaseIntegrationTest;
 import net.spy.memcached.collection.CollectionAttributes;
 import net.spy.memcached.collection.ElementFlagFilter;

--- a/src/test/manual/net/spy/memcached/btreesmget/SMGetWithEflagTest.java
+++ b/src/test/manual/net/spy/memcached/btreesmget/SMGetWithEflagTest.java
@@ -22,7 +22,7 @@ import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import net.spy.memcached.collection.ElementFlagFilter;
 import net.spy.memcached.collection.BaseIntegrationTest;
 import net.spy.memcached.collection.CollectionAttributes;

--- a/src/test/manual/net/spy/memcached/bulkoperation/BopInsertBulkMultipleBoundaryTest.java
+++ b/src/test/manual/net/spy/memcached/bulkoperation/BopInsertBulkMultipleBoundaryTest.java
@@ -22,7 +22,7 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import net.spy.memcached.collection.BaseIntegrationTest;
 import net.spy.memcached.collection.CollectionAttributes;
 import net.spy.memcached.collection.CollectionOverflowAction;

--- a/src/test/manual/net/spy/memcached/bulkoperation/BopInsertBulkMultipleTest.java
+++ b/src/test/manual/net/spy/memcached/bulkoperation/BopInsertBulkMultipleTest.java
@@ -23,7 +23,7 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import net.spy.memcached.collection.BaseIntegrationTest;
 import net.spy.memcached.collection.CollectionAttributes;
 import net.spy.memcached.collection.Element;

--- a/src/test/manual/net/spy/memcached/bulkoperation/BopInsertBulkTest.java
+++ b/src/test/manual/net/spy/memcached/bulkoperation/BopInsertBulkTest.java
@@ -22,7 +22,7 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import net.spy.memcached.collection.BaseIntegrationTest;
 import net.spy.memcached.collection.ByteArrayBKey;
 import net.spy.memcached.collection.CollectionAttributes;

--- a/src/test/manual/net/spy/memcached/bulkoperation/BopPipeUpdateTest.java
+++ b/src/test/manual/net/spy/memcached/bulkoperation/BopPipeUpdateTest.java
@@ -21,7 +21,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import net.spy.memcached.collection.BaseIntegrationTest;
 import net.spy.memcached.collection.CollectionAttributes;
 import net.spy.memcached.collection.CollectionResponse;
@@ -97,12 +97,12 @@ public class BopPipeUpdateTest extends BaseIntegrationTest {
       // System.out.println(map2.size());
       Assert.assertTrue(map2.isEmpty());
 
-      for (int i = 0; i < elementCount; i++) {
+      for (long i = 0; i < elementCount; i++) {
         assertEquals(
                 "updated" + i,
                 mc.asyncBopGet(KEY, i, ElementFlagFilter.DO_NOT_FILTER,
                         false, false).get(1000L, TimeUnit.MILLISECONDS)
-                        .get(new Long(i)).getValue());
+                        .get(i).getValue());
       }
 
     } catch (Exception e) {
@@ -136,11 +136,11 @@ public class BopPipeUpdateTest extends BaseIntegrationTest {
       // System.out.println(map2.size());
       Assert.assertTrue(map2.isEmpty());
 
-      for (int i = 0; i < elementCount; i++) {
+      for (long i = 0; i < elementCount; i++) {
         Element<Object> element = mc
                 .asyncBopGet(KEY, i, ElementFlagFilter.DO_NOT_FILTER,
                         false, false).get(1000L, TimeUnit.MILLISECONDS)
-                .get(new Long(i));
+                .get(i);
 
         // System.out.println(element.getFlagByHex());
         assertEquals("value" + i, element.getValue());
@@ -174,11 +174,11 @@ public class BopPipeUpdateTest extends BaseIntegrationTest {
       // System.out.println(map2.size());
       Assert.assertTrue(map2.isEmpty());
 
-      for (int i = 0; i < elementCount; i++) {
+      for (long i = 0; i < elementCount; i++) {
         Element<Object> element = mc
                 .asyncBopGet(KEY, i, ElementFlagFilter.DO_NOT_FILTER,
                         false, false).get(1000L, TimeUnit.MILLISECONDS)
-                .get(new Long(i));
+                .get(i);
 
         // System.out.println(element.getFlagByHex());
         assertEquals("value" + i, element.getValue());
@@ -223,12 +223,12 @@ public class BopPipeUpdateTest extends BaseIntegrationTest {
       assertEquals(CollectionResponse.NOT_FOUND_ELEMENT, map2.get(0)
               .getResponse());
 
-      for (int i = 600; i < elementCount; i++) {
+      for (long i = 600; i < elementCount; i++) {
         assertEquals(
                 "updated" + i,
                 mc.asyncBopGet(KEY, i, ElementFlagFilter.DO_NOT_FILTER,
                         false, false).get(1000L, TimeUnit.MILLISECONDS)
-                        .get(new Long(i)).getValue());
+                        .get(i).getValue());
       }
 
     } catch (Exception e) {

--- a/src/test/manual/net/spy/memcached/bulkoperation/BulkDeleteTest.java
+++ b/src/test/manual/net/spy/memcached/bulkoperation/BulkDeleteTest.java
@@ -16,7 +16,7 @@
  */
 package net.spy.memcached.bulkoperation;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import net.spy.memcached.collection.BaseIntegrationTest;
 import net.spy.memcached.ops.OperationStatus;
 import net.spy.memcached.ops.StatusCode;

--- a/src/test/manual/net/spy/memcached/bulkoperation/BulkSetVariousTypeTest.java
+++ b/src/test/manual/net/spy/memcached/bulkoperation/BulkSetVariousTypeTest.java
@@ -23,7 +23,7 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import net.spy.memcached.collection.BaseIntegrationTest;
 import net.spy.memcached.ops.CollectionOperationStatus;
 
@@ -32,7 +32,7 @@ public class BulkSetVariousTypeTest extends BaseIntegrationTest {
   private static class MyBean implements Serializable {
     private static final long serialVersionUID = -5977830942924286134L;
 
-    private String name;
+    private final String name;
 
     public MyBean(String name) {
       this.name = name;
@@ -44,6 +44,18 @@ public class BulkSetVariousTypeTest extends BaseIntegrationTest {
         return this.name.equals(((MyBean) obj).name);
       }
       return false;
+    }
+
+    @Override
+    public int hashCode() {
+      return toString().hashCode();
+    }
+
+    @Override
+    public String toString() {
+      return "MyBean{" +
+          "name='" + name + '\'' +
+          '}';
     }
   }
 
@@ -59,6 +71,7 @@ public class BulkSetVariousTypeTest extends BaseIntegrationTest {
         mc.delete(key[0]);
 
         // SET
+        @SuppressWarnings("deprecation")
         Future<Map<String, CollectionOperationStatus>> future = mc
                 .asyncSetBulk(Arrays.asList(key), 60, valueList[i]);
 
@@ -74,7 +87,7 @@ public class BulkSetVariousTypeTest extends BaseIntegrationTest {
 
         // GET
         Object v = mc.get(key[0]);
-        Assert.assertEquals(String.format("K=%s, V=%s", key, v),
+        Assert.assertEquals(String.format("K=%s, V=%s", Arrays.toString(key), v),
                 valueList[i], v);
       }
     } catch (Exception e) {

--- a/src/test/manual/net/spy/memcached/bulkoperation/BulkStoreTest.java
+++ b/src/test/manual/net/spy/memcached/bulkoperation/BulkStoreTest.java
@@ -25,7 +25,7 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import net.spy.memcached.collection.BaseIntegrationTest;
 import net.spy.memcached.ops.CollectionOperationStatus;
 import net.spy.memcached.ops.OperationStatus;
@@ -68,6 +68,7 @@ public class BulkStoreTest extends BaseIntegrationTest {
       try {
         mc.asyncStoreBulk(StoreType.set, null, 60);
       } catch (Exception e) {
+        e.printStackTrace();
         assertEquals("Map is null.", e.getMessage());
       }
 
@@ -124,6 +125,7 @@ public class BulkStoreTest extends BaseIntegrationTest {
       try {
         mc.asyncStoreBulk(StoreType.set, null, 60, value);
       } catch (Exception e) {
+        e.printStackTrace();
         assertEquals("Key list is null.", e.getMessage());
       }
 
@@ -384,6 +386,7 @@ public class BulkStoreTest extends BaseIntegrationTest {
       }
 
       // Store
+      @SuppressWarnings("deprecation")
       Future<Map<String, CollectionOperationStatus>> future = mc
           .asyncSetBulk(Arrays.asList(keys), 60, value, transcoder);
 
@@ -433,6 +436,7 @@ public class BulkStoreTest extends BaseIntegrationTest {
       }
 
       //  Store
+      @SuppressWarnings("deprecation")
       Future<Map<String, CollectionOperationStatus>> future = mc
           .asyncSetBulk(o, 60, transcoder);
 

--- a/src/test/manual/net/spy/memcached/bulkoperation/LopInsertBulkMultipleValueTest.java
+++ b/src/test/manual/net/spy/memcached/bulkoperation/LopInsertBulkMultipleValueTest.java
@@ -23,7 +23,7 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import net.spy.memcached.collection.BaseIntegrationTest;
 import net.spy.memcached.collection.CollectionAttributes;
 import net.spy.memcached.ops.CollectionOperationStatus;

--- a/src/test/manual/net/spy/memcached/bulkoperation/LopInsertBulkTest.java
+++ b/src/test/manual/net/spy/memcached/bulkoperation/LopInsertBulkTest.java
@@ -23,7 +23,7 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import net.spy.memcached.collection.BaseIntegrationTest;
 import net.spy.memcached.collection.CollectionAttributes;
 import net.spy.memcached.ops.CollectionOperationStatus;

--- a/src/test/manual/net/spy/memcached/bulkoperation/MopInsertBulkMultipleTest.java
+++ b/src/test/manual/net/spy/memcached/bulkoperation/MopInsertBulkMultipleTest.java
@@ -23,7 +23,7 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import net.spy.memcached.collection.BaseIntegrationTest;
 import net.spy.memcached.collection.CollectionAttributes;
 import net.spy.memcached.ops.CollectionOperationStatus;

--- a/src/test/manual/net/spy/memcached/bulkoperation/MopInsertBulkTest.java
+++ b/src/test/manual/net/spy/memcached/bulkoperation/MopInsertBulkTest.java
@@ -22,7 +22,7 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import net.spy.memcached.collection.BaseIntegrationTest;
 import net.spy.memcached.collection.CollectionAttributes;
 import net.spy.memcached.ops.CollectionOperationStatus;

--- a/src/test/manual/net/spy/memcached/bulkoperation/PipeInsertTest.java
+++ b/src/test/manual/net/spy/memcached/bulkoperation/PipeInsertTest.java
@@ -22,7 +22,7 @@ import java.util.Map;
 import java.util.TreeMap;
 import java.util.concurrent.TimeUnit;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import net.spy.memcached.collection.BaseIntegrationTest;
 import net.spy.memcached.collection.CollectionAttributes;
 import net.spy.memcached.collection.Element;

--- a/src/test/manual/net/spy/memcached/bulkoperation/SopInsertBulkMultipleValueTest.java
+++ b/src/test/manual/net/spy/memcached/bulkoperation/SopInsertBulkMultipleValueTest.java
@@ -23,7 +23,7 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import net.spy.memcached.collection.BaseIntegrationTest;
 import net.spy.memcached.collection.CollectionAttributes;
 import net.spy.memcached.ops.CollectionOperationStatus;

--- a/src/test/manual/net/spy/memcached/bulkoperation/SopInsertBulkTest.java
+++ b/src/test/manual/net/spy/memcached/bulkoperation/SopInsertBulkTest.java
@@ -23,7 +23,7 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import net.spy.memcached.collection.BaseIntegrationTest;
 import net.spy.memcached.collection.CollectionAttributes;
 import net.spy.memcached.ops.CollectionOperationStatus;

--- a/src/test/manual/net/spy/memcached/collection/ElementFlagFilterTest.java
+++ b/src/test/manual/net/spy/memcached/collection/ElementFlagFilterTest.java
@@ -18,7 +18,7 @@ package net.spy.memcached.collection;
 
 import net.spy.memcached.collection.ElementFlagFilter.BitWiseOperands;
 import net.spy.memcached.collection.ElementFlagFilter.CompOperands;
-import junit.framework.Assert;
+import org.junit.Assert;
 import junit.framework.TestCase;
 
 public class ElementFlagFilterTest extends TestCase {

--- a/src/test/manual/net/spy/memcached/collection/attribute/BTreeGetAttrTest.java
+++ b/src/test/manual/net/spy/memcached/collection/attribute/BTreeGetAttrTest.java
@@ -16,7 +16,7 @@
  */
 package net.spy.memcached.collection.attribute;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import net.spy.memcached.collection.BaseIntegrationTest;
 import net.spy.memcached.collection.CollectionAttributes;
 import net.spy.memcached.collection.CollectionOverflowAction;
@@ -60,7 +60,7 @@ public class BTreeGetAttrTest extends BaseIntegrationTest {
       // get trimmed
       CollectionAttributes btreeAttrs = mc.asyncGetAttr(KEY).get();
       if (btreeAttrs.getTrimmed() != null) { // not support
-        Assert.assertEquals(new Long(0L), btreeAttrs.getTrimmed());
+        Assert.assertEquals(Long.valueOf(0L), btreeAttrs.getTrimmed());
       }
 
       Assert.assertTrue(mc.asyncBopInsert(KEY, 3L, EFLAG, VALUE,
@@ -71,7 +71,7 @@ public class BTreeGetAttrTest extends BaseIntegrationTest {
       // get trimmed
       btreeAttrs = mc.asyncGetAttr(KEY).get();
       if (btreeAttrs.getTrimmed() != null) { // not support
-        Assert.assertEquals(new Long(1L), btreeAttrs.getTrimmed());
+        Assert.assertEquals(Long.valueOf(1L), btreeAttrs.getTrimmed());
       }
 
     } catch (Exception e) {
@@ -93,8 +93,8 @@ public class BTreeGetAttrTest extends BaseIntegrationTest {
 
       btreeAttrs = mc.asyncGetAttr(KEY).get();
       if (btreeAttrs.getMinBkey() != null) { // not support
-        Assert.assertEquals(new Long(0L), btreeAttrs.getMinBkey());
-        Assert.assertEquals(new Long(0L), btreeAttrs.getMaxBkey());
+        Assert.assertEquals(Long.valueOf(0L), btreeAttrs.getMinBkey());
+        Assert.assertEquals(Long.valueOf(0L), btreeAttrs.getMaxBkey());
       }
 
       Assert.assertTrue(mc.asyncBopInsert(KEY, 1L, EFLAG, VALUE, null)
@@ -104,8 +104,8 @@ public class BTreeGetAttrTest extends BaseIntegrationTest {
 
       btreeAttrs = mc.asyncGetAttr(KEY).get();
       if (btreeAttrs.getMinBkey() != null) { // not support
-        Assert.assertEquals(new Long(0L), btreeAttrs.getMinBkey());
-        Assert.assertEquals(new Long(2L), btreeAttrs.getMaxBkey());
+        Assert.assertEquals(Long.valueOf(0L), btreeAttrs.getMinBkey());
+        Assert.assertEquals(Long.valueOf(2L), btreeAttrs.getMaxBkey());
       }
     } catch (Exception e) {
       Assert.fail(e.getMessage());

--- a/src/test/manual/net/spy/memcached/collection/attribute/GetAttrTest.java
+++ b/src/test/manual/net/spy/memcached/collection/attribute/GetAttrTest.java
@@ -37,7 +37,7 @@ public class GetAttrTest extends BaseIntegrationTest {
             TimeUnit.MILLISECONDS);
 
     assertNotNull(rattrs);
-    assertEquals(new Integer(0), rattrs.getFlags());
+    assertEquals(Integer.valueOf(0), rattrs.getFlags());
     assertEquals(CollectionType.kv, rattrs.getType());
   }
 

--- a/src/test/manual/net/spy/memcached/collection/attribute/MaxBkeyRangeTest.java
+++ b/src/test/manual/net/spy/memcached/collection/attribute/MaxBkeyRangeTest.java
@@ -19,7 +19,7 @@ package net.spy.memcached.collection.attribute;
 import java.util.Arrays;
 import java.util.Map;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import net.spy.memcached.collection.BaseIntegrationTest;
 import net.spy.memcached.collection.CollectionAttributes;
 import net.spy.memcached.collection.Element;

--- a/src/test/manual/net/spy/memcached/collection/attribute/UnReadableBTreeTest.java
+++ b/src/test/manual/net/spy/memcached/collection/attribute/UnReadableBTreeTest.java
@@ -18,7 +18,7 @@ package net.spy.memcached.collection.attribute;
 
 import java.util.Map;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import net.spy.memcached.collection.BaseIntegrationTest;
 import net.spy.memcached.collection.CollectionAttributes;
 import net.spy.memcached.collection.Element;
@@ -58,9 +58,9 @@ public class UnReadableBTreeTest extends BaseIntegrationTest {
       // check attribute
       CollectionAttributes attr = mc.asyncGetAttr(KEY).get();
 
-      Assert.assertEquals(new Long(0), attr.getCount());
-      Assert.assertEquals(new Long(4000), attr.getMaxCount());
-      Assert.assertEquals(new Integer(0), attr.getExpireTime());
+      Assert.assertEquals(Long.valueOf(0), attr.getCount());
+      Assert.assertEquals(Long.valueOf(4000), attr.getMaxCount());
+      Assert.assertEquals(Integer.valueOf(0), attr.getExpireTime());
       Assert.assertFalse(attr.getReadable());
 
       // insert an item
@@ -105,9 +105,9 @@ public class UnReadableBTreeTest extends BaseIntegrationTest {
       // check attribute
       CollectionAttributes attr = mc.asyncGetAttr(KEY).get();
 
-      Assert.assertEquals(new Long(0), attr.getCount());
-      Assert.assertEquals(new Long(4000), attr.getMaxCount());
-      Assert.assertEquals(new Integer(0), attr.getExpireTime());
+      Assert.assertEquals(Long.valueOf(0), attr.getCount());
+      Assert.assertEquals(Long.valueOf(4000), attr.getMaxCount());
+      Assert.assertEquals(Integer.valueOf(0), attr.getExpireTime());
       Assert.assertTrue(attr.getReadable());
 
       // insert an item

--- a/src/test/manual/net/spy/memcached/collection/attribute/UnReadableExtendedBTreeTest.java
+++ b/src/test/manual/net/spy/memcached/collection/attribute/UnReadableExtendedBTreeTest.java
@@ -18,7 +18,7 @@ package net.spy.memcached.collection.attribute;
 
 import java.util.Map;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import net.spy.memcached.collection.BaseIntegrationTest;
 import net.spy.memcached.collection.ByteArrayBKey;
 import net.spy.memcached.collection.CollectionAttributes;
@@ -59,9 +59,9 @@ public class UnReadableExtendedBTreeTest extends BaseIntegrationTest {
       // check attribute
       CollectionAttributes attr = mc.asyncGetAttr(KEY).get();
 
-      Assert.assertEquals(new Long(0), attr.getCount());
-      Assert.assertEquals(new Long(4000), attr.getMaxCount());
-      Assert.assertEquals(new Integer(0), attr.getExpireTime());
+      Assert.assertEquals(Long.valueOf(0), attr.getCount());
+      Assert.assertEquals(Long.valueOf(4000), attr.getMaxCount());
+      Assert.assertEquals(Integer.valueOf(0), attr.getExpireTime());
       Assert.assertFalse(attr.getReadable());
 
       // insert an item
@@ -109,9 +109,9 @@ public class UnReadableExtendedBTreeTest extends BaseIntegrationTest {
       // check attribute
       CollectionAttributes attr = mc.asyncGetAttr(KEY).get();
 
-      Assert.assertEquals(new Long(0), attr.getCount());
-      Assert.assertEquals(new Long(4000), attr.getMaxCount());
-      Assert.assertEquals(new Integer(0), attr.getExpireTime());
+      Assert.assertEquals(Long.valueOf(0), attr.getCount());
+      Assert.assertEquals(Long.valueOf(4000), attr.getMaxCount());
+      Assert.assertEquals(Integer.valueOf(0), attr.getExpireTime());
       Assert.assertTrue(attr.getReadable());
 
       // insert an item

--- a/src/test/manual/net/spy/memcached/collection/attribute/UnReadableListTest.java
+++ b/src/test/manual/net/spy/memcached/collection/attribute/UnReadableListTest.java
@@ -18,7 +18,7 @@ package net.spy.memcached.collection.attribute;
 
 import java.util.List;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import net.spy.memcached.collection.BaseIntegrationTest;
 import net.spy.memcached.collection.CollectionAttributes;
 import net.spy.memcached.collection.ElementValueType;
@@ -56,9 +56,9 @@ public class UnReadableListTest extends BaseIntegrationTest {
       // check attribute
       CollectionAttributes attr = mc.asyncGetAttr(KEY).get();
 
-      Assert.assertEquals(new Long(0), attr.getCount());
-      Assert.assertEquals(new Long(4000), attr.getMaxCount());
-      Assert.assertEquals(new Integer(0), attr.getExpireTime());
+      Assert.assertEquals(Long.valueOf(0), attr.getCount());
+      Assert.assertEquals(Long.valueOf(4000), attr.getMaxCount());
+      Assert.assertEquals(Integer.valueOf(0), attr.getExpireTime());
       Assert.assertFalse(attr.getReadable());
 
       // insert an item
@@ -101,9 +101,9 @@ public class UnReadableListTest extends BaseIntegrationTest {
       // check attribute
       CollectionAttributes attr = mc.asyncGetAttr(KEY).get();
 
-      Assert.assertEquals(new Long(0), attr.getCount());
-      Assert.assertEquals(new Long(4000), attr.getMaxCount());
-      Assert.assertEquals(new Integer(0), attr.getExpireTime());
+      Assert.assertEquals(Long.valueOf(0), attr.getCount());
+      Assert.assertEquals(Long.valueOf(4000), attr.getMaxCount());
+      Assert.assertEquals(Integer.valueOf(0), attr.getExpireTime());
       Assert.assertTrue(attr.getReadable());
 
       // insert an item

--- a/src/test/manual/net/spy/memcached/collection/attribute/UnReadableMapTest.java
+++ b/src/test/manual/net/spy/memcached/collection/attribute/UnReadableMapTest.java
@@ -18,7 +18,7 @@ package net.spy.memcached.collection.attribute;
 
 import java.util.Map;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import net.spy.memcached.collection.BaseIntegrationTest;
 import net.spy.memcached.collection.CollectionAttributes;
 import net.spy.memcached.collection.ElementValueType;
@@ -56,9 +56,9 @@ public class UnReadableMapTest extends BaseIntegrationTest {
       // check attribute
       CollectionAttributes attr = mc.asyncGetAttr(KEY).get();
 
-      Assert.assertEquals(new Long(0), attr.getCount());
-      Assert.assertEquals(new Long(4000), attr.getMaxCount());
-      Assert.assertEquals(new Integer(0), attr.getExpireTime());
+      Assert.assertEquals(Long.valueOf(0), attr.getCount());
+      Assert.assertEquals(Long.valueOf(4000), attr.getMaxCount());
+      Assert.assertEquals(Integer.valueOf(0), attr.getExpireTime());
       Assert.assertFalse(attr.getReadable());
 
       // insert an item
@@ -102,9 +102,9 @@ public class UnReadableMapTest extends BaseIntegrationTest {
       // check attribute
       CollectionAttributes attr = mc.asyncGetAttr(KEY).get();
 
-      Assert.assertEquals(new Long(0), attr.getCount());
-      Assert.assertEquals(new Long(4000), attr.getMaxCount());
-      Assert.assertEquals(new Integer(0), attr.getExpireTime());
+      Assert.assertEquals(Long.valueOf(0), attr.getCount());
+      Assert.assertEquals(Long.valueOf(4000), attr.getMaxCount());
+      Assert.assertEquals(Integer.valueOf(0), attr.getExpireTime());
       Assert.assertTrue(attr.getReadable());
 
       // insert an item

--- a/src/test/manual/net/spy/memcached/collection/attribute/UnReadableSetTest.java
+++ b/src/test/manual/net/spy/memcached/collection/attribute/UnReadableSetTest.java
@@ -18,7 +18,7 @@ package net.spy.memcached.collection.attribute;
 
 import java.util.Set;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import net.spy.memcached.collection.BaseIntegrationTest;
 import net.spy.memcached.collection.CollectionAttributes;
 import net.spy.memcached.collection.ElementValueType;
@@ -56,9 +56,9 @@ public class UnReadableSetTest extends BaseIntegrationTest {
       // check attribute
       CollectionAttributes attr = mc.asyncGetAttr(KEY).get();
 
-      Assert.assertEquals(new Long(0), attr.getCount());
-      Assert.assertEquals(new Long(4000), attr.getMaxCount());
-      Assert.assertEquals(new Integer(0), attr.getExpireTime());
+      Assert.assertEquals(Long.valueOf(0), attr.getCount());
+      Assert.assertEquals(Long.valueOf(4000), attr.getMaxCount());
+      Assert.assertEquals(Integer.valueOf(0), attr.getExpireTime());
       Assert.assertFalse(attr.getReadable());
 
       // insert an item
@@ -102,9 +102,9 @@ public class UnReadableSetTest extends BaseIntegrationTest {
       // check attribute
       CollectionAttributes attr = mc.asyncGetAttr(KEY).get();
 
-      Assert.assertEquals(new Long(0), attr.getCount());
-      Assert.assertEquals(new Long(4000), attr.getMaxCount());
-      Assert.assertEquals(new Integer(0), attr.getExpireTime());
+      Assert.assertEquals(Long.valueOf(0), attr.getCount());
+      Assert.assertEquals(Long.valueOf(4000), attr.getMaxCount());
+      Assert.assertEquals(Integer.valueOf(0), attr.getExpireTime());
       Assert.assertTrue(attr.getReadable());
 
       // insert an item

--- a/src/test/manual/net/spy/memcached/collection/btree/BopDeleteTest.java
+++ b/src/test/manual/net/spy/memcached/collection/btree/BopDeleteTest.java
@@ -19,7 +19,7 @@ package net.spy.memcached.collection.btree;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import net.spy.memcached.collection.BaseIntegrationTest;
 import net.spy.memcached.collection.ByteArrayBKey;
 import net.spy.memcached.collection.CollectionAttributes;

--- a/src/test/manual/net/spy/memcached/collection/btree/BopGetBulkTest.java
+++ b/src/test/manual/net/spy/memcached/collection/btree/BopGetBulkTest.java
@@ -23,7 +23,7 @@ import java.util.Map;
 import java.util.Random;
 import java.util.concurrent.TimeUnit;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import net.spy.memcached.collection.BTreeElement;
 import net.spy.memcached.collection.BTreeGetResult;
 import net.spy.memcached.collection.BaseIntegrationTest;

--- a/src/test/manual/net/spy/memcached/collection/btree/BopGetIrregularEflagTest.java
+++ b/src/test/manual/net/spy/memcached/collection/btree/BopGetIrregularEflagTest.java
@@ -19,7 +19,7 @@ package net.spy.memcached.collection.btree;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import net.spy.memcached.collection.BaseIntegrationTest;
 import net.spy.memcached.collection.CollectionAttributes;
 import net.spy.memcached.collection.Element;

--- a/src/test/manual/net/spy/memcached/collection/btree/BopInsertAndGetWithElementFlagTest.java
+++ b/src/test/manual/net/spy/memcached/collection/btree/BopInsertAndGetWithElementFlagTest.java
@@ -19,7 +19,7 @@ package net.spy.memcached.collection.btree;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import net.spy.memcached.collection.Element;
 import net.spy.memcached.collection.ElementFlagFilter;
 import net.spy.memcached.collection.ElementMultiFlagsFilter;

--- a/src/test/manual/net/spy/memcached/collection/btree/BopInsertWhenKeyExists.java
+++ b/src/test/manual/net/spy/memcached/collection/btree/BopInsertWhenKeyExists.java
@@ -19,7 +19,7 @@ package net.spy.memcached.collection.btree;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 
 import net.spy.memcached.collection.BaseIntegrationTest;
 import net.spy.memcached.collection.CollectionAttributes;

--- a/src/test/manual/net/spy/memcached/collection/btree/BopOverflowActionTest.java
+++ b/src/test/manual/net/spy/memcached/collection/btree/BopOverflowActionTest.java
@@ -23,7 +23,7 @@ import java.util.Map;
 import java.util.TreeMap;
 import java.util.concurrent.TimeUnit;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import net.spy.memcached.collection.BaseIntegrationTest;
 import net.spy.memcached.collection.CollectionAttributes;
 import net.spy.memcached.collection.CollectionOverflowAction;

--- a/src/test/manual/net/spy/memcached/collection/btree/BopSortMergeOldTest.java
+++ b/src/test/manual/net/spy/memcached/collection/btree/BopSortMergeOldTest.java
@@ -16,7 +16,7 @@
  */
 package net.spy.memcached.collection.btree;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import net.spy.memcached.collection.BaseIntegrationTest;
 import net.spy.memcached.collection.CollectionAttributes;
 import net.spy.memcached.collection.CollectionOverflowAction;
@@ -32,30 +32,27 @@ import java.util.concurrent.TimeUnit;
 
 public class BopSortMergeOldTest extends BaseIntegrationTest {
 
-  private List<String> keyList3 = new ArrayList<String>() {
-    {
-      add("key0");
-      add("key1");
-      add("key2");
-    }
-  };
+  private final List<String> keyList3 = new ArrayList<String>();
+  private final List<String> keyList2 = new ArrayList<String>();
 
-  private List<String> keyList2 = new ArrayList<String>() {
-    {
-      add("key0");
-      add("key1");
-    }
-  };
+  public BopSortMergeOldTest() {
+    keyList3.add("key0");
+    keyList3.add("key1");
+    keyList3.add("key2");
+
+    keyList2.add("key0");
+    keyList2.add("key1");
+  }
 
   @Override
   protected void setUp() throws Exception {
     super.setUp();
-    for (int i = 0; i < keyList3.size(); i++) {
-      mc.delete(keyList3.get(i));
+    for (String s : keyList3) {
+      mc.delete(s);
     }
 
-    for (int i = 0; i < keyList2.size(); i++) {
-      mc.delete(keyList2.get(i));
+    for (String s : keyList2) {
+      mc.delete(s);
     }
   }
 

--- a/src/test/manual/net/spy/memcached/collection/btree/BopSortMergeTest.java
+++ b/src/test/manual/net/spy/memcached/collection/btree/BopSortMergeTest.java
@@ -16,7 +16,7 @@
  */
 package net.spy.memcached.collection.btree;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import net.spy.memcached.collection.BaseIntegrationTest;
 import net.spy.memcached.collection.CollectionAttributes;
 import net.spy.memcached.collection.CollectionOverflowAction;
@@ -36,29 +36,26 @@ import java.util.concurrent.TimeUnit;
 
 public class BopSortMergeTest extends BaseIntegrationTest {
 
-  private List<String> keyList3 = new ArrayList<String>() {
-    {
-      add("key0");
-      add("key1");
-      add("key2");
-    }
-  };
+  private final List<String> keyList3 = new ArrayList<String>();
+  private final List<String> keyList2 = new ArrayList<String>();
 
-  private List<String> keyList2 = new ArrayList<String>() {
-    {
-      add("key0");
-      add("key1");
-    }
-  };
+  public BopSortMergeTest() {
+    keyList3.add("key0");
+    keyList3.add("key1");
+    keyList3.add("key2");
+
+    keyList2.add("key0");
+    keyList2.add("key1");
+  }
 
   @Override
   protected void setUp() throws Exception {
     super.setUp();
-    for (int i = 0; i < keyList3.size(); i++) {
-      mc.delete(keyList3.get(i));
+    for (String s : keyList3) {
+      mc.delete(s);
     }
-    for (int i = 0; i < keyList2.size(); i++) {
-      mc.delete(keyList2.get(i));
+    for (String s : keyList2) {
+      mc.delete(s);
     }
   }
 

--- a/src/test/manual/net/spy/memcached/collection/btree/BopUpdateTest.java
+++ b/src/test/manual/net/spy/memcached/collection/btree/BopUpdateTest.java
@@ -18,7 +18,7 @@ package net.spy.memcached.collection.btree;
 
 import java.util.concurrent.ExecutionException;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import net.spy.memcached.collection.BaseIntegrationTest;
 import net.spy.memcached.collection.CollectionAttributes;
 import net.spy.memcached.collection.ElementFlagUpdate;

--- a/src/test/manual/net/spy/memcached/collection/btree/BopUpsertTest.java
+++ b/src/test/manual/net/spy/memcached/collection/btree/BopUpsertTest.java
@@ -16,7 +16,7 @@
  */
 package net.spy.memcached.collection.btree;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import net.spy.memcached.collection.BaseIntegrationTest;
 import net.spy.memcached.collection.CollectionAttributes;
 

--- a/src/test/manual/net/spy/memcached/collection/btree/longbkey/BopCountWithElementFlagFilterTest.java
+++ b/src/test/manual/net/spy/memcached/collection/btree/longbkey/BopCountWithElementFlagFilterTest.java
@@ -16,7 +16,7 @@
  */
 package net.spy.memcached.collection.btree.longbkey;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import net.spy.memcached.collection.BaseIntegrationTest;
 import net.spy.memcached.collection.CollectionAttributes;
 import net.spy.memcached.collection.CollectionResponse;
@@ -105,7 +105,7 @@ public class BopCountWithElementFlagFilterTest extends BaseIntegrationTest {
       Assert.assertTrue(insertResult2);
 
       // check count in attributes
-      Assert.assertEquals(new Long(2), mc.asyncGetAttr(KEY).get()
+      Assert.assertEquals(Long.valueOf(2), mc.asyncGetAttr(KEY).get()
               .getCount());
 
       // get btree item count
@@ -113,7 +113,7 @@ public class BopCountWithElementFlagFilterTest extends BaseIntegrationTest {
               BKEY, BKEY, filter);
       Integer count = future.get();
       Assert.assertNotNull(count);
-      Assert.assertEquals(new Integer(1), count);
+      Assert.assertEquals(Integer.valueOf(1), count);
     } catch (Exception e) {
       e.printStackTrace();
       Assert.fail(e.getMessage());
@@ -139,7 +139,7 @@ public class BopCountWithElementFlagFilterTest extends BaseIntegrationTest {
       Assert.assertTrue(insertResult2);
 
       // check count in attributes
-      Assert.assertEquals(new Long(2), mc.asyncGetAttr(KEY).get()
+      Assert.assertEquals(Long.valueOf(2), mc.asyncGetAttr(KEY).get()
               .getCount());
 
       // get btree item count
@@ -147,7 +147,7 @@ public class BopCountWithElementFlagFilterTest extends BaseIntegrationTest {
               BKEY, BKEY2, filter);
       Integer count = future.get();
       Assert.assertNotNull(count);
-      Assert.assertEquals(new Integer(1), count);
+      Assert.assertEquals(Integer.valueOf(1), count);
     } catch (Exception e) {
       e.printStackTrace();
       Assert.fail(e.getMessage());
@@ -174,7 +174,7 @@ public class BopCountWithElementFlagFilterTest extends BaseIntegrationTest {
       Assert.assertTrue(insertResult2);
 
       // check count in attributes
-      Assert.assertEquals(new Long(2), mc.asyncGetAttr(KEY).get()
+      Assert.assertEquals(Long.valueOf(2), mc.asyncGetAttr(KEY).get()
               .getCount());
 
       // get btree item count
@@ -182,7 +182,7 @@ public class BopCountWithElementFlagFilterTest extends BaseIntegrationTest {
               BKEY, BKEY, filter);
       Integer count = future.get();
       Assert.assertNotNull(count);
-      Assert.assertEquals(new Integer(1), count);
+      Assert.assertEquals(Integer.valueOf(1), count);
     } catch (Exception e) {
       e.printStackTrace();
       Assert.fail(e.getMessage());

--- a/src/test/manual/net/spy/memcached/collection/btree/longbkey/BopGetBulkTest.java
+++ b/src/test/manual/net/spy/memcached/collection/btree/longbkey/BopGetBulkTest.java
@@ -23,7 +23,7 @@ import java.util.Map;
 import java.util.Random;
 import java.util.concurrent.TimeUnit;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import net.spy.memcached.collection.BTreeElement;
 import net.spy.memcached.collection.BTreeGetResult;
 import net.spy.memcached.collection.BaseIntegrationTest;

--- a/src/test/manual/net/spy/memcached/collection/btree/longbkey/BopGetIrregularEflagTest.java
+++ b/src/test/manual/net/spy/memcached/collection/btree/longbkey/BopGetIrregularEflagTest.java
@@ -19,7 +19,7 @@ package net.spy.memcached.collection.btree.longbkey;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import net.spy.memcached.collection.BaseIntegrationTest;
 import net.spy.memcached.collection.ByteArrayBKey;
 import net.spy.memcached.collection.CollectionAttributes;

--- a/src/test/manual/net/spy/memcached/collection/btree/longbkey/BopGetTest.java
+++ b/src/test/manual/net/spy/memcached/collection/btree/longbkey/BopGetTest.java
@@ -18,7 +18,7 @@ package net.spy.memcached.collection.btree.longbkey;
 
 import java.util.Map;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import net.spy.memcached.collection.BaseIntegrationTest;
 import net.spy.memcached.collection.ByteArrayBKey;
 import net.spy.memcached.collection.CollectionAttributes;

--- a/src/test/manual/net/spy/memcached/collection/btree/longbkey/BopUpdateTest.java
+++ b/src/test/manual/net/spy/memcached/collection/btree/longbkey/BopUpdateTest.java
@@ -16,7 +16,7 @@
  */
 package net.spy.memcached.collection.btree.longbkey;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import net.spy.memcached.collection.BaseIntegrationTest;
 import net.spy.memcached.collection.CollectionAttributes;
 import net.spy.memcached.collection.ElementFlagFilter.BitWiseOperands;

--- a/src/test/manual/net/spy/memcached/collection/list/LopBulkAPITest.java
+++ b/src/test/manual/net/spy/memcached/collection/list/LopBulkAPITest.java
@@ -22,7 +22,7 @@ import java.util.Map;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 
 import net.spy.memcached.collection.BaseIntegrationTest;
 import net.spy.memcached.collection.CollectionAttributes;

--- a/src/test/manual/net/spy/memcached/collection/list/LopInsertDataType.java
+++ b/src/test/manual/net/spy/memcached/collection/list/LopInsertDataType.java
@@ -78,13 +78,13 @@ public class LopInsertDataType extends BaseIntegrationTest {
             new CollectionAttributes()).get(1000, TimeUnit.MILLISECONDS));
 
     // Then insert another items with different data types
-    assertTrue(mc.asyncLopInsert(key, -1, new Integer(100), null).get(1000,
+    assertTrue(mc.asyncLopInsert(key, -1, 100, null).get(1000,
             TimeUnit.MILLISECONDS));
 
-    assertTrue(mc.asyncLopInsert(key, -1, new Long(101L), null).get(1000,
+    assertTrue(mc.asyncLopInsert(key, -1, 101L, null).get(1000,
             TimeUnit.MILLISECONDS));
 
-    assertTrue(mc.asyncLopInsert(key, -1, new Character('f'), null).get(
+    assertTrue(mc.asyncLopInsert(key, -1, 'f', null).get(
             1000, TimeUnit.MILLISECONDS));
 
     // Retrieve items from the list and check they're in same data type
@@ -99,7 +99,7 @@ public class LopInsertDataType extends BaseIntegrationTest {
 
   public void testLopInsert_DifferentDataType_ErrorCase() throws Exception {
     // First, create a list and insert one item in it
-    assertTrue(mc.asyncLopInsert(key, 0, new Character('a'),
+    assertTrue(mc.asyncLopInsert(key, 0, 'a',
             new CollectionAttributes()).get(1000, TimeUnit.MILLISECONDS));
 
     // Then insert an another item with different data type

--- a/src/test/manual/net/spy/memcached/collection/map/MopBulkAPITest.java
+++ b/src/test/manual/net/spy/memcached/collection/map/MopBulkAPITest.java
@@ -16,7 +16,7 @@
  */
 package net.spy.memcached.collection.map;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import net.spy.memcached.collection.BaseIntegrationTest;
 import net.spy.memcached.collection.CollectionAttributes;
 import net.spy.memcached.collection.CollectionOverflowAction;

--- a/src/test/manual/net/spy/memcached/collection/map/MopOverflowActionTest.java
+++ b/src/test/manual/net/spy/memcached/collection/map/MopOverflowActionTest.java
@@ -16,7 +16,7 @@
  */
 package net.spy.memcached.collection.map;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import net.spy.memcached.collection.BaseIntegrationTest;
 import net.spy.memcached.collection.CollectionAttributes;
 import net.spy.memcached.collection.CollectionOverflowAction;

--- a/src/test/manual/net/spy/memcached/collection/map/MopServerMessageTest.java
+++ b/src/test/manual/net/spy/memcached/collection/map/MopServerMessageTest.java
@@ -27,7 +27,7 @@ import java.util.concurrent.TimeUnit;
 
 public class MopServerMessageTest extends BaseIntegrationTest {
 
-  private String key = "MopServerMessageTest";
+  private final String key = "MopServerMessageTest";
 
   @Override
   protected void setUp() throws Exception {
@@ -36,7 +36,7 @@ public class MopServerMessageTest extends BaseIntegrationTest {
   }
 
   public void testNotFound() throws Exception {
-    CollectionFuture<Map<String, Object>> future = (CollectionFuture<Map<String, Object>>) mc
+    CollectionFuture<Map<String, Object>> future = mc
             .asyncMopGet(key, false, false);
     assertNull(future.get(1000, TimeUnit.MILLISECONDS));
 
@@ -46,7 +46,7 @@ public class MopServerMessageTest extends BaseIntegrationTest {
   }
 
   public void testCreatedStored() throws Exception {
-    CollectionFuture<Boolean> future = (CollectionFuture<Boolean>) mc
+    CollectionFuture<Boolean> future = mc
             .asyncMopInsert(key, "0", 0, new CollectionAttributes());
     assertTrue(future.get(1000, TimeUnit.MILLISECONDS));
 
@@ -56,11 +56,11 @@ public class MopServerMessageTest extends BaseIntegrationTest {
   }
 
   public void testStored() throws Exception {
-    CollectionFuture<Boolean> future = (CollectionFuture<Boolean>) mc
+    CollectionFuture<Boolean> future = mc
             .asyncMopInsert(key, "0", 0, new CollectionAttributes());
     assertTrue(future.get(1000, TimeUnit.MILLISECONDS));
 
-    future = (CollectionFuture<Boolean>) mc.asyncMopInsert(key, "1", 1,
+    future = mc.asyncMopInsert(key, "1", 1,
             new CollectionAttributes());
     assertTrue(future.get(1000, TimeUnit.MILLISECONDS));
 
@@ -70,7 +70,7 @@ public class MopServerMessageTest extends BaseIntegrationTest {
   }
 
   public void testOverflowed() throws Exception {
-    CollectionFuture<Boolean> future = (CollectionFuture<Boolean>) mc
+    CollectionFuture<Boolean> future = mc
             .asyncMopInsert(key, "0", 0, new CollectionAttributes());
     assertTrue(future.get(1000, TimeUnit.MILLISECONDS));
 
@@ -78,11 +78,11 @@ public class MopServerMessageTest extends BaseIntegrationTest {
             new CollectionAttributes(null, 2L, CollectionOverflowAction.error))
             .get(1000, TimeUnit.MILLISECONDS));
 
-    future = (CollectionFuture<Boolean>) mc.asyncMopInsert(key, "1", 1,
+    future = mc.asyncMopInsert(key, "1", 1,
             new CollectionAttributes());
     assertTrue(future.get(1000, TimeUnit.MILLISECONDS));
 
-    future = (CollectionFuture<Boolean>) mc.asyncMopInsert(key, "2", 1,
+    future = mc.asyncMopInsert(key, "2", 1,
             new CollectionAttributes());
     assertFalse(future.get(1000, TimeUnit.MILLISECONDS));
 
@@ -93,12 +93,12 @@ public class MopServerMessageTest extends BaseIntegrationTest {
 
   public void testDeletedDropped() throws Exception {
     // create
-    CollectionFuture<Boolean> future = (CollectionFuture<Boolean>) mc
+    CollectionFuture<Boolean> future = mc
             .asyncMopInsert(key, "0", "aaa", new CollectionAttributes());
     assertTrue(future.get(1000, TimeUnit.MILLISECONDS));
 
     // delete
-    future = (CollectionFuture<Boolean>) mc.asyncMopDelete(key, true);
+    future = mc.asyncMopDelete(key, true);
     assertTrue(future.get(1000, TimeUnit.MILLISECONDS));
 
     OperationStatus status = future.getOperationStatus();
@@ -108,17 +108,17 @@ public class MopServerMessageTest extends BaseIntegrationTest {
 
   public void testDeleted() throws Exception {
     // create
-    CollectionFuture<Boolean> future = (CollectionFuture<Boolean>) mc
+    CollectionFuture<Boolean> future = mc
             .asyncMopInsert(key, "0", "aaa", new CollectionAttributes());
     assertTrue(future.get(1000, TimeUnit.MILLISECONDS));
 
     // insert
-    future = (CollectionFuture<Boolean>) mc.asyncMopInsert(key, "1", "bbb",
+    future = mc.asyncMopInsert(key, "1", "bbb",
             new CollectionAttributes());
     assertTrue(future.get(1000, TimeUnit.MILLISECONDS));
 
     // delete
-    future = (CollectionFuture<Boolean>) mc.asyncMopDelete(key, "0", false);
+    future = mc.asyncMopDelete(key, "0", false);
     assertTrue(future.get(1000, TimeUnit.MILLISECONDS));
 
     OperationStatus status = future.getOperationStatus();
@@ -128,12 +128,12 @@ public class MopServerMessageTest extends BaseIntegrationTest {
 
   public void testDeletedDroppedAfterRetrieval() throws Exception {
     // create
-    CollectionFuture<Boolean> future = (CollectionFuture<Boolean>) mc
+    CollectionFuture<Boolean> future = mc
             .asyncMopInsert(key, "0", "aaa", new CollectionAttributes());
     assertTrue(future.get(1000, TimeUnit.MILLISECONDS));
 
     // get
-    CollectionFuture<Map<String, Object>> future2 = (CollectionFuture<Map<String, Object>>) mc
+    CollectionFuture<Map<String, Object>> future2 = mc
             .asyncMopGet(key, true, true);
     assertNotNull(future2.get(1000, TimeUnit.MILLISECONDS));
 
@@ -144,17 +144,17 @@ public class MopServerMessageTest extends BaseIntegrationTest {
 
   public void testDeletedAfterRetrieval() throws Exception {
     // create
-    CollectionFuture<Boolean> future = (CollectionFuture<Boolean>) mc
+    CollectionFuture<Boolean> future = mc
             .asyncMopInsert(key, "0", "aaa", new CollectionAttributes());
     assertTrue(future.get(1000, TimeUnit.MILLISECONDS));
 
     // insert
-    future = (CollectionFuture<Boolean>) mc.asyncMopInsert(key, "1", "bbb",
+    future = mc.asyncMopInsert(key, "1", "bbb",
             new CollectionAttributes());
     assertTrue(future.get(1000, TimeUnit.MILLISECONDS));
 
     // get
-    CollectionFuture<Map<String, Object>> future2 = (CollectionFuture<Map<String, Object>>) mc
+    CollectionFuture<Map<String, Object>> future2 = mc
             .asyncMopGet(key, true, false);
     assertNotNull(future2.get(1000, TimeUnit.MILLISECONDS));
 

--- a/src/test/manual/net/spy/memcached/collection/map/MopUpdateTest.java
+++ b/src/test/manual/net/spy/memcached/collection/map/MopUpdateTest.java
@@ -16,7 +16,7 @@
  */
 package net.spy.memcached.collection.map;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import net.spy.memcached.collection.BaseIntegrationTest;
 import net.spy.memcached.collection.CollectionAttributes;
 

--- a/src/test/manual/net/spy/memcached/collection/set/SopBulkAPITest.java
+++ b/src/test/manual/net/spy/memcached/collection/set/SopBulkAPITest.java
@@ -23,7 +23,7 @@ import java.util.Set;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import net.spy.memcached.collection.BaseIntegrationTest;
 import net.spy.memcached.collection.CollectionAttributes;
 import net.spy.memcached.internal.CollectionFuture;

--- a/src/test/manual/net/spy/memcached/collection/set/SopDeleteTest.java
+++ b/src/test/manual/net/spy/memcached/collection/set/SopDeleteTest.java
@@ -18,7 +18,7 @@ package net.spy.memcached.collection.set;
 
 import java.util.concurrent.ExecutionException;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import net.spy.memcached.collection.BaseIntegrationTest;
 import net.spy.memcached.collection.CollectionAttributes;
 

--- a/src/test/manual/net/spy/memcached/collection/set/SopOverflowActionTest.java
+++ b/src/test/manual/net/spy/memcached/collection/set/SopOverflowActionTest.java
@@ -21,7 +21,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import net.spy.memcached.collection.BaseIntegrationTest;
 import net.spy.memcached.collection.CollectionAttributes;
 import net.spy.memcached.collection.CollectionOverflowAction;

--- a/src/test/manual/net/spy/memcached/collection/set/SopPipedExistTest.java
+++ b/src/test/manual/net/spy/memcached/collection/set/SopPipedExistTest.java
@@ -20,7 +20,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import net.spy.memcached.collection.BaseIntegrationTest;
 import net.spy.memcached.collection.CollectionAttributes;
 import net.spy.memcached.collection.ElementValueType;

--- a/src/test/manual/net/spy/memcached/emptycollection/BTreeDeleteWithFilterTest.java
+++ b/src/test/manual/net/spy/memcached/emptycollection/BTreeDeleteWithFilterTest.java
@@ -16,7 +16,7 @@
  */
 package net.spy.memcached.emptycollection;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import net.spy.memcached.collection.ElementFlagFilter;
 import net.spy.memcached.collection.ElementFlagFilter.CompOperands;
 import net.spy.memcached.collection.BaseIntegrationTest;
@@ -54,7 +54,7 @@ public class BTreeDeleteWithFilterTest extends BaseIntegrationTest {
       Assert.assertTrue(insertResult);
 
       // check attr
-      Assert.assertEquals(new Long(1), mc.asyncGetAttr(KEY).get()
+      Assert.assertEquals(Long.valueOf(1), mc.asyncGetAttr(KEY).get()
               .getCount());
 
       // delete one bkey
@@ -62,7 +62,7 @@ public class BTreeDeleteWithFilterTest extends BaseIntegrationTest {
       Assert.assertTrue(delete);
 
       // check attr again
-      Assert.assertEquals(new Long(0), mc.asyncGetAttr(KEY).get()
+      Assert.assertEquals(Long.valueOf(0), mc.asyncGetAttr(KEY).get()
               .getCount());
     } catch (Exception e) {
       e.printStackTrace();
@@ -80,7 +80,7 @@ public class BTreeDeleteWithFilterTest extends BaseIntegrationTest {
       Assert.assertTrue(insertResult);
 
       // check attr
-      Assert.assertEquals(new Long(1), mc.asyncGetAttr(KEY).get()
+      Assert.assertEquals(Long.valueOf(1), mc.asyncGetAttr(KEY).get()
               .getCount());
 
       // delete one bkey
@@ -88,7 +88,7 @@ public class BTreeDeleteWithFilterTest extends BaseIntegrationTest {
       Assert.assertFalse(delete);
 
       // check attr again
-      Assert.assertEquals(new Long(1), mc.asyncGetAttr(KEY).get()
+      Assert.assertEquals(Long.valueOf(1), mc.asyncGetAttr(KEY).get()
               .getCount());
     } catch (Exception e) {
       e.printStackTrace();

--- a/src/test/manual/net/spy/memcached/emptycollection/BTreeGetWithFilterTest.java
+++ b/src/test/manual/net/spy/memcached/emptycollection/BTreeGetWithFilterTest.java
@@ -18,7 +18,7 @@ package net.spy.memcached.emptycollection;
 
 import java.util.Map;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import net.spy.memcached.collection.Element;
 import net.spy.memcached.collection.ElementFlagFilter;
 import net.spy.memcached.collection.ElementFlagFilter.BitWiseOperands;
@@ -56,7 +56,7 @@ public class BTreeGetWithFilterTest extends BaseIntegrationTest {
               CompOperands.Equal, "flag".getBytes());
 
       // check attr
-      Assert.assertEquals(new Long(1), mc.asyncGetAttr(KEY).get()
+      Assert.assertEquals(Long.valueOf(1), mc.asyncGetAttr(KEY).get()
               .getCount());
 
       // get value delete=true, drop=false
@@ -68,7 +68,7 @@ public class BTreeGetWithFilterTest extends BaseIntegrationTest {
       // check exists empty btree
       CollectionAttributes attr = mc.asyncGetAttr(KEY).get();
       Assert.assertNotNull(attr);
-      Assert.assertEquals(new Long(0), attr.getCount());
+      Assert.assertEquals(Long.valueOf(0), attr.getCount());
 
       Map<Long, Element<Object>> map = mc.asyncBopGet(KEY, BKEY,
               ElementFlagFilter.DO_NOT_FILTER, false, false).get();
@@ -87,7 +87,7 @@ public class BTreeGetWithFilterTest extends BaseIntegrationTest {
       filter.setBitOperand(BitWiseOperands.AND, "flag".getBytes());
 
       // check attr
-      Assert.assertEquals(new Long(1), mc.asyncGetAttr(KEY).get()
+      Assert.assertEquals(Long.valueOf(1), mc.asyncGetAttr(KEY).get()
               .getCount());
 
       // get value delete=true, drop=false
@@ -115,7 +115,7 @@ public class BTreeGetWithFilterTest extends BaseIntegrationTest {
               CompOperands.Equal, "flag".getBytes());
 
       // check attr
-      Assert.assertEquals(new Long(1), mc.asyncGetAttr(KEY).get()
+      Assert.assertEquals(Long.valueOf(1), mc.asyncGetAttr(KEY).get()
               .getCount());
 
       // get value delete=true, drop=false
@@ -126,7 +126,7 @@ public class BTreeGetWithFilterTest extends BaseIntegrationTest {
       // check exists empty btree
       CollectionAttributes attr = mc.asyncGetAttr(KEY).get();
       Assert.assertNotNull(attr);
-      Assert.assertEquals(new Long(0), attr.getCount());
+      Assert.assertEquals(Long.valueOf(0), attr.getCount());
 
       Map<Long, Element<Object>> map = mc.asyncBopGet(KEY, BKEY,
               ElementFlagFilter.DO_NOT_FILTER, false, false).get();
@@ -145,7 +145,7 @@ public class BTreeGetWithFilterTest extends BaseIntegrationTest {
       filter.setBitOperand(BitWiseOperands.AND, "flag".getBytes());
 
       // check attr
-      Assert.assertEquals(new Long(1), mc.asyncGetAttr(KEY).get()
+      Assert.assertEquals(Long.valueOf(1), mc.asyncGetAttr(KEY).get()
               .getCount());
 
       // get value delete=true, drop=false
@@ -172,7 +172,7 @@ public class BTreeGetWithFilterTest extends BaseIntegrationTest {
               CompOperands.Equal, "flag".getBytes());
 
       // check attr
-      Assert.assertEquals(new Long(1), mc.asyncGetAttr(KEY).get()
+      Assert.assertEquals(Long.valueOf(1), mc.asyncGetAttr(KEY).get()
               .getCount());
 
       // get value delete=true, drop=false

--- a/src/test/manual/net/spy/memcached/emptycollection/CreateEmptyBTreeTest.java
+++ b/src/test/manual/net/spy/memcached/emptycollection/CreateEmptyBTreeTest.java
@@ -16,7 +16,7 @@
  */
 package net.spy.memcached.emptycollection;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import net.spy.memcached.collection.BaseIntegrationTest;
 import net.spy.memcached.collection.CollectionAttributes;
 import net.spy.memcached.collection.ElementValueType;
@@ -50,9 +50,9 @@ public class CreateEmptyBTreeTest extends BaseIntegrationTest {
       // check attribute
       CollectionAttributes attr = mc.asyncGetAttr(KEY).get();
 
-      Assert.assertEquals(new Long(0), attr.getCount());
-      Assert.assertEquals(new Long(4000), attr.getMaxCount());
-      Assert.assertEquals(new Integer(0), attr.getExpireTime());
+      Assert.assertEquals(Long.valueOf(0), attr.getCount());
+      Assert.assertEquals(Long.valueOf(4000), attr.getMaxCount());
+      Assert.assertEquals(Integer.valueOf(0), attr.getExpireTime());
     } catch (Exception e) {
       e.printStackTrace();
       Assert.fail(e.getMessage());
@@ -74,8 +74,8 @@ public class CreateEmptyBTreeTest extends BaseIntegrationTest {
       // check attribute
       CollectionAttributes attr = mc.asyncGetAttr(KEY).get();
 
-      Assert.assertEquals(new Long(0), attr.getCount());
-      Assert.assertEquals(new Long(10000), attr.getMaxCount());
+      Assert.assertEquals(Long.valueOf(0), attr.getCount());
+      Assert.assertEquals(Long.valueOf(10000), attr.getMaxCount());
       Assert.assertEquals(CollectionOverflowAction.error,
               attr.getOverflowAction());
     } catch (Exception e) {

--- a/src/test/manual/net/spy/memcached/emptycollection/CreateEmptyListTest.java
+++ b/src/test/manual/net/spy/memcached/emptycollection/CreateEmptyListTest.java
@@ -16,7 +16,7 @@
  */
 package net.spy.memcached.emptycollection;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import net.spy.memcached.collection.BaseIntegrationTest;
 import net.spy.memcached.collection.CollectionAttributes;
 import net.spy.memcached.collection.ElementValueType;
@@ -51,9 +51,9 @@ public class CreateEmptyListTest extends BaseIntegrationTest {
       // check attribute
       CollectionAttributes attr = mc.asyncGetAttr(KEY).get();
 
-      Assert.assertEquals(new Long(0), attr.getCount());
-      Assert.assertEquals(new Long(4000), attr.getMaxCount());
-      Assert.assertEquals(new Integer(0), attr.getExpireTime());
+      Assert.assertEquals(Long.valueOf(0), attr.getCount());
+      Assert.assertEquals(Long.valueOf(4000), attr.getMaxCount());
+      Assert.assertEquals(Integer.valueOf(0), attr.getExpireTime());
     } catch (Exception e) {
       e.printStackTrace();
       Assert.fail(e.getMessage());
@@ -75,8 +75,8 @@ public class CreateEmptyListTest extends BaseIntegrationTest {
       // check attribute
       CollectionAttributes attr = mc.asyncGetAttr(KEY).get();
 
-      Assert.assertEquals(new Long(0), attr.getCount());
-      Assert.assertEquals(new Long(10000), attr.getMaxCount());
+      Assert.assertEquals(Long.valueOf(0), attr.getCount());
+      Assert.assertEquals(Long.valueOf(10000), attr.getMaxCount());
       Assert.assertEquals(CollectionOverflowAction.error,
               attr.getOverflowAction());
     } catch (Exception e) {

--- a/src/test/manual/net/spy/memcached/emptycollection/CreateEmptyMapTest.java
+++ b/src/test/manual/net/spy/memcached/emptycollection/CreateEmptyMapTest.java
@@ -16,7 +16,7 @@
  */
 package net.spy.memcached.emptycollection;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import net.spy.memcached.collection.BaseIntegrationTest;
 import net.spy.memcached.collection.CollectionAttributes;
 import net.spy.memcached.collection.ElementValueType;
@@ -50,9 +50,9 @@ public class CreateEmptyMapTest extends BaseIntegrationTest {
       // check attribute
       CollectionAttributes attr = mc.asyncGetAttr(KEY).get();
 
-      Assert.assertEquals(new Long(0), attr.getCount());
-      Assert.assertEquals(new Long(4000), attr.getMaxCount());
-      Assert.assertEquals(new Integer(0), attr.getExpireTime());
+      Assert.assertEquals(Long.valueOf(0), attr.getCount());
+      Assert.assertEquals(Long.valueOf(4000), attr.getMaxCount());
+      Assert.assertEquals(Integer.valueOf(0), attr.getExpireTime());
     } catch (Exception e) {
       e.printStackTrace();
       Assert.fail(e.getMessage());
@@ -74,8 +74,8 @@ public class CreateEmptyMapTest extends BaseIntegrationTest {
       // check attribute
       CollectionAttributes attr = mc.asyncGetAttr(KEY).get();
 
-      Assert.assertEquals(new Long(0), attr.getCount());
-      Assert.assertEquals(new Long(10000), attr.getMaxCount());
+      Assert.assertEquals(Long.valueOf(0), attr.getCount());
+      Assert.assertEquals(Long.valueOf(10000), attr.getMaxCount());
       Assert.assertEquals(CollectionOverflowAction.error,
               attr.getOverflowAction());
     } catch (Exception e) {

--- a/src/test/manual/net/spy/memcached/emptycollection/CreateEmptySetTest.java
+++ b/src/test/manual/net/spy/memcached/emptycollection/CreateEmptySetTest.java
@@ -16,7 +16,7 @@
  */
 package net.spy.memcached.emptycollection;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import net.spy.memcached.collection.BaseIntegrationTest;
 import net.spy.memcached.collection.CollectionAttributes;
 import net.spy.memcached.collection.ElementValueType;
@@ -51,9 +51,9 @@ public class CreateEmptySetTest extends BaseIntegrationTest {
       // check attribute
       CollectionAttributes attr = mc.asyncGetAttr(KEY).get();
 
-      Assert.assertEquals(new Long(0), attr.getCount());
-      Assert.assertEquals(new Long(4000), attr.getMaxCount());
-      Assert.assertEquals(new Integer(0), attr.getExpireTime());
+      Assert.assertEquals(Long.valueOf(0), attr.getCount());
+      Assert.assertEquals(Long.valueOf(4000), attr.getMaxCount());
+      Assert.assertEquals(Integer.valueOf(0), attr.getExpireTime());
     } catch (Exception e) {
       e.printStackTrace();
       Assert.fail(e.getMessage());
@@ -75,8 +75,8 @@ public class CreateEmptySetTest extends BaseIntegrationTest {
       // check attribute
       CollectionAttributes attr = mc.asyncGetAttr(KEY).get();
 
-      Assert.assertEquals(new Long(0), attr.getCount());
-      Assert.assertEquals(new Long(10000), attr.getMaxCount());
+      Assert.assertEquals(Long.valueOf(0), attr.getCount());
+      Assert.assertEquals(Long.valueOf(10000), attr.getMaxCount());
       Assert.assertEquals(CollectionOverflowAction.error,
               attr.getOverflowAction());
     } catch (Exception e) {

--- a/src/test/manual/net/spy/memcached/emptycollection/GetCountBTreeTest.java
+++ b/src/test/manual/net/spy/memcached/emptycollection/GetCountBTreeTest.java
@@ -16,7 +16,7 @@
  */
 package net.spy.memcached.emptycollection;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import net.spy.memcached.collection.BaseIntegrationTest;
 import net.spy.memcached.collection.CollectionAttributes;
 import net.spy.memcached.collection.CollectionResponse;
@@ -137,7 +137,7 @@ public class GetCountBTreeTest extends BaseIntegrationTest {
       Assert.assertTrue(insertResult2);
 
       // check count in attributes
-      Assert.assertEquals(new Long(2), mc.asyncGetAttr(KEY).get()
+      Assert.assertEquals(Long.valueOf(2), mc.asyncGetAttr(KEY).get()
               .getCount());
 
       // get btree item count
@@ -145,7 +145,7 @@ public class GetCountBTreeTest extends BaseIntegrationTest {
               BKEY, BKEY, ElementFlagFilter.DO_NOT_FILTER);
       Integer count = future.get();
       Assert.assertNotNull(count);
-      Assert.assertEquals(new Integer(1), count);
+      Assert.assertEquals(Integer.valueOf(1), count);
       Assert.assertEquals(CollectionResponse.END, future
               .getOperationStatus().getResponse());
     } catch (Exception e) {
@@ -169,7 +169,7 @@ public class GetCountBTreeTest extends BaseIntegrationTest {
       Assert.assertTrue(insertResult2);
 
       // check count in attributes
-      Assert.assertEquals(new Long(2), mc.asyncGetAttr(KEY).get()
+      Assert.assertEquals(Long.valueOf(2), mc.asyncGetAttr(KEY).get()
               .getCount());
 
       // get btree item count
@@ -177,7 +177,7 @@ public class GetCountBTreeTest extends BaseIntegrationTest {
               BKEY, BKEY + 1, ElementFlagFilter.DO_NOT_FILTER);
       Integer count = future.get();
       Assert.assertNotNull(count);
-      Assert.assertEquals(new Integer(2), count);
+      Assert.assertEquals(Integer.valueOf(2), count);
     } catch (Exception e) {
       e.printStackTrace();
       Assert.fail(e.getMessage());
@@ -199,7 +199,7 @@ public class GetCountBTreeTest extends BaseIntegrationTest {
       Assert.assertTrue(insertResult2);
 
       // check count in attributes
-      Assert.assertEquals(new Long(2), mc.asyncGetAttr(KEY).get()
+      Assert.assertEquals(Long.valueOf(2), mc.asyncGetAttr(KEY).get()
               .getCount());
 
       // get btree item count
@@ -207,7 +207,7 @@ public class GetCountBTreeTest extends BaseIntegrationTest {
               BKEY + 3, BKEY + 3, ElementFlagFilter.DO_NOT_FILTER);
       Integer count = future.get();
       Assert.assertNotNull(count);
-      Assert.assertEquals(new Integer(0), count);
+      Assert.assertEquals(Integer.valueOf(0), count);
     } catch (Exception e) {
       e.printStackTrace();
       Assert.fail(e.getMessage());
@@ -229,7 +229,7 @@ public class GetCountBTreeTest extends BaseIntegrationTest {
       Assert.assertTrue(insertResult2);
 
       // check count in attributes
-      Assert.assertEquals(new Long(2), mc.asyncGetAttr(KEY).get()
+      Assert.assertEquals(Long.valueOf(2), mc.asyncGetAttr(KEY).get()
               .getCount());
 
       // get btree item count
@@ -237,7 +237,7 @@ public class GetCountBTreeTest extends BaseIntegrationTest {
               BKEY + 2, BKEY + 3, ElementFlagFilter.DO_NOT_FILTER);
       Integer count = future.get();
       Assert.assertNotNull(count);
-      Assert.assertEquals(new Integer(0), count);
+      Assert.assertEquals(Integer.valueOf(0), count);
     } catch (Exception e) {
       e.printStackTrace();
       Assert.fail(e.getMessage());

--- a/src/test/manual/net/spy/memcached/emptycollection/GetCountBTreeTestWithElementFlagFilterTest.java
+++ b/src/test/manual/net/spy/memcached/emptycollection/GetCountBTreeTestWithElementFlagFilterTest.java
@@ -16,7 +16,7 @@
  */
 package net.spy.memcached.emptycollection;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import net.spy.memcached.collection.BaseIntegrationTest;
 import net.spy.memcached.collection.CollectionAttributes;
 import net.spy.memcached.collection.CollectionResponse;
@@ -104,7 +104,7 @@ public class GetCountBTreeTestWithElementFlagFilterTest extends BaseIntegrationT
       Assert.assertTrue(insertResult2);
 
       // check count in attributes
-      Assert.assertEquals(new Long(2), mc.asyncGetAttr(KEY).get()
+      Assert.assertEquals(Long.valueOf(2), mc.asyncGetAttr(KEY).get()
               .getCount());
 
       // get btree item count
@@ -112,7 +112,7 @@ public class GetCountBTreeTestWithElementFlagFilterTest extends BaseIntegrationT
               BKEY, BKEY, filter);
       Integer count = future.get();
       Assert.assertNotNull(count);
-      Assert.assertEquals(new Integer(1), count);
+      Assert.assertEquals(Integer.valueOf(1), count);
     } catch (Exception e) {
       e.printStackTrace();
       Assert.fail(e.getMessage());
@@ -137,7 +137,7 @@ public class GetCountBTreeTestWithElementFlagFilterTest extends BaseIntegrationT
       Assert.assertTrue(insertResult2);
 
       // check count in attributes
-      Assert.assertEquals(new Long(2), mc.asyncGetAttr(KEY).get()
+      Assert.assertEquals(Long.valueOf(2), mc.asyncGetAttr(KEY).get()
               .getCount());
 
       // get btree item count
@@ -145,7 +145,7 @@ public class GetCountBTreeTestWithElementFlagFilterTest extends BaseIntegrationT
               BKEY, BKEY + 1, filter);
       Integer count = future.get();
       Assert.assertNotNull(count);
-      Assert.assertEquals(new Integer(0), count);
+      Assert.assertEquals(Integer.valueOf(0), count);
     } catch (Exception e) {
       e.printStackTrace();
       Assert.fail(e.getMessage());
@@ -172,7 +172,7 @@ public class GetCountBTreeTestWithElementFlagFilterTest extends BaseIntegrationT
       Assert.assertTrue(insertResult2);
 
       // check count in attributes
-      Assert.assertEquals(new Long(2), mc.asyncGetAttr(KEY).get()
+      Assert.assertEquals(Long.valueOf(2), mc.asyncGetAttr(KEY).get()
               .getCount());
 
       // get btree item count
@@ -180,7 +180,7 @@ public class GetCountBTreeTestWithElementFlagFilterTest extends BaseIntegrationT
               BKEY, BKEY, filter);
       Integer count = future.get();
       Assert.assertNotNull(count);
-      Assert.assertEquals(new Integer(1), count);
+      Assert.assertEquals(Integer.valueOf(1), count);
     } catch (Exception e) {
       e.printStackTrace();
       Assert.fail(e.getMessage());
@@ -205,7 +205,7 @@ public class GetCountBTreeTestWithElementFlagFilterTest extends BaseIntegrationT
       Assert.assertTrue(insertResult2);
 
       // check count in attributes
-      Assert.assertEquals(new Long(2), mc.asyncGetAttr(KEY).get()
+      Assert.assertEquals(Long.valueOf(2), mc.asyncGetAttr(KEY).get()
               .getCount());
 
       // get btree item count
@@ -213,7 +213,7 @@ public class GetCountBTreeTestWithElementFlagFilterTest extends BaseIntegrationT
               BKEY + 3, BKEY + 3, filter);
       Integer count = future.get();
       Assert.assertNotNull(count);
-      Assert.assertEquals(new Integer(0), count);
+      Assert.assertEquals(Integer.valueOf(0), count);
     } catch (Exception e) {
       e.printStackTrace();
       Assert.fail(e.getMessage());
@@ -238,7 +238,7 @@ public class GetCountBTreeTestWithElementFlagFilterTest extends BaseIntegrationT
       Assert.assertTrue(insertResult2);
 
       // check count in attributes
-      Assert.assertEquals(new Long(2), mc.asyncGetAttr(KEY).get()
+      Assert.assertEquals(Long.valueOf(2), mc.asyncGetAttr(KEY).get()
               .getCount());
 
       // get btree item count
@@ -246,7 +246,7 @@ public class GetCountBTreeTestWithElementFlagFilterTest extends BaseIntegrationT
               BKEY + 2, BKEY + 3, filter);
       Integer count = future.get();
       Assert.assertNotNull(count);
-      Assert.assertEquals(new Integer(0), count);
+      Assert.assertEquals(Integer.valueOf(0), count);
     } catch (Exception e) {
       e.printStackTrace();
       Assert.fail(e.getMessage());

--- a/src/test/manual/net/spy/memcached/emptycollection/GetWithDropBTreeTest.java
+++ b/src/test/manual/net/spy/memcached/emptycollection/GetWithDropBTreeTest.java
@@ -18,7 +18,7 @@ package net.spy.memcached.emptycollection;
 
 import java.util.Map;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import net.spy.memcached.collection.Element;
 import net.spy.memcached.collection.ElementFlagFilter;
 import net.spy.memcached.collection.BaseIntegrationTest;
@@ -43,7 +43,7 @@ public class GetWithDropBTreeTest extends BaseIntegrationTest {
   public void testGetWithoutDeleteAndDrop() {
     try {
       // check attr
-      Assert.assertEquals(new Long(1), mc.asyncGetAttr(KEY).get()
+      Assert.assertEquals(Long.valueOf(1), mc.asyncGetAttr(KEY).get()
               .getCount());
 
       // get value delete=false, drop=true
@@ -53,7 +53,7 @@ public class GetWithDropBTreeTest extends BaseIntegrationTest {
                       false, false).get().get(BKEY).getValue());
 
       // check exists
-      Assert.assertEquals(new Long(1), mc.asyncGetAttr(KEY).get()
+      Assert.assertEquals(Long.valueOf(1), mc.asyncGetAttr(KEY).get()
               .getCount());
 
       // get value again
@@ -70,7 +70,7 @@ public class GetWithDropBTreeTest extends BaseIntegrationTest {
   public void testGetWithtDeleteAndWithoutDrop() {
     try {
       // check attr
-      Assert.assertEquals(new Long(1), mc.asyncGetAttr(KEY).get()
+      Assert.assertEquals(Long.valueOf(1), mc.asyncGetAttr(KEY).get()
               .getCount());
 
       // get value delete=true, drop=false
@@ -82,7 +82,7 @@ public class GetWithDropBTreeTest extends BaseIntegrationTest {
       // check exists empty btree
       CollectionAttributes attr = mc.asyncGetAttr(KEY).get();
       Assert.assertNotNull(attr);
-      Assert.assertEquals(new Long(0), attr.getCount());
+      Assert.assertEquals(Long.valueOf(0), attr.getCount());
 
       Map<Long, Element<Object>> map = mc.asyncBopGet(KEY, BKEY,
               ElementFlagFilter.DO_NOT_FILTER, false, false).get();
@@ -97,7 +97,7 @@ public class GetWithDropBTreeTest extends BaseIntegrationTest {
   public void testGetWithtDeleteAndWithDrop() {
     try {
       // check attr
-      Assert.assertEquals(new Long(1), mc.asyncGetAttr(KEY).get()
+      Assert.assertEquals(Long.valueOf(1), mc.asyncGetAttr(KEY).get()
               .getCount());
 
       // get value delete=true, drop=false

--- a/src/test/manual/net/spy/memcached/emptycollection/GetWithDropListTest.java
+++ b/src/test/manual/net/spy/memcached/emptycollection/GetWithDropListTest.java
@@ -18,7 +18,7 @@ package net.spy.memcached.emptycollection;
 
 import java.util.List;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import net.spy.memcached.collection.BaseIntegrationTest;
 import net.spy.memcached.collection.CollectionAttributes;
 import net.spy.memcached.internal.CollectionFuture;
@@ -42,7 +42,7 @@ public class GetWithDropListTest extends BaseIntegrationTest {
   public void testGetWithoutDeleteAndDrop() {
     try {
       // check attr
-      Assert.assertEquals(new Long(1), mc.asyncGetAttr(KEY).get()
+      Assert.assertEquals(Long.valueOf(1), mc.asyncGetAttr(KEY).get()
               .getCount());
 
       // get value delete=false, drop=true
@@ -50,7 +50,7 @@ public class GetWithDropListTest extends BaseIntegrationTest {
               .get().get(INDEX));
 
       // check exists
-      Assert.assertEquals(new Long(1), mc.asyncGetAttr(KEY).get()
+      Assert.assertEquals(Long.valueOf(1), mc.asyncGetAttr(KEY).get()
               .getCount());
 
       // get value againg
@@ -65,7 +65,7 @@ public class GetWithDropListTest extends BaseIntegrationTest {
   public void testGetWithtDeleteAndWithoutDrop() {
     try {
       // check attr
-      Assert.assertEquals(new Long(1), mc.asyncGetAttr(KEY).get()
+      Assert.assertEquals(Long.valueOf(1), mc.asyncGetAttr(KEY).get()
               .getCount());
 
       // get value delete=true, drop=false
@@ -75,7 +75,7 @@ public class GetWithDropListTest extends BaseIntegrationTest {
       // check exists empty btree
       CollectionAttributes attr = mc.asyncGetAttr(KEY).get();
       Assert.assertNotNull(attr);
-      Assert.assertEquals(new Long(0), attr.getCount());
+      Assert.assertEquals(Long.valueOf(0), attr.getCount());
 
       // get value again
       CollectionFuture<List<Object>> asyncLopGet = mc.asyncLopGet(KEY,
@@ -92,7 +92,7 @@ public class GetWithDropListTest extends BaseIntegrationTest {
   public void testGetWithtDeleteAndWithDrop() {
     try {
       // check attr
-      Assert.assertEquals(new Long(1), mc.asyncGetAttr(KEY).get()
+      Assert.assertEquals(Long.valueOf(1), mc.asyncGetAttr(KEY).get()
               .getCount());
 
       // get value delete=true, drop=false

--- a/src/test/manual/net/spy/memcached/emptycollection/GetWithDropMapTest.java
+++ b/src/test/manual/net/spy/memcached/emptycollection/GetWithDropMapTest.java
@@ -18,7 +18,7 @@ package net.spy.memcached.emptycollection;
 
 import java.util.Map;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import net.spy.memcached.collection.BaseIntegrationTest;
 import net.spy.memcached.collection.CollectionAttributes;
 
@@ -41,7 +41,7 @@ public class GetWithDropMapTest extends BaseIntegrationTest {
   public void testGetWithoutDeleteAndDrop() {
     try {
       // check attr
-      Assert.assertEquals(new Long(1), mc.asyncGetAttr(KEY).get()
+      Assert.assertEquals(Long.valueOf(1), mc.asyncGetAttr(KEY).get()
               .getCount());
 
       // get value delete=false, drop=false
@@ -50,7 +50,7 @@ public class GetWithDropMapTest extends BaseIntegrationTest {
               mc.asyncMopGet(KEY, MKEY, false, false).get().get(MKEY));
 
       // check exists
-      Assert.assertEquals(new Long(1), mc.asyncGetAttr(KEY).get()
+      Assert.assertEquals(Long.valueOf(1), mc.asyncGetAttr(KEY).get()
               .getCount());
 
       // get value again
@@ -66,7 +66,7 @@ public class GetWithDropMapTest extends BaseIntegrationTest {
   public void testGetWithtDeleteAndWithoutDrop() {
     try {
       // check attr
-      Assert.assertEquals(new Long(1), mc.asyncGetAttr(KEY).get()
+      Assert.assertEquals(Long.valueOf(1), mc.asyncGetAttr(KEY).get()
               .getCount());
 
       // get value delete=true, drop=false
@@ -77,7 +77,7 @@ public class GetWithDropMapTest extends BaseIntegrationTest {
       // check exists empty map
       CollectionAttributes attr = mc.asyncGetAttr(KEY).get();
       Assert.assertNotNull(attr);
-      Assert.assertEquals(new Long(0), attr.getCount());
+      Assert.assertEquals(Long.valueOf(0), attr.getCount());
 
       Map<String, Object> map = mc.asyncMopGet(KEY, MKEY, false, false).get();
       Assert.assertNotNull(map);
@@ -91,7 +91,7 @@ public class GetWithDropMapTest extends BaseIntegrationTest {
   public void testGetWithtDeleteAndWithDrop() {
     try {
       // check attr
-      Assert.assertEquals(new Long(1), mc.asyncGetAttr(KEY).get()
+      Assert.assertEquals(Long.valueOf(1), mc.asyncGetAttr(KEY).get()
               .getCount());
 
       // get value delete=true, drop=true

--- a/src/test/manual/net/spy/memcached/emptycollection/GetWithDropSetTest.java
+++ b/src/test/manual/net/spy/memcached/emptycollection/GetWithDropSetTest.java
@@ -18,7 +18,7 @@ package net.spy.memcached.emptycollection;
 
 import java.util.Set;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import net.spy.memcached.collection.BaseIntegrationTest;
 import net.spy.memcached.collection.CollectionAttributes;
 
@@ -40,7 +40,7 @@ public class GetWithDropSetTest extends BaseIntegrationTest {
   public void testGetWithoutDeleteAndDrop() {
     try {
       // check attr
-      Assert.assertEquals(new Long(1), mc.asyncGetAttr(KEY).get()
+      Assert.assertEquals(Long.valueOf(1), mc.asyncGetAttr(KEY).get()
               .getCount());
 
       // get value delete=false, drop=true
@@ -48,7 +48,7 @@ public class GetWithDropSetTest extends BaseIntegrationTest {
               .contains(VALUE));
 
       // check exists
-      Assert.assertEquals(new Long(1), mc.asyncGetAttr(KEY).get()
+      Assert.assertEquals(Long.valueOf(1), mc.asyncGetAttr(KEY).get()
               .getCount());
 
       // get value again
@@ -63,7 +63,7 @@ public class GetWithDropSetTest extends BaseIntegrationTest {
   public void testGetWithtDeleteAndWithoutDrop() {
     try {
       // check attr
-      Assert.assertEquals(new Long(1), mc.asyncGetAttr(KEY).get()
+      Assert.assertEquals(Long.valueOf(1), mc.asyncGetAttr(KEY).get()
               .getCount());
 
       // get value delete=true, drop=false
@@ -73,7 +73,7 @@ public class GetWithDropSetTest extends BaseIntegrationTest {
       // check exists empty btree
       CollectionAttributes attr = mc.asyncGetAttr(KEY).get();
       Assert.assertNotNull(attr);
-      Assert.assertEquals(new Long(0), attr.getCount());
+      Assert.assertEquals(Long.valueOf(0), attr.getCount());
 
       Set<Object> set = mc.asyncSopGet(KEY, 10, false, false).get();
       Assert.assertNotNull(set);
@@ -87,7 +87,7 @@ public class GetWithDropSetTest extends BaseIntegrationTest {
   public void testGetWithtDeleteAndWithDrop() {
     try {
       // check attr
-      Assert.assertEquals(new Long(1), mc.asyncGetAttr(KEY).get()
+      Assert.assertEquals(Long.valueOf(1), mc.asyncGetAttr(KEY).get()
               .getCount());
 
       // get value delete=true, drop=false
@@ -109,7 +109,7 @@ public class GetWithDropSetTest extends BaseIntegrationTest {
   public void testGetWithoutDeleteAndDropOptions() {
     try {
       // check attr
-      assertEquals(new Long(1), mc.asyncGetAttr(KEY).get()
+      assertEquals(Long.valueOf(1), mc.asyncGetAttr(KEY).get()
               .getCount());
 
       //get value
@@ -117,7 +117,7 @@ public class GetWithDropSetTest extends BaseIntegrationTest {
               .contains(VALUE));
 
       // check exists
-      assertEquals(new Long(1), mc.asyncGetAttr(KEY).get()
+      assertEquals(Long.valueOf(1), mc.asyncGetAttr(KEY).get()
               .getCount());
 
       // get value again

--- a/src/test/manual/net/spy/memcached/emptycollection/InsertBTreeWithAttrAndEFlagTest.java
+++ b/src/test/manual/net/spy/memcached/emptycollection/InsertBTreeWithAttrAndEFlagTest.java
@@ -18,7 +18,7 @@ package net.spy.memcached.emptycollection;
 
 import java.util.Map;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import net.spy.memcached.collection.Element;
 import net.spy.memcached.collection.ElementFlagFilter;
 import net.spy.memcached.collection.BaseIntegrationTest;
@@ -60,7 +60,7 @@ public class InsertBTreeWithAttrAndEFlagTest extends BaseIntegrationTest {
       // check attribute
       CollectionAttributes collectionAttributes = mc.asyncGetAttr(KEY)
               .get();
-      Assert.assertEquals(new Long(3333),
+      Assert.assertEquals(Long.valueOf(3333),
               collectionAttributes.getMaxCount());
 
       // check expire time
@@ -88,7 +88,7 @@ public class InsertBTreeWithAttrAndEFlagTest extends BaseIntegrationTest {
       // check attribute
       CollectionAttributes collectionAttributes = mc.asyncGetAttr(KEY)
               .get();
-      Assert.assertEquals(new Long(4000),
+      Assert.assertEquals(Long.valueOf(4000),
               collectionAttributes.getMaxCount());
     } catch (Exception e) {
       Assert.fail(e.getMessage());
@@ -114,7 +114,7 @@ public class InsertBTreeWithAttrAndEFlagTest extends BaseIntegrationTest {
       // check attribute
       CollectionAttributes collectionAttributes = mc.asyncGetAttr(KEY)
               .get();
-      Assert.assertEquals(new Long(3333),
+      Assert.assertEquals(Long.valueOf(3333),
               collectionAttributes.getMaxCount());
 
       // check expire time

--- a/src/test/manual/net/spy/memcached/emptycollection/InsertListWithAttrTest.java
+++ b/src/test/manual/net/spy/memcached/emptycollection/InsertListWithAttrTest.java
@@ -18,7 +18,7 @@ package net.spy.memcached.emptycollection;
 
 import java.util.List;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import net.spy.memcached.collection.BaseIntegrationTest;
 import net.spy.memcached.collection.CollectionAttributes;
 
@@ -58,7 +58,7 @@ public class InsertListWithAttrTest extends BaseIntegrationTest {
       // check attribute
       CollectionAttributes collectionAttributes = mc.asyncGetAttr(KEY)
               .get();
-      Assert.assertEquals(new Long(3333),
+      Assert.assertEquals(Long.valueOf(3333),
               collectionAttributes.getMaxCount());
 
       // check expire time
@@ -86,7 +86,7 @@ public class InsertListWithAttrTest extends BaseIntegrationTest {
       // check attribute
       CollectionAttributes collectionAttributes = mc.asyncGetAttr(KEY)
               .get();
-      Assert.assertEquals(new Long(4000),
+      Assert.assertEquals(Long.valueOf(4000),
               collectionAttributes.getMaxCount());
     } catch (Exception e) {
       e.printStackTrace();

--- a/src/test/manual/net/spy/memcached/emptycollection/InsertMapWithAttrTest.java
+++ b/src/test/manual/net/spy/memcached/emptycollection/InsertMapWithAttrTest.java
@@ -18,7 +18,7 @@ package net.spy.memcached.emptycollection;
 
 import java.util.Map;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import net.spy.memcached.collection.BaseIntegrationTest;
 import net.spy.memcached.collection.CollectionAttributes;
 
@@ -58,7 +58,7 @@ public class InsertMapWithAttrTest extends BaseIntegrationTest {
       // check attribute
       CollectionAttributes collectionAttributes = mc.asyncGetAttr(KEY)
               .get();
-      Assert.assertEquals(new Long(3333),
+      Assert.assertEquals(Long.valueOf(3333),
               collectionAttributes.getMaxCount());
 
       // check expire time
@@ -86,7 +86,7 @@ public class InsertMapWithAttrTest extends BaseIntegrationTest {
       // check attribute
       CollectionAttributes collectionAttributes = mc.asyncGetAttr(KEY)
               .get();
-      Assert.assertEquals(new Long(4000),
+      Assert.assertEquals(Long.valueOf(4000),
               collectionAttributes.getMaxCount());
     } catch (Exception e) {
       e.printStackTrace();

--- a/src/test/manual/net/spy/memcached/emptycollection/InsertSetWithAttrTest.java
+++ b/src/test/manual/net/spy/memcached/emptycollection/InsertSetWithAttrTest.java
@@ -18,7 +18,7 @@ package net.spy.memcached.emptycollection;
 
 import java.util.Set;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import net.spy.memcached.collection.BaseIntegrationTest;
 import net.spy.memcached.collection.CollectionAttributes;
 
@@ -56,7 +56,7 @@ public class InsertSetWithAttrTest extends BaseIntegrationTest {
       // check attribute
       CollectionAttributes collectionAttributes = mc.asyncGetAttr(KEY)
               .get();
-      Assert.assertEquals(new Long(3333),
+      Assert.assertEquals(Long.valueOf(3333),
               collectionAttributes.getMaxCount());
 
       // check expire time
@@ -83,7 +83,7 @@ public class InsertSetWithAttrTest extends BaseIntegrationTest {
       // check attribute
       CollectionAttributes collectionAttributes = mc.asyncGetAttr(KEY)
               .get();
-      Assert.assertEquals(new Long(4000),
+      Assert.assertEquals(Long.valueOf(4000),
               collectionAttributes.getMaxCount());
     } catch (Exception e) {
       e.printStackTrace();

--- a/src/test/manual/net/spy/memcached/emptycollection/PipedBulkInsertBTreeWithAttrTest.java
+++ b/src/test/manual/net/spy/memcached/emptycollection/PipedBulkInsertBTreeWithAttrTest.java
@@ -21,7 +21,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import net.spy.memcached.collection.BaseIntegrationTest;
 import net.spy.memcached.collection.ByteArrayBKey;
 import net.spy.memcached.collection.CollectionAttributes;
@@ -70,7 +70,7 @@ public class PipedBulkInsertBTreeWithAttrTest extends BaseIntegrationTest {
       // check attribute
       CollectionAttributes collectionAttributes = mc.asyncGetAttr(KEY)
               .get();
-      Assert.assertEquals(new Long(3333),
+      Assert.assertEquals(Long.valueOf(3333),
               collectionAttributes.getMaxCount());
 
       // check expire time
@@ -103,7 +103,7 @@ public class PipedBulkInsertBTreeWithAttrTest extends BaseIntegrationTest {
       // check attribute
       CollectionAttributes collectionAttributes = mc.asyncGetAttr(KEY)
               .get();
-      Assert.assertEquals(new Long(4000),
+      Assert.assertEquals(Long.valueOf(4000),
               collectionAttributes.getMaxCount());
     } catch (Exception e) {
       e.printStackTrace();
@@ -128,7 +128,7 @@ public class PipedBulkInsertBTreeWithAttrTest extends BaseIntegrationTest {
       // check attribute
       CollectionAttributes collectionAttributes = mc.asyncGetAttr(KEY)
               .get();
-      Assert.assertEquals(new Long(4000),
+      Assert.assertEquals(Long.valueOf(4000),
               collectionAttributes.getMaxCount());
     } catch (Exception e) {
       e.printStackTrace();

--- a/src/test/manual/net/spy/memcached/emptycollection/PipedBulkInsertListWithAttrTest.java
+++ b/src/test/manual/net/spy/memcached/emptycollection/PipedBulkInsertListWithAttrTest.java
@@ -20,7 +20,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import net.spy.memcached.collection.BaseIntegrationTest;
 import net.spy.memcached.collection.CollectionAttributes;
 import net.spy.memcached.ops.CollectionOperationStatus;
@@ -66,9 +66,9 @@ public class PipedBulkInsertListWithAttrTest extends BaseIntegrationTest {
       // check attribute
       CollectionAttributes collectionAttributes = mc.asyncGetAttr(KEY)
               .get();
-      Assert.assertEquals(new Long(3333),
+      Assert.assertEquals(Long.valueOf(3333),
               collectionAttributes.getMaxCount());
-      Assert.assertEquals(new Long(10), collectionAttributes.getCount());
+      Assert.assertEquals(Long.valueOf(10), collectionAttributes.getCount());
 
       // check values
       List<Object> list2 = mc.asyncLopGet(KEY, 0, 10, false, false).get();
@@ -106,9 +106,9 @@ public class PipedBulkInsertListWithAttrTest extends BaseIntegrationTest {
       // check attribute
       CollectionAttributes collectionAttributes = mc.asyncGetAttr(KEY)
               .get();
-      Assert.assertEquals(new Long(4000),
+      Assert.assertEquals(Long.valueOf(4000),
               collectionAttributes.getMaxCount());
-      Assert.assertEquals(new Long(10), collectionAttributes.getCount());
+      Assert.assertEquals(Long.valueOf(10), collectionAttributes.getCount());
 
       // check values
       List<Object> list2 = mc.asyncLopGet(KEY, 0, 10, false, false).get();
@@ -139,9 +139,9 @@ public class PipedBulkInsertListWithAttrTest extends BaseIntegrationTest {
       // check attribute
       CollectionAttributes collectionAttributes = mc.asyncGetAttr(KEY)
               .get();
-      Assert.assertEquals(new Long(4000),
+      Assert.assertEquals(Long.valueOf(4000),
               collectionAttributes.getMaxCount());
-      Assert.assertEquals(new Long(10), collectionAttributes.getCount());
+      Assert.assertEquals(Long.valueOf(10), collectionAttributes.getCount());
 
       // check values
       List<Object> list2 = mc.asyncLopGet(KEY, 0, 10, false, false).get();

--- a/src/test/manual/net/spy/memcached/emptycollection/PipedBulkInsertMapWithAttrTest.java
+++ b/src/test/manual/net/spy/memcached/emptycollection/PipedBulkInsertMapWithAttrTest.java
@@ -19,7 +19,7 @@ package net.spy.memcached.emptycollection;
 import java.util.HashMap;
 import java.util.Map;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import net.spy.memcached.collection.BaseIntegrationTest;
 import net.spy.memcached.collection.CollectionAttributes;
 import net.spy.memcached.ops.CollectionOperationStatus;
@@ -64,7 +64,7 @@ public class PipedBulkInsertMapWithAttrTest extends BaseIntegrationTest {
       // check attribute
       CollectionAttributes collectionAttributes = mc.asyncGetAttr(KEY)
               .get();
-      Assert.assertEquals(new Long(3333),
+      Assert.assertEquals(Long.valueOf(3333),
               collectionAttributes.getMaxCount());
 
       // check expire time
@@ -97,7 +97,7 @@ public class PipedBulkInsertMapWithAttrTest extends BaseIntegrationTest {
       // check attribute
       CollectionAttributes collectionAttributes = mc.asyncGetAttr(KEY)
               .get();
-      Assert.assertEquals(new Long(4000),
+      Assert.assertEquals(Long.valueOf(4000),
               collectionAttributes.getMaxCount());
     } catch (Exception e) {
       e.printStackTrace();
@@ -122,7 +122,7 @@ public class PipedBulkInsertMapWithAttrTest extends BaseIntegrationTest {
       // check attribute
       CollectionAttributes collectionAttributes = mc.asyncGetAttr(KEY)
               .get();
-      Assert.assertEquals(new Long(4000),
+      Assert.assertEquals(Long.valueOf(4000),
               collectionAttributes.getMaxCount());
     } catch (Exception e) {
       e.printStackTrace();

--- a/src/test/manual/net/spy/memcached/emptycollection/PipedBulkInsertSetWithAttrTest.java
+++ b/src/test/manual/net/spy/memcached/emptycollection/PipedBulkInsertSetWithAttrTest.java
@@ -20,7 +20,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import net.spy.memcached.collection.BaseIntegrationTest;
 import net.spy.memcached.collection.CollectionAttributes;
 import net.spy.memcached.ops.CollectionOperationStatus;
@@ -66,9 +66,9 @@ public class PipedBulkInsertSetWithAttrTest extends BaseIntegrationTest {
       // check attribute
       CollectionAttributes collectionAttributes = mc.asyncGetAttr(KEY)
               .get();
-      Assert.assertEquals(new Long(3333),
+      Assert.assertEquals(Long.valueOf(3333),
               collectionAttributes.getMaxCount());
-      Assert.assertEquals(new Long(10), collectionAttributes.getCount());
+      Assert.assertEquals(Long.valueOf(10), collectionAttributes.getCount());
 
       // check values
       List<Object> list2 = mc.asyncLopGet(KEY, 0, 10, false, false).get();
@@ -106,9 +106,9 @@ public class PipedBulkInsertSetWithAttrTest extends BaseIntegrationTest {
       // check attribute
       CollectionAttributes collectionAttributes = mc.asyncGetAttr(KEY)
               .get();
-      Assert.assertEquals(new Long(4000),
+      Assert.assertEquals(Long.valueOf(4000),
               collectionAttributes.getMaxCount());
-      Assert.assertEquals(new Long(10), collectionAttributes.getCount());
+      Assert.assertEquals(Long.valueOf(10), collectionAttributes.getCount());
 
       // check values
       List<Object> list2 = mc.asyncLopGet(KEY, 0, 10, false, false).get();
@@ -139,9 +139,9 @@ public class PipedBulkInsertSetWithAttrTest extends BaseIntegrationTest {
       // check attribute
       CollectionAttributes collectionAttributes = mc.asyncGetAttr(KEY)
               .get();
-      Assert.assertEquals(new Long(4000),
+      Assert.assertEquals(Long.valueOf(4000),
               collectionAttributes.getMaxCount());
-      Assert.assertEquals(new Long(10), collectionAttributes.getCount());
+      Assert.assertEquals(Long.valueOf(10), collectionAttributes.getCount());
 
       // check values
       List<Object> list2 = mc.asyncLopGet(KEY, 0, 10, false, false).get();

--- a/src/test/manual/net/spy/memcached/emptycollection/ProtocolBTreeDeleteTest.java
+++ b/src/test/manual/net/spy/memcached/emptycollection/ProtocolBTreeDeleteTest.java
@@ -16,7 +16,7 @@
  */
 package net.spy.memcached.emptycollection;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import junit.framework.TestCase;
 import net.spy.memcached.collection.ElementFlagFilter;
 import net.spy.memcached.collection.BTreeDelete;

--- a/src/test/manual/net/spy/memcached/emptycollection/ProtocolBTreeGetTest.java
+++ b/src/test/manual/net/spy/memcached/emptycollection/ProtocolBTreeGetTest.java
@@ -16,7 +16,7 @@
  */
 package net.spy.memcached.emptycollection;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import junit.framework.TestCase;
 import net.spy.memcached.collection.ElementFlagFilter;
 import net.spy.memcached.collection.BTreeGet;

--- a/src/test/manual/net/spy/memcached/emptycollection/ProtocolListDeleteTest.java
+++ b/src/test/manual/net/spy/memcached/emptycollection/ProtocolListDeleteTest.java
@@ -16,7 +16,7 @@
  */
 package net.spy.memcached.emptycollection;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import junit.framework.TestCase;
 import net.spy.memcached.collection.ListDelete;
 

--- a/src/test/manual/net/spy/memcached/emptycollection/ProtocolListGetTest.java
+++ b/src/test/manual/net/spy/memcached/emptycollection/ProtocolListGetTest.java
@@ -16,7 +16,7 @@
  */
 package net.spy.memcached.emptycollection;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import junit.framework.TestCase;
 import net.spy.memcached.collection.ListGet;
 

--- a/src/test/manual/net/spy/memcached/emptycollection/ProtocolMapDeleteTest.java
+++ b/src/test/manual/net/spy/memcached/emptycollection/ProtocolMapDeleteTest.java
@@ -16,7 +16,7 @@
  */
 package net.spy.memcached.emptycollection;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import junit.framework.TestCase;
 import net.spy.memcached.collection.MapDelete;
 

--- a/src/test/manual/net/spy/memcached/emptycollection/ProtocolMapGetTest.java
+++ b/src/test/manual/net/spy/memcached/emptycollection/ProtocolMapGetTest.java
@@ -16,7 +16,7 @@
  */
 package net.spy.memcached.emptycollection;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import junit.framework.TestCase;
 import net.spy.memcached.collection.MapGet;
 

--- a/src/test/manual/net/spy/memcached/emptycollection/ProtocolSetGetTest.java
+++ b/src/test/manual/net/spy/memcached/emptycollection/ProtocolSetGetTest.java
@@ -16,7 +16,7 @@
  */
 package net.spy.memcached.emptycollection;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import junit.framework.TestCase;
 import net.spy.memcached.collection.SetGet;
 

--- a/src/test/manual/net/spy/memcached/emptycollection/VariousTypeTest.java
+++ b/src/test/manual/net/spy/memcached/emptycollection/VariousTypeTest.java
@@ -18,12 +18,11 @@ package net.spy.memcached.emptycollection;
 
 import java.io.Serializable;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import net.spy.memcached.collection.Element;
 import net.spy.memcached.collection.ElementFlagFilter;
 import net.spy.memcached.collection.BaseIntegrationTest;
@@ -258,8 +257,8 @@ public class VariousTypeTest extends BaseIntegrationTest {
       // get value
       Map<Long, Element<Object>> map = mc.asyncBopGet(KEY, BKEY,
               ElementFlagFilter.DO_NOT_FILTER, false, false).get();
-      Assert.assertTrue(Arrays.equals(value, (byte[]) map.get(BKEY)
-              .getValue()));
+      Assert.assertArrayEquals(value, (byte[]) map.get(BKEY)
+          .getValue());
     } catch (Exception e) {
       e.printStackTrace();
       Assert.fail(e.getMessage());
@@ -283,7 +282,7 @@ public class VariousTypeTest extends BaseIntegrationTest {
       // get value
       Map<Long, Element<Object>> map = mc.asyncBopGet(KEY, BKEY,
               ElementFlagFilter.DO_NOT_FILTER, false, false).get();
-      Assert.assertTrue(value.equals(map.get(BKEY).getValue()));
+      Assert.assertEquals(value, map.get(BKEY).getValue());
     } catch (Exception e) {
       e.printStackTrace();
       Assert.fail(e.getMessage());
@@ -342,26 +341,42 @@ public class VariousTypeTest extends BaseIntegrationTest {
 
       UserDefinedClass c = (UserDefinedClass) o;
 
-      boolean eq = this.i == c.i;
-
-      if (this.list == null && c.list == null) {
-        return eq;
+      if (this.i != c.i) {
+        return false;
       }
 
-      eq &= this.list.size() == c.list.size();
+      if (this.list == null && c.list == null) {
+        return true;
+      }
 
-      if (!eq) {
-        return eq;
+      if (this.list == null || c.list == null) {
+        return false;
+      }
+
+      if (this.list.size() != c.list.size()) {
+        return false;
       }
 
       for (int i = 0; i < this.list.size(); i++) {
-        eq &= this.list.get(i).equals(c.list.get(i));
-        if (!eq) {
-          return eq;
+        if (!this.list.get(i).equals(c.list.get(i))) {
+          return false;
         }
       }
 
-      return eq;
+      return true;
+    }
+
+    @Override
+    public int hashCode() {
+      return toString().hashCode();
+    }
+
+    @Override
+    public String toString() {
+      return "UserDefinedClass{" +
+          "i=" + i +
+          ", list=" + list +
+          '}';
     }
   }
 }

--- a/src/test/manual/net/spy/memcached/test/MutateWithDefaultTest.java
+++ b/src/test/manual/net/spy/memcached/test/MutateWithDefaultTest.java
@@ -19,7 +19,7 @@ package net.spy.memcached.test;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import net.spy.memcached.collection.BaseIntegrationTest;
 
 public class MutateWithDefaultTest extends BaseIntegrationTest {

--- a/src/test/manual/net/spy/memcached/test/SASLConnectReconnect.java
+++ b/src/test/manual/net/spy/memcached/test/SASLConnectReconnect.java
@@ -9,7 +9,7 @@ import java.util.logging.Handler;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import net.spy.memcached.AddrUtil;
 import net.spy.memcached.ConnectionFactoryBuilder;
 import net.spy.memcached.ConnectionFactoryBuilder.Protocol;


### PR DESCRIPTION
MacOS JDK 11 버전과 CentOS 7 JDK 8 버전에서 발생하는 컴파일 워닝을 제거했습니다.
컴파일 워닝이 정확히 제거되었는지 확인하기 위해 모든 컴파일 워닝을 출력하도록 했고 컴파일 워닝이 1개라도 생기면 컴파일 에러가 발생하도록 수정했습니다.