### PR TITLE
CLEANUP: Refactor CollectionFutrue to extend OperationFuture

### DIFF
--- a/src/main/java/net/spy/memcached/internal/BTreeStoreAndGetFuture.java
+++ b/src/main/java/net/spy/memcached/internal/BTreeStoreAndGetFuture.java
@@ -43,7 +43,7 @@ public class BTreeStoreAndGetFuture<T, E> extends CollectionFuture<T> {
 
   public void set(T o, CollectionOperationStatus status) {
     objRef.set(o);
-    opStatus = status;
+    collectionOpStatus = status;
   }
 
   public Element<E> getElement() {

--- a/src/main/java/net/spy/memcached/internal/OperationFuture.java
+++ b/src/main/java/net/spy/memcached/internal/OperationFuture.java
@@ -41,10 +41,10 @@ import net.spy.memcached.ops.StatusCode;
 public class OperationFuture<T> extends SpyObject implements Future<T> {
 
   protected final CountDownLatch latch;
-  private final AtomicReference<T> objRef;
+  protected final AtomicReference<T> objRef;
   protected OperationStatus status;
-  private final long timeout;
-  private Operation op;
+  protected final long timeout;
+  protected Operation op;
 
   public OperationFuture(CountDownLatch l, long opTimeout) {
     this(l, new AtomicReference<T>(null), opTimeout);
@@ -55,7 +55,6 @@ public class OperationFuture<T> extends SpyObject implements Future<T> {
     super();
     latch = l;
     objRef = oref;
-    status = null;
     timeout = opTimeout;
   }
 


### PR DESCRIPTION
- CollectionFuture가 OperationFuture을 상속받도록 구조를 변경하는 PR입니다.
- https://github.com/jam2in/arcus-works/issues/403 해당 이슈와 관련된 PR입니다.