### PR TITLE
INTERNAL: Refactor pipe insert and pipe update api.

### DIFF
--- a/src/main/java/net/spy/memcached/ArcusClient.java
+++ b/src/main/java/net/spy/memcached/ArcusClient.java
@@ -831,7 +831,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
 
     final CountDownLatch latch = new CountDownLatch(updateList.size());
     final PipedCollectionFuture<Integer, CollectionOperationStatus> rv =
-            new PipedCollectionFuture<Integer, CollectionOperationStatus>(latch, operationTimeout, updateList.size());
+            new PipedCollectionFuture<Integer, CollectionOperationStatus>(latch, operationTimeout);
 
     for (int i = 0; i < updateList.size(); i++) {
       final CollectionPipedUpdate<T> update = updateList.get(i);
@@ -868,8 +868,8 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
               }
             }
           });
-      addOp(key, op);
       rv.addOperation(op);
+      addOp(key, op);
     }
     return rv;
   }
@@ -3699,7 +3699,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
 
     final CountDownLatch latch = new CountDownLatch(insertList.size());
     final PipedCollectionFuture<Integer, CollectionOperationStatus> rv =
-            new PipedCollectionFuture<Integer, CollectionOperationStatus>(latch, operationTimeout, insertList.size());
+            new PipedCollectionFuture<Integer, CollectionOperationStatus>(latch, operationTimeout);
 
     for (int i = 0; i < insertList.size(); i++) {
       final CollectionPipedInsert<T> insert = insertList.get(i);
@@ -3736,8 +3736,8 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
               }
             }
           });
-      addOp(key, op);
       rv.addOperation(op);
+      addOp(key, op);
     }
     return rv;
   }

--- a/src/main/java/net/spy/memcached/internal/PipedCollectionFuture.java
+++ b/src/main/java/net/spy/memcached/internal/PipedCollectionFuture.java
@@ -21,15 +21,14 @@ import java.util.concurrent.ExecutionException;
 public class PipedCollectionFuture<K, V>
         extends CollectionFuture<Map<K, V>> {
   private final ConcurrentLinkedQueue<Operation> ops = new ConcurrentLinkedQueue<Operation>();
-  private final List<CollectionOperationStatus> mergedOperationStatus;
+  private final List<CollectionOperationStatus> mergedOperationStatus
+          = Collections.synchronizedList(new ArrayList<CollectionOperationStatus>());
 
   private final Map<K, V> mergedResult =
           new ConcurrentHashMap<K, V>();
 
-  public PipedCollectionFuture(CountDownLatch l, long opTimeout, int opSize) {
+  public PipedCollectionFuture(CountDownLatch l, long opTimeout) {
     super(l, opTimeout);
-    mergedOperationStatus = Collections
-            .synchronizedList(new ArrayList<CollectionOperationStatus>(opSize));
   }
 
   @Override


### PR DESCRIPTION
## 관련 이슈
https://github.com/jam2in/arcus-works/issues/423

## 변경 내용
1. PipedCollectionFuture 생성자의 `updateList.size()` 인자 삭제
2. `rv.addOperation(op);`와 `addOp(key, op);`의 호출 순서 변경