### PR TITLE
INTERNAL: Change decode logic in asyncBopGet APIs.

### DIFF
--- a/src/main/java/net/spy/memcached/internal/BTreeStoreAndGetFuture.java
+++ b/src/main/java/net/spy/memcached/internal/BTreeStoreAndGetFuture.java
@@ -20,7 +20,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicReference;
 
 import net.spy.memcached.collection.Element;
-import net.spy.memcached.ops.CollectionOperationStatus;
+import net.spy.memcached.ops.CollectionGetOpCallback;
 
 /**
  * Future object that contains an b+tree element object
@@ -36,17 +36,13 @@ public class BTreeStoreAndGetFuture<T, E> extends CollectionFuture<T> {
     this(l, new AtomicReference<T>(null), opTimeout);
   }
 
-  public BTreeStoreAndGetFuture(CountDownLatch l, AtomicReference<T> oref,
-                                long opTimeout) {
+  public BTreeStoreAndGetFuture(CountDownLatch l, AtomicReference<T> oref, long opTimeout) {
     super(l, oref, opTimeout);
   }
 
-  public void set(T o, CollectionOperationStatus status) {
-    objRef.set(o);
-    collectionOpStatus = status;
-  }
-
   public Element<E> getElement() {
+    CollectionGetOpCallback callback = (CollectionGetOpCallback) op.getCallback();
+    callback.addResult();
     return element;
   }
 

--- a/src/main/java/net/spy/memcached/internal/CollectionGetFuture.java
+++ b/src/main/java/net/spy/memcached/internal/CollectionGetFuture.java
@@ -1,11 +1,11 @@
 package net.spy.memcached.internal;
 
+import net.spy.memcached.ops.CollectionGetOpCallback;
+
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
-
-import net.spy.memcached.ops.CollectionGetOperation.Callback;
 
 public class CollectionGetFuture<T> extends CollectionFuture<T> {
 
@@ -19,7 +19,7 @@ public class CollectionGetFuture<T> extends CollectionFuture<T> {
 
     T result = super.get(duration, units);
     if (result != null) {
-      Callback callback = (Callback) op.getCallback();
+      CollectionGetOpCallback callback = (CollectionGetOpCallback) op.getCallback();
       callback.addResult();
     }
     return result;

--- a/src/main/java/net/spy/memcached/ops/BTreeFindPositionWithGetOperation.java
+++ b/src/main/java/net/spy/memcached/ops/BTreeFindPositionWithGetOperation.java
@@ -23,8 +23,7 @@ public interface BTreeFindPositionWithGetOperation extends KeyedOperation {
 
   BTreeFindPositionWithGet getGet();
 
-  interface Callback extends OperationCallback {
-    void gotData(String key, int flags, int pos, BKeyObject bkey, byte[] eflag, byte[] data);
+  interface Callback extends CollectionGetOpCallback {
+    void gotData(int pos, int flags, BKeyObject bkey, byte[] eflag, byte[] data);
   }
-
 }

--- a/src/main/java/net/spy/memcached/ops/BTreeGetByPositionOperation.java
+++ b/src/main/java/net/spy/memcached/ops/BTreeGetByPositionOperation.java
@@ -23,8 +23,7 @@ public interface BTreeGetByPositionOperation extends KeyedOperation {
 
   BTreeGetByPosition getGet();
 
-  interface Callback extends OperationCallback {
-    void gotData(String key, int flags, int pos, BKeyObject bkey, byte[] eflag, byte[] data);
+  interface Callback extends CollectionGetOpCallback {
+    void gotData(int pos, int flags, BKeyObject bkey, byte[] eflag, byte[] data);
   }
-
 }

--- a/src/main/java/net/spy/memcached/ops/BTreeInsertAndGetOperation.java
+++ b/src/main/java/net/spy/memcached/ops/BTreeInsertAndGetOperation.java
@@ -23,8 +23,8 @@ public interface BTreeInsertAndGetOperation extends KeyedOperation {
 
   BTreeInsertAndGet<?> getGet();
 
-  interface Callback extends OperationCallback {
-    void gotData(String key, int flags, BKeyObject bkeyObject, byte[] elementFlag, byte[] data);
+  interface Callback extends CollectionGetOpCallback {
+    void gotData(int flags, BKeyObject bkeyObject, byte[] elementFlag, byte[] data);
   }
 
 }

--- a/src/main/java/net/spy/memcached/ops/CollectionGetOpCallback.java
+++ b/src/main/java/net/spy/memcached/ops/CollectionGetOpCallback.java
@@ -1,0 +1,5 @@
+package net.spy.memcached.ops;
+
+public interface CollectionGetOpCallback extends OperationCallback {
+  void addResult();
+}

--- a/src/main/java/net/spy/memcached/ops/CollectionGetOperation.java
+++ b/src/main/java/net/spy/memcached/ops/CollectionGetOperation.java
@@ -25,9 +25,7 @@ public interface CollectionGetOperation extends KeyedOperation {
 
   CollectionGet getGet();
 
-  interface Callback extends OperationCallback {
+  interface Callback extends CollectionGetOpCallback {
     void gotData(String subkey, int flags, byte[] data, byte[] eflag);
-    void addResult();
   }
-
 }

--- a/src/main/java/net/spy/memcached/protocol/ascii/BTreeFindPositionWithGetOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/BTreeFindPositionWithGetOperationImpl.java
@@ -201,7 +201,7 @@ public class BTreeFindPositionWithGetOperationImpl extends OperationImpl impleme
       // put an element data.
       BTreeFindPositionWithGetOperation.Callback cb =
           (BTreeFindPositionWithGetOperation.Callback) getCallback();
-      cb.gotData(key, flags, pos, get.getBkey(), get.getEflag(), data);
+      cb.gotData(pos, flags, get.getBkey(), get.getEflag(), data);
 
       // next position.
       pos += posDiff;

--- a/src/main/java/net/spy/memcached/protocol/ascii/BTreeGetByPositionOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/BTreeGetByPositionOperationImpl.java
@@ -208,7 +208,7 @@ public class BTreeGetByPositionOperationImpl extends OperationImpl implements
       // put an element data.
       BTreeGetByPositionOperation.Callback cb =
           (BTreeGetByPositionOperation.Callback) getCallback();
-      cb.gotData(key, flags, pos, get.getBkey(), get.getEflag(), data);
+      cb.gotData(pos, flags, get.getBkey(), get.getEflag(), data);
 
       // next position.
       pos += posDiff;

--- a/src/main/java/net/spy/memcached/protocol/ascii/BTreeInsertAndGetOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/BTreeInsertAndGetOperationImpl.java
@@ -246,7 +246,7 @@ public class BTreeInsertAndGetOperationImpl extends OperationImpl implements
     if (lookingFor == '\0' && readOffset == data.length) {
       // put an element data.
       BTreeInsertAndGetOperation.Callback cb = (BTreeInsertAndGetOperation.Callback) getCallback();
-      cb.gotData(key, flags, get.getBkeyObject(), get.getElementFlag(), data);
+      cb.gotData(flags, get.getBkeyObject(), get.getElementFlag(), data);
 
       lookingFor = '\r';
     }

--- a/src/test/manual/net/spy/memcached/MultibyteKeyTest.java
+++ b/src/test/manual/net/spy/memcached/MultibyteKeyTest.java
@@ -553,8 +553,11 @@ public class MultibyteKeyTest {
           new BTreeGetByPosition(BTreeOrder.ASC, 0),
           new BTreeGetByPositionOperation.Callback() {
             @Override
-            public void gotData(String key, int flags, int pos, BKeyObject bkey,
-                                byte[] eflag, byte[] data) {
+            public void addResult() {
+            }
+
+            @Override
+            public void gotData(int pos, int flags, BKeyObject bkey, byte[] eflag, byte[] data) {
             }
 
             @Override
@@ -667,8 +670,7 @@ public class MultibyteKeyTest {
                   new Random().nextInt(), new CollectionAttributes()),
           testData, new BTreeInsertAndGetOperation.Callback() {
             @Override
-            public void gotData(String key, int flags, BKeyObject bkeyObject,
-                                byte[] elementFlag, byte[] data) {
+            public void gotData(int flags, BKeyObject bkeyObject, byte[] elementFlag, byte[] data) {
             }
 
             @Override
@@ -677,6 +679,10 @@ public class MultibyteKeyTest {
 
             @Override
             public void complete() {
+            }
+
+            @Override
+            public void addResult() {
             }
           }).initialize();
     } catch (java.nio.BufferOverflowException e) {


### PR DESCRIPTION
## 관련 PR
https://github.com/jam2in/arcus-works/issues/406

## Motivation
아래 3가지 api는 IO 쓰레드가 역직렬화 작업을 수행하도록 구현되어있다.

- asyncBopFindPositionWithGet
- asyncBTreeInsertAndGet
- asyncBopGetByPosition

역직렬화 작업을 응용의 worker thread가 get을 호출하여
api의 결과를 받고자 할 때, 수행하도록 변경한다.

## 변경 사항
https://github.com/naver/arcus-java-client/pull/634
- 위의 PR과 마찬가지로 **Future에서 콜백을 호출하여 decode를 수행하도록 변경**하였습니다.
- positon이 사용되는 api의 경우 해당 position 값을 콜백에서 처리하도록 변경하였습니다.
    - 기존에는 gotData의 인자로 넘어 왔는데 해당 값을 Map의 key로 사용하면 bKey를 저장하지 못하는 문제가 발생하여 이와 같이 변경했습니다.
- `BTreeStoreAndGetFuture`의 경우 아래와 같은 문제가 있습니다.
    - 기존 구현은 getElement를 통해 연산의 Element의 참조를 바로 반환합니다.
    - 만약 연산이 완료되지 않은 상황에서 getElement를 호출할 경우 부정확한 값이 리턴됩니다.
    - 이러한 문제를 내부에서 get()을 통해 연산이 완료됨을 보장하고 Element를 리턴하도록 변경했습니다.