### PR TITLE
FIX: Resolve redundant access warning.

### DIFF
--- a/src/main/java/net/spy/memcached/protocol/ascii/BTreeSortMergeGetOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/BTreeSortMergeGetOperationImpl.java
@@ -255,7 +255,7 @@ public class BTreeSortMergeGetOperationImpl extends OperationImpl implements
     }
 
     if (lookingFor == '\0' && readOffset == data.length && count < lineCount) {
-      BTreeSortMergeGetOperation.Callback cb = (BTreeSortMergeGetOperation.Callback) getCallback();
+      Callback cb = (Callback) getCallback();
       cb.gotData(smGet.getKey(), smGet.getFlags(), smGet.getSubkey(), smGet.getEflag(), data);
       lookingFor = '\r';
     }
@@ -331,7 +331,7 @@ public class BTreeSortMergeGetOperationImpl extends OperationImpl implements
             String line = new String(byteBuffer.toByteArray());
             String chunk[] = line.split(" ");
             if (chunk.length == 2) {
-              ((BTreeSortMergeGetOperation.Callback) getCallback())
+              ((Callback) getCallback())
                       .gotMissedKey(chunk[0], matchStatus(chunk[1],
                               NOT_FOUND, UNREADABLE, OUT_OF_RANGE));
               /* ENABLE_MIGRATION if */
@@ -339,7 +339,7 @@ public class BTreeSortMergeGetOperationImpl extends OperationImpl implements
               addRedirectMultiKeyOperation(getNotMyKey(line), chunk[0]);
               /* ENABLE_MIGRATION end */
             } else {
-              ((BTreeSortMergeGetOperation.Callback) getCallback())
+              ((Callback) getCallback())
                       .gotMissedKey(chunk[0], new CollectionOperationStatus(false,
                               "UNDEFINED", CollectionResponse.UNDEFINED));
             }
@@ -397,10 +397,10 @@ public class BTreeSortMergeGetOperationImpl extends OperationImpl implements
             String[] chunk = new String(byteBuffer.toByteArray())
                     .split(" ");
             if (smGet instanceof BTreeSMGetWithLongTypeBkey) {
-              ((BTreeSortMergeGetOperation.Callback) getCallback())
+              ((Callback) getCallback())
                   .gotTrimmedKey(chunk[0], Long.parseLong(chunk[1]));
             } else if (smGet instanceof BTreeSMGetWithByteTypeBkey) {
-              ((BTreeSortMergeGetOperation.Callback) getCallback())
+              ((Callback) getCallback())
                   .gotTrimmedKey(chunk[0],
                       BTreeUtil.hexStringToByteArrays(chunk[1].substring(2)));
             }

--- a/src/main/java/net/spy/memcached/protocol/ascii/BTreeSortMergeGetOperationOldImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/BTreeSortMergeGetOperationOldImpl.java
@@ -217,8 +217,7 @@ public class BTreeSortMergeGetOperationOldImpl extends OperationImpl implements
     }
 
     if (lookingFor == '\0' && readOffset == data.length) {
-      BTreeSortMergeGetOperationOld.Callback cb =
-          (BTreeSortMergeGetOperationOld.Callback) getCallback();
+      Callback cb = (Callback) getCallback();
       cb.gotData(smGet.getKey(), smGet.getFlags(), smGet.getSubkey(), smGet.getEflag(), data);
       lookingFor = '\r';
     }
@@ -271,8 +270,7 @@ public class BTreeSortMergeGetOperationOldImpl extends OperationImpl implements
             transitionState(OperationState.COMPLETE);
             return;
           } else {
-            ((BTreeSortMergeGetOperationOld.Callback) getCallback())
-                    .gotMissedKey(byteBuffer.toByteArray());
+            ((Callback) getCallback()).gotMissedKey(byteBuffer.toByteArray());
           }
           byteBuffer.reset();
         } else {


### PR DESCRIPTION
`BTreeSortMergeGetOperation.Callback` 타입에 대한 접근을 `Callback`으로 단순화 했습니다.
같은 이름의 `Callback`이라는 타입이 여러 군데에 있어도 이러한 단순화가 가능한 이유는, 같은 이름이면 가장 가까운 것을 access 하기 때문입니다.
`BTreeSortMergeGetOperationImpl` 타입 입장에서 가장 가까운 `Callback`은 자신이 구현하고 있는 interface인 `BTreeSortMergeGetOperation`의 `Callback` 입니다.