### PR TITLE
ENHANCE: Optimize groupingKeys() logic

### DIFF
--- a/src/test/manual/net/spy/memcached/btreesmget/SMGetErrorTest.java
+++ b/src/test/manual/net/spy/memcached/btreesmget/SMGetErrorTest.java
@@ -457,7 +457,7 @@ public class SMGetErrorTest extends BaseIntegrationTest {
       mc.asyncBopSortMergeGet(null, 10, 0, ElementFlagFilter.DO_NOT_FILTER, -1, 10);
       fail("This should be an exception");
     } catch (Exception e) {
-      assertEquals("Key list is empty.", e.getMessage());
+      assertEquals("Key list is null.", e.getMessage());
     }
 
     // keylist is empty

--- a/src/test/manual/net/spy/memcached/collection/btree/BopGetBulkTest.java
+++ b/src/test/manual/net/spy/memcached/collection/btree/BopGetBulkTest.java
@@ -243,10 +243,14 @@ public class BopGetBulkTest extends BaseIntegrationTest {
       CollectionGetBulkFuture<Map<String, BTreeGetResult<Long, Object>>> f = null;
 
       // empty key list
-      f = mc.asyncBopGetBulk(new ArrayList<String>(), 0, 10,
-              ElementFlagFilter.DO_NOT_FILTER, 0, 10);
-      results = f.get(1000L, TimeUnit.MILLISECONDS);
-      Assert.assertEquals(0, results.size());
+      try {
+        f = mc.asyncBopGetBulk(new ArrayList<String>(), 0, 10,
+                ElementFlagFilter.DO_NOT_FILTER, 0, 10);
+        results = f.get(1000L, TimeUnit.MILLISECONDS);
+      } catch (IllegalArgumentException e) {
+        // test success
+        Assert.assertEquals("Key list is empty.", e.getMessage());
+      }
 
       // max count list
       try {

--- a/src/test/manual/net/spy/memcached/collection/btree/longbkey/BopGetBulkTest.java
+++ b/src/test/manual/net/spy/memcached/collection/btree/longbkey/BopGetBulkTest.java
@@ -266,10 +266,14 @@ public class BopGetBulkTest extends BaseIntegrationTest {
       CollectionGetBulkFuture<Map<String, BTreeGetResult<ByteArrayBKey, Object>>> f = null;
 
       // empty key list
-      f = mc.asyncBopGetBulk(new ArrayList<String>(), new byte[]{0},
-              new byte[]{10}, ElementFlagFilter.DO_NOT_FILTER, 0, 10);
-      results = f.get(1000L, TimeUnit.MILLISECONDS);
-      Assert.assertEquals(0, results.size());
+      try {
+        f = mc.asyncBopGetBulk(new ArrayList<String>(), new byte[]{0},
+                new byte[]{10}, ElementFlagFilter.DO_NOT_FILTER, 0, 10);
+        results = f.get(1000L, TimeUnit.MILLISECONDS);
+      } catch (IllegalArgumentException e) {
+        // test success
+        Assert.assertEquals("Key list is empty.", e.getMessage());
+      }
 
       // max key list
       try {


### PR DESCRIPTION
### 작업 개요
- 해당 이슈와 관련하여 작업했습니다.  https://github.com/jam2in/arcus-works/issues/380
- 아래 로직을 `validateKeys(keyList)`로 치환하게 되면 null 검사 뿐만아니라 empty 검사를 함께 수행합니다.
```java
if (keyList == null) {
      throw new IllegalArgumentException("Key list is null.");
    }
```
- 만약 empty 검사를 하지 않으면 groupingKeys() 메서드 내에서 for Loop을 돌지 않아 **empty Collection을 반환**하게 됩니다.

### 변경 사항
- 기존에는 List<String> keyList가 empty로 들어올 경우 예외를 발생 시키지 않고 size 0인 컬렉션을 반환했습니다.
- 저는 해당 사항 또한 예외를 통해 사용자에게 상황을 알려줘야한다고 생각하여 empty check를 수행했습니다.
- ~~List<String> 요소가 Duplication인 경우는 기존에는 예외를 발생시켰는데 저는 자동으로 중복 요소를 걸러서 연산을 진행하도록 변경했습니다.~~
- 위 두 사항으로 인해 일부 테스트 코드에 변경이 있었습니다.
- 위 두 가지 부분에 대해서 의견 부탁드립니다.