### PR TITLE
INTERNAL:refactor opsTimeOut method caller

### DIFF
--- a/src/main/java/net/spy/memcached/ArcusClient.java
+++ b/src/main/java/net/spy/memcached/ArcusClient.java
@@ -1030,15 +1030,18 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
           for (Operation op : ops) {
             if (op.getState() != OperationState.COMPLETE) {
               timedoutOps.add(op);
+            } else {
+              MemcachedConnection.opSucceeded(op);
             }
           }
           if (timedoutOps.size() > 0) {
             MemcachedConnection.opTimedOut(timedoutOps.iterator().next());
             throw new CheckedOperationTimeoutException(duration, units, timedoutOps);
           }
+        } else {
+          // continuous timeout counter will be reset only once in pipe
+          MemcachedConnection.opSucceeded(ops.iterator().next());
         }
-        // continuous timeout counter will be reset only once in pipe
-        MemcachedConnection.opSucceeded(ops.iterator().next());
 
         for (Operation op : ops) {
           if (op != null && op.hasErrored()) {
@@ -3993,16 +3996,18 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
           for (Operation op : ops) {
             if (op.getState() != OperationState.COMPLETE) {
               timedoutOps.add(op);
+            } else {
+              MemcachedConnection.opSucceeded(op);
             }
           }
           if (timedoutOps.size() > 0) {
             MemcachedConnection.opTimedOut(timedoutOps.iterator().next());
             throw new CheckedOperationTimeoutException(duration, units, timedoutOps);
           }
+        } else {
+          // continuous timeout counter will be reset only once in pipe
+          MemcachedConnection.opSucceeded(ops.iterator().next());
         }
-        // continuous timeout counter will be reset only once in pipe
-        MemcachedConnection.opSucceeded(ops.iterator().next());
-
         for (Operation op : ops) {
           if (op != null && op.hasErrored()) {
             throw new ExecutionException(op.getException());

--- a/src/main/java/net/spy/memcached/MemcachedClient.java
+++ b/src/main/java/net/spy/memcached/MemcachedClient.java
@@ -28,7 +28,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -51,7 +50,6 @@ import net.spy.memcached.auth.AuthThreadMonitor;
 import net.spy.memcached.compat.SpyThread;
 import net.spy.memcached.internal.BulkFuture;
 import net.spy.memcached.internal.BulkGetFuture;
-import net.spy.memcached.internal.CheckedOperationTimeoutException;
 import net.spy.memcached.internal.GetFuture;
 import net.spy.memcached.internal.OperationFuture;
 import net.spy.memcached.internal.SingleElementInfiniteIterator;
@@ -1587,18 +1585,7 @@ public class MemcachedClient extends SpyThread
     }, nodes);
     try {
       if (!blatch.await(operationTimeout, TimeUnit.MILLISECONDS)) {
-        Collection<Operation> timedoutOps = new HashSet<Operation>();
-        for (Operation op : ops) {
-          if (op.getState() != OperationState.COMPLETE) {
-            MemcachedConnection.opTimedOut(op);
-            timedoutOps.add(op);
-          } else {
-            MemcachedConnection.opSucceeded(op);
-          }
-        }
-        if (timedoutOps.size() > 0) {
-          throw new OperationTimeoutException(operationTimeout, TimeUnit.MILLISECONDS, timedoutOps);
-        }
+        ArcusClient.noneKeyOpTimeOutHandlerWithUnChecked(operationTimeout, ops);
       } else {
         MemcachedConnection.opsSucceeded(ops);
       }
@@ -1676,18 +1663,7 @@ public class MemcachedClient extends SpyThread
     }, nodes);
     try {
       if (!blatch.await(operationTimeout, TimeUnit.MILLISECONDS)) {
-        Collection<Operation> timedoutOps = new HashSet<Operation>();
-        for (Operation op : ops) {
-          if (op.getState() != OperationState.COMPLETE) {
-            MemcachedConnection.opTimedOut(op);
-            timedoutOps.add(op);
-          } else {
-            MemcachedConnection.opSucceeded(op);
-          }
-        }
-        if (timedoutOps.size() > 0) {
-          throw new OperationTimeoutException(operationTimeout, TimeUnit.MILLISECONDS, timedoutOps);
-        }
+        ArcusClient.noneKeyOpTimeOutHandlerWithUnChecked(operationTimeout, ops);
       } else {
         MemcachedConnection.opsSucceeded(ops);
       }
@@ -2061,19 +2037,7 @@ public class MemcachedClient extends SpyThread
       public Boolean get(long duration, TimeUnit units)
               throws InterruptedException, TimeoutException, ExecutionException {
         if (!blatch.await(duration, units)) {
-          // whenever timeout occurs, continuous timeout counter will increase by 1.
-          Collection<Operation> timedoutOps = new HashSet<Operation>();
-          for (Operation op : ops) {
-            if (op.getState() != OperationState.COMPLETE) {
-              MemcachedConnection.opTimedOut(op);
-              timedoutOps.add(op);
-            } else {
-              MemcachedConnection.opSucceeded(op);
-            }
-          }
-          if (timedoutOps.size() > 0) {
-            throw new CheckedOperationTimeoutException(duration, units, timedoutOps);
-          }
+          ArcusClient.noneKeyOpTimeOutHandlerWithChecked(duration, units, ops);
         } else {
           // continuous timeout counter will be reset
           MemcachedConnection.opsSucceeded(ops);
@@ -2142,18 +2106,7 @@ public class MemcachedClient extends SpyThread
 
     try {
       if (!blatch.await(operationTimeout, TimeUnit.MILLISECONDS)) {
-        Collection<Operation> timedoutOps = new HashSet<Operation>();
-        for (Operation op : ops) {
-          if (op.getState() != OperationState.COMPLETE) {
-            MemcachedConnection.opTimedOut(op);
-            timedoutOps.add(op);
-          } else {
-            MemcachedConnection.opSucceeded(op);
-          }
-        }
-        if (timedoutOps.size() > 0) {
-          throw new OperationTimeoutException(operationTimeout, TimeUnit.MILLISECONDS, timedoutOps);
-        }
+        ArcusClient.noneKeyOpTimeOutHandlerWithUnChecked(operationTimeout, ops);
       } else {
         MemcachedConnection.opsSucceeded(ops);
       }

--- a/src/main/java/net/spy/memcached/internal/BulkOperationFuture.java
+++ b/src/main/java/net/spy/memcached/internal/BulkOperationFuture.java
@@ -1,5 +1,6 @@
 package net.spy.memcached.internal;
 
+import net.spy.memcached.ArcusClient;
 import net.spy.memcached.MemcachedConnection;
 import net.spy.memcached.ops.Operation;
 import net.spy.memcached.ops.OperationState;
@@ -7,7 +8,6 @@ import net.spy.memcached.ops.OperationState;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.HashSet;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
@@ -53,18 +53,7 @@ public abstract class BulkOperationFuture<T>
                             TimeUnit units) throws InterruptedException,
           TimeoutException, ExecutionException {
     if (!latch.await(duration, units)) {
-      Collection<Operation> timedoutOps = new HashSet<Operation>();
-      for (Operation op : ops) {
-        if (op.getState() != OperationState.COMPLETE) {
-          timedoutOps.add(op);
-        } else {
-          MemcachedConnection.opSucceeded(op);
-        }
-      }
-      if (timedoutOps.size() > 0) {
-        MemcachedConnection.opsTimedOut(timedoutOps);
-        throw new CheckedOperationTimeoutException(duration, units, timedoutOps);
-      }
+      ArcusClient.bulkOpTimeOutHandler(duration, units, ops);
     } else {
       // continuous timeout counter will be reset
       MemcachedConnection.opsSucceeded(ops);

--- a/src/main/java/net/spy/memcached/internal/CollectionBulkFuture.java
+++ b/src/main/java/net/spy/memcached/internal/CollectionBulkFuture.java
@@ -1,0 +1,89 @@
+package net.spy.memcached.internal;
+
+import net.spy.memcached.ArcusClient;
+import net.spy.memcached.MemcachedConnection;
+import net.spy.memcached.OperationTimeoutException;
+import net.spy.memcached.ops.Operation;
+import net.spy.memcached.ops.OperationState;
+
+import java.util.Collection;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+public class CollectionBulkFuture<T> implements Future<T> {
+
+  private final Collection<Operation> ops;
+  private final long timeout;
+  private final CountDownLatch latch;
+  private final T result;
+
+  public CollectionBulkFuture(Collection<Operation> ops, long timeout,
+                              CountDownLatch latch, T result) {
+    this.ops = ops;
+    this.timeout = timeout;
+    this.latch = latch;
+    this.result = result;
+  }
+
+  @Override
+  public T get() throws InterruptedException, ExecutionException {
+    try {
+      return get(timeout, TimeUnit.MILLISECONDS);
+    } catch (TimeoutException e) {
+      throw new OperationTimeoutException(e);
+    }
+  }
+
+  @Override
+  public T get(long duration, TimeUnit units)
+          throws InterruptedException, TimeoutException, ExecutionException {
+    if (!latch.await(duration, units)) {
+      ArcusClient.bulkOpTimeOutHandler(duration, units, ops);
+    } else {
+        // continuous timeout counter will be reset
+      MemcachedConnection.opsSucceeded(ops);
+    }
+    for (Operation op : ops) {
+      if (op != null && op.hasErrored()) {
+        throw new ExecutionException(op.getException());
+      }
+      if (op != null && op.isCancelled()) {
+        throw new ExecutionException(new RuntimeException(op.getCancelCause()));
+      }
+    }
+    return result;
+  }
+
+  @Override
+  public boolean cancel(boolean ign) {
+    boolean rv = false;
+    for (Operation op : ops) {
+      op.cancel("by application.");
+      rv |= op.getState() == OperationState.WRITE_QUEUED;
+    }
+    return rv;
+  }
+
+  @Override
+  public boolean isDone() {
+    for (Operation op : ops) {
+      if (!(op.getState() == OperationState.COMPLETE || op.isCancelled())) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  @Override
+  public boolean isCancelled() {
+    for (Operation op : ops) {
+      if (op.isCancelled()) {
+        return true;
+      }
+    }
+    return false;
+  }
+}

--- a/src/main/java/net/spy/memcached/internal/CollectionGetBulkFuture.java
+++ b/src/main/java/net/spy/memcached/internal/CollectionGetBulkFuture.java
@@ -18,73 +18,19 @@ package net.spy.memcached.internal;
 
 import java.util.Collection;
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Future;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 
-import net.spy.memcached.ArcusClient;
-import net.spy.memcached.MemcachedConnection;
-import net.spy.memcached.OperationTimeoutException;
 import net.spy.memcached.ops.CollectionOperationStatus;
 import net.spy.memcached.ops.Operation;
-import net.spy.memcached.ops.OperationState;
 import net.spy.memcached.ops.OperationStatus;
 
-public class CollectionGetBulkFuture<T> implements Future<T> {
+public class CollectionGetBulkFuture<T> extends CollectionBulkFuture<T> {
 
   private final Collection<Operation> ops;
-  private final long timeout;
-  private final CountDownLatch latch;
-  private final T result;
 
   public CollectionGetBulkFuture(CountDownLatch latch, Collection<Operation> ops, T result,
                                  long timeout) {
-    this.latch = latch;
+    super(ops, timeout, latch, result);
     this.ops = ops;
-    this.result = result;
-    this.timeout = timeout;
-  }
-
-  @Override
-  public T get() throws InterruptedException, ExecutionException {
-    try {
-      return get(timeout, TimeUnit.MILLISECONDS);
-    } catch (TimeoutException e) {
-      throw new OperationTimeoutException(e);
-    }
-  }
-
-  @Override
-  public T get(long duration, TimeUnit units)
-      throws InterruptedException, TimeoutException, ExecutionException {
-    if (!latch.await(duration, units)) {
-      ArcusClient.bulkOpTimeOutHandler(duration, units, ops);
-    } else {
-      // continuous timeout counter will be reset
-      MemcachedConnection.opsSucceeded(ops);
-    }
-
-    for (Operation op : ops) {
-      if (op != null && op.hasErrored()) {
-        throw new ExecutionException(op.getException());
-      }
-      if (op != null && op.isCancelled()) {
-        throw new ExecutionException(new RuntimeException(op.getCancelCause()));
-      }
-    }
-
-    return result;
-  }
-
-  @Override
-  public boolean cancel(boolean ign) {
-    boolean rv = false;
-    for (Operation op : ops) {
-      op.cancel("by application.");
-      rv |= op.getState() == OperationState.WRITE_QUEUED;
-    }
-    return rv;
   }
 
   @Override
@@ -96,21 +42,10 @@ public class CollectionGetBulkFuture<T> implements Future<T> {
     return rv;
   }
 
-  @Override
-  public boolean isDone() {
-    for (Operation op : ops) {
-      if (!(op.getState() == OperationState.COMPLETE || op.isCancelled())) {
-        return false;
-      }
-    }
-    return true;
-  }
-
   public CollectionOperationStatus getOperationStatus() {
     if (isCancelled()) {
       return new CollectionOperationStatus(new OperationStatus(false, "CANCELED"));
     }
-
     return new CollectionOperationStatus(new OperationStatus(true, "END"));
   }
 }

--- a/src/main/java/net/spy/memcached/internal/CollectionInsertBulkFuture.java
+++ b/src/main/java/net/spy/memcached/internal/CollectionInsertBulkFuture.java
@@ -1,0 +1,2 @@
+package net.spy.memcached.internal;public class CollectionInsertBulkFuture {
+}

--- a/src/main/java/net/spy/memcached/internal/CollectionInsertBulkFuture.java
+++ b/src/main/java/net/spy/memcached/internal/CollectionInsertBulkFuture.java
@@ -1,2 +1,24 @@
-package net.spy.memcached.internal;public class CollectionInsertBulkFuture {
+package net.spy.memcached.internal;
+
+import net.spy.memcached.ops.CollectionOperationStatus;
+import net.spy.memcached.ops.Operation;
+
+import java.util.Collection;
+import java.util.concurrent.CountDownLatch;
+
+
+public class CollectionInsertBulkFuture<T> extends CollectionBulkFuture<T> {
+
+  private final Collection<Operation> ops;
+
+  public CollectionInsertBulkFuture(Collection<Operation> ops, long timeout,
+                                    CountDownLatch latch, T result) {
+    super(ops, timeout, latch, result);
+    this.ops = ops;
+  }
+
+  public CollectionOperationStatus getOperationStatus() {
+    return null;
+  }
+
 }

--- a/src/main/java/net/spy/memcached/internal/PipeOperationFuture.java
+++ b/src/main/java/net/spy/memcached/internal/PipeOperationFuture.java
@@ -1,0 +1,104 @@
+package net.spy.memcached.internal;
+
+import net.spy.memcached.MemcachedConnection;
+import net.spy.memcached.collection.CollectionResponse;
+import net.spy.memcached.ops.CollectionOperationStatus;
+import net.spy.memcached.ops.Operation;
+import net.spy.memcached.ops.OperationState;
+import net.spy.memcached.ops.OperationStatus;
+
+import java.util.List;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.ExecutionException;
+
+import static net.spy.memcached.ArcusClient.pipeOpTimeOutHandler;
+
+public class PipeOperationFuture<T> extends CollectionFuture<T> {
+
+  private final ConcurrentLinkedQueue<Operation> ops;
+
+  private final List<OperationStatus> mergedOperationStatus;
+
+  private final T rv;
+
+  public PipeOperationFuture(CountDownLatch l, long opTimeout,
+                             ConcurrentLinkedQueue<Operation> ops,
+                             List<OperationStatus> mergedOperationStatus,
+                             T mergedResult) {
+    super(l, opTimeout);
+    this.ops = ops;
+    this.mergedOperationStatus = mergedOperationStatus;
+    this.rv = mergedResult;
+  }
+
+  @Override
+  public boolean cancel(boolean ign) {
+    boolean rv = false;
+    for (Operation op : ops) {
+      op.cancel("by application.");
+      rv |= op.getState() == OperationState.WRITE_QUEUED;
+    }
+    return rv;
+  }
+
+
+  @Override
+  public T get(long duration, TimeUnit units) throws
+          InterruptedException,
+          TimeoutException,
+          ExecutionException {
+    if (!latch.await(duration, units)) {
+      pipeOpTimeOutHandler(duration, units, ops);
+    } else {
+      // continuous timeout counter will be reset only once in pipe
+      MemcachedConnection.opSucceeded(ops.iterator().next());
+    }
+    for (Operation op : ops) {
+      if (op != null && op.hasErrored()) {
+        throw new ExecutionException(op.getException());
+      }
+      if (op != null && op.isCancelled()) {
+        throw new ExecutionException(new RuntimeException(op.getCancelCause()));
+      }
+    }
+    return rv;
+  }
+
+  @Override
+  public void setOperation(Operation to) {
+    super.setOperation(to);
+  }
+
+  @Override
+  public boolean isCancelled() {
+    for (Operation op : ops) {
+      if (op.isCancelled()) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  @Override
+  public boolean isDone() {
+    for (Operation op : ops) {
+      if (!(op.getState() == OperationState.COMPLETE || op.isCancelled())) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  @Override
+  public CollectionOperationStatus getOperationStatus() {
+    for (OperationStatus status : mergedOperationStatus) {
+      if (!status.isSuccess()) {
+        return new CollectionOperationStatus(status);
+      }
+    }
+    return new CollectionOperationStatus(true, "END", CollectionResponse.END);
+  }
+}

--- a/src/main/java/net/spy/memcached/internal/PipeOperationFuture.java
+++ b/src/main/java/net/spy/memcached/internal/PipeOperationFuture.java
@@ -22,7 +22,7 @@ public class PipeOperationFuture<T> extends CollectionFuture<T> {
 
   private final List<OperationStatus> mergedOperationStatus;
 
-  private final T rv;
+  private final T result;
 
   public PipeOperationFuture(CountDownLatch l, long opTimeout,
                              ConcurrentLinkedQueue<Operation> ops,
@@ -31,7 +31,7 @@ public class PipeOperationFuture<T> extends CollectionFuture<T> {
     super(l, opTimeout);
     this.ops = ops;
     this.mergedOperationStatus = mergedOperationStatus;
-    this.rv = mergedResult;
+    this.result = mergedResult;
   }
 
   @Override
@@ -64,7 +64,7 @@ public class PipeOperationFuture<T> extends CollectionFuture<T> {
         throw new ExecutionException(new RuntimeException(op.getCancelCause()));
       }
     }
-    return rv;
+    return result;
   }
 
   @Override


### PR DESCRIPTION
- https://github.com/jam2in/arcus-works/issues/345 관련 PR입니다.
- timeout 처리를 하는 공통 중복 로직을 메서드화 시켰습니다.
- 우선 노드당 op가 하나씩 들어가는 부분만 메서드화 하였습니다.
- checkedTimeOutHandlerByOp()는 CheckedOperationTimeoutException 발생시킵니다.
- uncheckedTimeOutHandlerByOp()는 OperationTimeoutException 발생시킵니다.
- 남은 작업들은 bulk와 piped 연산의 timeout 로직 메서드화 처리입니다.
- 진행 여부 검토 부탁드립니다