### PR TITLE
FIX: Resolve wrapper type warnings.

### DIFF
--- a/src/main/java/net/spy/memcached/ArcusClient.java
+++ b/src/main/java/net/spy/memcached/ArcusClient.java
@@ -1854,7 +1854,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
               cstatus = new CollectionOperationStatus(status);
             }
             if (cstatus.isSuccess()) {
-              rv.set(new Integer(cstatus.getMessage()),
+              rv.set(Integer.valueOf(cstatus.getMessage()),
                       new CollectionOperationStatus(new OperationStatus(true, "END")));
               return;
             }
@@ -4564,7 +4564,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
           public void receivedStatus(OperationStatus status) {
             if (status.isSuccess()) {
               try {
-                rv.set(new Long(status.getMessage()),
+                rv.set(Long.valueOf(status.getMessage()),
                         new CollectionOperationStatus(new OperationStatus(true, "END")));
               } catch (NumberFormatException e) {
                 rv.set(null, new CollectionOperationStatus(

--- a/src/main/java/net/spy/memcached/transcoders/CollectionTranscoder.java
+++ b/src/main/java/net/spy/memcached/transcoders/CollectionTranscoder.java
@@ -83,25 +83,25 @@ public class CollectionTranscoder extends SerializingTranscoder implements
     } else if (flags != 0 && data != null) {
       switch (flags) {
         case SPECIAL_BOOLEAN:
-          rv = Boolean.valueOf(tu.decodeBoolean(data));
+          rv = tu.decodeBoolean(data);
           break;
         case SPECIAL_INT:
-          rv = new Integer(tu.decodeInt(data));
+          rv = tu.decodeInt(data);
           break;
         case SPECIAL_LONG:
-          rv = new Long(tu.decodeLong(data));
+          rv = tu.decodeLong(data);
           break;
         case SPECIAL_DATE:
           rv = new Date(tu.decodeLong(data));
           break;
         case SPECIAL_BYTE:
-          rv = new Byte(tu.decodeByte(data));
+          rv = tu.decodeByte(data);
           break;
         case SPECIAL_FLOAT:
-          rv = new Float(Float.intBitsToFloat(tu.decodeInt(data)));
+          rv = Float.intBitsToFloat(tu.decodeInt(data));
           break;
         case SPECIAL_DOUBLE:
-          rv = new Double(Double.longBitsToDouble(tu.decodeLong(data)));
+          rv = Double.longBitsToDouble(tu.decodeLong(data));
           break;
         case SPECIAL_BYTEARRAY:
           rv = data;

--- a/src/main/java/net/spy/memcached/transcoders/SerializingTranscoder.java
+++ b/src/main/java/net/spy/memcached/transcoders/SerializingTranscoder.java
@@ -80,25 +80,25 @@ public class SerializingTranscoder extends BaseSerializingTranscoder
     } else if (flags != 0 && data != null) {
       switch (flags) {
         case SPECIAL_BOOLEAN:
-          rv = Boolean.valueOf(tu.decodeBoolean(data));
+          rv = tu.decodeBoolean(data);
           break;
         case SPECIAL_INT:
-          rv = new Integer(tu.decodeInt(data));
+          rv = tu.decodeInt(data);
           break;
         case SPECIAL_LONG:
-          rv = new Long(tu.decodeLong(data));
+          rv = tu.decodeLong(data);
           break;
         case SPECIAL_DATE:
           rv = new Date(tu.decodeLong(data));
           break;
         case SPECIAL_BYTE:
-          rv = new Byte(tu.decodeByte(data));
+          rv = tu.decodeByte(data);
           break;
         case SPECIAL_FLOAT:
-          rv = new Float(Float.intBitsToFloat(tu.decodeInt(data)));
+          rv = Float.intBitsToFloat(tu.decodeInt(data));
           break;
         case SPECIAL_DOUBLE:
-          rv = new Double(Double.longBitsToDouble(tu.decodeLong(data)));
+          rv = Double.longBitsToDouble(tu.decodeLong(data));
           break;
         case SPECIAL_BYTEARRAY:
           rv = data;

--- a/src/main/java/net/spy/memcached/transcoders/WhalinTranscoder.java
+++ b/src/main/java/net/spy/memcached/transcoders/WhalinTranscoder.java
@@ -60,28 +60,28 @@ public class WhalinTranscoder extends BaseSerializingTranscoder
       int f = d.getFlags() & ~COMPRESSED;
       switch (f) {
         case SPECIAL_BOOLEAN:
-          rv = Boolean.valueOf(this.decodeBoolean(data));
+          rv = this.decodeBoolean(data);
           break;
         case SPECIAL_INT:
-          rv = new Integer(tu.decodeInt(data));
+          rv = tu.decodeInt(data);
           break;
         case SPECIAL_SHORT:
-          rv = new Short((short) tu.decodeInt(data));
+          rv = (short) tu.decodeInt(data);
           break;
         case SPECIAL_LONG:
-          rv = new Long(tu.decodeLong(data));
+          rv = tu.decodeLong(data);
           break;
         case SPECIAL_DATE:
           rv = new Date(tu.decodeLong(data));
           break;
         case SPECIAL_BYTE:
-          rv = new Byte(tu.decodeByte(data));
+          rv = tu.decodeByte(data);
           break;
         case SPECIAL_FLOAT:
-          rv = new Float(Float.intBitsToFloat(tu.decodeInt(data)));
+          rv = Float.intBitsToFloat(tu.decodeInt(data));
           break;
         case SPECIAL_DOUBLE:
-          rv = new Double(Double.longBitsToDouble(tu.decodeLong(data)));
+          rv = Double.longBitsToDouble(tu.decodeLong(data));
           break;
         case SPECIAL_BYTEARRAY:
           rv = data;

--- a/src/test/manual/net/spy/memcached/collection/attribute/BTreeGetAttrTest.java
+++ b/src/test/manual/net/spy/memcached/collection/attribute/BTreeGetAttrTest.java
@@ -60,7 +60,7 @@ public class BTreeGetAttrTest extends BaseIntegrationTest {
       // get trimmed
       CollectionAttributes btreeAttrs = mc.asyncGetAttr(KEY).get();
       if (btreeAttrs.getTrimmed() != null) { // not support
-        Assert.assertEquals(new Long(0L), btreeAttrs.getTrimmed());
+        Assert.assertEquals(Long.valueOf(0L), btreeAttrs.getTrimmed());
       }
 
       Assert.assertTrue(mc.asyncBopInsert(KEY, 3L, EFLAG, VALUE,
@@ -71,7 +71,7 @@ public class BTreeGetAttrTest extends BaseIntegrationTest {
       // get trimmed
       btreeAttrs = mc.asyncGetAttr(KEY).get();
       if (btreeAttrs.getTrimmed() != null) { // not support
-        Assert.assertEquals(new Long(1L), btreeAttrs.getTrimmed());
+        Assert.assertEquals(Long.valueOf(1L), btreeAttrs.getTrimmed());
       }
 
     } catch (Exception e) {
@@ -93,8 +93,8 @@ public class BTreeGetAttrTest extends BaseIntegrationTest {
 
       btreeAttrs = mc.asyncGetAttr(KEY).get();
       if (btreeAttrs.getMinBkey() != null) { // not support
-        Assert.assertEquals(new Long(0L), btreeAttrs.getMinBkey());
-        Assert.assertEquals(new Long(0L), btreeAttrs.getMaxBkey());
+        Assert.assertEquals(Long.valueOf(0L), btreeAttrs.getMinBkey());
+        Assert.assertEquals(Long.valueOf(0L), btreeAttrs.getMaxBkey());
       }
 
       Assert.assertTrue(mc.asyncBopInsert(KEY, 1L, EFLAG, VALUE, null)
@@ -104,8 +104,8 @@ public class BTreeGetAttrTest extends BaseIntegrationTest {
 
       btreeAttrs = mc.asyncGetAttr(KEY).get();
       if (btreeAttrs.getMinBkey() != null) { // not support
-        Assert.assertEquals(new Long(0L), btreeAttrs.getMinBkey());
-        Assert.assertEquals(new Long(2L), btreeAttrs.getMaxBkey());
+        Assert.assertEquals(Long.valueOf(0L), btreeAttrs.getMinBkey());
+        Assert.assertEquals(Long.valueOf(2L), btreeAttrs.getMaxBkey());
       }
     } catch (Exception e) {
       Assert.fail(e.getMessage());

--- a/src/test/manual/net/spy/memcached/collection/attribute/GetAttrTest.java
+++ b/src/test/manual/net/spy/memcached/collection/attribute/GetAttrTest.java
@@ -37,7 +37,7 @@ public class GetAttrTest extends BaseIntegrationTest {
             TimeUnit.MILLISECONDS);
 
     assertNotNull(rattrs);
-    assertEquals(new Integer(0), rattrs.getFlags());
+    assertEquals(Integer.valueOf(0), rattrs.getFlags());
     assertEquals(CollectionType.kv, rattrs.getType());
   }
 

--- a/src/test/manual/net/spy/memcached/collection/attribute/UnReadableBTreeTest.java
+++ b/src/test/manual/net/spy/memcached/collection/attribute/UnReadableBTreeTest.java
@@ -58,9 +58,9 @@ public class UnReadableBTreeTest extends BaseIntegrationTest {
       // check attribute
       CollectionAttributes attr = mc.asyncGetAttr(KEY).get();
 
-      Assert.assertEquals(new Long(0), attr.getCount());
-      Assert.assertEquals(new Long(4000), attr.getMaxCount());
-      Assert.assertEquals(new Integer(0), attr.getExpireTime());
+      Assert.assertEquals(Long.valueOf(0), attr.getCount());
+      Assert.assertEquals(Long.valueOf(4000), attr.getMaxCount());
+      Assert.assertEquals(Integer.valueOf(0), attr.getExpireTime());
       Assert.assertFalse(attr.getReadable());
 
       // insert an item
@@ -105,9 +105,9 @@ public class UnReadableBTreeTest extends BaseIntegrationTest {
       // check attribute
       CollectionAttributes attr = mc.asyncGetAttr(KEY).get();
 
-      Assert.assertEquals(new Long(0), attr.getCount());
-      Assert.assertEquals(new Long(4000), attr.getMaxCount());
-      Assert.assertEquals(new Integer(0), attr.getExpireTime());
+      Assert.assertEquals(Long.valueOf(0), attr.getCount());
+      Assert.assertEquals(Long.valueOf(4000), attr.getMaxCount());
+      Assert.assertEquals(Integer.valueOf(0), attr.getExpireTime());
       Assert.assertTrue(attr.getReadable());
 
       // insert an item

--- a/src/test/manual/net/spy/memcached/collection/attribute/UnReadableExtendedBTreeTest.java
+++ b/src/test/manual/net/spy/memcached/collection/attribute/UnReadableExtendedBTreeTest.java
@@ -59,9 +59,9 @@ public class UnReadableExtendedBTreeTest extends BaseIntegrationTest {
       // check attribute
       CollectionAttributes attr = mc.asyncGetAttr(KEY).get();
 
-      Assert.assertEquals(new Long(0), attr.getCount());
-      Assert.assertEquals(new Long(4000), attr.getMaxCount());
-      Assert.assertEquals(new Integer(0), attr.getExpireTime());
+      Assert.assertEquals(Long.valueOf(0), attr.getCount());
+      Assert.assertEquals(Long.valueOf(4000), attr.getMaxCount());
+      Assert.assertEquals(Integer.valueOf(0), attr.getExpireTime());
       Assert.assertFalse(attr.getReadable());
 
       // insert an item
@@ -109,9 +109,9 @@ public class UnReadableExtendedBTreeTest extends BaseIntegrationTest {
       // check attribute
       CollectionAttributes attr = mc.asyncGetAttr(KEY).get();
 
-      Assert.assertEquals(new Long(0), attr.getCount());
-      Assert.assertEquals(new Long(4000), attr.getMaxCount());
-      Assert.assertEquals(new Integer(0), attr.getExpireTime());
+      Assert.assertEquals(Long.valueOf(0), attr.getCount());
+      Assert.assertEquals(Long.valueOf(4000), attr.getMaxCount());
+      Assert.assertEquals(Integer.valueOf(0), attr.getExpireTime());
       Assert.assertTrue(attr.getReadable());
 
       // insert an item

--- a/src/test/manual/net/spy/memcached/collection/attribute/UnReadableListTest.java
+++ b/src/test/manual/net/spy/memcached/collection/attribute/UnReadableListTest.java
@@ -56,9 +56,9 @@ public class UnReadableListTest extends BaseIntegrationTest {
       // check attribute
       CollectionAttributes attr = mc.asyncGetAttr(KEY).get();
 
-      Assert.assertEquals(new Long(0), attr.getCount());
-      Assert.assertEquals(new Long(4000), attr.getMaxCount());
-      Assert.assertEquals(new Integer(0), attr.getExpireTime());
+      Assert.assertEquals(Long.valueOf(0), attr.getCount());
+      Assert.assertEquals(Long.valueOf(4000), attr.getMaxCount());
+      Assert.assertEquals(Integer.valueOf(0), attr.getExpireTime());
       Assert.assertFalse(attr.getReadable());
 
       // insert an item
@@ -101,9 +101,9 @@ public class UnReadableListTest extends BaseIntegrationTest {
       // check attribute
       CollectionAttributes attr = mc.asyncGetAttr(KEY).get();
 
-      Assert.assertEquals(new Long(0), attr.getCount());
-      Assert.assertEquals(new Long(4000), attr.getMaxCount());
-      Assert.assertEquals(new Integer(0), attr.getExpireTime());
+      Assert.assertEquals(Long.valueOf(0), attr.getCount());
+      Assert.assertEquals(Long.valueOf(4000), attr.getMaxCount());
+      Assert.assertEquals(Integer.valueOf(0), attr.getExpireTime());
       Assert.assertTrue(attr.getReadable());
 
       // insert an item

--- a/src/test/manual/net/spy/memcached/collection/attribute/UnReadableMapTest.java
+++ b/src/test/manual/net/spy/memcached/collection/attribute/UnReadableMapTest.java
@@ -56,9 +56,9 @@ public class UnReadableMapTest extends BaseIntegrationTest {
       // check attribute
       CollectionAttributes attr = mc.asyncGetAttr(KEY).get();
 
-      Assert.assertEquals(new Long(0), attr.getCount());
-      Assert.assertEquals(new Long(4000), attr.getMaxCount());
-      Assert.assertEquals(new Integer(0), attr.getExpireTime());
+      Assert.assertEquals(Long.valueOf(0), attr.getCount());
+      Assert.assertEquals(Long.valueOf(4000), attr.getMaxCount());
+      Assert.assertEquals(Integer.valueOf(0), attr.getExpireTime());
       Assert.assertFalse(attr.getReadable());
 
       // insert an item
@@ -102,9 +102,9 @@ public class UnReadableMapTest extends BaseIntegrationTest {
       // check attribute
       CollectionAttributes attr = mc.asyncGetAttr(KEY).get();
 
-      Assert.assertEquals(new Long(0), attr.getCount());
-      Assert.assertEquals(new Long(4000), attr.getMaxCount());
-      Assert.assertEquals(new Integer(0), attr.getExpireTime());
+      Assert.assertEquals(Long.valueOf(0), attr.getCount());
+      Assert.assertEquals(Long.valueOf(4000), attr.getMaxCount());
+      Assert.assertEquals(Integer.valueOf(0), attr.getExpireTime());
       Assert.assertTrue(attr.getReadable());
 
       // insert an item

--- a/src/test/manual/net/spy/memcached/collection/attribute/UnReadableSetTest.java
+++ b/src/test/manual/net/spy/memcached/collection/attribute/UnReadableSetTest.java
@@ -56,9 +56,9 @@ public class UnReadableSetTest extends BaseIntegrationTest {
       // check attribute
       CollectionAttributes attr = mc.asyncGetAttr(KEY).get();
 
-      Assert.assertEquals(new Long(0), attr.getCount());
-      Assert.assertEquals(new Long(4000), attr.getMaxCount());
-      Assert.assertEquals(new Integer(0), attr.getExpireTime());
+      Assert.assertEquals(Long.valueOf(0), attr.getCount());
+      Assert.assertEquals(Long.valueOf(4000), attr.getMaxCount());
+      Assert.assertEquals(Integer.valueOf(0), attr.getExpireTime());
       Assert.assertFalse(attr.getReadable());
 
       // insert an item
@@ -102,9 +102,9 @@ public class UnReadableSetTest extends BaseIntegrationTest {
       // check attribute
       CollectionAttributes attr = mc.asyncGetAttr(KEY).get();
 
-      Assert.assertEquals(new Long(0), attr.getCount());
-      Assert.assertEquals(new Long(4000), attr.getMaxCount());
-      Assert.assertEquals(new Integer(0), attr.getExpireTime());
+      Assert.assertEquals(Long.valueOf(0), attr.getCount());
+      Assert.assertEquals(Long.valueOf(4000), attr.getMaxCount());
+      Assert.assertEquals(Integer.valueOf(0), attr.getExpireTime());
       Assert.assertTrue(attr.getReadable());
 
       // insert an item

--- a/src/test/manual/net/spy/memcached/collection/btree/longbkey/BopCountWithElementFlagFilterTest.java
+++ b/src/test/manual/net/spy/memcached/collection/btree/longbkey/BopCountWithElementFlagFilterTest.java
@@ -105,7 +105,7 @@ public class BopCountWithElementFlagFilterTest extends BaseIntegrationTest {
       Assert.assertTrue(insertResult2);
 
       // check count in attributes
-      Assert.assertEquals(new Long(2), mc.asyncGetAttr(KEY).get()
+      Assert.assertEquals(Long.valueOf(2), mc.asyncGetAttr(KEY).get()
               .getCount());
 
       // get btree item count
@@ -113,7 +113,7 @@ public class BopCountWithElementFlagFilterTest extends BaseIntegrationTest {
               BKEY, BKEY, filter);
       Integer count = future.get();
       Assert.assertNotNull(count);
-      Assert.assertEquals(new Integer(1), count);
+      Assert.assertEquals(Integer.valueOf(1), count);
     } catch (Exception e) {
       e.printStackTrace();
       Assert.fail(e.getMessage());
@@ -139,7 +139,7 @@ public class BopCountWithElementFlagFilterTest extends BaseIntegrationTest {
       Assert.assertTrue(insertResult2);
 
       // check count in attributes
-      Assert.assertEquals(new Long(2), mc.asyncGetAttr(KEY).get()
+      Assert.assertEquals(Long.valueOf(2), mc.asyncGetAttr(KEY).get()
               .getCount());
 
       // get btree item count
@@ -147,7 +147,7 @@ public class BopCountWithElementFlagFilterTest extends BaseIntegrationTest {
               BKEY, BKEY2, filter);
       Integer count = future.get();
       Assert.assertNotNull(count);
-      Assert.assertEquals(new Integer(1), count);
+      Assert.assertEquals(Integer.valueOf(1), count);
     } catch (Exception e) {
       e.printStackTrace();
       Assert.fail(e.getMessage());
@@ -174,7 +174,7 @@ public class BopCountWithElementFlagFilterTest extends BaseIntegrationTest {
       Assert.assertTrue(insertResult2);
 
       // check count in attributes
-      Assert.assertEquals(new Long(2), mc.asyncGetAttr(KEY).get()
+      Assert.assertEquals(Long.valueOf(2), mc.asyncGetAttr(KEY).get()
               .getCount());
 
       // get btree item count
@@ -182,7 +182,7 @@ public class BopCountWithElementFlagFilterTest extends BaseIntegrationTest {
               BKEY, BKEY, filter);
       Integer count = future.get();
       Assert.assertNotNull(count);
-      Assert.assertEquals(new Integer(1), count);
+      Assert.assertEquals(Integer.valueOf(1), count);
     } catch (Exception e) {
       e.printStackTrace();
       Assert.fail(e.getMessage());

--- a/src/test/manual/net/spy/memcached/collection/list/LopInsertDataType.java
+++ b/src/test/manual/net/spy/memcached/collection/list/LopInsertDataType.java
@@ -78,13 +78,13 @@ public class LopInsertDataType extends BaseIntegrationTest {
             new CollectionAttributes()).get(1000, TimeUnit.MILLISECONDS));
 
     // Then insert another items with different data types
-    assertTrue(mc.asyncLopInsert(key, -1, new Integer(100), null).get(1000,
+    assertTrue(mc.asyncLopInsert(key, -1, 100, null).get(1000,
             TimeUnit.MILLISECONDS));
 
-    assertTrue(mc.asyncLopInsert(key, -1, new Long(101L), null).get(1000,
+    assertTrue(mc.asyncLopInsert(key, -1, 101L, null).get(1000,
             TimeUnit.MILLISECONDS));
 
-    assertTrue(mc.asyncLopInsert(key, -1, new Character('f'), null).get(
+    assertTrue(mc.asyncLopInsert(key, -1, 'f', null).get(
             1000, TimeUnit.MILLISECONDS));
 
     // Retrieve items from the list and check they're in same data type
@@ -99,7 +99,7 @@ public class LopInsertDataType extends BaseIntegrationTest {
 
   public void testLopInsert_DifferentDataType_ErrorCase() throws Exception {
     // First, create a list and insert one item in it
-    assertTrue(mc.asyncLopInsert(key, 0, new Character('a'),
+    assertTrue(mc.asyncLopInsert(key, 0, 'a',
             new CollectionAttributes()).get(1000, TimeUnit.MILLISECONDS));
 
     // Then insert an another item with different data type

--- a/src/test/manual/net/spy/memcached/emptycollection/BTreeDeleteWithFilterTest.java
+++ b/src/test/manual/net/spy/memcached/emptycollection/BTreeDeleteWithFilterTest.java
@@ -54,7 +54,7 @@ public class BTreeDeleteWithFilterTest extends BaseIntegrationTest {
       Assert.assertTrue(insertResult);
 
       // check attr
-      Assert.assertEquals(new Long(1), mc.asyncGetAttr(KEY).get()
+      Assert.assertEquals(Long.valueOf(1), mc.asyncGetAttr(KEY).get()
               .getCount());
 
       // delete one bkey
@@ -62,7 +62,7 @@ public class BTreeDeleteWithFilterTest extends BaseIntegrationTest {
       Assert.assertTrue(delete);
 
       // check attr again
-      Assert.assertEquals(new Long(0), mc.asyncGetAttr(KEY).get()
+      Assert.assertEquals(Long.valueOf(0), mc.asyncGetAttr(KEY).get()
               .getCount());
     } catch (Exception e) {
       e.printStackTrace();
@@ -80,7 +80,7 @@ public class BTreeDeleteWithFilterTest extends BaseIntegrationTest {
       Assert.assertTrue(insertResult);
 
       // check attr
-      Assert.assertEquals(new Long(1), mc.asyncGetAttr(KEY).get()
+      Assert.assertEquals(Long.valueOf(1), mc.asyncGetAttr(KEY).get()
               .getCount());
 
       // delete one bkey
@@ -88,7 +88,7 @@ public class BTreeDeleteWithFilterTest extends BaseIntegrationTest {
       Assert.assertFalse(delete);
 
       // check attr again
-      Assert.assertEquals(new Long(1), mc.asyncGetAttr(KEY).get()
+      Assert.assertEquals(Long.valueOf(1), mc.asyncGetAttr(KEY).get()
               .getCount());
     } catch (Exception e) {
       e.printStackTrace();

--- a/src/test/manual/net/spy/memcached/emptycollection/BTreeGetWithFilterTest.java
+++ b/src/test/manual/net/spy/memcached/emptycollection/BTreeGetWithFilterTest.java
@@ -56,7 +56,7 @@ public class BTreeGetWithFilterTest extends BaseIntegrationTest {
               CompOperands.Equal, "flag".getBytes());
 
       // check attr
-      Assert.assertEquals(new Long(1), mc.asyncGetAttr(KEY).get()
+      Assert.assertEquals(Long.valueOf(1), mc.asyncGetAttr(KEY).get()
               .getCount());
 
       // get value delete=true, drop=false
@@ -68,7 +68,7 @@ public class BTreeGetWithFilterTest extends BaseIntegrationTest {
       // check exists empty btree
       CollectionAttributes attr = mc.asyncGetAttr(KEY).get();
       Assert.assertNotNull(attr);
-      Assert.assertEquals(new Long(0), attr.getCount());
+      Assert.assertEquals(Long.valueOf(0), attr.getCount());
 
       Map<Long, Element<Object>> map = mc.asyncBopGet(KEY, BKEY,
               ElementFlagFilter.DO_NOT_FILTER, false, false).get();
@@ -87,7 +87,7 @@ public class BTreeGetWithFilterTest extends BaseIntegrationTest {
       filter.setBitOperand(BitWiseOperands.AND, "flag".getBytes());
 
       // check attr
-      Assert.assertEquals(new Long(1), mc.asyncGetAttr(KEY).get()
+      Assert.assertEquals(Long.valueOf(1), mc.asyncGetAttr(KEY).get()
               .getCount());
 
       // get value delete=true, drop=false
@@ -115,7 +115,7 @@ public class BTreeGetWithFilterTest extends BaseIntegrationTest {
               CompOperands.Equal, "flag".getBytes());
 
       // check attr
-      Assert.assertEquals(new Long(1), mc.asyncGetAttr(KEY).get()
+      Assert.assertEquals(Long.valueOf(1), mc.asyncGetAttr(KEY).get()
               .getCount());
 
       // get value delete=true, drop=false
@@ -126,7 +126,7 @@ public class BTreeGetWithFilterTest extends BaseIntegrationTest {
       // check exists empty btree
       CollectionAttributes attr = mc.asyncGetAttr(KEY).get();
       Assert.assertNotNull(attr);
-      Assert.assertEquals(new Long(0), attr.getCount());
+      Assert.assertEquals(Long.valueOf(0), attr.getCount());
 
       Map<Long, Element<Object>> map = mc.asyncBopGet(KEY, BKEY,
               ElementFlagFilter.DO_NOT_FILTER, false, false).get();
@@ -145,7 +145,7 @@ public class BTreeGetWithFilterTest extends BaseIntegrationTest {
       filter.setBitOperand(BitWiseOperands.AND, "flag".getBytes());
 
       // check attr
-      Assert.assertEquals(new Long(1), mc.asyncGetAttr(KEY).get()
+      Assert.assertEquals(Long.valueOf(1), mc.asyncGetAttr(KEY).get()
               .getCount());
 
       // get value delete=true, drop=false
@@ -172,7 +172,7 @@ public class BTreeGetWithFilterTest extends BaseIntegrationTest {
               CompOperands.Equal, "flag".getBytes());
 
       // check attr
-      Assert.assertEquals(new Long(1), mc.asyncGetAttr(KEY).get()
+      Assert.assertEquals(Long.valueOf(1), mc.asyncGetAttr(KEY).get()
               .getCount());
 
       // get value delete=true, drop=false

--- a/src/test/manual/net/spy/memcached/emptycollection/CreateEmptyBTreeTest.java
+++ b/src/test/manual/net/spy/memcached/emptycollection/CreateEmptyBTreeTest.java
@@ -50,9 +50,9 @@ public class CreateEmptyBTreeTest extends BaseIntegrationTest {
       // check attribute
       CollectionAttributes attr = mc.asyncGetAttr(KEY).get();
 
-      Assert.assertEquals(new Long(0), attr.getCount());
-      Assert.assertEquals(new Long(4000), attr.getMaxCount());
-      Assert.assertEquals(new Integer(0), attr.getExpireTime());
+      Assert.assertEquals(Long.valueOf(0), attr.getCount());
+      Assert.assertEquals(Long.valueOf(4000), attr.getMaxCount());
+      Assert.assertEquals(Integer.valueOf(0), attr.getExpireTime());
     } catch (Exception e) {
       e.printStackTrace();
       Assert.fail(e.getMessage());
@@ -74,8 +74,8 @@ public class CreateEmptyBTreeTest extends BaseIntegrationTest {
       // check attribute
       CollectionAttributes attr = mc.asyncGetAttr(KEY).get();
 
-      Assert.assertEquals(new Long(0), attr.getCount());
-      Assert.assertEquals(new Long(10000), attr.getMaxCount());
+      Assert.assertEquals(Long.valueOf(0), attr.getCount());
+      Assert.assertEquals(Long.valueOf(10000), attr.getMaxCount());
       Assert.assertEquals(CollectionOverflowAction.error,
               attr.getOverflowAction());
     } catch (Exception e) {

--- a/src/test/manual/net/spy/memcached/emptycollection/CreateEmptyListTest.java
+++ b/src/test/manual/net/spy/memcached/emptycollection/CreateEmptyListTest.java
@@ -51,9 +51,9 @@ public class CreateEmptyListTest extends BaseIntegrationTest {
       // check attribute
       CollectionAttributes attr = mc.asyncGetAttr(KEY).get();
 
-      Assert.assertEquals(new Long(0), attr.getCount());
-      Assert.assertEquals(new Long(4000), attr.getMaxCount());
-      Assert.assertEquals(new Integer(0), attr.getExpireTime());
+      Assert.assertEquals(Long.valueOf(0), attr.getCount());
+      Assert.assertEquals(Long.valueOf(4000), attr.getMaxCount());
+      Assert.assertEquals(Integer.valueOf(0), attr.getExpireTime());
     } catch (Exception e) {
       e.printStackTrace();
       Assert.fail(e.getMessage());
@@ -75,8 +75,8 @@ public class CreateEmptyListTest extends BaseIntegrationTest {
       // check attribute
       CollectionAttributes attr = mc.asyncGetAttr(KEY).get();
 
-      Assert.assertEquals(new Long(0), attr.getCount());
-      Assert.assertEquals(new Long(10000), attr.getMaxCount());
+      Assert.assertEquals(Long.valueOf(0), attr.getCount());
+      Assert.assertEquals(Long.valueOf(10000), attr.getMaxCount());
       Assert.assertEquals(CollectionOverflowAction.error,
               attr.getOverflowAction());
     } catch (Exception e) {

--- a/src/test/manual/net/spy/memcached/emptycollection/CreateEmptyMapTest.java
+++ b/src/test/manual/net/spy/memcached/emptycollection/CreateEmptyMapTest.java
@@ -50,9 +50,9 @@ public class CreateEmptyMapTest extends BaseIntegrationTest {
       // check attribute
       CollectionAttributes attr = mc.asyncGetAttr(KEY).get();
 
-      Assert.assertEquals(new Long(0), attr.getCount());
-      Assert.assertEquals(new Long(4000), attr.getMaxCount());
-      Assert.assertEquals(new Integer(0), attr.getExpireTime());
+      Assert.assertEquals(Long.valueOf(0), attr.getCount());
+      Assert.assertEquals(Long.valueOf(4000), attr.getMaxCount());
+      Assert.assertEquals(Integer.valueOf(0), attr.getExpireTime());
     } catch (Exception e) {
       e.printStackTrace();
       Assert.fail(e.getMessage());
@@ -74,8 +74,8 @@ public class CreateEmptyMapTest extends BaseIntegrationTest {
       // check attribute
       CollectionAttributes attr = mc.asyncGetAttr(KEY).get();
 
-      Assert.assertEquals(new Long(0), attr.getCount());
-      Assert.assertEquals(new Long(10000), attr.getMaxCount());
+      Assert.assertEquals(Long.valueOf(0), attr.getCount());
+      Assert.assertEquals(Long.valueOf(10000), attr.getMaxCount());
       Assert.assertEquals(CollectionOverflowAction.error,
               attr.getOverflowAction());
     } catch (Exception e) {

--- a/src/test/manual/net/spy/memcached/emptycollection/CreateEmptySetTest.java
+++ b/src/test/manual/net/spy/memcached/emptycollection/CreateEmptySetTest.java
@@ -51,9 +51,9 @@ public class CreateEmptySetTest extends BaseIntegrationTest {
       // check attribute
       CollectionAttributes attr = mc.asyncGetAttr(KEY).get();
 
-      Assert.assertEquals(new Long(0), attr.getCount());
-      Assert.assertEquals(new Long(4000), attr.getMaxCount());
-      Assert.assertEquals(new Integer(0), attr.getExpireTime());
+      Assert.assertEquals(Long.valueOf(0), attr.getCount());
+      Assert.assertEquals(Long.valueOf(4000), attr.getMaxCount());
+      Assert.assertEquals(Integer.valueOf(0), attr.getExpireTime());
     } catch (Exception e) {
       e.printStackTrace();
       Assert.fail(e.getMessage());
@@ -75,8 +75,8 @@ public class CreateEmptySetTest extends BaseIntegrationTest {
       // check attribute
       CollectionAttributes attr = mc.asyncGetAttr(KEY).get();
 
-      Assert.assertEquals(new Long(0), attr.getCount());
-      Assert.assertEquals(new Long(10000), attr.getMaxCount());
+      Assert.assertEquals(Long.valueOf(0), attr.getCount());
+      Assert.assertEquals(Long.valueOf(10000), attr.getMaxCount());
       Assert.assertEquals(CollectionOverflowAction.error,
               attr.getOverflowAction());
     } catch (Exception e) {

--- a/src/test/manual/net/spy/memcached/emptycollection/GetCountBTreeTest.java
+++ b/src/test/manual/net/spy/memcached/emptycollection/GetCountBTreeTest.java
@@ -137,7 +137,7 @@ public class GetCountBTreeTest extends BaseIntegrationTest {
       Assert.assertTrue(insertResult2);
 
       // check count in attributes
-      Assert.assertEquals(new Long(2), mc.asyncGetAttr(KEY).get()
+      Assert.assertEquals(Long.valueOf(2), mc.asyncGetAttr(KEY).get()
               .getCount());
 
       // get btree item count
@@ -145,7 +145,7 @@ public class GetCountBTreeTest extends BaseIntegrationTest {
               BKEY, BKEY, ElementFlagFilter.DO_NOT_FILTER);
       Integer count = future.get();
       Assert.assertNotNull(count);
-      Assert.assertEquals(new Integer(1), count);
+      Assert.assertEquals(Integer.valueOf(1), count);
       Assert.assertEquals(CollectionResponse.END, future
               .getOperationStatus().getResponse());
     } catch (Exception e) {
@@ -169,7 +169,7 @@ public class GetCountBTreeTest extends BaseIntegrationTest {
       Assert.assertTrue(insertResult2);
 
       // check count in attributes
-      Assert.assertEquals(new Long(2), mc.asyncGetAttr(KEY).get()
+      Assert.assertEquals(Long.valueOf(2), mc.asyncGetAttr(KEY).get()
               .getCount());
 
       // get btree item count
@@ -177,7 +177,7 @@ public class GetCountBTreeTest extends BaseIntegrationTest {
               BKEY, BKEY + 1, ElementFlagFilter.DO_NOT_FILTER);
       Integer count = future.get();
       Assert.assertNotNull(count);
-      Assert.assertEquals(new Integer(2), count);
+      Assert.assertEquals(Integer.valueOf(2), count);
     } catch (Exception e) {
       e.printStackTrace();
       Assert.fail(e.getMessage());
@@ -199,7 +199,7 @@ public class GetCountBTreeTest extends BaseIntegrationTest {
       Assert.assertTrue(insertResult2);
 
       // check count in attributes
-      Assert.assertEquals(new Long(2), mc.asyncGetAttr(KEY).get()
+      Assert.assertEquals(Long.valueOf(2), mc.asyncGetAttr(KEY).get()
               .getCount());
 
       // get btree item count
@@ -207,7 +207,7 @@ public class GetCountBTreeTest extends BaseIntegrationTest {
               BKEY + 3, BKEY + 3, ElementFlagFilter.DO_NOT_FILTER);
       Integer count = future.get();
       Assert.assertNotNull(count);
-      Assert.assertEquals(new Integer(0), count);
+      Assert.assertEquals(Integer.valueOf(0), count);
     } catch (Exception e) {
       e.printStackTrace();
       Assert.fail(e.getMessage());
@@ -229,7 +229,7 @@ public class GetCountBTreeTest extends BaseIntegrationTest {
       Assert.assertTrue(insertResult2);
 
       // check count in attributes
-      Assert.assertEquals(new Long(2), mc.asyncGetAttr(KEY).get()
+      Assert.assertEquals(Long.valueOf(2), mc.asyncGetAttr(KEY).get()
               .getCount());
 
       // get btree item count
@@ -237,7 +237,7 @@ public class GetCountBTreeTest extends BaseIntegrationTest {
               BKEY + 2, BKEY + 3, ElementFlagFilter.DO_NOT_FILTER);
       Integer count = future.get();
       Assert.assertNotNull(count);
-      Assert.assertEquals(new Integer(0), count);
+      Assert.assertEquals(Integer.valueOf(0), count);
     } catch (Exception e) {
       e.printStackTrace();
       Assert.fail(e.getMessage());

--- a/src/test/manual/net/spy/memcached/emptycollection/GetCountBTreeTestWithElementFlagFilterTest.java
+++ b/src/test/manual/net/spy/memcached/emptycollection/GetCountBTreeTestWithElementFlagFilterTest.java
@@ -104,7 +104,7 @@ public class GetCountBTreeTestWithElementFlagFilterTest extends BaseIntegrationT
       Assert.assertTrue(insertResult2);
 
       // check count in attributes
-      Assert.assertEquals(new Long(2), mc.asyncGetAttr(KEY).get()
+      Assert.assertEquals(Long.valueOf(2), mc.asyncGetAttr(KEY).get()
               .getCount());
 
       // get btree item count
@@ -112,7 +112,7 @@ public class GetCountBTreeTestWithElementFlagFilterTest extends BaseIntegrationT
               BKEY, BKEY, filter);
       Integer count = future.get();
       Assert.assertNotNull(count);
-      Assert.assertEquals(new Integer(1), count);
+      Assert.assertEquals(Integer.valueOf(1), count);
     } catch (Exception e) {
       e.printStackTrace();
       Assert.fail(e.getMessage());
@@ -137,7 +137,7 @@ public class GetCountBTreeTestWithElementFlagFilterTest extends BaseIntegrationT
       Assert.assertTrue(insertResult2);
 
       // check count in attributes
-      Assert.assertEquals(new Long(2), mc.asyncGetAttr(KEY).get()
+      Assert.assertEquals(Long.valueOf(2), mc.asyncGetAttr(KEY).get()
               .getCount());
 
       // get btree item count
@@ -145,7 +145,7 @@ public class GetCountBTreeTestWithElementFlagFilterTest extends BaseIntegrationT
               BKEY, BKEY + 1, filter);
       Integer count = future.get();
       Assert.assertNotNull(count);
-      Assert.assertEquals(new Integer(0), count);
+      Assert.assertEquals(Integer.valueOf(0), count);
     } catch (Exception e) {
       e.printStackTrace();
       Assert.fail(e.getMessage());
@@ -172,7 +172,7 @@ public class GetCountBTreeTestWithElementFlagFilterTest extends BaseIntegrationT
       Assert.assertTrue(insertResult2);
 
       // check count in attributes
-      Assert.assertEquals(new Long(2), mc.asyncGetAttr(KEY).get()
+      Assert.assertEquals(Long.valueOf(2), mc.asyncGetAttr(KEY).get()
               .getCount());
 
       // get btree item count
@@ -180,7 +180,7 @@ public class GetCountBTreeTestWithElementFlagFilterTest extends BaseIntegrationT
               BKEY, BKEY, filter);
       Integer count = future.get();
       Assert.assertNotNull(count);
-      Assert.assertEquals(new Integer(1), count);
+      Assert.assertEquals(Integer.valueOf(1), count);
     } catch (Exception e) {
       e.printStackTrace();
       Assert.fail(e.getMessage());
@@ -205,7 +205,7 @@ public class GetCountBTreeTestWithElementFlagFilterTest extends BaseIntegrationT
       Assert.assertTrue(insertResult2);
 
       // check count in attributes
-      Assert.assertEquals(new Long(2), mc.asyncGetAttr(KEY).get()
+      Assert.assertEquals(Long.valueOf(2), mc.asyncGetAttr(KEY).get()
               .getCount());
 
       // get btree item count
@@ -213,7 +213,7 @@ public class GetCountBTreeTestWithElementFlagFilterTest extends BaseIntegrationT
               BKEY + 3, BKEY + 3, filter);
       Integer count = future.get();
       Assert.assertNotNull(count);
-      Assert.assertEquals(new Integer(0), count);
+      Assert.assertEquals(Integer.valueOf(0), count);
     } catch (Exception e) {
       e.printStackTrace();
       Assert.fail(e.getMessage());
@@ -238,7 +238,7 @@ public class GetCountBTreeTestWithElementFlagFilterTest extends BaseIntegrationT
       Assert.assertTrue(insertResult2);
 
       // check count in attributes
-      Assert.assertEquals(new Long(2), mc.asyncGetAttr(KEY).get()
+      Assert.assertEquals(Long.valueOf(2), mc.asyncGetAttr(KEY).get()
               .getCount());
 
       // get btree item count
@@ -246,7 +246,7 @@ public class GetCountBTreeTestWithElementFlagFilterTest extends BaseIntegrationT
               BKEY + 2, BKEY + 3, filter);
       Integer count = future.get();
       Assert.assertNotNull(count);
-      Assert.assertEquals(new Integer(0), count);
+      Assert.assertEquals(Integer.valueOf(0), count);
     } catch (Exception e) {
       e.printStackTrace();
       Assert.fail(e.getMessage());

--- a/src/test/manual/net/spy/memcached/emptycollection/GetWithDropBTreeTest.java
+++ b/src/test/manual/net/spy/memcached/emptycollection/GetWithDropBTreeTest.java
@@ -43,7 +43,7 @@ public class GetWithDropBTreeTest extends BaseIntegrationTest {
   public void testGetWithoutDeleteAndDrop() {
     try {
       // check attr
-      Assert.assertEquals(new Long(1), mc.asyncGetAttr(KEY).get()
+      Assert.assertEquals(Long.valueOf(1), mc.asyncGetAttr(KEY).get()
               .getCount());
 
       // get value delete=false, drop=true
@@ -53,7 +53,7 @@ public class GetWithDropBTreeTest extends BaseIntegrationTest {
                       false, false).get().get(BKEY).getValue());
 
       // check exists
-      Assert.assertEquals(new Long(1), mc.asyncGetAttr(KEY).get()
+      Assert.assertEquals(Long.valueOf(1), mc.asyncGetAttr(KEY).get()
               .getCount());
 
       // get value again
@@ -70,7 +70,7 @@ public class GetWithDropBTreeTest extends BaseIntegrationTest {
   public void testGetWithtDeleteAndWithoutDrop() {
     try {
       // check attr
-      Assert.assertEquals(new Long(1), mc.asyncGetAttr(KEY).get()
+      Assert.assertEquals(Long.valueOf(1), mc.asyncGetAttr(KEY).get()
               .getCount());
 
       // get value delete=true, drop=false
@@ -82,7 +82,7 @@ public class GetWithDropBTreeTest extends BaseIntegrationTest {
       // check exists empty btree
       CollectionAttributes attr = mc.asyncGetAttr(KEY).get();
       Assert.assertNotNull(attr);
-      Assert.assertEquals(new Long(0), attr.getCount());
+      Assert.assertEquals(Long.valueOf(0), attr.getCount());
 
       Map<Long, Element<Object>> map = mc.asyncBopGet(KEY, BKEY,
               ElementFlagFilter.DO_NOT_FILTER, false, false).get();
@@ -97,7 +97,7 @@ public class GetWithDropBTreeTest extends BaseIntegrationTest {
   public void testGetWithtDeleteAndWithDrop() {
     try {
       // check attr
-      Assert.assertEquals(new Long(1), mc.asyncGetAttr(KEY).get()
+      Assert.assertEquals(Long.valueOf(1), mc.asyncGetAttr(KEY).get()
               .getCount());
 
       // get value delete=true, drop=false

--- a/src/test/manual/net/spy/memcached/emptycollection/GetWithDropListTest.java
+++ b/src/test/manual/net/spy/memcached/emptycollection/GetWithDropListTest.java
@@ -42,7 +42,7 @@ public class GetWithDropListTest extends BaseIntegrationTest {
   public void testGetWithoutDeleteAndDrop() {
     try {
       // check attr
-      Assert.assertEquals(new Long(1), mc.asyncGetAttr(KEY).get()
+      Assert.assertEquals(Long.valueOf(1), mc.asyncGetAttr(KEY).get()
               .getCount());
 
       // get value delete=false, drop=true
@@ -50,7 +50,7 @@ public class GetWithDropListTest extends BaseIntegrationTest {
               .get().get(INDEX));
 
       // check exists
-      Assert.assertEquals(new Long(1), mc.asyncGetAttr(KEY).get()
+      Assert.assertEquals(Long.valueOf(1), mc.asyncGetAttr(KEY).get()
               .getCount());
 
       // get value againg
@@ -65,7 +65,7 @@ public class GetWithDropListTest extends BaseIntegrationTest {
   public void testGetWithtDeleteAndWithoutDrop() {
     try {
       // check attr
-      Assert.assertEquals(new Long(1), mc.asyncGetAttr(KEY).get()
+      Assert.assertEquals(Long.valueOf(1), mc.asyncGetAttr(KEY).get()
               .getCount());
 
       // get value delete=true, drop=false
@@ -75,7 +75,7 @@ public class GetWithDropListTest extends BaseIntegrationTest {
       // check exists empty btree
       CollectionAttributes attr = mc.asyncGetAttr(KEY).get();
       Assert.assertNotNull(attr);
-      Assert.assertEquals(new Long(0), attr.getCount());
+      Assert.assertEquals(Long.valueOf(0), attr.getCount());
 
       // get value again
       CollectionFuture<List<Object>> asyncLopGet = mc.asyncLopGet(KEY,
@@ -92,7 +92,7 @@ public class GetWithDropListTest extends BaseIntegrationTest {
   public void testGetWithtDeleteAndWithDrop() {
     try {
       // check attr
-      Assert.assertEquals(new Long(1), mc.asyncGetAttr(KEY).get()
+      Assert.assertEquals(Long.valueOf(1), mc.asyncGetAttr(KEY).get()
               .getCount());
 
       // get value delete=true, drop=false

--- a/src/test/manual/net/spy/memcached/emptycollection/GetWithDropMapTest.java
+++ b/src/test/manual/net/spy/memcached/emptycollection/GetWithDropMapTest.java
@@ -41,7 +41,7 @@ public class GetWithDropMapTest extends BaseIntegrationTest {
   public void testGetWithoutDeleteAndDrop() {
     try {
       // check attr
-      Assert.assertEquals(new Long(1), mc.asyncGetAttr(KEY).get()
+      Assert.assertEquals(Long.valueOf(1), mc.asyncGetAttr(KEY).get()
               .getCount());
 
       // get value delete=false, drop=false
@@ -50,7 +50,7 @@ public class GetWithDropMapTest extends BaseIntegrationTest {
               mc.asyncMopGet(KEY, MKEY, false, false).get().get(MKEY));
 
       // check exists
-      Assert.assertEquals(new Long(1), mc.asyncGetAttr(KEY).get()
+      Assert.assertEquals(Long.valueOf(1), mc.asyncGetAttr(KEY).get()
               .getCount());
 
       // get value again
@@ -66,7 +66,7 @@ public class GetWithDropMapTest extends BaseIntegrationTest {
   public void testGetWithtDeleteAndWithoutDrop() {
     try {
       // check attr
-      Assert.assertEquals(new Long(1), mc.asyncGetAttr(KEY).get()
+      Assert.assertEquals(Long.valueOf(1), mc.asyncGetAttr(KEY).get()
               .getCount());
 
       // get value delete=true, drop=false
@@ -77,7 +77,7 @@ public class GetWithDropMapTest extends BaseIntegrationTest {
       // check exists empty map
       CollectionAttributes attr = mc.asyncGetAttr(KEY).get();
       Assert.assertNotNull(attr);
-      Assert.assertEquals(new Long(0), attr.getCount());
+      Assert.assertEquals(Long.valueOf(0), attr.getCount());
 
       Map<String, Object> map = mc.asyncMopGet(KEY, MKEY, false, false).get();
       Assert.assertNotNull(map);
@@ -91,7 +91,7 @@ public class GetWithDropMapTest extends BaseIntegrationTest {
   public void testGetWithtDeleteAndWithDrop() {
     try {
       // check attr
-      Assert.assertEquals(new Long(1), mc.asyncGetAttr(KEY).get()
+      Assert.assertEquals(Long.valueOf(1), mc.asyncGetAttr(KEY).get()
               .getCount());
 
       // get value delete=true, drop=true

--- a/src/test/manual/net/spy/memcached/emptycollection/GetWithDropSetTest.java
+++ b/src/test/manual/net/spy/memcached/emptycollection/GetWithDropSetTest.java
@@ -40,7 +40,7 @@ public class GetWithDropSetTest extends BaseIntegrationTest {
   public void testGetWithoutDeleteAndDrop() {
     try {
       // check attr
-      Assert.assertEquals(new Long(1), mc.asyncGetAttr(KEY).get()
+      Assert.assertEquals(Long.valueOf(1), mc.asyncGetAttr(KEY).get()
               .getCount());
 
       // get value delete=false, drop=true
@@ -48,7 +48,7 @@ public class GetWithDropSetTest extends BaseIntegrationTest {
               .contains(VALUE));
 
       // check exists
-      Assert.assertEquals(new Long(1), mc.asyncGetAttr(KEY).get()
+      Assert.assertEquals(Long.valueOf(1), mc.asyncGetAttr(KEY).get()
               .getCount());
 
       // get value again
@@ -63,7 +63,7 @@ public class GetWithDropSetTest extends BaseIntegrationTest {
   public void testGetWithtDeleteAndWithoutDrop() {
     try {
       // check attr
-      Assert.assertEquals(new Long(1), mc.asyncGetAttr(KEY).get()
+      Assert.assertEquals(Long.valueOf(1), mc.asyncGetAttr(KEY).get()
               .getCount());
 
       // get value delete=true, drop=false
@@ -73,7 +73,7 @@ public class GetWithDropSetTest extends BaseIntegrationTest {
       // check exists empty btree
       CollectionAttributes attr = mc.asyncGetAttr(KEY).get();
       Assert.assertNotNull(attr);
-      Assert.assertEquals(new Long(0), attr.getCount());
+      Assert.assertEquals(Long.valueOf(0), attr.getCount());
 
       Set<Object> set = mc.asyncSopGet(KEY, 10, false, false).get();
       Assert.assertNotNull(set);
@@ -87,7 +87,7 @@ public class GetWithDropSetTest extends BaseIntegrationTest {
   public void testGetWithtDeleteAndWithDrop() {
     try {
       // check attr
-      Assert.assertEquals(new Long(1), mc.asyncGetAttr(KEY).get()
+      Assert.assertEquals(Long.valueOf(1), mc.asyncGetAttr(KEY).get()
               .getCount());
 
       // get value delete=true, drop=false
@@ -109,7 +109,7 @@ public class GetWithDropSetTest extends BaseIntegrationTest {
   public void testGetWithoutDeleteAndDropOptions() {
     try {
       // check attr
-      assertEquals(new Long(1), mc.asyncGetAttr(KEY).get()
+      assertEquals(Long.valueOf(1), mc.asyncGetAttr(KEY).get()
               .getCount());
 
       //get value
@@ -117,7 +117,7 @@ public class GetWithDropSetTest extends BaseIntegrationTest {
               .contains(VALUE));
 
       // check exists
-      assertEquals(new Long(1), mc.asyncGetAttr(KEY).get()
+      assertEquals(Long.valueOf(1), mc.asyncGetAttr(KEY).get()
               .getCount());
 
       // get value again

--- a/src/test/manual/net/spy/memcached/emptycollection/InsertBTreeWithAttrAndEFlagTest.java
+++ b/src/test/manual/net/spy/memcached/emptycollection/InsertBTreeWithAttrAndEFlagTest.java
@@ -60,7 +60,7 @@ public class InsertBTreeWithAttrAndEFlagTest extends BaseIntegrationTest {
       // check attribute
       CollectionAttributes collectionAttributes = mc.asyncGetAttr(KEY)
               .get();
-      Assert.assertEquals(new Long(3333),
+      Assert.assertEquals(Long.valueOf(3333),
               collectionAttributes.getMaxCount());
 
       // check expire time
@@ -88,7 +88,7 @@ public class InsertBTreeWithAttrAndEFlagTest extends BaseIntegrationTest {
       // check attribute
       CollectionAttributes collectionAttributes = mc.asyncGetAttr(KEY)
               .get();
-      Assert.assertEquals(new Long(4000),
+      Assert.assertEquals(Long.valueOf(4000),
               collectionAttributes.getMaxCount());
     } catch (Exception e) {
       Assert.fail(e.getMessage());
@@ -114,7 +114,7 @@ public class InsertBTreeWithAttrAndEFlagTest extends BaseIntegrationTest {
       // check attribute
       CollectionAttributes collectionAttributes = mc.asyncGetAttr(KEY)
               .get();
-      Assert.assertEquals(new Long(3333),
+      Assert.assertEquals(Long.valueOf(3333),
               collectionAttributes.getMaxCount());
 
       // check expire time

--- a/src/test/manual/net/spy/memcached/emptycollection/InsertListWithAttrTest.java
+++ b/src/test/manual/net/spy/memcached/emptycollection/InsertListWithAttrTest.java
@@ -58,7 +58,7 @@ public class InsertListWithAttrTest extends BaseIntegrationTest {
       // check attribute
       CollectionAttributes collectionAttributes = mc.asyncGetAttr(KEY)
               .get();
-      Assert.assertEquals(new Long(3333),
+      Assert.assertEquals(Long.valueOf(3333),
               collectionAttributes.getMaxCount());
 
       // check expire time
@@ -86,7 +86,7 @@ public class InsertListWithAttrTest extends BaseIntegrationTest {
       // check attribute
       CollectionAttributes collectionAttributes = mc.asyncGetAttr(KEY)
               .get();
-      Assert.assertEquals(new Long(4000),
+      Assert.assertEquals(Long.valueOf(4000),
               collectionAttributes.getMaxCount());
     } catch (Exception e) {
       e.printStackTrace();

--- a/src/test/manual/net/spy/memcached/emptycollection/InsertMapWithAttrTest.java
+++ b/src/test/manual/net/spy/memcached/emptycollection/InsertMapWithAttrTest.java
@@ -58,7 +58,7 @@ public class InsertMapWithAttrTest extends BaseIntegrationTest {
       // check attribute
       CollectionAttributes collectionAttributes = mc.asyncGetAttr(KEY)
               .get();
-      Assert.assertEquals(new Long(3333),
+      Assert.assertEquals(Long.valueOf(3333),
               collectionAttributes.getMaxCount());
 
       // check expire time
@@ -86,7 +86,7 @@ public class InsertMapWithAttrTest extends BaseIntegrationTest {
       // check attribute
       CollectionAttributes collectionAttributes = mc.asyncGetAttr(KEY)
               .get();
-      Assert.assertEquals(new Long(4000),
+      Assert.assertEquals(Long.valueOf(4000),
               collectionAttributes.getMaxCount());
     } catch (Exception e) {
       e.printStackTrace();

--- a/src/test/manual/net/spy/memcached/emptycollection/InsertSetWithAttrTest.java
+++ b/src/test/manual/net/spy/memcached/emptycollection/InsertSetWithAttrTest.java
@@ -56,7 +56,7 @@ public class InsertSetWithAttrTest extends BaseIntegrationTest {
       // check attribute
       CollectionAttributes collectionAttributes = mc.asyncGetAttr(KEY)
               .get();
-      Assert.assertEquals(new Long(3333),
+      Assert.assertEquals(Long.valueOf(3333),
               collectionAttributes.getMaxCount());
 
       // check expire time
@@ -83,7 +83,7 @@ public class InsertSetWithAttrTest extends BaseIntegrationTest {
       // check attribute
       CollectionAttributes collectionAttributes = mc.asyncGetAttr(KEY)
               .get();
-      Assert.assertEquals(new Long(4000),
+      Assert.assertEquals(Long.valueOf(4000),
               collectionAttributes.getMaxCount());
     } catch (Exception e) {
       e.printStackTrace();

--- a/src/test/manual/net/spy/memcached/emptycollection/PipedBulkInsertBTreeWithAttrTest.java
+++ b/src/test/manual/net/spy/memcached/emptycollection/PipedBulkInsertBTreeWithAttrTest.java
@@ -70,7 +70,7 @@ public class PipedBulkInsertBTreeWithAttrTest extends BaseIntegrationTest {
       // check attribute
       CollectionAttributes collectionAttributes = mc.asyncGetAttr(KEY)
               .get();
-      Assert.assertEquals(new Long(3333),
+      Assert.assertEquals(Long.valueOf(3333),
               collectionAttributes.getMaxCount());
 
       // check expire time
@@ -103,7 +103,7 @@ public class PipedBulkInsertBTreeWithAttrTest extends BaseIntegrationTest {
       // check attribute
       CollectionAttributes collectionAttributes = mc.asyncGetAttr(KEY)
               .get();
-      Assert.assertEquals(new Long(4000),
+      Assert.assertEquals(Long.valueOf(4000),
               collectionAttributes.getMaxCount());
     } catch (Exception e) {
       e.printStackTrace();
@@ -128,7 +128,7 @@ public class PipedBulkInsertBTreeWithAttrTest extends BaseIntegrationTest {
       // check attribute
       CollectionAttributes collectionAttributes = mc.asyncGetAttr(KEY)
               .get();
-      Assert.assertEquals(new Long(4000),
+      Assert.assertEquals(Long.valueOf(4000),
               collectionAttributes.getMaxCount());
     } catch (Exception e) {
       e.printStackTrace();

--- a/src/test/manual/net/spy/memcached/emptycollection/PipedBulkInsertListWithAttrTest.java
+++ b/src/test/manual/net/spy/memcached/emptycollection/PipedBulkInsertListWithAttrTest.java
@@ -66,9 +66,9 @@ public class PipedBulkInsertListWithAttrTest extends BaseIntegrationTest {
       // check attribute
       CollectionAttributes collectionAttributes = mc.asyncGetAttr(KEY)
               .get();
-      Assert.assertEquals(new Long(3333),
+      Assert.assertEquals(Long.valueOf(3333),
               collectionAttributes.getMaxCount());
-      Assert.assertEquals(new Long(10), collectionAttributes.getCount());
+      Assert.assertEquals(Long.valueOf(10), collectionAttributes.getCount());
 
       // check values
       List<Object> list2 = mc.asyncLopGet(KEY, 0, 10, false, false).get();
@@ -106,9 +106,9 @@ public class PipedBulkInsertListWithAttrTest extends BaseIntegrationTest {
       // check attribute
       CollectionAttributes collectionAttributes = mc.asyncGetAttr(KEY)
               .get();
-      Assert.assertEquals(new Long(4000),
+      Assert.assertEquals(Long.valueOf(4000),
               collectionAttributes.getMaxCount());
-      Assert.assertEquals(new Long(10), collectionAttributes.getCount());
+      Assert.assertEquals(Long.valueOf(10), collectionAttributes.getCount());
 
       // check values
       List<Object> list2 = mc.asyncLopGet(KEY, 0, 10, false, false).get();
@@ -139,9 +139,9 @@ public class PipedBulkInsertListWithAttrTest extends BaseIntegrationTest {
       // check attribute
       CollectionAttributes collectionAttributes = mc.asyncGetAttr(KEY)
               .get();
-      Assert.assertEquals(new Long(4000),
+      Assert.assertEquals(Long.valueOf(4000),
               collectionAttributes.getMaxCount());
-      Assert.assertEquals(new Long(10), collectionAttributes.getCount());
+      Assert.assertEquals(Long.valueOf(10), collectionAttributes.getCount());
 
       // check values
       List<Object> list2 = mc.asyncLopGet(KEY, 0, 10, false, false).get();

--- a/src/test/manual/net/spy/memcached/emptycollection/PipedBulkInsertMapWithAttrTest.java
+++ b/src/test/manual/net/spy/memcached/emptycollection/PipedBulkInsertMapWithAttrTest.java
@@ -64,7 +64,7 @@ public class PipedBulkInsertMapWithAttrTest extends BaseIntegrationTest {
       // check attribute
       CollectionAttributes collectionAttributes = mc.asyncGetAttr(KEY)
               .get();
-      Assert.assertEquals(new Long(3333),
+      Assert.assertEquals(Long.valueOf(3333),
               collectionAttributes.getMaxCount());
 
       // check expire time
@@ -97,7 +97,7 @@ public class PipedBulkInsertMapWithAttrTest extends BaseIntegrationTest {
       // check attribute
       CollectionAttributes collectionAttributes = mc.asyncGetAttr(KEY)
               .get();
-      Assert.assertEquals(new Long(4000),
+      Assert.assertEquals(Long.valueOf(4000),
               collectionAttributes.getMaxCount());
     } catch (Exception e) {
       e.printStackTrace();
@@ -122,7 +122,7 @@ public class PipedBulkInsertMapWithAttrTest extends BaseIntegrationTest {
       // check attribute
       CollectionAttributes collectionAttributes = mc.asyncGetAttr(KEY)
               .get();
-      Assert.assertEquals(new Long(4000),
+      Assert.assertEquals(Long.valueOf(4000),
               collectionAttributes.getMaxCount());
     } catch (Exception e) {
       e.printStackTrace();

--- a/src/test/manual/net/spy/memcached/emptycollection/PipedBulkInsertSetWithAttrTest.java
+++ b/src/test/manual/net/spy/memcached/emptycollection/PipedBulkInsertSetWithAttrTest.java
@@ -66,9 +66,9 @@ public class PipedBulkInsertSetWithAttrTest extends BaseIntegrationTest {
       // check attribute
       CollectionAttributes collectionAttributes = mc.asyncGetAttr(KEY)
               .get();
-      Assert.assertEquals(new Long(3333),
+      Assert.assertEquals(Long.valueOf(3333),
               collectionAttributes.getMaxCount());
-      Assert.assertEquals(new Long(10), collectionAttributes.getCount());
+      Assert.assertEquals(Long.valueOf(10), collectionAttributes.getCount());
 
       // check values
       List<Object> list2 = mc.asyncLopGet(KEY, 0, 10, false, false).get();
@@ -106,9 +106,9 @@ public class PipedBulkInsertSetWithAttrTest extends BaseIntegrationTest {
       // check attribute
       CollectionAttributes collectionAttributes = mc.asyncGetAttr(KEY)
               .get();
-      Assert.assertEquals(new Long(4000),
+      Assert.assertEquals(Long.valueOf(4000),
               collectionAttributes.getMaxCount());
-      Assert.assertEquals(new Long(10), collectionAttributes.getCount());
+      Assert.assertEquals(Long.valueOf(10), collectionAttributes.getCount());
 
       // check values
       List<Object> list2 = mc.asyncLopGet(KEY, 0, 10, false, false).get();
@@ -139,9 +139,9 @@ public class PipedBulkInsertSetWithAttrTest extends BaseIntegrationTest {
       // check attribute
       CollectionAttributes collectionAttributes = mc.asyncGetAttr(KEY)
               .get();
-      Assert.assertEquals(new Long(4000),
+      Assert.assertEquals(Long.valueOf(4000),
               collectionAttributes.getMaxCount());
-      Assert.assertEquals(new Long(10), collectionAttributes.getCount());
+      Assert.assertEquals(Long.valueOf(10), collectionAttributes.getCount());
 
       // check values
       List<Object> list2 = mc.asyncLopGet(KEY, 0, 10, false, false).get();


### PR DESCRIPTION
- Wrapper type 사용에 관한 warning을 제거했습니다.
1. Wrapper type을 사용하지 않아도 되는 경우
    ```java
    boolean a = true;
    boolean b = Boolean.valueOf(false); // Not necessary
    ``` 
2. Deprecated wrapper type constructor
    ```java
    Boolean a = new Boolean(true); // deprecated
    Boolean b = Boolean.valueOf(false);
    ```