### PR TITLE
FIX: Change cancel method logic in multi-operation Future.

### DIFF
--- a/src/main/java/net/spy/memcached/ArcusClient.java
+++ b/src/main/java/net/spy/memcached/ArcusClient.java
@@ -2015,8 +2015,10 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
       public boolean cancel(boolean ign) {
         boolean rv = false;
         for (Operation op : ops) {
-          op.cancel("by application.");
-          rv |= op.getState() == OperationState.WRITE_QUEUED;
+          if (op.getState() != OperationState.COMPLETE) {
+            rv = true;
+            op.cancel("by application.");
+          }
         }
         return rv;
       }
@@ -4055,8 +4057,10 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
       public boolean cancel(boolean ign) {
         boolean rv = false;
         for (Operation op : ops) {
-          op.cancel("by application.");
-          rv |= op.getState() == OperationState.WRITE_QUEUED;
+          if (op.getState() != OperationState.COMPLETE) {
+            rv = true;
+            op.cancel("by application.");
+          }
         }
         return rv;
       }

--- a/src/main/java/net/spy/memcached/MemcachedClient.java
+++ b/src/main/java/net/spy/memcached/MemcachedClient.java
@@ -2027,8 +2027,10 @@ public class MemcachedClient extends SpyThread
       public boolean cancel(boolean ign) {
         boolean rv = false;
         for (Operation op : ops) {
-          op.cancel("by application.");
-          rv |= op.getState() == OperationState.WRITE_QUEUED;
+          if (op.getState() != OperationState.COMPLETE) {
+            rv = true;
+            op.cancel("by application.");
+          }
         }
         return rv;
       }

--- a/src/main/java/net/spy/memcached/internal/BulkGetFuture.java
+++ b/src/main/java/net/spy/memcached/internal/BulkGetFuture.java
@@ -64,8 +64,10 @@ public class BulkGetFuture<T> implements BulkFuture<Map<String, T>> {
   public boolean cancel(boolean ign) {
     boolean rv = false;
     for (Operation op : ops) {
-      rv |= op.getState() == OperationState.WRITE_QUEUED;
-      op.cancel("by application.");
+      if (op.getState() != OperationState.COMPLETE) {
+        rv = true;
+        op.cancel("by application.");
+      }
     }
     return rv;
   }

--- a/src/main/java/net/spy/memcached/internal/BulkOperationFuture.java
+++ b/src/main/java/net/spy/memcached/internal/BulkOperationFuture.java
@@ -31,8 +31,10 @@ public class BulkOperationFuture<T> implements Future<Map<String, T>> {
   public boolean cancel(boolean ign) {
     boolean rv = false;
     for (Operation op : ops) {
-      op.cancel("by application.");
-      rv |= op.getState() == OperationState.WRITE_QUEUED;
+      if (op.getState() != OperationState.COMPLETE) {
+        rv = true;
+        op.cancel("by application.");
+      }
     }
     return rv;
   }

--- a/src/main/java/net/spy/memcached/internal/CollectionGetBulkFuture.java
+++ b/src/main/java/net/spy/memcached/internal/CollectionGetBulkFuture.java
@@ -92,8 +92,10 @@ public class CollectionGetBulkFuture<T> implements Future<T> {
   public boolean cancel(boolean ign) {
     boolean rv = false;
     for (Operation op : ops) {
-      op.cancel("by application.");
-      rv |= op.getState() == OperationState.WRITE_QUEUED;
+      if (op.getState() != OperationState.COMPLETE) {
+        rv = true;
+        op.cancel("by application.");
+      }
     }
     return rv;
   }

--- a/src/main/java/net/spy/memcached/internal/PipedCollectionFuture.java
+++ b/src/main/java/net/spy/memcached/internal/PipedCollectionFuture.java
@@ -36,8 +36,10 @@ public class PipedCollectionFuture<K, V>
   public boolean cancel(boolean ign) {
     boolean rv = false;
     for (Operation op : ops) {
-      op.cancel("by application.");
-      rv |= op.getState() == OperationState.WRITE_QUEUED;
+      if (op.getState() != OperationState.COMPLETE) {
+        rv = true;
+        op.cancel("by application.");
+      }
     }
     return rv;
   }

--- a/src/main/java/net/spy/memcached/internal/SMGetFuture.java
+++ b/src/main/java/net/spy/memcached/internal/SMGetFuture.java
@@ -53,8 +53,10 @@ public abstract class SMGetFuture<T> implements Future<T> {
   public boolean cancel(boolean ign) {
     boolean rv = false;
     for (Operation op : ops) {
-      op.cancel("by application.");
-      rv |= op.getState() == OperationState.WRITE_QUEUED;
+      if (op.getState() != OperationState.COMPLETE) {
+        rv = true;
+        op.cancel("by application.");
+      }
     }
     return rv;
   }


### PR DESCRIPTION
## Motivation
기존의 multi-op를 가지는 Future의 cancel은 
Operation 객체의 완료 여부에 관계 없이 모두 
`op.cancel()`을 호출하도록 되어 있다.
이를 아래의 기준을 통해 호출되도록 변경한다.

- 모든 op 완료 : `return false` 반환 및 `op.cancel()` 호출X
- 일부 op 완료 : `return true` 반환 및 완료되지 않은 op들의 `op.cancel()` 호출
- 모든 op 진행 중 : `return true` 반환 및 모든 op들의 `op.cancel()` 호출

## 변경 사항
위의 3가지 경우를 기준으로 multi op를 가지는 Future의 cancel 메서드 로직 수정


## 관련 이슈
https://github.com/jam2in/arcus-works/issues/419
