### PR TITLE
FIX: Resolve unnecessary usage of StringBuffer warning.

### DIFF
--- a/src/test/java/net/spy/memcached/ConsistentHashingTest.java
+++ b/src/test/java/net/spy/memcached/ConsistentHashingTest.java
@@ -95,14 +95,14 @@ public class ConsistentHashingTest extends TestCase {
     String port = ":11211 ";
     int last = (int) ((now % 100) + 3);
 
-    StringBuffer prefix = new StringBuffer();
+    StringBuilder prefix = new StringBuilder();
     prefix.append(first);
     prefix.append(".");
     prefix.append(second);
     prefix.append(".1.");
 
     // Don't protect the possible range too much, as we are our own client.
-    StringBuffer buf = new StringBuffer();
+    StringBuilder buf = new StringBuilder();
     for (int ix = 0; ix < maxSize - 1; ix++) {
       buf.append(prefix);
       buf.append(last + ix);


### PR DESCRIPTION
StringBuffer 클래스는 thread-safe 합니다. 때문에 multi-threaded가 아닌 경우 StringBuilder에 비해 성능이 떨어집니다.
multi-threaded가 아닌 환경에서 StringBuffer를 사용하려고 하여 생긴 warning입니다.