### PR TITLE
FIX: Element sequence when using asyncLopInsert api.

### DIFF
--- a/src/main/java/net/spy/memcached/collection/CollectionPipedInsert.java
+++ b/src/main/java/net/spy/memcached/collection/CollectionPipedInsert.java
@@ -90,7 +90,11 @@ public abstract class CollectionPipedInsert<T> extends CollectionPipe {
           CollectionCreate.makeCreateClause(attribute, cd.getFlags()) : "";
       for (int i = this.nextOpIndex; i < eSize; i++) {
         byte[] each = encodedList.get(i);
-        setArguments(bb, COMMAND, key, index, each.length,
+        int eIndex = index;
+        if (index >= 0) {
+          eIndex += i;
+        }
+        setArguments(bb, COMMAND, key, eIndex, each.length,
                      createOption, (i < eSize - 1) ? PIPE : "");
         bb.put(each);
         bb.put(CRLF);

--- a/src/test/manual/net/spy/memcached/emptycollection/PipedBulkInsertListWithAttrTest.java
+++ b/src/test/manual/net/spy/memcached/emptycollection/PipedBulkInsertListWithAttrTest.java
@@ -56,7 +56,7 @@ public class PipedBulkInsertListWithAttrTest extends BaseIntegrationTest {
       attr.setMaxCount(3333);
 
       List<Object> valueList = new ArrayList<Object>();
-      for (int i = 1; i < 11; i++) {
+      for (int i = 1; i <= 10; i++) {
         valueList.add(i);
       }
 
@@ -74,7 +74,7 @@ public class PipedBulkInsertListWithAttrTest extends BaseIntegrationTest {
       // check values
       List<Object> list2 = mc.asyncLopGet(KEY, 0, 10, false, false).get();
       for (int i = 0; i < list2.size(); i++) {
-        Assert.assertEquals(10 - i, list2.get(i));
+        Assert.assertEquals(i +  1, list2.get(i));
       }
 
       // check expire time
@@ -96,7 +96,7 @@ public class PipedBulkInsertListWithAttrTest extends BaseIntegrationTest {
       CollectionAttributes attr = new CollectionAttributes();
 
       List<Object> valueList = new ArrayList<Object>();
-      for (int i = 1; i < 11; i++) {
+      for (int i = 1; i <= 10; i++) {
         valueList.add(i);
       }
 
@@ -114,7 +114,7 @@ public class PipedBulkInsertListWithAttrTest extends BaseIntegrationTest {
       // check values
       List<Object> list2 = mc.asyncLopGet(KEY, 0, 10, false, false).get();
       for (int i = 0; i < list2.size(); i++) {
-        Assert.assertEquals(10 - i, list2.get(i));
+        Assert.assertEquals(i +  1, list2.get(i));
       }
     } catch (Exception e) {
       e.printStackTrace();
@@ -128,7 +128,7 @@ public class PipedBulkInsertListWithAttrTest extends BaseIntegrationTest {
       Assert.assertNull(mc.asyncGetAttr(KEY).get());
 
       List<Object> valueList = new ArrayList<Object>();
-      for (int i = 1; i < 11; i++) {
+      for (int i = 1; i <= 10; i++) {
         valueList.add(i);
       }
 
@@ -147,7 +147,7 @@ public class PipedBulkInsertListWithAttrTest extends BaseIntegrationTest {
       // check values
       List<Object> list2 = mc.asyncLopGet(KEY, 0, 10, false, false).get();
       for (int i = 0; i < list2.size(); i++) {
-        Assert.assertEquals(10 - i, list2.get(i));
+        Assert.assertEquals(i +  1, list2.get(i));
       }
     } catch (Exception e) {
       e.printStackTrace();


### PR DESCRIPTION
## 현재 문제점
아래 예는 [A,E] 리스트에 [B,C,D] 리스트의 elements를 
`asyncLopPipedInsertBulk(Key, 1, elements, attr)` API로 삽입할 경우의 결과입니다.
현재 동작은 고정된 index 값을 사용하여 의도하지 않은 결과를 만듭니다.
따라서, 이를 수정하여 아래의 변경 후 동작의 결과로 만들고자 합니다.
```
// 현재 동작
[A,E] -> [A,D,C,B,E]
// 변경 후 동작
[A,E] -> [A,B,C,D,E]
```

### 변경사항
1. CollectionPipedInsert.java에서 서버에 요청을 보낼 때 사용되는 index값을 1 증가 시킴으로서 해결하였습니다.
2. PipeInsertTest.java에 요소들의 Index에 대한 test case 추가하였습니다.
3. PipeBulkInsertListWithAttrTest.java의 테스트 내용 변경하였습니다.
4. PipeBulkInsertSetWithAttrTest.java의 경우 PipeBulkInsertListWithAttrTest와 동일한 테스트를 수행하고 있어서 Set Api를 사용하도록 변경하였습니다.