### PR TITLE
ENHANCE: Remove repeating encode logic in CollectionBulkInsert.

### DIFF
--- a/src/main/java/net/spy/memcached/ArcusClient.java
+++ b/src/main/java/net/spy/memcached/ArcusClient.java
@@ -3886,9 +3886,13 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
     List<CollectionBulkInsert<T>> insertList = new ArrayList<CollectionBulkInsert<T>>(
             arrangedKey.size());
 
+    CachedData insertValue = tc.encode(value);
+
     for (Entry<MemcachedNode, List<String>> entry : arrangedKey) {
       insertList.add(new CollectionBulkInsert.BTreeBulkInsert<T>(
-          entry.getKey(), entry.getValue(), bkey, eFlag, value, attributesForCreate, tc));
+              entry.getKey(), entry.getValue(),
+              String.valueOf(bkey), BTreeUtil.toHex(eFlag),
+              insertValue, attributesForCreate));
     }
 
     return asyncCollectionInsertBulk2(insertList);
@@ -3915,9 +3919,13 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
     List<CollectionBulkInsert<T>> insertList = new ArrayList<CollectionBulkInsert<T>>(
             arrangedKey.size());
 
+    CachedData insertValue = tc.encode(value);
+
     for (Entry<MemcachedNode, List<String>> entry : arrangedKey) {
       insertList.add(new CollectionBulkInsert.BTreeBulkInsert<T>(
-          entry.getKey(), entry.getValue(), bkey, eFlag, value, attributesForCreate, tc));
+              entry.getKey(), entry.getValue(),
+              BTreeUtil.toHex(bkey), BTreeUtil.toHex(eFlag),
+              insertValue, attributesForCreate));
     }
 
     return asyncCollectionInsertBulk2(insertList);
@@ -3945,9 +3953,12 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
     List<CollectionBulkInsert<T>> insertList = new ArrayList<CollectionBulkInsert<T>>(
             arrangedKey.size());
 
+    CachedData insertValue = tc.encode(value);
+
     for (Entry<MemcachedNode, List<String>> entry : arrangedKey) {
-      insertList.add(new CollectionBulkInsert.MapBulkInsert<T>(entry.getKey(),
-            entry.getValue(), mkey, value, attributesForCreate, tc));
+      insertList.add(new CollectionBulkInsert.MapBulkInsert<T>(
+              entry.getKey(), entry.getValue(),
+              mkey, insertValue, attributesForCreate));
     }
 
     return asyncCollectionInsertBulk2(insertList);
@@ -3973,9 +3984,12 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
     List<CollectionBulkInsert<T>> insertList = new ArrayList<CollectionBulkInsert<T>>(
             arrangedKey.size());
 
+    CachedData insertValue = tc.encode(value);
+
     for (Entry<MemcachedNode, List<String>> entry : arrangedKey) {
-      insertList.add(new CollectionBulkInsert.SetBulkInsert<T>(entry.getKey(),
-            entry.getValue(), value, attributesForCreate, tc));
+      insertList.add(new CollectionBulkInsert.SetBulkInsert<T>(
+              entry.getKey(), entry.getValue(),
+              insertValue, attributesForCreate));
     }
 
     return asyncCollectionInsertBulk2(insertList);
@@ -4001,9 +4015,12 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
     List<CollectionBulkInsert<T>> insertList = new ArrayList<CollectionBulkInsert<T>>(
             arrangedKey.size());
 
+    CachedData insertValue = tc.encode(value);
+
     for (Entry<MemcachedNode, List<String>> entry : arrangedKey) {
-      insertList.add(new CollectionBulkInsert.ListBulkInsert<T>(entry.getKey(),
-            entry.getValue(), index, value, attributesForCreate, tc));
+      insertList.add(new CollectionBulkInsert.ListBulkInsert<T>(
+              entry.getKey(), entry.getValue(),
+              index, insertValue, attributesForCreate));
     }
 
     return asyncCollectionInsertBulk2(insertList);

--- a/src/main/java/net/spy/memcached/collection/CollectionBulkInsert.java
+++ b/src/main/java/net/spy/memcached/collection/CollectionBulkInsert.java
@@ -24,23 +24,21 @@ import java.util.List;
 import net.spy.memcached.CachedData;
 import net.spy.memcached.KeyUtil;
 import net.spy.memcached.MemcachedNode;
