### PR TITLE
FIX: Resolve generic warning

### DIFF
--- a/src/main/java/net/spy/memcached/BulkService.java
+++ b/src/main/java/net/spy/memcached/BulkService.java
@@ -124,7 +124,7 @@ class BulkService extends SpyObject {
 
     protected final int keyCount;
 
-    public BulkWorker(Collection keys, long timeout, ArcusClient[] clientList) {
+    public BulkWorker(Collection<?> keys, long timeout, ArcusClient[] clientList) {
       this.future = new ArrayList<Future<Boolean>>(keys.size());
       this.operationTimeout = timeout;
       this.clientList = clientList;


### PR DESCRIPTION
Generic 클래스에 generic 타입을 주지 않아서 생기는 warning을 해결했습니다.
참고로 `Collection`을 그냥 쓰는 것과 `Collection<?>`을 쓰는 것은 컴파일 결과는 같습니다.