### PR TITLE
INTERNAL: Refactor Future in asyncCollectionInsertBulk2 method.

### DIFF
--- a/src/main/java/net/spy/memcached/internal/BulkOperationFuture.java
+++ b/src/main/java/net/spy/memcached/internal/BulkOperationFuture.java
@@ -103,11 +103,15 @@ public class BulkOperationFuture<T> implements Future<Map<String, T>> {
     return failedResult;
   }
 
+  public void addFailedResult(String key, T value) {
+    failedResult.put(key, value);
+  }
+
   public void setOperations(Collection<Operation> ops) {
     this.ops.addAll(ops);
   }
 
-  public void addFailedResult(String key, T value) {
-    failedResult.put(key, value);
+  public void addOperation(Operation op) {
+    ops.add(op);
   }
 }


### PR DESCRIPTION
## 관련 이슈 
https://github.com/jam2in/arcus-works/issues/403

## Motivation
기존의 `asyncCollectionInsertBulk2` 메서드는 
내부적으로 익명 Future 클래스를 구현하여 리턴한다.
이러한 구조를 다른 api들과 동일하게 
`Future rv 생성 -> 연산 결과를 rv에 전달 -> rv 리턴`
구조로 변경한다.

참고로 `asyncCollectionInsertBulk2`는 
여러 컬렉션에 동일한 Elem을 삽입하는 api에서 사용된다.

## 변경된 지점
기존에 존재하는 `BulkOperationFuture `를 사용하여 Future를 생성합니다.
