### PR TITLE
TEST: change python install script in ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,9 +21,9 @@ jobs:
         cache: 'maven'
     - name: Setup Python
       id: setup_python
-      uses: actions/setup-python@v3
+      uses: MatteoH2O1999/setup-python@v1
       with:
-        python-version: 2.7
+        python-version: '2.7'
     - name: Caching PIP
       id: python_cache
       uses: actions/cache@v3


### PR DESCRIPTION
https://github.com/jam2in/arcus-works/issues/417 이슈에 대한 PR입니다.

기존의 actions/setup-python@v3가 더이상 python2에 대한 지원을 하지 않아
이를 MatteoH2O1999/setup-python@v1으로 변경했습니다.

우선 CI 검사를 위해 위 action을 사용합니다.

추후 python2 자체를 memcached 레포에 넣어 이로부터 python2를 설치하는 작업이 필요할 것 같습니다.