### PR TITLE
FIX: Change syncronization tool in getVersion().

### DIFF
--- a/src/main/java/net/spy/memcached/ArcusClient.java
+++ b/src/main/java/net/spy/memcached/ArcusClient.java
@@ -184,8 +184,8 @@ import net.spy.memcached.util.BTreeUtil;
  * }</pre>
  */
 public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClientIF {
-
-  private static String VERSION = "INIT";
+  private static String VERSION = null;
+  private static final Object VERSION_LOCK = new Object();
   private static final Logger arcusLogger = LoggerFactory.getLogger(ArcusClient.class);
   private static final String ARCUS_CLOUD_ADDR = "127.0.0.1:2181";
   private static final String DEFAULT_ARCUS_CLIENT_NAME = "ArcusClient";
@@ -4273,11 +4273,11 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
    * @return version string
    */
   public static String getVersion() {
-    if (!VERSION.equals("INIT")) {
+    if (VERSION != null) {
       return VERSION;
     }
-    synchronized (VERSION) {
-      if (VERSION.equals("INIT")) {
+    synchronized (VERSION_LOCK) {
+      if (VERSION == null) {
         Enumeration<URL> resEnum;
         try {
           resEnum = Thread.currentThread()
@@ -4298,7 +4298,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
         } catch (Exception e) {
           // Failed to get version.
         } finally {
-          if (VERSION.equals("INIT")) {
+          if (VERSION == null) {
             VERSION = "NONE";
           }
         }


### PR DESCRIPTION
## Motivation
기존의 getVersion에서 동시성 이슈 해결은 synchronized 블럭을 통해 진행한다.
이는 쓰레드의 blocking을 야기해 성능의 문제가 존재한다.
또한 **현재 synchronized 블럭의 인자인 `VERSION`은
synchronized 블럭 내에서 참조가 변경될 수 있다.**
즉, threadA가 lock을 걸고 내부 로직에서 참조를 변경하면
threadB가 lock을 거는 참조 대상이 달라져
**동기화가 제대로 이루어지지 않을 가능성이 존재**한다.

## 변경지점
이러한 문제를 AtomicReference를 통해 해결합니다.
기존과 동일하게 버전 파싱 중 예외 발생 시는 "NONE"을 대입합니다.