### PR TITLE
FIX: Resolve static variable should be qualified by type name warning.

### DIFF
--- a/src/main/java/net/spy/memcached/protocol/ascii/BTreeSortMergeGetOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/BTreeSortMergeGetOperationImpl.java
@@ -178,7 +178,7 @@ public class BTreeSortMergeGetOperationImpl extends OperationImpl implements
           // Adjust space count if item header has a element flag.
           String[] chunk = new String(byteBuffer.toByteArray())
                   .split(" ");
-          if (chunk.length == smGet.headerCount) {
+          if (chunk.length == BTreeSMGet.headerCount) {
             if (chunk[3].startsWith("0x")) {
               spaceCount--;
             }

--- a/src/main/java/net/spy/memcached/protocol/ascii/BTreeSortMergeGetOperationOldImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/BTreeSortMergeGetOperationOldImpl.java
@@ -144,7 +144,7 @@ public class BTreeSortMergeGetOperationOldImpl extends OperationImpl implements
           // Adjust space count if item header has a element flag.
           String[] chunk = new String(byteBuffer.toByteArray())
                   .split(" ");
-          if (chunk.length == smGet.headerCount) {
+          if (chunk.length == BTreeSMGet.headerCount) {
             if (chunk[3].startsWith("0x")) {
               spaceCount--;
             }


### PR DESCRIPTION
static field는 클래스 이름에 의해 참조하는 것이 올바른 사용법입니다.