### PR TITLE
INTERNAL: Add eflag parameter in collectionGetOperation callback.

### DIFF
--- a/src/main/java/net/spy/memcached/ArcusClient.java
+++ b/src/main/java/net/spy/memcached/ArcusClient.java
@@ -528,8 +528,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
             latch.countDown();
           }
 
-          public void gotData(String key, int flags, String subkey, byte[] data) {
-            assert key.equals(k) : "Wrong key returned";
+          public void gotData(String subkey, int flags, byte[] data, byte[] eflag) {
             list.add(tc.decode(new CachedData(flags, data, tc.getMaxSize())));
           }
         });
@@ -607,8 +606,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
             latch.countDown();
           }
 
-          public void gotData(String key, int flags, String subkey, byte[] data) {
-            assert key.equals(k) : "Wrong key returned";
+          public void gotData(String subkey, int flags, byte[] data, byte[] eflag) {
             set.add(tc.decode(new CachedData(flags, data, tc.getMaxSize())));
           }
         });
@@ -674,12 +672,10 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
             latch.countDown();
           }
 
-          public void gotData(String key, int flags, String bkey, byte[] data) {
-            assert key.equals(k) : "Wrong key returned";
+          public void gotData(String bkey, int flags, byte[] data, byte[] eflag) {
             long longBkey = Long.parseLong(bkey);
             map.put(longBkey, new Element<T>(longBkey,
-                            tc.decode(new CachedData(flags, data, tc.getMaxSize())),
-                            collectionGet.getElementFlag()));
+                            tc.decode(new CachedData(flags, data, tc.getMaxSize())), eflag));
           }
         });
     rv.setOperation(op);
@@ -740,8 +736,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
             latch.countDown();
           }
 
-          public void gotData(String key, int flags, String mkey, byte[] data) {
-            assert key.equals(k) : "Wrong key returned";
+          public void gotData(String mkey, int flags, byte[] data, byte[] eflag) {
             map.put(mkey, tc.decode(new CachedData(flags, data, tc.getMaxSize())));
           }
         });
@@ -2980,12 +2975,10 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
             latch.countDown();
           }
 
-          public void gotData(String key, int flags, String bkey, byte[] data) {
-            assert key.equals(k) : "Wrong key returned";
+          public void gotData(String bkey, int flags, byte[] data, byte[] eflag) {
             byte[] byteBkey = BTreeUtil.hexStringToByteArrays(bkey);
             Element<T> element = new Element<T>(byteBkey,
-                    tc.decode(new CachedData(flags, data, tc.getMaxSize())),
-                    collectionGet.getElementFlag());
+                    tc.decode(new CachedData(flags, data, tc.getMaxSize())), eflag);
             map.put(new ByteArrayBKey(byteBkey), element);
           }
         });

--- a/src/main/java/net/spy/memcached/ops/CollectionGetOperation.java
+++ b/src/main/java/net/spy/memcached/ops/CollectionGetOperation.java
@@ -26,7 +26,7 @@ public interface CollectionGetOperation extends KeyedOperation {
   CollectionGet getGet();
 
   interface Callback extends OperationCallback {
-    void gotData(String key, int flags, String subkey, byte[] data);
+    void gotData(String subkey, int flags, byte[] data, byte[] eflag);
   }
 
 }

--- a/src/main/java/net/spy/memcached/protocol/ascii/CollectionGetOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/CollectionGetOperationImpl.java
@@ -223,7 +223,7 @@ public class CollectionGetOperationImpl extends OperationImpl
     if (lookingFor == '\0' && readOffset == data.length) {
       CollectionGetOperation.Callback cb =
               (CollectionGetOperation.Callback) getCallback();
-      cb.gotData(key, flags, collectionGet.getSubkey(), data);
+      cb.gotData(collectionGet.getSubkey(), flags, data, collectionGet.getElementFlag());
       lookingFor = '\r';
     }
 

--- a/src/test/manual/net/spy/memcached/MultibyteKeyTest.java
+++ b/src/test/manual/net/spy/memcached/MultibyteKeyTest.java
@@ -166,7 +166,7 @@ public class MultibyteKeyTest {
         }
       }, new CollectionGetOperation.Callback() {
         @Override
-        public void gotData(String key, int flags, String subkey, byte[] data) {
+        public void gotData(String subkey, int flags, byte[] data, byte[] eflag) {
         }
 
         @Override
@@ -425,7 +425,7 @@ public class MultibyteKeyTest {
           new BTreeGet(from, to, 0, 0, false, false, ElementFlagFilter.DO_NOT_FILTER),
           new CollectionGetOperation.Callback() {
             @Override
-            public void gotData(String key, int flags, String subkey, byte[] data) {
+            public void gotData(String subkey, int flags, byte[] data, byte[] eflag) {
             }
 
             @Override


### PR DESCRIPTION
## Motivation
https://github.com/naver/arcus-java-client/pull/634
위 PR에서 BTreeGet의 eflag는 CollectionGet 인스턴스의 
내부 field을 통해 얻어져 Element를 생성할 때 사용된다.
eflag의 경우에도 bKey,data와 마찬가지로 콜백의 gotData를 호출할 때
인자로 넘겨주면 일관성 있는 구조로 변경된다.

변경을 통해 위 PR을 구현할 때에 eflag 값을 
gotData()를 통해 곧바로 얻어올 수 있다.

또한 gotData()의 key 인자의 경우 api인자로 들어온 값과
api 인자를 통해 설정된 동일한 값을 assert를 통해
불필요한 비교를 진행한다.
그래서 key 인자의 경우 삭제시킨다.

## 변경 지점
CollectionGetOperation의 콜백의 gotData() 메서드의 인자가 변경되었습니다.