### PR TITLE
FIX: Call Future.get() for fix CI bug.

### DIFF
--- a/src/test/manual/net/spy/memcached/bulkoperation/BopInsertBulkMultipleBoundaryTest.java
+++ b/src/test/manual/net/spy/memcached/bulkoperation/BopInsertBulkMultipleBoundaryTest.java
@@ -40,7 +40,7 @@ public class BopInsertBulkMultipleBoundaryTest extends BaseIntegrationTest {
             true).get();
 
     // Create a B+ Tree
-    mc.asyncBopInsert(key, 0, null, "item0", new CollectionAttributes());
+    mc.asyncBopInsert(key, 0, null, "item0", new CollectionAttributes()).get();
 
     int maxcount = 10;
 

--- a/src/test/manual/net/spy/memcached/bulkoperation/BopInsertBulkMultipleTest.java
+++ b/src/test/manual/net/spy/memcached/bulkoperation/BopInsertBulkMultipleTest.java
@@ -45,7 +45,7 @@ public class BopInsertBulkMultipleTest extends BaseIntegrationTest {
     try {
       // REMOVE
       mc.asyncBopDelete(key, 0, 4000, ElementFlagFilter.DO_NOT_FILTER, 0,
-              true);
+              true).get();
 
       // SET
       Future<Map<Integer, CollectionOperationStatus>> future = mc

--- a/src/test/manual/net/spy/memcached/bulkoperation/BulkDeleteTest.java
+++ b/src/test/manual/net/spy/memcached/bulkoperation/BulkDeleteTest.java
@@ -68,7 +68,7 @@ public class BulkDeleteTest extends BaseIntegrationTest {
 
         // SET
         for (String key : keys) {
-          mc.set(key, 60, value);
+          mc.set(key, 60, value).get();
         }
 
         // Bulk delete
@@ -116,9 +116,9 @@ public class BulkDeleteTest extends BaseIntegrationTest {
 
         for (int i = 0; i < keys.length; i++) {
           if (i % 2 == 0) {
-            mc.set(keys[i], 60, "value");
+            mc.set(keys[i], 60, "value").get();
           } else {
-            mc.delete(keys[i]);
+            mc.delete(keys[i]).get();
           }
         }
 

--- a/src/test/manual/net/spy/memcached/bulkoperation/BulkSetVariousTypeTest.java
+++ b/src/test/manual/net/spy/memcached/bulkoperation/BulkSetVariousTypeTest.java
@@ -68,7 +68,7 @@ public class BulkSetVariousTypeTest extends BaseIntegrationTest {
       for (int i = 0; i < valueList.length; i++) {
         String[] key = new String[]{keyPrefix + i};
         // REMOVE
-        mc.delete(key[0]);
+        mc.delete(key[0]).get();
 
         // SET
         @SuppressWarnings("deprecation")

--- a/src/test/manual/net/spy/memcached/bulkoperation/BulkStoreTest.java
+++ b/src/test/manual/net/spy/memcached/bulkoperation/BulkStoreTest.java
@@ -81,7 +81,7 @@ public class BulkStoreTest extends BaseIntegrationTest {
 
       // REMOVE
       for (String key : keys) {
-        mc.delete(key);
+        mc.delete(key).get();
       }
 
       // SET
@@ -107,7 +107,7 @@ public class BulkStoreTest extends BaseIntegrationTest {
 
         Assert.assertEquals(k + " has unexpected value.", o.get(k), v);
 
-        mc.delete(k);
+        mc.delete(k).get();
       }
     } catch (Exception e) {
       e.printStackTrace();
@@ -137,7 +137,7 @@ public class BulkStoreTest extends BaseIntegrationTest {
 
       // REMOVE
       for (String key : keys) {
-        mc.delete(key);
+        mc.delete(key).get();
       }
 
       // SET
@@ -163,7 +163,7 @@ public class BulkStoreTest extends BaseIntegrationTest {
 
       // REMOVE
       for (String key : keys) {
-        mc.delete(key);
+        mc.delete(key).get();
       }
     } catch (Exception e) {
       e.printStackTrace();
@@ -186,7 +186,7 @@ public class BulkStoreTest extends BaseIntegrationTest {
 
       // REMOVE
       for (String key : keys) {
-        mc.delete(key);
+        mc.delete(key).get();
       }
 
       // ADD
@@ -212,7 +212,7 @@ public class BulkStoreTest extends BaseIntegrationTest {
 
       // REMOVE
       for (String key : keys) {
-        mc.delete(key);
+        mc.delete(key).get();
       }
     } catch (Exception e) {
       e.printStackTrace();
@@ -235,7 +235,7 @@ public class BulkStoreTest extends BaseIntegrationTest {
 
       // SET
       for (String key : keys) {
-        mc.set(key, 60, "oldValue");
+        mc.set(key, 60, "oldValue").get();
       }
 
       // REPLACE
@@ -261,7 +261,7 @@ public class BulkStoreTest extends BaseIntegrationTest {
 
       // REMOVE
       for (String key : keys) {
-        mc.delete(key);
+        mc.delete(key).get();
       }
     } catch (Exception e) {
       e.printStackTrace();
@@ -284,7 +284,7 @@ public class BulkStoreTest extends BaseIntegrationTest {
 
       // REMOVE
       for (String key : keys) {
-        mc.delete(key);
+        mc.delete(key).get();
       }
 
       //  Store
@@ -310,7 +310,7 @@ public class BulkStoreTest extends BaseIntegrationTest {
 
       // REMOVE
       for (String key : keys) {
-        mc.delete(key);
+        mc.delete(key).get();
       }
     } catch (Exception e) {
       e.printStackTrace();
@@ -334,7 +334,7 @@ public class BulkStoreTest extends BaseIntegrationTest {
 
       // REMOVE
       for (String key : keys) {
-        mc.delete(key);
+        mc.delete(key).get();
       }
 
       // Store
@@ -359,7 +359,7 @@ public class BulkStoreTest extends BaseIntegrationTest {
 
       // REMOVE
       for (String key : keys) {
-        mc.delete(key);
+        mc.delete(key).get();
       }
     } catch (Exception e) {
       e.printStackTrace();
@@ -382,7 +382,7 @@ public class BulkStoreTest extends BaseIntegrationTest {
 
       // REMOVE
       for (String key : keys) {
-        mc.delete(key);
+        mc.delete(key).get();
       }
 
       // Store
@@ -409,7 +409,7 @@ public class BulkStoreTest extends BaseIntegrationTest {
 
       // REMOVE
       for (String key : keys) {
-        mc.delete(key);
+        mc.delete(key).get();
       }
     } catch (Exception e) {
       e.printStackTrace();
@@ -432,7 +432,7 @@ public class BulkStoreTest extends BaseIntegrationTest {
 
       // REMOVE
       for (String key : keys) {
-        mc.delete(key);
+        mc.delete(key).get();
       }
 
       //  Store
@@ -459,7 +459,7 @@ public class BulkStoreTest extends BaseIntegrationTest {
 
       // REMOVE
       for (String key : o.keySet()) {
-        mc.delete(key);
+        mc.delete(key).get();
       }
     } catch (Exception e) {
       e.printStackTrace();

--- a/src/test/manual/net/spy/memcached/bulkoperation/MopInsertBulkMultipleTest.java
+++ b/src/test/manual/net/spy/memcached/bulkoperation/MopInsertBulkMultipleTest.java
@@ -42,7 +42,7 @@ public class MopInsertBulkMultipleTest extends BaseIntegrationTest {
 
     try {
       // REMOVE
-      mc.asyncMopDelete(key, true);
+      mc.asyncMopDelete(key, true).get();
 
       // SET
       Future<Map<Integer, CollectionOperationStatus>> future = mc

--- a/src/test/manual/net/spy/memcached/collection/btree/BopMutateTest.java
+++ b/src/test/manual/net/spy/memcached/collection/btree/BopMutateTest.java
@@ -34,7 +34,7 @@ public class BopMutateTest extends BaseIntegrationTest {
   @Override
   protected void setUp() throws Exception {
     super.setUp();
-    mc.delete(key);
+    mc.delete(key).get();
   }
 
   public void testBopIncrDecr_Basic() throws Exception {

--- a/src/test/manual/net/spy/memcached/collection/btree/BopOverflowActionTest.java
+++ b/src/test/manual/net/spy/memcached/collection/btree/BopOverflowActionTest.java
@@ -77,7 +77,7 @@ public class BopOverflowActionTest extends BaseIntegrationTest {
 
   public void testBopGet_Overflow() throws Exception {
     // Create a B+ Tree
-    mc.asyncBopInsert(key, 0, null, "item0", new CollectionAttributes());
+    mc.asyncBopInsert(key, 0, null, "item0", new CollectionAttributes()).get();
 
     int maxcount = 100;
 
@@ -112,7 +112,7 @@ public class BopOverflowActionTest extends BaseIntegrationTest {
 
   public void testBopGet_LargestTrim() throws Exception {
     // Create a B+ Tree
-    mc.asyncBopInsert(key, 0, null, "item0", new CollectionAttributes());
+    mc.asyncBopInsert(key, 0, null, "item0", new CollectionAttributes()).get();
 
     int maxcount = 100;
 
@@ -147,7 +147,7 @@ public class BopOverflowActionTest extends BaseIntegrationTest {
 
   public void testBopGet_SmallestTrim() throws Exception {
     // Create a B+ Tree
-    mc.asyncBopInsert(key, 0, null, "item0", new CollectionAttributes());
+    mc.asyncBopInsert(key, 0, null, "item0", new CollectionAttributes()).get();
 
     int maxcount = 100;
 
@@ -182,7 +182,7 @@ public class BopOverflowActionTest extends BaseIntegrationTest {
 
   public void testBopGet_SmallestTrim_OutOfRange() throws Exception {
     // Create a set
-    mc.asyncBopInsert(key, 1, null, "item1", new CollectionAttributes());
+    mc.asyncBopInsert(key, 1, null, "item1", new CollectionAttributes()).get();
 
     // smallest_trim
     assertTrue(mc.asyncSetAttr(key,
@@ -199,7 +199,7 @@ public class BopOverflowActionTest extends BaseIntegrationTest {
 
   public void testBopGet_LargestTrim_OutOfRange() throws Exception {
     // Create a set
-    mc.asyncBopInsert(key, 1, null, "item1", new CollectionAttributes());
+    mc.asyncBopInsert(key, 1, null, "item1", new CollectionAttributes()).get();
 
     // largest_trim
     assertTrue(mc.asyncSetAttr(key,
@@ -216,7 +216,7 @@ public class BopOverflowActionTest extends BaseIntegrationTest {
 
   public void testBopGet_AvailableOverflowAction() throws Exception {
     // Create a set
-    mc.asyncBopInsert(key, 0, null, "item0", new CollectionAttributes());
+    mc.asyncBopInsert(key, 0, null, "item0", new CollectionAttributes()).get();
 
     // Set OverflowAction
     // error

--- a/src/test/manual/net/spy/memcached/collection/list/LopOverflowActionTest.java
+++ b/src/test/manual/net/spy/memcached/collection/list/LopOverflowActionTest.java
@@ -40,7 +40,7 @@ public class LopOverflowActionTest extends BaseIntegrationTest {
     // Test
     for (int maxcount = 100; maxcount <= 200; maxcount += 100) {
       // Create a list
-      mc.asyncLopInsert(key, 0, "item0", new CollectionAttributes());
+      mc.asyncLopInsert(key, 0, "item0", new CollectionAttributes()).get();
 
       // Set maxcount
       CollectionAttributes attrs = new CollectionAttributes();
@@ -63,7 +63,7 @@ public class LopOverflowActionTest extends BaseIntegrationTest {
 
   public void testLopGet_Overflow() throws Exception {
     // Create a List
-    mc.asyncLopInsert(key, 0, "item0", new CollectionAttributes());
+    mc.asyncLopInsert(key, 0, "item0", new CollectionAttributes()).get();
 
     int maxcount = 100;
 
@@ -93,7 +93,7 @@ public class LopOverflowActionTest extends BaseIntegrationTest {
 
   public void testLopGet_HeadTrim() throws Exception {
     // Create a List
-    mc.asyncLopInsert(key, 0, "item0", new CollectionAttributes());
+    mc.asyncLopInsert(key, 0, "item0", new CollectionAttributes()).get();
 
     int maxcount = 100;
 
@@ -122,7 +122,7 @@ public class LopOverflowActionTest extends BaseIntegrationTest {
 
   public void testLopGet_TailTrim() throws Exception {
     // Create a List
-    mc.asyncLopInsert(key, 0, "item0", new CollectionAttributes());
+    mc.asyncLopInsert(key, 0, "item0", new CollectionAttributes()).get();
 
     int maxcount = 100;
 
@@ -151,7 +151,7 @@ public class LopOverflowActionTest extends BaseIntegrationTest {
 
   public void testLopGet_HeadTrim_OutOfRange() throws Exception {
     // Create a set
-    mc.asyncLopInsert(key, 1, "item1", new CollectionAttributes());
+    mc.asyncLopInsert(key, 1, "item1", new CollectionAttributes()).get();
 
     // head_trim
     assertFalse(mc.asyncSetAttr(key,
@@ -167,7 +167,7 @@ public class LopOverflowActionTest extends BaseIntegrationTest {
 
   public void testLopGet_TailTrim_OutOfRange() throws Exception {
     // Create a set
-    mc.asyncLopInsert(key, 1, "item1", new CollectionAttributes());
+    mc.asyncLopInsert(key, 1, "item1", new CollectionAttributes()).get();
 
     // tail_trim
     assertFalse(mc.asyncSetAttr(key,
@@ -183,7 +183,7 @@ public class LopOverflowActionTest extends BaseIntegrationTest {
 
   public void testLopGet_AvailableOverflowAction() throws Exception {
     // Create a set
-    mc.asyncLopInsert(key, 0, "item0", new CollectionAttributes());
+    mc.asyncLopInsert(key, 0, "item0", new CollectionAttributes()).get();
 
     // Set OverflowAction
     // error

--- a/src/test/manual/net/spy/memcached/collection/map/MopOverflowActionTest.java
+++ b/src/test/manual/net/spy/memcached/collection/map/MopOverflowActionTest.java
@@ -42,7 +42,7 @@ public class MopOverflowActionTest extends BaseIntegrationTest {
     // Test
     for (int maxcount = 100; maxcount <= 200; maxcount += 100) {
       // Create a map
-      mc.asyncMopInsert(key, "0", "item0", new CollectionAttributes());
+      mc.asyncMopInsert(key, "0", "item0", new CollectionAttributes()).get();
 
       // Set maxcount
       CollectionAttributes attrs = new CollectionAttributes();
@@ -65,7 +65,7 @@ public class MopOverflowActionTest extends BaseIntegrationTest {
 
   public void testMopGet_Overflow() throws Exception {
     // Create a map
-    mc.asyncMopInsert(key, "0", "item0", new CollectionAttributes());
+    mc.asyncMopInsert(key, "0", "item0", new CollectionAttributes()).get();
 
     int maxcount = 100;
 
@@ -95,7 +95,7 @@ public class MopOverflowActionTest extends BaseIntegrationTest {
 
   public void testMopGet_AvailableOverflowAction() throws Exception {
     // Create a set
-    mc.asyncMopInsert(key, "0", "item0", new CollectionAttributes());
+    mc.asyncMopInsert(key, "0", "item0", new CollectionAttributes()).get();
 
     // Set OverflowAction
     // error

--- a/src/test/manual/net/spy/memcached/collection/set/SopOverflowActionTest.java
+++ b/src/test/manual/net/spy/memcached/collection/set/SopOverflowActionTest.java
@@ -41,7 +41,7 @@ public class SopOverflowActionTest extends BaseIntegrationTest {
     // Test
     for (int maxcount = 50000; maxcount <= 10000; maxcount += 1000) {
       // Create a B+ Tree
-      mc.asyncSopInsert(key, "item0", new CollectionAttributes());
+      mc.asyncSopInsert(key, "item0", new CollectionAttributes()).get();
 
       // Set maxcount
       CollectionAttributes attrs = new CollectionAttributes();
@@ -73,7 +73,7 @@ public class SopOverflowActionTest extends BaseIntegrationTest {
 
   public void testSopGet_AvailableOverflowAction() throws Exception {
     // Create a set
-    mc.asyncSopInsert(key, "item0", new CollectionAttributes());
+    mc.asyncSopInsert(key, "item0", new CollectionAttributes()).get();
 
     // Set OverflowAction
     // error

--- a/src/test/manual/net/spy/memcached/collection/set/SopServerMessageTest.java
+++ b/src/test/manual/net/spy/memcached/collection/set/SopServerMessageTest.java
@@ -32,8 +32,8 @@ public class SopServerMessageTest extends BaseIntegrationTest {
   @Override
   protected void setUp() throws Exception {
     super.setUp();
-    mc.asyncSopDelete(key, "aaa", true);
-    mc.asyncSopDelete(key, "bbbb", true);
+    mc.asyncSopDelete(key, "aaa", true).get();
+    mc.asyncSopDelete(key, "bbbb", true).get();
   }
 
   public void testNotFound() throws Exception {

--- a/src/test/manual/net/spy/memcached/ops/OperationStatusTest.java
+++ b/src/test/manual/net/spy/memcached/ops/OperationStatusTest.java
@@ -25,9 +25,9 @@ public class OperationStatusTest extends BaseIntegrationTest {
     OperationFuture<Boolean> prependOperationFuture = mc.prepend(10, "abc", appendValue);
     OperationFuture<Boolean> appendOperationFuture = mc.append(10, "abc", appendValue);
 
-    mc.add("bcc", EXP, value);
-    mc.add("cbd", EXP, "2222");
-    mc.add("efg", EXP, "3333");
+    mc.add("bcc", EXP, value).get();
+    mc.add("cbd", EXP, "2222").get();
+    mc.add("efg", EXP, "3333").get();
 
     //then
     assertEquals(StatusCode.SUCCESS, addOperationFuture.getStatus().getStatusCode());
@@ -44,7 +44,7 @@ public class OperationStatusTest extends BaseIntegrationTest {
     String appendValue = "plus";
 
     //when
-    mc.add("abc", EXP, value);
+    mc.add("abc", EXP, value).get();
 
     // add already stored key
     OperationFuture<Boolean> addOperationFuture = mc.add("abc", EXP, replaceValue);
@@ -67,7 +67,7 @@ public class OperationStatusTest extends BaseIntegrationTest {
     String key = "key";
     String value = "65";
     int value2 = 61;
-    mc.set(key, EXP, value);
+    mc.set(key, EXP, value).get();
 
     //when
     OperationFuture<Long> incrOperationFuture = mc.asyncIncr(key, value2);
@@ -83,7 +83,7 @@ public class OperationStatusTest extends BaseIntegrationTest {
     int value = 1;
     int value2 = 2;
 
-    mc.set("abc", EXP, value);
+    mc.set("abc", EXP, value).get();
 
     //when
     OperationFuture<Long> incrOperationFuture = mc.asyncIncr("bc", value2);
@@ -98,7 +98,7 @@ public class OperationStatusTest extends BaseIntegrationTest {
     //given
     String value = "example";
 
-    mc.add("abc", EXP, value);
+    mc.add("abc", EXP, value).get();
 
     //when
     OperationFuture<Boolean> deleteOperationFuture = mc.delete("abc");
@@ -111,7 +111,7 @@ public class OperationStatusTest extends BaseIntegrationTest {
     //given
     String value = "example";
 
-    mc.add("abc", EXP, value);
+    mc.add("abc", EXP, value).get();
 
     //when
     OperationFuture<Boolean> deleteOperationFuture = mc.delete("bc");

--- a/src/test/manual/net/spy/memcached/test/MemcachedThreadBench.java
+++ b/src/test/manual/net/spy/memcached/test/MemcachedThreadBench.java
@@ -155,7 +155,11 @@ public class MemcachedThreadBench extends TestCase {
 
       long begin = System.currentTimeMillis();
       for (int i = stat.start; i < stat.start + stat.runs; i++) {
-        mc.set("" + i + keyBase, 3600, object);
+        try {
+          mc.set("" + i + keyBase, 3600, object).get();
+        } catch (Exception e) {
+          fail(e.getMessage());
+        }
         if (total.incrementAndGet() >= MAX_QUEUE) {
           flush();
         }

--- a/src/test/manual/net/spy/memcached/test/SASLConnectReconnect.java
+++ b/src/test/manual/net/spy/memcached/test/SASLConnectReconnect.java
@@ -3,6 +3,7 @@ package net.spy.memcached.test;
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.util.List;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.ConsoleHandler;
 import java.util.logging.Handler;
@@ -19,6 +20,7 @@ import net.spy.memcached.auth.AuthDescriptor;
 import net.spy.memcached.auth.PlainCallbackHandler;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 
 /**
  * A very simple test of using SASL PLAIN auth and ensuring that operations are
@@ -110,7 +112,11 @@ public class SASLConnectReconnect {
   public void verifySetAndGet() {
     int iterations = 20;
     for (int i = 0; i < iterations; i++) {
-      mc.set("test" + i, 0, "test" + i);
+      try {
+        mc.set("test" + i, 0, "test" + i).get();
+      } catch (Exception e) {
+        fail(e.getMessage());
+      }
     }
 
     for (int i = 0; i < iterations; i++) {
@@ -125,7 +131,7 @@ public class SASLConnectReconnect {
   public void verifySetAndGet2(int iterations) {
     try {
       for (int i = 0; i <= iterations; i++) {
-        mc.set("me" + i, 0, "me" + i);
+        mc.set("me" + i, 0, "me" + i).get();
       }
 
       for (int i = 0; i < iterations; i++) {


### PR DESCRIPTION
모든 테스트 코드에서 모든 연산을 동기로 수행합니다.
Future.get()을 호출하지 않아 생기는 잠재적인 버그를 제거하고, 모든 연산에서 Future.get()을 호출하는 일관성을 맞추기 위함입니다.