### PR TITLE
FIX: sync problem in Operation cancel and transitionState method

### DIFF
--- a/src/main/java/net/spy/memcached/ArcusClient.java
+++ b/src/main/java/net/spy/memcached/ArcusClient.java
@@ -1936,10 +1936,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
       public boolean cancel(boolean ign) {
         boolean rv = false;
         for (Operation op : ops) {
-          if (op.getState() != OperationState.COMPLETE) {
-            rv = true;
-            op.cancel("by application.");
-          }
+          rv |= op.cancel("by application.");
         }
         return rv;
       }

--- a/src/main/java/net/spy/memcached/MemcachedClient.java
+++ b/src/main/java/net/spy/memcached/MemcachedClient.java
@@ -2027,10 +2027,7 @@ public class MemcachedClient extends SpyThread
       public boolean cancel(boolean ign) {
         boolean rv = false;
         for (Operation op : ops) {
-          if (op.getState() != OperationState.COMPLETE) {
-            rv = true;
-            op.cancel("by application.");
-          }
+          rv |= op.cancel("by application.");
         }
         return rv;
       }

--- a/src/main/java/net/spy/memcached/internal/BulkGetFuture.java
+++ b/src/main/java/net/spy/memcached/internal/BulkGetFuture.java
@@ -64,10 +64,7 @@ public class BulkGetFuture<T> implements BulkFuture<Map<String, T>> {
   public boolean cancel(boolean ign) {
     boolean rv = false;
     for (Operation op : ops) {
-      if (op.getState() != OperationState.COMPLETE) {
-        rv = true;
-        op.cancel("by application.");
-      }
+      rv |= op.cancel("by application.");
     }
     return rv;
   }

--- a/src/main/java/net/spy/memcached/internal/BulkOperationFuture.java
+++ b/src/main/java/net/spy/memcached/internal/BulkOperationFuture.java
@@ -31,10 +31,7 @@ public class BulkOperationFuture<T> implements Future<Map<String, T>> {
   public boolean cancel(boolean ign) {
     boolean rv = false;
     for (Operation op : ops) {
-      if (op.getState() != OperationState.COMPLETE) {
-        rv = true;
-        op.cancel("by application.");
-      }
+      rv |= op.cancel("by application.");
     }
     return rv;
   }

--- a/src/main/java/net/spy/memcached/internal/CollectionGetBulkFuture.java
+++ b/src/main/java/net/spy/memcached/internal/CollectionGetBulkFuture.java
@@ -92,10 +92,7 @@ public class CollectionGetBulkFuture<T> implements Future<T> {
   public boolean cancel(boolean ign) {
     boolean rv = false;
     for (Operation op : ops) {
-      if (op.getState() != OperationState.COMPLETE) {
-        rv = true;
-        op.cancel("by application.");
-      }
+      rv |= op.cancel("by application.");
     }
     return rv;
   }

--- a/src/main/java/net/spy/memcached/internal/OperationFuture.java
+++ b/src/main/java/net/spy/memcached/internal/OperationFuture.java
@@ -60,11 +60,7 @@ public class OperationFuture<T> extends SpyObject implements Future<T> {
 
   public boolean cancel(boolean ign) {
     assert op != null : "No operation";
-    if (op.getState() == OperationState.COMPLETE) {
-      return false;
-    }
-    op.cancel("by application.");
-    return true;
+    return op.cancel("by application.");
   }
 
   public T get() throws InterruptedException, ExecutionException {

--- a/src/main/java/net/spy/memcached/internal/PipedCollectionFuture.java
+++ b/src/main/java/net/spy/memcached/internal/PipedCollectionFuture.java
@@ -35,10 +35,7 @@ public class PipedCollectionFuture<K, V>
   public boolean cancel(boolean ign) {
     boolean rv = false;
     for (Operation op : ops) {
-      if (op.getState() != OperationState.COMPLETE) {
-        rv = true;
-        op.cancel("by application.");
-      }
+      rv |= op.cancel("by application.");
     }
     return rv;
   }

--- a/src/main/java/net/spy/memcached/internal/SMGetFuture.java
+++ b/src/main/java/net/spy/memcached/internal/SMGetFuture.java
@@ -53,10 +53,7 @@ public abstract class SMGetFuture<T> implements Future<T> {
   public boolean cancel(boolean ign) {
     boolean rv = false;
     for (Operation op : ops) {
-      if (op.getState() != OperationState.COMPLETE) {
-        rv = true;
-        op.cancel("by application.");
-      }
+      rv |= op.cancel("by application.");
     }
     return rv;
   }

--- a/src/main/java/net/spy/memcached/ops/Operation.java
+++ b/src/main/java/net/spy/memcached/ops/Operation.java
@@ -52,7 +52,7 @@ public interface Operation {
   /**
    * Cancel this operation.
    */
-  void cancel(String cause);
+  boolean cancel(String cause);
 
   /**
    * Get the cause of cancel.


### PR DESCRIPTION
## 관련 이슈
https://github.com/jam2in/arcus-works/issues/419

## Motivation
오프라인에서 논의된 syncronized를 사용한 동시성 발생 문제를 
AtomicBoolean, volatile을 사용하여 해결하도록 변경한다.
스레드가 block이 되지 않기 때문에 기존의 논의된 사항보다
스레드가 가지는 overhead가 감소한다.

## 변경내용
1. Operation 내의 cancel 메서드의 리턴 타입, 로직
2. Operation 내의 transitionState 메서드의 로직 
3. cancelld 변수 -> `atomicBoolean`로 타입 변경 , state 변수 -> `volatile` 추가