### PR TITLE
FIX: Fix buggy code.

### DIFF
--- a/src/test/java/net/spy/memcached/CacheMonitorTest.java
+++ b/src/test/java/net/spy/memcached/CacheMonitorTest.java
@@ -50,7 +50,7 @@ public class CacheMonitorTest extends MockObjectTestCase {
     children = new ArrayList<String>();
 
     cacheMonitor = new CacheMonitor(zooKeeper, ARCUS_BASE_CACHE_LIST_ZPATH,
-            serviceCode, (CacheMonitorListener) listener.proxy());
+            serviceCode, true, (CacheMonitorListener) listener.proxy());
   }
 
   @Override


### PR DESCRIPTION
오프라인으로 논의된 사항을 적용했습니다.

```java
if (zk.exists(ARCUS_BASE_CACHE_LIST_ZPATH + serviceCode, false) != null) {
  arcusReplEnabled = false;
  cfb.internalArcusReplEnabled(false);
  getLogger().info("Connected to Arcus cluster (seriveCode=%s)", serviceCode);
}
```
논의되지 않은 코드도 추가되었습니다. 실제로 이런 상황이 일어나진 않겠지만, EE 버전 사용 중 -> ZK 연결 끊김 -> Community 버전으로 교체 -> ZK 연결 되는 상황을 가정하고 방어 코드를 추가했습니다.