### PR TITLE
ENHANCE: Reconnect to ZK when cache_list znode is deleted.

### DIFF
--- a/src/main/java/net/spy/memcached/CacheMonitor.java
+++ b/src/main/java/net/spy/memcached/CacheMonitor.java
@@ -123,6 +123,7 @@ public class CacheMonitor extends SpyObject implements Watcher,
         getLogger().fatal(
             "Cannot find your service code. Please contact Arcus support to solve this problem. "
             + getInfo());
+        shutdown();
         countDown = true;
         break;
       case SESSIONEXPIRED:


### PR DESCRIPTION
`cache_list` 혹은 `cache_list/<service code>` znode가 제거되었을 때 ZK 연결을 끊고, ZK 연결 시작부터 다시 수행 하도록 수정했습니다.