### PR TITLE
ENHANCE: Modify decoding logic in collection get api.

### DIFF
--- a/src/main/java/net/spy/memcached/CachedData.java
+++ b/src/main/java/net/spy/memcached/CachedData.java
@@ -16,24 +16,38 @@ public final class CachedData {
 
   private final int flags;
   private final byte[] data;
+  private byte[] eFlag;
 
   /**
    * Get a CachedData instance for the given flags and byte array.
    *
-   * @param f        the flags
-   * @param d        the data
-   * @param max_size the maximum allowable size.
+   * @param flags       the flags
+   * @param data        the data
+   * @param max_size    the maximum allowable size.
    */
-  public CachedData(int f, byte[] d, int max_size) {
+  public CachedData(int flags, byte[] data, int max_size) {
     super();
-    if (d.length > max_size) {
+    if (data.length > max_size) {
       throw new IllegalArgumentException(
               "Cannot cache data larger than " + max_size
                       + " bytes (you tried to cache a "
-                      + d.length + " byte object)");
+                      + data.length + " byte object)");
     }
-    flags = f;
-    data = d;
+    this.flags = flags;
+    this.data = data;
+  }
+
+  /**
+   * Get a CachedData instance for the given flags and byte array.
+   *
+   * @param flag        the flags
+   * @param data        the data
+   * @param eFlag       the eFlag
+   * @param max_size    the maximum allowable size.
+   */
+  public CachedData(int flag, byte[] data, byte[] eFlag, int max_size) {
+    this(flag, data, max_size);
+    this.eFlag = eFlag;
   }
 
   /**
@@ -50,9 +64,14 @@ public final class CachedData {
     return flags;
   }
 
+  public byte[] getEFlag() {
+    return eFlag;
+  }
+
   @Override
   public String toString() {
-    return "{CachedData flags=" + flags + " data="
-            + Arrays.toString(data) + "}";
+    return "{CachedData flags=" + flags +
+            " data=" + Arrays.toString(data) +
+            " eFlag=" + Arrays.toString(eFlag) + " }";
   }
 }

--- a/src/main/java/net/spy/memcached/internal/CollectionGetFuture.java
+++ b/src/main/java/net/spy/memcached/internal/CollectionGetFuture.java
@@ -1,0 +1,27 @@
+package net.spy.memcached.internal;
+
+import net.spy.memcached.ops.CollectionGetOperation.Callback;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+public class CollectionGetFuture<T> extends CollectionFuture<T> {
+
+  public CollectionGetFuture(CountDownLatch l, long opTimeout) {
+    super(l, opTimeout);
+  }
+
+  @Override
+  public T get(long duration, TimeUnit units)
+          throws InterruptedException, TimeoutException, ExecutionException {
+
+    T result = super.get(duration, units);
+    if (result != null) {
+      Callback callback = (Callback) op.getCallback();
+      callback.addResult();
+    }
+    return result;
+  }
+}

--- a/src/main/java/net/spy/memcached/ops/CollectionGetOperation.java
+++ b/src/main/java/net/spy/memcached/ops/CollectionGetOperation.java
@@ -27,6 +27,7 @@ public interface CollectionGetOperation extends KeyedOperation {
 
   interface Callback extends OperationCallback {
     void gotData(String subkey, int flags, byte[] data, byte[] eflag);
+    void addResult();
   }
 
 }

--- a/src/test/java/net/spy/memcached/transcoders/CachedDataTest.java
+++ b/src/test/java/net/spy/memcached/transcoders/CachedDataTest.java
@@ -12,7 +12,7 @@ public class CachedDataTest extends TestCase {
   public void testToString() throws Exception {
     String exp = "{CachedData flags=13 data=[84, 104, 105, 115, 32, 105, "
             + "115, 32, 97, 32, 115, 105, 109, 112, 108, 101, 32, 116, 101, "
-            + "115, 116, 32, 115, 116, 114, 105, 110, 103, 46]}";
+            + "115, 116, 32, 115, 116, 114, 105, 110, 103, 46] eFlag=null }";
     CachedData cd = new CachedData(13,
             "This is a simple test string.".getBytes("UTF-8"),
             CachedData.MAX_SIZE);

--- a/src/test/manual/net/spy/memcached/MultibyteKeyTest.java
+++ b/src/test/manual/net/spy/memcached/MultibyteKeyTest.java
@@ -176,6 +176,10 @@ public class MultibyteKeyTest {
         @Override
         public void complete() {
         }
+
+        @Override
+        public void addResult() {
+        }
       }).initialize();
     } catch (java.nio.BufferOverflowException e) {
       Assert.fail();
@@ -434,6 +438,10 @@ public class MultibyteKeyTest {
 
             @Override
             public void complete() {
+            }
+
+            @Override
+            public void addResult() {
             }
           }).initialize();
     } catch (java.nio.BufferOverflowException e) {


### PR DESCRIPTION
## 관련 이슈
https://github.com/jam2in/arcus-works/issues/406

## 변경사항
### 구현 로직
기존에는 collection get을 호출할 경우 decode 로직이 IO 쓰레드에서 수행됩니다.
이러한 decode 로직을 appilcation의 Worker 쓰레드에서 수행하도록 변경하였습니다.

응용이 get()을 호출할 경우 decode를 진행하는 로직으로 변경하였습니다.
변경된 로직은 아래와 같은 절차를 거칩니다.

1. 응용에서 collection get api 호출한다.
2. api 내에서 CollectionGetFuture 생성을 하고 decode 수행에 필요한 TransCoder 주입한다.
3. IO 쓰레드에 의해 callback 함수 gotData() 호출되고 decode 시 필요한 CachedData 인스턴스를 생성하고 이를 CollectionGetFuture 인스턴스에 put 또는 add한다.
4. 응용은 리턴 받은 CollectionFuture의 get() 함수를 호출한다.
5. CollectionGetFuture의 get()이 호출되면 super class로부터 collection의 타입에 맞게 리턴할 value를 받아온다. 이후 tc.decode()를 수행한다. 그 결과로 나온 T타입의 객체를 결과 value(list, map, set 중 하나)에 추가하고 사용자에게 value를 리턴한다.


### CollectionGetFuture의 Inner 클래스
기존 PR에서는 CollectionGetFuture 내에서 분기 처리를 통해
Lop,Sop,Bop,Mop를 구별하여 처리해주었습니다.
하지만 이는 코드를 읽기 쉽지 않아서
CollectionGetFuture 내부에 4가지의 inner 클래스를 정의하는 방식으로 변경하였습니다.

### BTreeGet과 CollectionGet 클래스 변경 이유
기존로직은 gotData 메서드에서 Element 인스턴스를 생성하였기 때문에 B Tree 요소마다 각기 다른 값일 수도 있는 EFlag를 저장할 필요가 없었습니다.
하지만 변경된 로직은 gotData에서 decode를 하지 않고 Element도 생성하지 않습니다.
**결론적으로 collectionGet에 저장되는 요소들의 EFlag 값들을 리스트의 요소 형태로 저장해두고 추후에 Element 인스턴스를 생성하기위해 이를 사용**해야합니다.
`testMultipleLongBkeyWithEFlag` 테스트 케이스를 보시면 쉽게 이해할 수 있습니다.

