### PR TITLE
FIX: remove duplicate maven dependency caching

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,14 +18,9 @@ jobs:
       with:
         java-version: '11'
         distribution: 'temurin'
-        cache: maven
+        cache: 'maven'
     - name: Install ARCUS Dependencies
       run: sudo apt-get install -qq build-essential autoconf automake libtool libcppunit-dev python-setuptools python-dev ant
-    - name: Cache Maven Dependencies
-      uses: actions/cache@v3.0.0
-      with:
-        path: ~/.m2
-        key: ${{runner.os}}-maven
     - name: Cache ARCUS Directory
       id: arcus-cache
       uses: actions/cache@v3.0.0


### PR DESCRIPTION
## Description

`ci.yml`에서 중복된 maven 의존성 캐싱 step을 제거하였습니다. `actions/setup-java@v2`는 `actions/cache`를 내장하고 있습니다.

**AS-IS**

```yml
- name: Set up JDK 11
  uses: actions/setup-java@v2
  with:
    java-version: '11'
    distribution: 'temurin'
    cache: maven

- name: Cache Maven Dependencies
  uses: actions/cache@v3.0.0
  with:
    path: ~/.m2
    key: ${{runner.os}}-maven
```

**TO-BE**

```yml
- name: Set up JDK 11
  uses: actions/setup-java@v2
  with:
    java-version: '11'
    distribution: 'temurin'
    cache: 'maven'
```

## References
- [actions/setup-java#caching-maven-dependencies](https://github.com/actions/setup-java/tree/v2#caching-maven-dependencies)
