### PR TITLE
FIX: getOperationStatus method in asyncCollectionPipedInsert/Update.

### DIFF
--- a/src/main/java/net/spy/memcached/ArcusClient.java
+++ b/src/main/java/net/spy/memcached/ArcusClient.java
@@ -952,8 +952,8 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
 
     final CountDownLatch latch = new CountDownLatch(updateList.size());
 
-    final List<OperationStatus> mergedOperationStatus = Collections
-            .synchronizedList(new ArrayList<OperationStatus>(updateList.size()));
+    final List<CollectionOperationStatus> mergedOperationStatus = Collections
+            .synchronizedList(new ArrayList<CollectionOperationStatus>(updateList.size()));
 
     final Map<Integer, CollectionOperationStatus> mergedResult =
         new ConcurrentHashMap<Integer, CollectionOperationStatus>();
@@ -1058,9 +1058,9 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
 
       @Override
       public CollectionOperationStatus getOperationStatus() {
-        for (OperationStatus status : mergedOperationStatus) {
+        for (CollectionOperationStatus status : mergedOperationStatus) {
           if (!status.isSuccess()) {
-            return new CollectionOperationStatus(status);
+            return status;
           }
         }
         return new CollectionOperationStatus(true, "END", CollectionResponse.END);
@@ -3907,8 +3907,8 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
 
     final CountDownLatch latch = new CountDownLatch(insertList.size());
 
-    final List<OperationStatus> mergedOperationStatus = Collections
-            .synchronizedList(new ArrayList<OperationStatus>(insertList.size()));
+    final List<CollectionOperationStatus> mergedOperationStatus = Collections
+            .synchronizedList(new ArrayList<CollectionOperationStatus>(insertList.size()));
 
     final Map<Integer, CollectionOperationStatus> mergedResult =
         new ConcurrentHashMap<Integer, CollectionOperationStatus>();
@@ -4012,9 +4012,9 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
 
       @Override
       public CollectionOperationStatus getOperationStatus() {
-        for (OperationStatus status : mergedOperationStatus) {
+        for (CollectionOperationStatus status : mergedOperationStatus) {
           if (!status.isSuccess()) {
-            return new CollectionOperationStatus(status);
+            return status;
           }
         }
         return new CollectionOperationStatus(true, "END", CollectionResponse.END);


### PR DESCRIPTION
https://github.com/naver/arcus-java-client/pull/619
로부터 파생된 PR입니다.
piped 연산에서 getOperationStatus의 로직을 수정했습니다.