### PR TITLE
FIX: change cancel method logic in OperationFuture.

### DIFF
--- a/src/main/java/net/spy/memcached/internal/OperationFuture.java
+++ b/src/main/java/net/spy/memcached/internal/OperationFuture.java
@@ -60,10 +60,11 @@ public class OperationFuture<T> extends SpyObject implements Future<T> {
 
   public boolean cancel(boolean ign) {
     assert op != null : "No operation";
+    if (op.getState() == OperationState.COMPLETE) {
+      return false;
+    }
     op.cancel("by application.");
-    // This isn't exactly correct, but it's close enough.  If we're in
-    // a writing state, we *probably* haven't started.
-    return op.getState() == OperationState.WRITE_QUEUED;
+    return true;
   }
 
   public T get() throws InterruptedException, ExecutionException {


### PR DESCRIPTION
## 관련 이슈
https://github.com/jam2in/arcus-works/issues/419

## Motivation
기존의 단일 Op를 가지는 Future의 cancel 로직은 아래와 같은 문제가 있다.

아래의 세가지 경우를 고려하지 않고 
모든 case에 대해 op.cancel()을 호출시킨다.
그리고 `OperationState.WRITE_QUEUED`를 기준으로
cancel()의 성공 및 실패 여부를 알려준다.

- op 진행 전 cancel() 요청
- op 진행 중 cancel() 요청
- op 완료 후 cancel() 요청

만약 op가 완료 된 후, cancel() 요청이 들어올 경우
응답값은 false로 정상적으로 돌려준다.
하지만 cancel() 요청 후, get() 메서드를 호출할 경우엔 
`ExecutionException`을 발생시킨다.
**즉, 작업의 완료로 인해 cancel이 실패하였음에도 
cancel에 의한 예외가 발생한다.**
정상 동작은 예외가 발생하지 않고 완료된 결과를 리턴해줘야한다.

## 변경 후 로직
- op 진행 전 cancel() 요청 : return True, ExecutionException 발생
    - op의 state : `OperationState.WRITE_QUEUED`
- op 진행 중 cancel() 요청 : return True, ExecutionException 발생
    - op의 state : `OperationState.READING` , `OperationState.WRITING`
- op 완료 후 cancel() 요청 : return False, Future의 get() 호출 시 정상 응답
    - op의 state : `OperationState.COMPLETE`

참고로 single Op만을 가지는 `Future`들은 모두 `OperationFuture`의 `cancel()` 구현을 사용합니다.