### PR TITLE
FIX: Resolve deprecation warning.

### DIFF
--- a/docs/arcus-java-client-getting-started.md
+++ b/docs/arcus-java-client-getting-started.md
@@ -109,7 +109,7 @@ $ mvn eclipse:eclipse // 이클립스 IDE를 사용하는 경우 실행하여 �
 // HelloArcusTest.java
 package com.navercorp.arcus;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 
 import org.junit.Before;
 import org.junit.Test;

--- a/src/test/java/net/spy/memcached/ArcusTimeoutMessageTest.java
+++ b/src/test/java/net/spy/memcached/ArcusTimeoutMessageTest.java
@@ -39,8 +39,8 @@ import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.internal.runners.JUnit4ClassRunner;
 import org.junit.runner.RunWith;
+import org.junit.runners.BlockJUnit4ClassRunner;
 
 import java.io.IOException;
 import java.net.InetSocketAddress;
@@ -56,7 +56,7 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
-@RunWith(JUnit4ClassRunner.class)
+@RunWith(BlockJUnit4ClassRunner.class)
 public class ArcusTimeoutMessageTest extends TestCase {
   private ArcusClient mc = null;
 
@@ -193,6 +193,7 @@ public class ArcusTimeoutMessageTest extends TestCase {
       map.put(key + i, i);
     }
 
+    @SuppressWarnings("deprecation")
     Future<Map<String, CollectionOperationStatus>> f = mc.asyncSetBulk(map, 30);
 
     try {
@@ -219,6 +220,7 @@ public class ArcusTimeoutMessageTest extends TestCase {
       map.put(key + i, i);
     }
 
+    @SuppressWarnings("deprecation")
     Future<Map<String, CollectionOperationStatus>> f = mc.asyncSetBulk(map, 30);
 
     try {

--- a/src/test/java/net/spy/memcached/ArcusTimeoutTest.java
+++ b/src/test/java/net/spy/memcached/ArcusTimeoutTest.java
@@ -30,7 +30,7 @@ import net.spy.memcached.ops.OperationStatus;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.internal.runners.JUnit4ClassRunner;
+import org.junit.runners.BlockJUnit4ClassRunner;
 import org.junit.runner.RunWith;
 
 import java.io.IOException;
@@ -44,7 +44,7 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
-@RunWith(JUnit4ClassRunner.class)
+@RunWith(BlockJUnit4ClassRunner.class)
 public class ArcusTimeoutTest extends TestCase {
   private ArcusClient mc = null;
 
@@ -101,6 +101,7 @@ public class ArcusTimeoutTest extends TestCase {
     }
 
     String value = "MyValue";
+    @SuppressWarnings("deprecation")
     Future<Map<String, CollectionOperationStatus>> future = mc.asyncSetBulk(
             Arrays.asList(keys), 60, value);
     future.get(1L, TimeUnit.MILLISECONDS);
@@ -118,6 +119,7 @@ public class ArcusTimeoutTest extends TestCase {
 
     String value = "MyValue";
 
+    @SuppressWarnings("deprecation")
     Future<Map<String, CollectionOperationStatus>> future = mc.asyncSetBulk(
             Arrays.asList(keys), 60, value);
     future.get(1L, TimeUnit.MILLISECONDS);

--- a/src/test/java/net/spy/memcached/ObserverTest.java
+++ b/src/test/java/net/spy/memcached/ObserverTest.java
@@ -10,7 +10,7 @@ import net.spy.memcached.compat.SpyObject;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.internal.runners.JUnit4ClassRunner;
+import org.junit.runners.BlockJUnit4ClassRunner;
 import org.junit.runner.RunWith;
 
 import static org.junit.Assume.assumeTrue;
@@ -18,7 +18,7 @@ import static org.junit.Assume.assumeTrue;
 /**
  * Test observer hooks.
  */
-@RunWith(JUnit4ClassRunner.class)
+@RunWith(BlockJUnit4ClassRunner.class)
 public class ObserverTest extends ClientBaseCase {
 
   @Before

--- a/src/test/manual/net/spy/memcached/ArcusClientConnectTest.java
+++ b/src/test/manual/net/spy/memcached/ArcusClientConnectTest.java
@@ -20,12 +20,12 @@ import junit.framework.TestCase;
 import net.spy.memcached.collection.BaseIntegrationTest;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.internal.runners.JUnit4ClassRunner;
+import org.junit.runners.BlockJUnit4ClassRunner;
 import org.junit.runner.RunWith;
 
 import static org.junit.Assume.assumeTrue;
 
-@RunWith(JUnit4ClassRunner.class)
+@RunWith(BlockJUnit4ClassRunner.class)
 public class ArcusClientConnectTest extends TestCase {
 
   @Before

--- a/src/test/manual/net/spy/memcached/ArcusClientFrontCacheTest.java
+++ b/src/test/manual/net/spy/memcached/ArcusClientFrontCacheTest.java
@@ -16,17 +16,17 @@
  */
 package net.spy.memcached;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import junit.framework.TestCase;
 import net.spy.memcached.collection.BaseIntegrationTest;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.internal.runners.JUnit4ClassRunner;
+import org.junit.runners.BlockJUnit4ClassRunner;
 import org.junit.runner.RunWith;
 
 import static org.junit.Assume.assumeTrue;
 
-@RunWith(JUnit4ClassRunner.class)
+@RunWith(BlockJUnit4ClassRunner.class)
 public class ArcusClientFrontCacheTest extends TestCase {
 
   @Before

--- a/src/test/manual/net/spy/memcached/ArcusClientPoolShutdownTest.java
+++ b/src/test/manual/net/spy/memcached/ArcusClientPoolShutdownTest.java
@@ -19,7 +19,7 @@ package net.spy.memcached;
 import java.util.ArrayList;
 import java.util.List;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import junit.framework.TestCase;
 import net.spy.memcached.collection.BaseIntegrationTest;
 

--- a/src/test/manual/net/spy/memcached/ArcusClientShutdownTest.java
+++ b/src/test/manual/net/spy/memcached/ArcusClientShutdownTest.java
@@ -19,7 +19,7 @@ package net.spy.memcached;
 import java.util.ArrayList;
 import java.util.List;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import junit.framework.TestCase;
 import net.spy.memcached.collection.BaseIntegrationTest;
 

--- a/src/test/manual/net/spy/memcached/LongKeyTest/BaseLongKeyTest.java
+++ b/src/test/manual/net/spy/memcached/LongKeyTest/BaseLongKeyTest.java
@@ -1,6 +1,6 @@
 package net.spy.memcached.LongKeyTest;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import net.spy.memcached.collection.BTreeGetResult;
 import net.spy.memcached.collection.BaseIntegrationTest;
 import net.spy.memcached.collection.CollectionAttributes;

--- a/src/test/manual/net/spy/memcached/MultibyteKeyTest.java
+++ b/src/test/manual/net/spy/memcached/MultibyteKeyTest.java
@@ -16,7 +16,7 @@
  */
 package net.spy.memcached;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import net.spy.memcached.collection.Attributes;
 import net.spy.memcached.collection.BKeyObject;
 import net.spy.memcached.collection.BTreeCount;

--- a/src/test/manual/net/spy/memcached/btreesmget/ByteArrayBKeySMGetErrorTest.java
+++ b/src/test/manual/net/spy/memcached/btreesmget/ByteArrayBKeySMGetErrorTest.java
@@ -21,7 +21,7 @@ import java.util.List;
 import java.util.Random;
 import java.util.concurrent.TimeUnit;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import net.spy.memcached.collection.BaseIntegrationTest;
 import net.spy.memcached.collection.CollectionAttributes;
 import net.spy.memcached.collection.CollectionOverflowAction;

--- a/src/test/manual/net/spy/memcached/btreesmget/ByteArrayBKeySMGetIrregularEflagTest.java
+++ b/src/test/manual/net/spy/memcached/btreesmget/ByteArrayBKeySMGetIrregularEflagTest.java
@@ -20,7 +20,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import net.spy.memcached.collection.BaseIntegrationTest;
 import net.spy.memcached.collection.CollectionAttributes;
 import net.spy.memcached.collection.ElementFlagFilter;

--- a/src/test/manual/net/spy/memcached/btreesmget/ByteArrayBKeySMGetTest.java
+++ b/src/test/manual/net/spy/memcached/btreesmget/ByteArrayBKeySMGetTest.java
@@ -23,7 +23,7 @@ import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import net.spy.memcached.collection.BaseIntegrationTest;
 import net.spy.memcached.collection.CollectionAttributes;
 import net.spy.memcached.collection.ElementFlagFilter;

--- a/src/test/manual/net/spy/memcached/btreesmget/SMGetErrorTest.java
+++ b/src/test/manual/net/spy/memcached/btreesmget/SMGetErrorTest.java
@@ -22,7 +22,7 @@ import java.util.Map;
 import java.util.Random;
 import java.util.concurrent.TimeUnit;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import net.spy.memcached.collection.BaseIntegrationTest;
 import net.spy.memcached.collection.CollectionAttributes;
 import net.spy.memcached.collection.CollectionOverflowAction;

--- a/src/test/manual/net/spy/memcached/btreesmget/SMGetTest.java
+++ b/src/test/manual/net/spy/memcached/btreesmget/SMGetTest.java
@@ -23,7 +23,7 @@ import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import net.spy.memcached.collection.BaseIntegrationTest;
 import net.spy.memcached.collection.CollectionAttributes;
 import net.spy.memcached.collection.ElementFlagFilter;

--- a/src/test/manual/net/spy/memcached/btreesmget/SMGetWithCombinationEflagTest.java
+++ b/src/test/manual/net/spy/memcached/btreesmget/SMGetWithCombinationEflagTest.java
@@ -22,7 +22,7 @@ import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import net.spy.memcached.collection.BaseIntegrationTest;
 import net.spy.memcached.collection.CollectionAttributes;
 import net.spy.memcached.collection.ElementFlagFilter;

--- a/src/test/manual/net/spy/memcached/btreesmget/SMGetWithEflagTest.java
+++ b/src/test/manual/net/spy/memcached/btreesmget/SMGetWithEflagTest.java
@@ -22,7 +22,7 @@ import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import net.spy.memcached.collection.ElementFlagFilter;
 import net.spy.memcached.collection.BaseIntegrationTest;
 import net.spy.memcached.collection.CollectionAttributes;

--- a/src/test/manual/net/spy/memcached/bulkoperation/BopInsertBulkMultipleBoundaryTest.java
+++ b/src/test/manual/net/spy/memcached/bulkoperation/BopInsertBulkMultipleBoundaryTest.java
@@ -22,7 +22,7 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import net.spy.memcached.collection.BaseIntegrationTest;
 import net.spy.memcached.collection.CollectionAttributes;
 import net.spy.memcached.collection.CollectionOverflowAction;

--- a/src/test/manual/net/spy/memcached/bulkoperation/BopInsertBulkMultipleTest.java
+++ b/src/test/manual/net/spy/memcached/bulkoperation/BopInsertBulkMultipleTest.java
@@ -23,7 +23,7 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import net.spy.memcached.collection.BaseIntegrationTest;
 import net.spy.memcached.collection.CollectionAttributes;
 import net.spy.memcached.collection.Element;

--- a/src/test/manual/net/spy/memcached/bulkoperation/BopInsertBulkTest.java
+++ b/src/test/manual/net/spy/memcached/bulkoperation/BopInsertBulkTest.java
@@ -22,7 +22,7 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import net.spy.memcached.collection.BaseIntegrationTest;
 import net.spy.memcached.collection.ByteArrayBKey;
 import net.spy.memcached.collection.CollectionAttributes;

--- a/src/test/manual/net/spy/memcached/bulkoperation/BopPipeUpdateTest.java
+++ b/src/test/manual/net/spy/memcached/bulkoperation/BopPipeUpdateTest.java
@@ -21,7 +21,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import net.spy.memcached.collection.BaseIntegrationTest;
 import net.spy.memcached.collection.CollectionAttributes;
 import net.spy.memcached.collection.CollectionResponse;

--- a/src/test/manual/net/spy/memcached/bulkoperation/BulkDeleteTest.java
+++ b/src/test/manual/net/spy/memcached/bulkoperation/BulkDeleteTest.java
@@ -16,7 +16,7 @@
  */
 package net.spy.memcached.bulkoperation;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import net.spy.memcached.collection.BaseIntegrationTest;
 import net.spy.memcached.ops.OperationStatus;
 import net.spy.memcached.ops.StatusCode;

--- a/src/test/manual/net/spy/memcached/bulkoperation/BulkSetVariousTypeTest.java
+++ b/src/test/manual/net/spy/memcached/bulkoperation/BulkSetVariousTypeTest.java
@@ -23,7 +23,7 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import net.spy.memcached.collection.BaseIntegrationTest;
 import net.spy.memcached.ops.CollectionOperationStatus;
 

--- a/src/test/manual/net/spy/memcached/bulkoperation/BulkStoreTest.java
+++ b/src/test/manual/net/spy/memcached/bulkoperation/BulkStoreTest.java
@@ -25,7 +25,7 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import net.spy.memcached.collection.BaseIntegrationTest;
 import net.spy.memcached.ops.CollectionOperationStatus;
 import net.spy.memcached.ops.OperationStatus;
@@ -384,6 +384,7 @@ public class BulkStoreTest extends BaseIntegrationTest {
       }
 
       // Store
+      @SuppressWarnings("deprecation")
       Future<Map<String, CollectionOperationStatus>> future = mc
           .asyncSetBulk(Arrays.asList(keys), 60, value, transcoder);
 
@@ -433,6 +434,7 @@ public class BulkStoreTest extends BaseIntegrationTest {
       }
 
       //  Store
+      @SuppressWarnings("deprecation")
       Future<Map<String, CollectionOperationStatus>> future = mc
           .asyncSetBulk(o, 60, transcoder);
 

--- a/src/test/manual/net/spy/memcached/bulkoperation/LopInsertBulkMultipleValueTest.java
+++ b/src/test/manual/net/spy/memcached/bulkoperation/LopInsertBulkMultipleValueTest.java
@@ -23,7 +23,7 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import net.spy.memcached.collection.BaseIntegrationTest;
 import net.spy.memcached.collection.CollectionAttributes;
 import net.spy.memcached.ops.CollectionOperationStatus;

--- a/src/test/manual/net/spy/memcached/bulkoperation/LopInsertBulkTest.java
+++ b/src/test/manual/net/spy/memcached/bulkoperation/LopInsertBulkTest.java
@@ -23,7 +23,7 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import net.spy.memcached.collection.BaseIntegrationTest;
 import net.spy.memcached.collection.CollectionAttributes;
 import net.spy.memcached.ops.CollectionOperationStatus;

--- a/src/test/manual/net/spy/memcached/bulkoperation/MopInsertBulkMultipleTest.java
+++ b/src/test/manual/net/spy/memcached/bulkoperation/MopInsertBulkMultipleTest.java
@@ -23,7 +23,7 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import net.spy.memcached.collection.BaseIntegrationTest;
 import net.spy.memcached.collection.CollectionAttributes;
 import net.spy.memcached.ops.CollectionOperationStatus;

--- a/src/test/manual/net/spy/memcached/bulkoperation/MopInsertBulkTest.java
+++ b/src/test/manual/net/spy/memcached/bulkoperation/MopInsertBulkTest.java
@@ -22,7 +22,7 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import net.spy.memcached.collection.BaseIntegrationTest;
 import net.spy.memcached.collection.CollectionAttributes;
 import net.spy.memcached.ops.CollectionOperationStatus;

--- a/src/test/manual/net/spy/memcached/bulkoperation/PipeInsertTest.java
+++ b/src/test/manual/net/spy/memcached/bulkoperation/PipeInsertTest.java
@@ -22,7 +22,7 @@ import java.util.Map;
 import java.util.TreeMap;
 import java.util.concurrent.TimeUnit;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import net.spy.memcached.collection.BaseIntegrationTest;
 import net.spy.memcached.collection.CollectionAttributes;
 import net.spy.memcached.collection.Element;

--- a/src/test/manual/net/spy/memcached/bulkoperation/SopInsertBulkMultipleValueTest.java
+++ b/src/test/manual/net/spy/memcached/bulkoperation/SopInsertBulkMultipleValueTest.java
@@ -23,7 +23,7 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import net.spy.memcached.collection.BaseIntegrationTest;
 import net.spy.memcached.collection.CollectionAttributes;
 import net.spy.memcached.ops.CollectionOperationStatus;

--- a/src/test/manual/net/spy/memcached/bulkoperation/SopInsertBulkTest.java
+++ b/src/test/manual/net/spy/memcached/bulkoperation/SopInsertBulkTest.java
@@ -23,7 +23,7 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import net.spy.memcached.collection.BaseIntegrationTest;
 import net.spy.memcached.collection.CollectionAttributes;
 import net.spy.memcached.ops.CollectionOperationStatus;

--- a/src/test/manual/net/spy/memcached/collection/ElementFlagFilterTest.java
+++ b/src/test/manual/net/spy/memcached/collection/ElementFlagFilterTest.java
@@ -18,7 +18,7 @@ package net.spy.memcached.collection;
 
 import net.spy.memcached.collection.ElementFlagFilter.BitWiseOperands;
 import net.spy.memcached.collection.ElementFlagFilter.CompOperands;
-import junit.framework.Assert;
+import org.junit.Assert;
 import junit.framework.TestCase;
 
 public class ElementFlagFilterTest extends TestCase {

--- a/src/test/manual/net/spy/memcached/collection/attribute/BTreeGetAttrTest.java
+++ b/src/test/manual/net/spy/memcached/collection/attribute/BTreeGetAttrTest.java
@@ -16,7 +16,7 @@
  */
 package net.spy.memcached.collection.attribute;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import net.spy.memcached.collection.BaseIntegrationTest;
 import net.spy.memcached.collection.CollectionAttributes;
 import net.spy.memcached.collection.CollectionOverflowAction;

--- a/src/test/manual/net/spy/memcached/collection/attribute/MaxBkeyRangeTest.java
+++ b/src/test/manual/net/spy/memcached/collection/attribute/MaxBkeyRangeTest.java
@@ -19,7 +19,7 @@ package net.spy.memcached.collection.attribute;
 import java.util.Arrays;
 import java.util.Map;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import net.spy.memcached.collection.BaseIntegrationTest;
 import net.spy.memcached.collection.CollectionAttributes;
 import net.spy.memcached.collection.Element;

--- a/src/test/manual/net/spy/memcached/collection/attribute/UnReadableBTreeTest.java
+++ b/src/test/manual/net/spy/memcached/collection/attribute/UnReadableBTreeTest.java
@@ -18,7 +18,7 @@ package net.spy.memcached.collection.attribute;
 
 import java.util.Map;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import net.spy.memcached.collection.BaseIntegrationTest;
 import net.spy.memcached.collection.CollectionAttributes;
 import net.spy.memcached.collection.Element;

--- a/src/test/manual/net/spy/memcached/collection/attribute/UnReadableExtendedBTreeTest.java
+++ b/src/test/manual/net/spy/memcached/collection/attribute/UnReadableExtendedBTreeTest.java
@@ -18,7 +18,7 @@ package net.spy.memcached.collection.attribute;
 
 import java.util.Map;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import net.spy.memcached.collection.BaseIntegrationTest;
 import net.spy.memcached.collection.ByteArrayBKey;
 import net.spy.memcached.collection.CollectionAttributes;

--- a/src/test/manual/net/spy/memcached/collection/attribute/UnReadableListTest.java
+++ b/src/test/manual/net/spy/memcached/collection/attribute/UnReadableListTest.java
@@ -18,7 +18,7 @@ package net.spy.memcached.collection.attribute;
 
 import java.util.List;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import net.spy.memcached.collection.BaseIntegrationTest;
 import net.spy.memcached.collection.CollectionAttributes;
 import net.spy.memcached.collection.ElementValueType;

--- a/src/test/manual/net/spy/memcached/collection/attribute/UnReadableMapTest.java
+++ b/src/test/manual/net/spy/memcached/collection/attribute/UnReadableMapTest.java
@@ -18,7 +18,7 @@ package net.spy.memcached.collection.attribute;
 
 import java.util.Map;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import net.spy.memcached.collection.BaseIntegrationTest;
 import net.spy.memcached.collection.CollectionAttributes;
 import net.spy.memcached.collection.ElementValueType;

--- a/src/test/manual/net/spy/memcached/collection/attribute/UnReadableSetTest.java
+++ b/src/test/manual/net/spy/memcached/collection/attribute/UnReadableSetTest.java
@@ -18,7 +18,7 @@ package net.spy.memcached.collection.attribute;
 
 import java.util.Set;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import net.spy.memcached.collection.BaseIntegrationTest;
 import net.spy.memcached.collection.CollectionAttributes;
 import net.spy.memcached.collection.ElementValueType;

--- a/src/test/manual/net/spy/memcached/collection/btree/BopDeleteTest.java
+++ b/src/test/manual/net/spy/memcached/collection/btree/BopDeleteTest.java
@@ -19,7 +19,7 @@ package net.spy.memcached.collection.btree;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import net.spy.memcached.collection.BaseIntegrationTest;
 import net.spy.memcached.collection.ByteArrayBKey;
 import net.spy.memcached.collection.CollectionAttributes;

--- a/src/test/manual/net/spy/memcached/collection/btree/BopGetBulkTest.java
+++ b/src/test/manual/net/spy/memcached/collection/btree/BopGetBulkTest.java
@@ -23,7 +23,7 @@ import java.util.Map;
 import java.util.Random;
 import java.util.concurrent.TimeUnit;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import net.spy.memcached.collection.BTreeElement;
 import net.spy.memcached.collection.BTreeGetResult;
 import net.spy.memcached.collection.BaseIntegrationTest;

--- a/src/test/manual/net/spy/memcached/collection/btree/BopGetIrregularEflagTest.java
+++ b/src/test/manual/net/spy/memcached/collection/btree/BopGetIrregularEflagTest.java
@@ -19,7 +19,7 @@ package net.spy.memcached.collection.btree;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import net.spy.memcached.collection.BaseIntegrationTest;
 import net.spy.memcached.collection.CollectionAttributes;
 import net.spy.memcached.collection.Element;

--- a/src/test/manual/net/spy/memcached/collection/btree/BopInsertAndGetWithElementFlagTest.java
+++ b/src/test/manual/net/spy/memcached/collection/btree/BopInsertAndGetWithElementFlagTest.java
@@ -19,7 +19,7 @@ package net.spy.memcached.collection.btree;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import net.spy.memcached.collection.Element;
 import net.spy.memcached.collection.ElementFlagFilter;
 import net.spy.memcached.collection.ElementMultiFlagsFilter;

--- a/src/test/manual/net/spy/memcached/collection/btree/BopInsertWhenKeyExists.java
+++ b/src/test/manual/net/spy/memcached/collection/btree/BopInsertWhenKeyExists.java
@@ -19,7 +19,7 @@ package net.spy.memcached.collection.btree;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 
 import net.spy.memcached.collection.BaseIntegrationTest;
 import net.spy.memcached.collection.CollectionAttributes;

--- a/src/test/manual/net/spy/memcached/collection/btree/BopOverflowActionTest.java
+++ b/src/test/manual/net/spy/memcached/collection/btree/BopOverflowActionTest.java
@@ -23,7 +23,7 @@ import java.util.Map;
 import java.util.TreeMap;
 import java.util.concurrent.TimeUnit;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import net.spy.memcached.collection.BaseIntegrationTest;
 import net.spy.memcached.collection.CollectionAttributes;
 import net.spy.memcached.collection.CollectionOverflowAction;

--- a/src/test/manual/net/spy/memcached/collection/btree/BopSortMergeOldTest.java
+++ b/src/test/manual/net/spy/memcached/collection/btree/BopSortMergeOldTest.java
@@ -16,7 +16,7 @@
  */
 package net.spy.memcached.collection.btree;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import net.spy.memcached.collection.BaseIntegrationTest;
 import net.spy.memcached.collection.CollectionAttributes;
 import net.spy.memcached.collection.CollectionOverflowAction;

--- a/src/test/manual/net/spy/memcached/collection/btree/BopSortMergeTest.java
+++ b/src/test/manual/net/spy/memcached/collection/btree/BopSortMergeTest.java
@@ -16,7 +16,7 @@
  */
 package net.spy.memcached.collection.btree;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import net.spy.memcached.collection.BaseIntegrationTest;
 import net.spy.memcached.collection.CollectionAttributes;
 import net.spy.memcached.collection.CollectionOverflowAction;

--- a/src/test/manual/net/spy/memcached/collection/btree/BopUpdateTest.java
+++ b/src/test/manual/net/spy/memcached/collection/btree/BopUpdateTest.java
@@ -18,7 +18,7 @@ package net.spy.memcached.collection.btree;
 
 import java.util.concurrent.ExecutionException;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import net.spy.memcached.collection.BaseIntegrationTest;
 import net.spy.memcached.collection.CollectionAttributes;
 import net.spy.memcached.collection.ElementFlagUpdate;

--- a/src/test/manual/net/spy/memcached/collection/btree/BopUpsertTest.java
+++ b/src/test/manual/net/spy/memcached/collection/btree/BopUpsertTest.java
@@ -16,7 +16,7 @@
  */
 package net.spy.memcached.collection.btree;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import net.spy.memcached.collection.BaseIntegrationTest;
 import net.spy.memcached.collection.CollectionAttributes;
 

--- a/src/test/manual/net/spy/memcached/collection/btree/longbkey/BopCountWithElementFlagFilterTest.java
+++ b/src/test/manual/net/spy/memcached/collection/btree/longbkey/BopCountWithElementFlagFilterTest.java
@@ -16,7 +16,7 @@
  */
 package net.spy.memcached.collection.btree.longbkey;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import net.spy.memcached.collection.BaseIntegrationTest;
 import net.spy.memcached.collection.CollectionAttributes;
 import net.spy.memcached.collection.CollectionResponse;

--- a/src/test/manual/net/spy/memcached/collection/btree/longbkey/BopGetBulkTest.java
+++ b/src/test/manual/net/spy/memcached/collection/btree/longbkey/BopGetBulkTest.java
@@ -23,7 +23,7 @@ import java.util.Map;
 import java.util.Random;
 import java.util.concurrent.TimeUnit;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import net.spy.memcached.collection.BTreeElement;
 import net.spy.memcached.collection.BTreeGetResult;
 import net.spy.memcached.collection.BaseIntegrationTest;

--- a/src/test/manual/net/spy/memcached/collection/btree/longbkey/BopGetIrregularEflagTest.java
+++ b/src/test/manual/net/spy/memcached/collection/btree/longbkey/BopGetIrregularEflagTest.java
@@ -19,7 +19,7 @@ package net.spy.memcached.collection.btree.longbkey;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import net.spy.memcached.collection.BaseIntegrationTest;
 import net.spy.memcached.collection.ByteArrayBKey;
 import net.spy.memcached.collection.CollectionAttributes;

--- a/src/test/manual/net/spy/memcached/collection/btree/longbkey/BopGetTest.java
+++ b/src/test/manual/net/spy/memcached/collection/btree/longbkey/BopGetTest.java
@@ -18,7 +18,7 @@ package net.spy.memcached.collection.btree.longbkey;
 
 import java.util.Map;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import net.spy.memcached.collection.BaseIntegrationTest;
 import net.spy.memcached.collection.ByteArrayBKey;
 import net.spy.memcached.collection.CollectionAttributes;

--- a/src/test/manual/net/spy/memcached/collection/btree/longbkey/BopUpdateTest.java
+++ b/src/test/manual/net/spy/memcached/collection/btree/longbkey/BopUpdateTest.java
@@ -16,7 +16,7 @@
  */
 package net.spy.memcached.collection.btree.longbkey;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import net.spy.memcached.collection.BaseIntegrationTest;
 import net.spy.memcached.collection.CollectionAttributes;
 import net.spy.memcached.collection.ElementFlagFilter.BitWiseOperands;

--- a/src/test/manual/net/spy/memcached/collection/list/LopBulkAPITest.java
+++ b/src/test/manual/net/spy/memcached/collection/list/LopBulkAPITest.java
@@ -22,7 +22,7 @@ import java.util.Map;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 
 import net.spy.memcached.collection.BaseIntegrationTest;
 import net.spy.memcached.collection.CollectionAttributes;

--- a/src/test/manual/net/spy/memcached/collection/map/MopBulkAPITest.java
+++ b/src/test/manual/net/spy/memcached/collection/map/MopBulkAPITest.java
@@ -16,7 +16,7 @@
  */
 package net.spy.memcached.collection.map;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import net.spy.memcached.collection.BaseIntegrationTest;
 import net.spy.memcached.collection.CollectionAttributes;
 import net.spy.memcached.collection.CollectionOverflowAction;

--- a/src/test/manual/net/spy/memcached/collection/map/MopOverflowActionTest.java
+++ b/src/test/manual/net/spy/memcached/collection/map/MopOverflowActionTest.java
@@ -16,7 +16,7 @@
  */
 package net.spy.memcached.collection.map;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import net.spy.memcached.collection.BaseIntegrationTest;
 import net.spy.memcached.collection.CollectionAttributes;
 import net.spy.memcached.collection.CollectionOverflowAction;

--- a/src/test/manual/net/spy/memcached/collection/map/MopUpdateTest.java
+++ b/src/test/manual/net/spy/memcached/collection/map/MopUpdateTest.java
@@ -16,7 +16,7 @@
  */
 package net.spy.memcached.collection.map;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import net.spy.memcached.collection.BaseIntegrationTest;
 import net.spy.memcached.collection.CollectionAttributes;
 

--- a/src/test/manual/net/spy/memcached/collection/set/SopBulkAPITest.java
+++ b/src/test/manual/net/spy/memcached/collection/set/SopBulkAPITest.java
@@ -23,7 +23,7 @@ import java.util.Set;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import net.spy.memcached.collection.BaseIntegrationTest;
 import net.spy.memcached.collection.CollectionAttributes;
 import net.spy.memcached.internal.CollectionFuture;

--- a/src/test/manual/net/spy/memcached/collection/set/SopDeleteTest.java
+++ b/src/test/manual/net/spy/memcached/collection/set/SopDeleteTest.java
@@ -18,7 +18,7 @@ package net.spy.memcached.collection.set;
 
 import java.util.concurrent.ExecutionException;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import net.spy.memcached.collection.BaseIntegrationTest;
 import net.spy.memcached.collection.CollectionAttributes;
 

--- a/src/test/manual/net/spy/memcached/collection/set/SopOverflowActionTest.java
+++ b/src/test/manual/net/spy/memcached/collection/set/SopOverflowActionTest.java
@@ -21,7 +21,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import net.spy.memcached.collection.BaseIntegrationTest;
 import net.spy.memcached.collection.CollectionAttributes;
 import net.spy.memcached.collection.CollectionOverflowAction;

--- a/src/test/manual/net/spy/memcached/collection/set/SopPipedExistTest.java
+++ b/src/test/manual/net/spy/memcached/collection/set/SopPipedExistTest.java
@@ -20,7 +20,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import net.spy.memcached.collection.BaseIntegrationTest;
 import net.spy.memcached.collection.CollectionAttributes;
 import net.spy.memcached.collection.ElementValueType;

--- a/src/test/manual/net/spy/memcached/emptycollection/BTreeDeleteWithFilterTest.java
+++ b/src/test/manual/net/spy/memcached/emptycollection/BTreeDeleteWithFilterTest.java
@@ -16,7 +16,7 @@
  */
 package net.spy.memcached.emptycollection;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import net.spy.memcached.collection.ElementFlagFilter;
 import net.spy.memcached.collection.ElementFlagFilter.CompOperands;
 import net.spy.memcached.collection.BaseIntegrationTest;

--- a/src/test/manual/net/spy/memcached/emptycollection/BTreeGetWithFilterTest.java
+++ b/src/test/manual/net/spy/memcached/emptycollection/BTreeGetWithFilterTest.java
@@ -18,7 +18,7 @@ package net.spy.memcached.emptycollection;
 
 import java.util.Map;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import net.spy.memcached.collection.Element;
 import net.spy.memcached.collection.ElementFlagFilter;
 import net.spy.memcached.collection.ElementFlagFilter.BitWiseOperands;

--- a/src/test/manual/net/spy/memcached/emptycollection/CreateEmptyBTreeTest.java
+++ b/src/test/manual/net/spy/memcached/emptycollection/CreateEmptyBTreeTest.java
@@ -16,7 +16,7 @@
  */
 package net.spy.memcached.emptycollection;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import net.spy.memcached.collection.BaseIntegrationTest;
 import net.spy.memcached.collection.CollectionAttributes;
 import net.spy.memcached.collection.ElementValueType;

--- a/src/test/manual/net/spy/memcached/emptycollection/CreateEmptyListTest.java
+++ b/src/test/manual/net/spy/memcached/emptycollection/CreateEmptyListTest.java
@@ -16,7 +16,7 @@
  */
 package net.spy.memcached.emptycollection;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import net.spy.memcached.collection.BaseIntegrationTest;
 import net.spy.memcached.collection.CollectionAttributes;
 import net.spy.memcached.collection.ElementValueType;

--- a/src/test/manual/net/spy/memcached/emptycollection/CreateEmptyMapTest.java
+++ b/src/test/manual/net/spy/memcached/emptycollection/CreateEmptyMapTest.java
@@ -16,7 +16,7 @@
  */
 package net.spy.memcached.emptycollection;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import net.spy.memcached.collection.BaseIntegrationTest;
 import net.spy.memcached.collection.CollectionAttributes;
 import net.spy.memcached.collection.ElementValueType;

--- a/src/test/manual/net/spy/memcached/emptycollection/CreateEmptySetTest.java
+++ b/src/test/manual/net/spy/memcached/emptycollection/CreateEmptySetTest.java
@@ -16,7 +16,7 @@
  */
 package net.spy.memcached.emptycollection;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import net.spy.memcached.collection.BaseIntegrationTest;
 import net.spy.memcached.collection.CollectionAttributes;
 import net.spy.memcached.collection.ElementValueType;

--- a/src/test/manual/net/spy/memcached/emptycollection/GetCountBTreeTest.java
+++ b/src/test/manual/net/spy/memcached/emptycollection/GetCountBTreeTest.java
@@ -16,7 +16,7 @@
  */
 package net.spy.memcached.emptycollection;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import net.spy.memcached.collection.BaseIntegrationTest;
 import net.spy.memcached.collection.CollectionAttributes;
 import net.spy.memcached.collection.CollectionResponse;

--- a/src/test/manual/net/spy/memcached/emptycollection/GetCountBTreeTestWithElementFlagFilterTest.java
+++ b/src/test/manual/net/spy/memcached/emptycollection/GetCountBTreeTestWithElementFlagFilterTest.java
@@ -16,7 +16,7 @@
  */
 package net.spy.memcached.emptycollection;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import net.spy.memcached.collection.BaseIntegrationTest;
 import net.spy.memcached.collection.CollectionAttributes;
 import net.spy.memcached.collection.CollectionResponse;

--- a/src/test/manual/net/spy/memcached/emptycollection/GetWithDropBTreeTest.java
+++ b/src/test/manual/net/spy/memcached/emptycollection/GetWithDropBTreeTest.java
@@ -18,7 +18,7 @@ package net.spy.memcached.emptycollection;
 
 import java.util.Map;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import net.spy.memcached.collection.Element;
 import net.spy.memcached.collection.ElementFlagFilter;
 import net.spy.memcached.collection.BaseIntegrationTest;

--- a/src/test/manual/net/spy/memcached/emptycollection/GetWithDropListTest.java
+++ b/src/test/manual/net/spy/memcached/emptycollection/GetWithDropListTest.java
@@ -18,7 +18,7 @@ package net.spy.memcached.emptycollection;
 
 import java.util.List;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import net.spy.memcached.collection.BaseIntegrationTest;
 import net.spy.memcached.collection.CollectionAttributes;
 import net.spy.memcached.internal.CollectionFuture;

--- a/src/test/manual/net/spy/memcached/emptycollection/GetWithDropMapTest.java
+++ b/src/test/manual/net/spy/memcached/emptycollection/GetWithDropMapTest.java
@@ -18,7 +18,7 @@ package net.spy.memcached.emptycollection;
 
 import java.util.Map;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import net.spy.memcached.collection.BaseIntegrationTest;
 import net.spy.memcached.collection.CollectionAttributes;
 

--- a/src/test/manual/net/spy/memcached/emptycollection/GetWithDropSetTest.java
+++ b/src/test/manual/net/spy/memcached/emptycollection/GetWithDropSetTest.java
@@ -18,7 +18,7 @@ package net.spy.memcached.emptycollection;
 
 import java.util.Set;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import net.spy.memcached.collection.BaseIntegrationTest;
 import net.spy.memcached.collection.CollectionAttributes;
 

--- a/src/test/manual/net/spy/memcached/emptycollection/InsertBTreeWithAttrAndEFlagTest.java
+++ b/src/test/manual/net/spy/memcached/emptycollection/InsertBTreeWithAttrAndEFlagTest.java
@@ -18,7 +18,7 @@ package net.spy.memcached.emptycollection;
 
 import java.util.Map;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import net.spy.memcached.collection.Element;
 import net.spy.memcached.collection.ElementFlagFilter;
 import net.spy.memcached.collection.BaseIntegrationTest;

--- a/src/test/manual/net/spy/memcached/emptycollection/InsertListWithAttrTest.java
+++ b/src/test/manual/net/spy/memcached/emptycollection/InsertListWithAttrTest.java
@@ -18,7 +18,7 @@ package net.spy.memcached.emptycollection;
 
 import java.util.List;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import net.spy.memcached.collection.BaseIntegrationTest;
 import net.spy.memcached.collection.CollectionAttributes;
 

--- a/src/test/manual/net/spy/memcached/emptycollection/InsertMapWithAttrTest.java
+++ b/src/test/manual/net/spy/memcached/emptycollection/InsertMapWithAttrTest.java
@@ -18,7 +18,7 @@ package net.spy.memcached.emptycollection;
 
 import java.util.Map;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import net.spy.memcached.collection.BaseIntegrationTest;
 import net.spy.memcached.collection.CollectionAttributes;
 

--- a/src/test/manual/net/spy/memcached/emptycollection/InsertSetWithAttrTest.java
+++ b/src/test/manual/net/spy/memcached/emptycollection/InsertSetWithAttrTest.java
@@ -18,7 +18,7 @@ package net.spy.memcached.emptycollection;
 
 import java.util.Set;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import net.spy.memcached.collection.BaseIntegrationTest;
 import net.spy.memcached.collection.CollectionAttributes;
 

--- a/src/test/manual/net/spy/memcached/emptycollection/PipedBulkInsertBTreeWithAttrTest.java
+++ b/src/test/manual/net/spy/memcached/emptycollection/PipedBulkInsertBTreeWithAttrTest.java
@@ -21,7 +21,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import net.spy.memcached.collection.BaseIntegrationTest;
 import net.spy.memcached.collection.ByteArrayBKey;
 import net.spy.memcached.collection.CollectionAttributes;

--- a/src/test/manual/net/spy/memcached/emptycollection/PipedBulkInsertListWithAttrTest.java
+++ b/src/test/manual/net/spy/memcached/emptycollection/PipedBulkInsertListWithAttrTest.java
@@ -20,7 +20,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import net.spy.memcached.collection.BaseIntegrationTest;
 import net.spy.memcached.collection.CollectionAttributes;
 import net.spy.memcached.ops.CollectionOperationStatus;

--- a/src/test/manual/net/spy/memcached/emptycollection/PipedBulkInsertMapWithAttrTest.java
+++ b/src/test/manual/net/spy/memcached/emptycollection/PipedBulkInsertMapWithAttrTest.java
@@ -19,7 +19,7 @@ package net.spy.memcached.emptycollection;
 import java.util.HashMap;
 import java.util.Map;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import net.spy.memcached.collection.BaseIntegrationTest;
 import net.spy.memcached.collection.CollectionAttributes;
 import net.spy.memcached.ops.CollectionOperationStatus;

--- a/src/test/manual/net/spy/memcached/emptycollection/PipedBulkInsertSetWithAttrTest.java
+++ b/src/test/manual/net/spy/memcached/emptycollection/PipedBulkInsertSetWithAttrTest.java
@@ -20,7 +20,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import net.spy.memcached.collection.BaseIntegrationTest;
 import net.spy.memcached.collection.CollectionAttributes;
 import net.spy.memcached.ops.CollectionOperationStatus;

--- a/src/test/manual/net/spy/memcached/emptycollection/ProtocolBTreeDeleteTest.java
+++ b/src/test/manual/net/spy/memcached/emptycollection/ProtocolBTreeDeleteTest.java
@@ -16,7 +16,7 @@
  */
 package net.spy.memcached.emptycollection;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import junit.framework.TestCase;
 import net.spy.memcached.collection.ElementFlagFilter;
 import net.spy.memcached.collection.BTreeDelete;

--- a/src/test/manual/net/spy/memcached/emptycollection/ProtocolBTreeGetTest.java
+++ b/src/test/manual/net/spy/memcached/emptycollection/ProtocolBTreeGetTest.java
@@ -16,7 +16,7 @@
  */
 package net.spy.memcached.emptycollection;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import junit.framework.TestCase;
 import net.spy.memcached.collection.ElementFlagFilter;
 import net.spy.memcached.collection.BTreeGet;

--- a/src/test/manual/net/spy/memcached/emptycollection/ProtocolListDeleteTest.java
+++ b/src/test/manual/net/spy/memcached/emptycollection/ProtocolListDeleteTest.java
@@ -16,7 +16,7 @@
  */
 package net.spy.memcached.emptycollection;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import junit.framework.TestCase;
 import net.spy.memcached.collection.ListDelete;
 

--- a/src/test/manual/net/spy/memcached/emptycollection/ProtocolListGetTest.java
+++ b/src/test/manual/net/spy/memcached/emptycollection/ProtocolListGetTest.java
@@ -16,7 +16,7 @@
  */
 package net.spy.memcached.emptycollection;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import junit.framework.TestCase;
 import net.spy.memcached.collection.ListGet;
 

--- a/src/test/manual/net/spy/memcached/emptycollection/ProtocolMapDeleteTest.java
+++ b/src/test/manual/net/spy/memcached/emptycollection/ProtocolMapDeleteTest.java
@@ -16,7 +16,7 @@
  */
 package net.spy.memcached.emptycollection;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import junit.framework.TestCase;
 import net.spy.memcached.collection.MapDelete;
 

--- a/src/test/manual/net/spy/memcached/emptycollection/ProtocolMapGetTest.java
+++ b/src/test/manual/net/spy/memcached/emptycollection/ProtocolMapGetTest.java
@@ -16,7 +16,7 @@
  */
 package net.spy.memcached.emptycollection;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import junit.framework.TestCase;
 import net.spy.memcached.collection.MapGet;
 

--- a/src/test/manual/net/spy/memcached/emptycollection/ProtocolSetGetTest.java
+++ b/src/test/manual/net/spy/memcached/emptycollection/ProtocolSetGetTest.java
@@ -16,7 +16,7 @@
  */
 package net.spy.memcached.emptycollection;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import junit.framework.TestCase;
 import net.spy.memcached.collection.SetGet;
 

--- a/src/test/manual/net/spy/memcached/emptycollection/VariousTypeTest.java
+++ b/src/test/manual/net/spy/memcached/emptycollection/VariousTypeTest.java
@@ -23,7 +23,7 @@ import java.util.Date;
 import java.util.List;
 import java.util.Map;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import net.spy.memcached.collection.Element;
 import net.spy.memcached.collection.ElementFlagFilter;
 import net.spy.memcached.collection.BaseIntegrationTest;

--- a/src/test/manual/net/spy/memcached/test/MutateWithDefaultTest.java
+++ b/src/test/manual/net/spy/memcached/test/MutateWithDefaultTest.java
@@ -19,7 +19,7 @@ package net.spy.memcached.test;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import net.spy.memcached.collection.BaseIntegrationTest;
 
 public class MutateWithDefaultTest extends BaseIntegrationTest {

--- a/src/test/manual/net/spy/memcached/test/SASLConnectReconnect.java
+++ b/src/test/manual/net/spy/memcached/test/SASLConnectReconnect.java
@@ -9,7 +9,7 @@ import java.util.logging.Handler;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import net.spy.memcached.AddrUtil;
 import net.spy.memcached.ConnectionFactoryBuilder;
 import net.spy.memcached.ConnectionFactoryBuilder.Protocol;


### PR DESCRIPTION
- Junit의 deprecated 클래스를 대체 클래스로 변경했습니다.
- SupressWarnings 관련
    - Arcus API 중 하나인 asyncSetBulk() 메소드가 deprecated 되었습니다.
    - asyncSetBulk() 메소드를 Test code에서 수행하기 때문에 warning이 발생합니다.
    - Deprecated API라도 Test code는 남아 있어야 한다고 생각해서 asyncSetBulk() 호출 시 deprecation warning을 무시하도록 했습니다.