### PR TITLE
FIX: Resolve the serializable class does not declare a static final serialVersionUID field of type long warning.

### DIFF
--- a/src/test/java/net/spy/memcached/protocol/TCPMemcachedNodeImplTest.java
+++ b/src/test/java/net/spy/memcached/protocol/TCPMemcachedNodeImplTest.java
@@ -76,28 +76,26 @@ public class TCPMemcachedNodeImplTest extends TestCase {
         4096
     );
 
-    List<Operation> fromOperations = new LinkedList<Operation>() {{
-        for (int i = 0; i < fromAllOpCount; i++) {
-          Operation op = factory.getOperationFactory().get(
-              "cacheKey=" + i,
-              new GetOperation.Callback() {
-                @Override
-                public void receivedStatus(OperationStatus status) {
-                }
+    List<Operation> fromOperations = new LinkedList<Operation>();
+    for (int i = 0; i < fromAllOpCount; i++) {
+      Operation op = factory.getOperationFactory().get(
+          "cacheKey=" + i,
+          new GetOperation.Callback() {
+            @Override
+            public void receivedStatus(OperationStatus status) {
+            }
 
-                @Override
-                public void gotData(String key, int flags, byte[] data) {
-                }
+            @Override
+            public void gotData(String key, int flags, byte[] data) {
+            }
 
-                @Override
-                public void complete() {
-                }
-              });
-          op.initialize();
-          add(op);
-        }
-      }
-    };
+            @Override
+            public void complete() {
+            }
+          });
+      op.initialize();
+      fromOperations.add(op);
+    }
 
     for (int i = 0; i < fromAllOpCount; i++) {
       if (fromNode.getReadQueueSize() < fromReadOpCount) {

--- a/src/test/manual/net/spy/memcached/LongKeyTest/BaseLongKeyTest.java
+++ b/src/test/manual/net/spy/memcached/LongKeyTest/BaseLongKeyTest.java
@@ -21,23 +21,24 @@ import java.util.Map;
 
 public class BaseLongKeyTest extends BaseIntegrationTest {
 
-  private int keySize = 200;
-  private char[] chars = "abcdefghijklmnopqrstuvwxyz".toCharArray();
-  private final List<String> keys = new ArrayList<String>() {
-    {
-      int defaultKeyLenght = 4000 - 10; // MAX_KEY_LENGTH - key index string length
-      for (int i = 0; i < keySize; i++) {
-        StringBuilder sb = new StringBuilder();
-        Random random = new Random();
-        for (int j = 0; j < defaultKeyLenght; j++) {
-          char c = chars[random.nextInt(chars.length)];
-          sb.append(c);
-        }
-        sb.append(i);
-        add(sb.toString());
+  private final int keySize = 200;
+  private final List<String> keys = new ArrayList<String>();
+
+  public BaseLongKeyTest() {
+    int defaultKeyLenght = 4000 - 10; // MAX_KEY_LENGTH - key index string length
+    char[] chars = "abcdefghijklmnopqrstuvwxyz".toCharArray();
+
+    for (int i = 0; i < keySize; i++) {
+      StringBuilder sb = new StringBuilder();
+      Random random = new Random();
+      for (int j = 0; j < defaultKeyLenght; j++) {
+        char c = chars[random.nextInt(chars.length)];
+        sb.append(c);
       }
+      sb.append(i);
+      keys.add(sb.toString());
     }
-  };
+  }
 
   public void testKV_Long() throws Exception {
     // KV Set

--- a/src/test/manual/net/spy/memcached/collection/btree/BopSortMergeOldTest.java
+++ b/src/test/manual/net/spy/memcached/collection/btree/BopSortMergeOldTest.java
@@ -32,20 +32,17 @@ import java.util.concurrent.TimeUnit;
 
 public class BopSortMergeOldTest extends BaseIntegrationTest {
 
-  private List<String> keyList3 = new ArrayList<String>() {
-    {
-      add("key0");
-      add("key1");
-      add("key2");
-    }
-  };
+  private final List<String> keyList3 = new ArrayList<String>();
+  private final List<String> keyList2 = new ArrayList<String>();
 
-  private List<String> keyList2 = new ArrayList<String>() {
-    {
-      add("key0");
-      add("key1");
-    }
-  };
+  public BopSortMergeOldTest() {
+    keyList3.add("key0");
+    keyList3.add("key1");
+    keyList3.add("key2");
+
+    keyList2.add("key0");
+    keyList2.add("key1");
+  }
 
   @Override
   protected void setUp() throws Exception {

--- a/src/test/manual/net/spy/memcached/collection/btree/BopSortMergeTest.java
+++ b/src/test/manual/net/spy/memcached/collection/btree/BopSortMergeTest.java
@@ -36,20 +36,17 @@ import java.util.concurrent.TimeUnit;
 
 public class BopSortMergeTest extends BaseIntegrationTest {
 
-  private List<String> keyList3 = new ArrayList<String>() {
-    {
-      add("key0");
-      add("key1");
-      add("key2");
-    }
-  };
+  private final List<String> keyList3 = new ArrayList<String>();
+  private final List<String> keyList2 = new ArrayList<String>();
 
-  private List<String> keyList2 = new ArrayList<String>() {
-    {
-      add("key0");
-      add("key1");
-    }
-  };
+  public BopSortMergeTest() {
+    keyList3.add("key0");
+    keyList3.add("key1");
+    keyList3.add("key2");
+
+    keyList2.add("key0");
+    keyList2.add("key1");
+  }
 
   @Override
   protected void setUp() throws Exception {


### PR DESCRIPTION
```java
List<String> a = new ArrayList<String> {
  {
    add("a");
    add("b");
  }
}
```

기존 코드가 위와 같을 때, 이는 아래의 코드와 같습니다.

```java
public class AnnonymousClass1 extends ArrayList<String> {
  
}

AnnonymousClass1 a = new AnnonymousClass1();
a.add("a");
b.add("b");
```

문제는 ArrayList 클래스가 Serializable 인터페이스를 상속받습니다.
Serializable 인터페이스를 상속받는 클래스가 `private final static long serialVersionUID` 필드를 갖지 않으면 warning을 띄웁니다.
```java
new ArrayList<String> {
  {
    add("a");
    add("b");
  }
}
```
위 코드로 인해 생성되는 익명 클래스도 `private final static long serialVersionUID` 필드를 가져야 합니다.
하지만 객체의 용도에 따라 해당 필드가 필요하지 않아 보여서 다른 방식으로 warning을 해결했습니다.