### PR TITLE
INTERNAL: Changed the usage and implementation of BulkOperationFuture.

### DIFF
--- a/src/main/java/net/spy/memcached/MemcachedClient.java
+++ b/src/main/java/net/spy/memcached/MemcachedClient.java
@@ -366,6 +366,13 @@ public class MemcachedClient extends SpyThread
     return op;
   }
 
+  protected void addOpMap(final Map<String, Operation> opMap) {
+    checkState();
+    for (Map.Entry<String, Operation> me : opMap.entrySet()) {
+      conn.addOperation(me.getKey(), me.getValue());
+    }
+  }
+
   protected CountDownLatch broadcastOp(final BroadcastOpFactory of) {
     return broadcastOp(of, conn.getLocator().getAll(), true);
   }


### PR DESCRIPTION
https://github.com/jam2in/arcus-works/issues/403 기반 PR입니다.
## 작업 내용
1. 아래의 연산들을 asyncStore api와 내부 로직이 일관되도록 변경
    - asyncSetBulk(2개)
    - asyncStoreBulk(2개)
    - asyncDeleteBulk
2. 변경된 내부 로직은 다음과 같다.
    - 변경 전 : api 호출 -> return문과 동시에 future 생성자 호출 -> future의 생성자에서 createOp()를 통해 op 인스턴스들 생성
    - 변경 후 : api 호출 -> future 생성 -> api 내부 로직에서 op 인스턴스들 생성 -> return future
3. 위 작업에 의해 BulkOperationFutrue가 추상 클래스에서 일반 클래스로 변경됨
    - 추상 메서드인 createOp()가 없어지고 기존의 createOp()의 로직은 위 api 함수들의 내부 로직으로 이전시킴