### PR TITLE
FIX: Suppress fall through warning.

### DIFF
--- a/src/main/java/net/spy/memcached/protocol/TCPMemcachedNodeImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/TCPMemcachedNodeImpl.java
@@ -698,6 +698,7 @@ public abstract class TCPMemcachedNodeImpl extends SpyObject
     return sb.toString();
   }
 
+  @SuppressWarnings("fallthrough")
   private void resetOperation(Operation o) {
     switch (o.getState()) {
       case WRITING:


### PR DESCRIPTION
switch case 문에서 어느 한 case에서 break문 없이 다음 case로 계속 수행하도록 구현하면 fall through warning이 발생합니다.
구현상 해당 warning이 뜨지 않아도 될 것 같아서 무시하도록 했습니다.