### PR TITLE
FIX: Incorrect boolean result in asycn flush() method.

### DIFF
--- a/src/main/java/net/spy/memcached/ArcusClient.java
+++ b/src/main/java/net/spy/memcached/ArcusClient.java
@@ -1952,7 +1952,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
 
   @Override
   public OperationFuture<Boolean> flush(final String prefix, final int delay) {
-    final AtomicReference<Boolean> flushResult = new AtomicReference<Boolean>(null);
+    final AtomicReference<Boolean> flushResult = new AtomicReference<Boolean>(true);
     final ConcurrentLinkedQueue<Operation> ops = new ConcurrentLinkedQueue<Operation>();
 
     final CountDownLatch blatch = broadcastOp(new BroadcastOpFactory() {
@@ -1961,7 +1961,9 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
         Operation op = opFact.flush(prefix, delay, false,
             new OperationCallback() {
               public void receivedStatus(OperationStatus s) {
-                flushResult.set(s.isSuccess());
+                if (!s.isSuccess()) {
+                  flushResult.set(false);
+                }
               }
 
               public void complete() {

--- a/src/main/java/net/spy/memcached/MemcachedClient.java
+++ b/src/main/java/net/spy/memcached/MemcachedClient.java
@@ -2002,7 +2002,7 @@ public class MemcachedClient extends SpyThread
    */
   public Future<Boolean> flush(final int delay) {
     final AtomicReference<Boolean> flushResult =
-            new AtomicReference<Boolean>(null);
+            new AtomicReference<Boolean>(true);
     final ConcurrentLinkedQueue<Operation> ops =
             new ConcurrentLinkedQueue<Operation>();
     final CountDownLatch blatch = broadcastOp(new BroadcastOpFactory() {
@@ -2010,7 +2010,9 @@ public class MemcachedClient extends SpyThread
                              final CountDownLatch latch) {
         Operation op = opFact.flush(delay, new OperationCallback() {
           public void receivedStatus(OperationStatus s) {
-            flushResult.set(s.isSuccess());
+            if (!s.isSuccess()) {
+              flushResult.set(false);
+            }
           }
 
           public void complete() {


### PR DESCRIPTION
## Motivation
기존의 Flush 동작은 가장 최근 연산된 
op 인스턴스의 결과값만을 반영한다.
즉, 실패한 연산이 있더라도 최근 연산이 성공일 경우
성공으로 최종 결과가 연산된다.
실패한 연산이 있는 경우만 결과를 false로 설정하도록 구현을 변경한다.

## 관련 PR
https://github.com/naver/arcus-java-client/pull/646