-import net.spy.memcached.transcoders.Transcoder;
-import net.spy.memcached.util.BTreeUtil;
 
 public abstract class CollectionBulkInsert<T> extends CollectionPipe {
 
   protected final MemcachedNode node;
   protected final List<String> keyList;
-  protected final CollectionAttributes attribute;
   protected final CachedData cachedData;
+  protected final CollectionAttributes attribute;
 
   protected CollectionBulkInsert(MemcachedNode node, List<String> keyList,
-                                 CollectionAttributes attribute, CachedData cachedData) {
+                                 CachedData cachedData, CollectionAttributes attribute) {
     super(keyList.size());
     this.node = node;
     this.keyList = keyList;
-    this.attribute = attribute;
     this.cachedData = cachedData;
+    this.attribute = attribute;
   }
 
   public String getKey(int index) {
@@ -68,19 +66,9 @@ public abstract class CollectionBulkInsert<T> extends CollectionPipe {
     private final String bkey;
     private final String eflag;
 
-    public BTreeBulkInsert(MemcachedNode node, List<String> keyList, Long bkey,
-                           byte[] eflag, T value, CollectionAttributes attr, Transcoder<T> tc) {
-      this(node, keyList, String.valueOf(bkey), BTreeUtil.toHex(eflag), attr, tc.encode(value));
-    }
-
-    public BTreeBulkInsert(MemcachedNode node, List<String> keyList, byte[] bkey,
-                           byte[] eflag, T value, CollectionAttributes attr, Transcoder<T> tc) {
-      this(node, keyList, BTreeUtil.toHex(bkey), BTreeUtil.toHex(eflag), attr, tc.encode(value));
-    }
-
-    protected BTreeBulkInsert(MemcachedNode node, List<String> keyList, String bkey,
-                              String eflag, CollectionAttributes attr, CachedData cachedData) {
-      super(node, keyList, attr, cachedData);
+    public BTreeBulkInsert(MemcachedNode node, List<String> keyList, String bkey,
+                              String eflag, CachedData cachedData, CollectionAttributes attr) {
+      super(node, keyList, cachedData, attr);
       if (attr != null) { /* item creation option */
         CollectionCreate.checkOverflowAction(CollectionType.btree, attr.getOverflowAction());
       }
@@ -125,7 +113,7 @@ public abstract class CollectionBulkInsert<T> extends CollectionPipe {
     @Override
     public CollectionBulkInsert<T> clone(MemcachedNode node,
                                          List<String> keyList) {
-      return new BTreeBulkInsert<T>(node, keyList, bkey, eflag, attribute, cachedData);
+      return new BTreeBulkInsert<T>(node, keyList, bkey, eflag, cachedData, attribute);
     }
   }
 
@@ -135,13 +123,8 @@ public abstract class CollectionBulkInsert<T> extends CollectionPipe {
     private final String mkey;
 
     public MapBulkInsert(MemcachedNode node, List<String> keyList, String mkey,
-                         T value, CollectionAttributes attr, Transcoder<T> tc) {
-      this(node, keyList, mkey, attr, tc.encode(value));
-    }
-
-    protected MapBulkInsert(MemcachedNode node, List<String> keyList, String mkey,
-                            CollectionAttributes attr, CachedData cachedData) {
-      super(node, keyList, attr, cachedData);
+                         CachedData cachedData, CollectionAttributes attr) {
+      super(node, keyList, cachedData, attr);
       if (attr != null) { /* item creation option */
         CollectionCreate.checkOverflowAction(CollectionType.map, attr.getOverflowAction());
       }
@@ -184,7 +167,7 @@ public abstract class CollectionBulkInsert<T> extends CollectionPipe {
     @Override
     public CollectionBulkInsert<T> clone(MemcachedNode node,
                                          List<String> keyList) {
-      return new MapBulkInsert<T>(node, keyList, mkey, attribute, cachedData);
+      return new MapBulkInsert<T>(node, keyList, mkey, cachedData, attribute);
     }
   }
 
@@ -192,14 +175,9 @@ public abstract class CollectionBulkInsert<T> extends CollectionPipe {
 
     private static final String COMMAND = "sop insert";
 
-    public SetBulkInsert(MemcachedNode node, List<String> keyList, T value,
-                         CollectionAttributes attr, Transcoder<T> tc) {
-      this(node, keyList, attr, tc.encode(value));
-    }
-
-    protected SetBulkInsert(MemcachedNode node, List<String> keyList,
-                            CollectionAttributes attr, CachedData cachedData) {
-      super(node, keyList, attr, cachedData);
+    public SetBulkInsert(MemcachedNode node, List<String> keyList,
+                         CachedData cachedData, CollectionAttributes attr) {
+      super(node, keyList, cachedData, attr);
       if (attr != null) { /* item creation option */
         CollectionCreate.checkOverflowAction(CollectionType.set, attr.getOverflowAction());
       }
@@ -239,7 +217,7 @@ public abstract class CollectionBulkInsert<T> extends CollectionPipe {
     @Override
     public CollectionBulkInsert<T> clone(MemcachedNode node,
                                          List<String> keyList) {
-      return new SetBulkInsert<T>(node, keyList, attribute, cachedData);
+      return new SetBulkInsert<T>(node, keyList, cachedData, attribute);
     }
   }
 
@@ -249,13 +227,8 @@ public abstract class CollectionBulkInsert<T> extends CollectionPipe {
     private final int index;
 
     public ListBulkInsert(MemcachedNode node, List<String> keyList, int index,
-                          T value, CollectionAttributes attr, Transcoder<T> tc) {
-      this(node, keyList, index, attr, tc.encode(value));
-    }
-
-    protected ListBulkInsert(MemcachedNode node, List<String> keyList, int index,
-                             CollectionAttributes attr, CachedData cachedData) {
-      super(node, keyList, attr, cachedData);
+                          CachedData cachedData, CollectionAttributes attr) {
+      super(node, keyList, cachedData, attr);
       if (attr != null) { /* item creation option */
         CollectionCreate.checkOverflowAction(CollectionType.list, attr.getOverflowAction());
       }
@@ -298,7 +271,7 @@ public abstract class CollectionBulkInsert<T> extends CollectionPipe {
     @Override
     public CollectionBulkInsert<T> clone(MemcachedNode node,
                                          List<String> keyList) {
-      return new ListBulkInsert<T>(node, keyList, index, attribute, cachedData);
+      return new ListBulkInsert<T>(node, keyList, index, cachedData, attribute);
     }
   }
 }

--- a/src/test/manual/net/spy/memcached/MultibyteKeyTest.java
+++ b/src/test/manual/net/spy/memcached/MultibyteKeyTest.java
@@ -76,6 +76,7 @@ import net.spy.memcached.transcoders.CollectionTranscoder;
 import net.spy.memcached.transcoders.IntegerTranscoder;
 import net.spy.memcached.transcoders.Transcoder;
 
+import net.spy.memcached.util.BTreeUtil;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -478,17 +479,18 @@ public class MultibyteKeyTest {
         };
 
     insert = new CollectionBulkInsert.BTreeBulkInsert<Integer>(null, keyList,
-        1L, new byte[]{0, 0}, new Random().nextInt(),
-        new CollectionAttributes(), new IntegerTranscoder());
+            String.valueOf(1L), BTreeUtil.toHex(new byte[]{0, 0}),
+            new IntegerTranscoder().encode(new Random().nextInt()),
+            new CollectionAttributes());
     try {
       opFact.collectionBulkInsert(insert, cbsCallback).initialize();
     } catch (java.nio.BufferOverflowException e) {
       Assert.fail();
     }
 
-    insert = new CollectionBulkInsert.ListBulkInsert<Integer>(null, keyList, 0,
-        new Random().nextInt(), new CollectionAttributes(),
-        new IntegerTranscoder());
+    insert = new CollectionBulkInsert.ListBulkInsert<Integer>(null, keyList,
+            0, new IntegerTranscoder().encode(new Random().nextInt()),
+            new CollectionAttributes());
 
     try {
       opFact.collectionBulkInsert(insert, cbsCallback).initialize();
@@ -497,8 +499,8 @@ public class MultibyteKeyTest {
     }
 
     insert = new CollectionBulkInsert.SetBulkInsert<Integer>(null, keyList,
-        new Random().nextInt(), new CollectionAttributes(),
-        new IntegerTranscoder());
+            new IntegerTranscoder().encode(new Random().nextInt()),
+            new CollectionAttributes());
     try {
       opFact.collectionBulkInsert(insert, cbsCallback).initialize();
     } catch (java.nio.BufferOverflowException e) {


### PR DESCRIPTION
## Motivation
기존의 CollectionBulkInsert 연산은 수행 시 
**복수개의 Collection에 동일한 value를 Insert해주는 연산**이다.
위 로직을 수행할 때 추가할 value를 
Insert할 대상(CollectionBulkInsert) **객체를 만들 때마다 encode해주는 로직이 존재**한다.
**즉, 필요없는 다수의 `tc.encode()` 로직이 응용의 worker thread에서 발생**한다.

## 변경 로직
api마다 `insertValue`라는 값을 한번의 `tc.encode(value)`를 통해 얻어낸다.
이후 `insertValue`를 `CollectionBulkInsert`의 생성자의 인수로 사용한다.
(기존에는 tc와 value가 인수로 사용되었다.)
async(Sop,Lop,Mop,Bop)InsertBulk api 4가지 모두 한번의 endcode만 수행하도록 변경한다.
Bop의 경우는 bKey의 형태에 때문에 두 가지 변경지점이 발생한다.

추가적으로 테스트 코드 통과를 위한 테스트코드 변경도 일부 존재합니다.