### PR TITLE
INTERNAL: Use last nodes change.

### DIFF
--- a/src/main/java/net/spy/memcached/CacheManager.java
+++ b/src/main/java/net/spy/memcached/CacheManager.java
@@ -469,7 +469,7 @@ public class CacheManager extends SpyThread implements Watcher,
 
     for (ArcusClient ac : client) {
       MemcachedConnection conn = ac.getMemcachedConnection();
-      conn.putNodesChangeQueue(addrs);
+      conn.setCacheNodesChange(addrs);
     }
   }
 
@@ -541,7 +541,7 @@ public class CacheManager extends SpyThread implements Watcher,
     } else {
       for (ArcusClient ac : client) {
         MemcachedConnection conn = ac.getMemcachedConnection();
-        conn.putAlterNodesChangeQueue(addrs);
+        conn.setAlterNodesChange(addrs);
       }
     }
     return true;

--- a/src/test/java/net/spy/memcached/MemcachedConnectionTest.java
+++ b/src/test/java/net/spy/memcached/MemcachedConnectionTest.java
@@ -64,24 +64,28 @@ public class MemcachedConnectionTest extends TestCase {
 
   public void testNodesChangeQueue() throws Exception {
     // when
-    conn.putNodesChangeQueue("0.0.0.0:11211");
-    conn.putNodesChangeQueue("0.0.0.0:11211,0.0.0.0:11212,0.0.0.0:11213");
-    conn.putNodesChangeQueue("0.0.0.0:11212");
+    conn.setCacheNodesChange("0.0.0.0:11211");
 
     // 1st test (nodes=1)
-    conn.handleNodesChangeQueue();
+    conn.handleCacheNodesChange();
 
     // then
     assertTrue(1 == locator.getAll().size());
 
+    // when
+    conn.setCacheNodesChange("0.0.0.0:11211,0.0.0.0:11212,0.0.0.0:11213");
+
     // 2nd test (nodes=3)
-    conn.handleNodesChangeQueue();
+    conn.handleCacheNodesChange();
 
     // then
     assertTrue(3 == locator.getAll().size());
 
+    // when
+    conn.setCacheNodesChange("0.0.0.0:11212");
+
     // 3rd test (nodes=1)
-    conn.handleNodesChangeQueue();
+    conn.handleCacheNodesChange();
 
     // then
     assertTrue(1 == locator.getAll().size());
@@ -92,7 +96,7 @@ public class MemcachedConnectionTest extends TestCase {
     // on servers in the queue
 
     // test
-    conn.handleNodesChangeQueue();
+    conn.handleCacheNodesChange();
 
     // then
     assertTrue(0 == locator.getAll().size());
@@ -101,10 +105,10 @@ public class MemcachedConnectionTest extends TestCase {
   public void testNodesChangeQueue_invalid_addr() {
     try {
       // when : putting an invalid address
-      conn.putNodesChangeQueue("");
+      conn.setCacheNodesChange("");
 
       // test
-      conn.handleNodesChangeQueue();
+      conn.handleCacheNodesChange();
 
       // should not be here!
       //fail();
@@ -116,10 +120,10 @@ public class MemcachedConnectionTest extends TestCase {
 
   public void testNodesChangeQueue_redundent() throws Exception {
     // when
-    conn.putNodesChangeQueue("0.0.0.0:11211,0.0.0.0:11211");
+    conn.setCacheNodesChange("0.0.0.0:11211,0.0.0.0:11211");
 
     // test
-    conn.handleNodesChangeQueue();
+    conn.handleCacheNodesChange();
 
     // then
     assertTrue(2 == locator.getAll().size());
@@ -127,11 +131,11 @@ public class MemcachedConnectionTest extends TestCase {
 
   public void testNodesChangeQueue_twice() throws Exception {
     // when
-    conn.putNodesChangeQueue("0.0.0.0:11211");
-    conn.putNodesChangeQueue("0.0.0.0:11211");
+    conn.setCacheNodesChange("0.0.0.0:11211");
+    conn.setCacheNodesChange("0.0.0.0:11211");
 
     // test
-    conn.handleNodesChangeQueue();
+    conn.handleCacheNodesChange();
 
     // then
     assertTrue(1 == locator.getAll().size());


### PR DESCRIPTION
- https://github.com/jam2in/arcus-works/issues/378
- 위 이슈와 관련된 사전 PR 입니다.
- cache_list와 alter_list의 변경 사항을 Queue로 관리하지 않고 마지막 변경 사항만 적용하도록 수정했습니다.
- 이번 PR을 먼저 하는 것은 처음에 설계할 때 Queue로 관리하지 않고 마지막 변경 사항만 적용하도록 했기 때문입니다.