### PR TITLE
FIX: Resolve unnecessary usage of StringBuilder warning.

### DIFF
--- a/src/main/java/net/spy/memcached/protocol/TCPMemcachedNodeImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/TCPMemcachedNodeImpl.java
@@ -687,15 +687,13 @@ public abstract class TCPMemcachedNodeImpl extends SpyObject
 
   @Override
   public String getStatus() {
-    StringBuilder sb = new StringBuilder();
-    sb.append("#Tops=").append(addOpCount);
-    sb.append(" #iq=").append(getInputQueueSize());
-    sb.append(" #Wops=").append(getWriteQueueSize());
-    sb.append(" #Rops=").append(getReadQueueSize());
-    sb.append(" #CT=").append(getContinuousTimeout());
-    sb.append(" #TD=").append(getTimeoutDuration());
-    sb.append(" #TR=").append(getTimeoutRatioNow());
-    return sb.toString();
+    return "#Tops=" + addOpCount +
+        " #iq=" + getInputQueueSize() +
+        " #Wops=" + getWriteQueueSize() +
+        " #Rops=" + getReadQueueSize() +
+        " #CT=" + getContinuousTimeout() +
+        " #TD=" + getTimeoutDuration() +
+        " #TR=" + getTimeoutRatioNow();
   }
 
   private void resetOperation(Operation o) {


### PR DESCRIPTION
redundant usage of StringBuilder warning 입니다.
원리에 대해선 아래 문서를 참고해 주세요.

https://stackoverflow.com/questions/47605/string-concatenation-concat-vs-operator