### PR TITLE
FIX: Fix bug that is occurred when client is attached to Arcus cluster that is doing migration type=LEAVE.

### DIFF
--- a/src/main/java/net/spy/memcached/MemcachedConnection.java
+++ b/src/main/java/net/spy/memcached/MemcachedConnection.java
@@ -724,7 +724,6 @@ public final class MemcachedConnection extends SpyObject {
         if (!mgInProgress) {
           /* prepare connections of alter nodes */
           prepareAlterConnections(convertToSocketAddresses(addrs));
-          mgInProgress = true;
         } else {
           /* check joining node down */
           updateAlterConnections(convertToSocketAddresses(addrs));
@@ -761,6 +760,7 @@ public final class MemcachedConnection extends SpyObject {
       }
     }
     locator.prepareMigration(alterNodes, mgType);
+    mgInProgress = true;
   }
 
   private void updateAlterConnections(List<InetSocketAddress> addrs) throws IOException {


### PR DESCRIPTION
Migration이 이미 진행 중인 Cluster에 Client가 붙은 경우 에러가 발생하는 것을 수정했습니다.