### PR TITLE
FEATURE: Create new api asyncBopPipedUpsert.

### DIFF
--- a/src/main/java/net/spy/memcached/ArcusClient.java
+++ b/src/main/java/net/spy/memcached/ArcusClient.java
@@ -91,6 +91,9 @@ import net.spy.memcached.collection.CollectionPipedInsert.SetPipedInsert;
 import net.spy.memcached.collection.CollectionPipedUpdate;
 import net.spy.memcached.collection.CollectionPipedUpdate.BTreePipedUpdate;
 import net.spy.memcached.collection.CollectionPipedUpdate.MapPipedUpdate;
+import net.spy.memcached.collection.CollectionPipedUpsert;
+import net.spy.memcached.collection.CollectionPipedUpsert.BTreePipedUpsert;
+import net.spy.memcached.collection.CollectionPipedUpsert.ByteArrayBTreePipedUpsert;
 import net.spy.memcached.collection.CollectionResponse;
 import net.spy.memcached.collection.CollectionUpdate;
 import net.spy.memcached.collection.Element;
@@ -2705,6 +2708,64 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
     rv.setOperation(op);
     addOp(key, op);
     return rv;
+  }
+
+  @Override
+  public CollectionFuture<Map<Integer, CollectionOperationStatus>> asyncBopPipedUpsertBulk(
+          String key, Map<Long, Object> elements,
+          CollectionAttributes attributesForCreate) {
+    return asyncBopPipedUpsertBulk(key, elements, attributesForCreate, collectionTranscoder);
+  }
+
+  @Override
+  public CollectionFuture<Map<Integer, CollectionOperationStatus>> asyncBopPipedUpsertBulk(
+          String key, List<Element<Object>> elements, CollectionAttributes collectionAttributes) {
+    return asyncBopPipedUpsertBulk(key, elements, collectionAttributes, collectionTranscoder);
+  }
+
+  @Override
+  public <T> CollectionFuture<Map<Integer, CollectionOperationStatus>> asyncBopPipedUpsertBulk(
+          String key, Map<Long, T> elements, CollectionAttributes attributesForCreate, Transcoder<T> tc) {
+
+    if (elements.isEmpty()) {
+      throw new IllegalArgumentException("The number of piped operations must be larger than 0.");
+    }
+
+    List<CollectionPipedInsert<T>> upsertList = new ArrayList<CollectionPipedInsert<T>>();
+
+    if (elements.size() <= CollectionPipedUpsert.MAX_PIPED_ITEM_COUNT) {
+      upsertList.add(new BTreePipedUpsert<T>(key, elements, attributesForCreate, tc));
+    } else {
+      PartitionedMap<Long, T> list = new PartitionedMap<Long, T>(
+              elements, CollectionPipedUpsert.MAX_PIPED_ITEM_COUNT);
+      for (Map<Long, T> elementMap : list) {
+        upsertList.add(new BTreePipedUpsert<T>(key, elementMap, attributesForCreate, tc));
+      }
+    }
+    return asyncCollectionPipedInsert(key, upsertList);
+  }
+
+  @Override
+  public <T> CollectionFuture<Map<Integer, CollectionOperationStatus>> asyncBopPipedUpsertBulk(
+          String key, List<Element<T>> elements, CollectionAttributes attributesForCreate, Transcoder<T> tc) {
+
+    if (elements.isEmpty()) {
+      throw new IllegalArgumentException("The number of piped operations must be larger than 0.");
+    }
+
+    List<CollectionPipedInsert<T>> upsertList = new ArrayList<CollectionPipedInsert<T>>();
+
+
+    if (elements.size() <= CollectionPipedUpsert.MAX_PIPED_ITEM_COUNT) {
+      upsertList.add(new ByteArrayBTreePipedUpsert<T>(key, elements, attributesForCreate, tc));
+    } else {
+      PartitionedList<Element<T>> list = new PartitionedList<Element<T>>(
+              elements, CollectionPipedInsert.MAX_PIPED_ITEM_COUNT);
+      for (List<Element<T>> elementList : list) {
+        upsertList.add(new ByteArrayBTreePipedUpsert<T>(key, elementList, attributesForCreate, tc));
+      }
+    }
+    return asyncCollectionPipedInsert(key, upsertList);
   }
 
   @Override

--- a/src/main/java/net/spy/memcached/ArcusClientIF.java
+++ b/src/main/java/net/spy/memcached/ArcusClientIF.java
@@ -1527,6 +1527,61 @@ public interface ArcusClientIF {
                                                T value, Transcoder<T> tc);
 
   /**
+   * Upsert elements into the b+tree
+   *
+   * @param key      key of a b+tree
+   * @param elements list of b+tree elements
+   * @param attributesForCreate create a b+tree with this attributes,
+   *                            if given key of b+tree is not exists.
+   * @return a future indicating success
+   */
+  public CollectionFuture<Map<Integer, CollectionOperationStatus>> asyncBopPipedUpsertBulk(
+          String key, List<Element<Object>> elements, CollectionAttributes attributesForCreate);
+
+
+  /**
+   * Upsert elements into the b+tree
+   *
+   * @param key      key of a b+tree
+   * @param elements map of b+tree elements
+   * @param attributesForCreate create a b+tree with this attributes,
+   *                            if given key of b+tree is not exists.
+   * @return a future indicating success
+   */
+  public CollectionFuture<Map<Integer, CollectionOperationStatus>> asyncBopPipedUpsertBulk(
+          String key, Map<Long, Object> elements,
+          CollectionAttributes attributesForCreate);
+
+  /**
+   * Upsert elements into the b+tree
+   *
+   * @param key      key of a b+tree
+   * @param elements list of b+tree elements
+   * @param attributesForCreate create a b+tree with this attributes,
+   *                            if given key of b+tree is not exists.
+   * @param tc       a transcoder to encode the value of element
+   * @return a future indicating success
+   */
+  public <T> CollectionFuture<Map<Integer, CollectionOperationStatus>> asyncBopPipedUpsertBulk(
+          String key, List<Element<T>> elements,
+          CollectionAttributes attributesForCreate, Transcoder<T> tc);
+
+
+  /**
+   * Upsert elements into the b+tree
+   *
+   * @param key      key of a b+tree
+   * @param elements map of b+tree elements
+   * @param attributesForCreate create a b+tree with this attributes,
+   *                            if given key of b+tree is not exists.
+   * @param tc       a transcoder to encode the value of element
+   * @return a future indicating success
+   */
+  public <T> CollectionFuture<Map<Integer, CollectionOperationStatus>> asyncBopPipedUpsertBulk(
+          String key, Map<Long, T> elements,
+          CollectionAttributes attributesForCreate, Transcoder<T> tc);
+
+  /**
    * Update elements from the b+tree
    *
    * @param key      key of a b+tree

--- a/src/main/java/net/spy/memcached/ArcusClientPool.java
+++ b/src/main/java/net/spy/memcached/ArcusClientPool.java
@@ -1586,4 +1586,29 @@ public class ArcusClientPool implements MemcachedClientIF, ArcusClientIF {
             value, attributesForCreate, transcoder);
   }
 
+  @Override
+  public CollectionFuture<Map<Integer, CollectionOperationStatus>> asyncBopPipedUpsertBulk(
+          String key, List<Element<Object>> elements, CollectionAttributes attributesForCreate) {
+    return this.getClient().asyncBopPipedUpsertBulk(key, elements, attributesForCreate);
+  }
+
+  @Override
+  public CollectionFuture<Map<Integer, CollectionOperationStatus>> asyncBopPipedUpsertBulk(
+          String key, Map<Long, Object> elements, CollectionAttributes attributesForCreate) {
+    return this.getClient().asyncBopPipedUpsertBulk(key, elements, attributesForCreate);
+  }
+
+  @Override
+  public <T> CollectionFuture<Map<Integer, CollectionOperationStatus>> asyncBopPipedUpsertBulk(
+          String key, List<Element<T>> elements,
+          CollectionAttributes attributesForCreate, Transcoder<T> tc) {
+    return this.getClient().asyncBopPipedUpsertBulk(key, elements, attributesForCreate, tc);
+  }
+
+  @Override
+  public <T> CollectionFuture<Map<Integer, CollectionOperationStatus>> asyncBopPipedUpsertBulk(
+          String key, Map<Long, T> elements,
+          CollectionAttributes attributesForCreate, Transcoder<T> tc) {
+    return this.getClient().asyncBopPipedUpsertBulk(key, elements, attributesForCreate, tc);
+  }
 }

--- a/src/main/java/net/spy/memcached/collection/CollectionPipedInsert.java
+++ b/src/main/java/net/spy/memcached/collection/CollectionPipedInsert.java
@@ -212,7 +212,7 @@ public abstract class CollectionPipedInsert<T> extends CollectionPipe {
       for (i = this.nextOpIndex; i < keySize; i++) {
         Long bkey = keyList.get(i);
         byte[] value = encodedList.get(i);
-        setArguments(bb, COMMAND, key, bkey, value.length,
+        setArguments(bb, getCommand(), key, bkey, value.length,
             createOption, (i < keySize - 1) ? PIPE : "");
         bb.put(value);
         bb.put(CRLF);
@@ -222,6 +222,10 @@ public abstract class CollectionPipedInsert<T> extends CollectionPipe {
       ((Buffer) bb).flip();
 
       return bb;
+    }
+
+    public String getCommand() {
+      return COMMAND;
     }
   }
 
@@ -274,7 +278,7 @@ public abstract class CollectionPipedInsert<T> extends CollectionPipe {
       for (i = this.nextOpIndex; i < eSize; i++) {
         Element<T> element = elements.get(i);
         byte[] value = encodedList.get(i);
-        setArguments(bb, COMMAND, key,
+        setArguments(bb, getCommand(), key,
                      element.getStringBkey(), element.getStringEFlag(), value.length,
                      createOption, (i < eSize - 1) ? PIPE : "");
         bb.put(value);
@@ -285,6 +289,10 @@ public abstract class CollectionPipedInsert<T> extends CollectionPipe {
       ((Buffer) bb).flip();
 
       return bb;
+    }
+
+    public String getCommand() {
+      return COMMAND;
     }
   }
 

--- a/src/main/java/net/spy/memcached/collection/CollectionPipedUpsert.java
+++ b/src/main/java/net/spy/memcached/collection/CollectionPipedUpsert.java
@@ -1,0 +1,42 @@
+package net.spy.memcached.collection;
+
+import java.util.List;
+import java.util.Map;
+
+import net.spy.memcached.transcoders.Transcoder;
+
+public abstract class CollectionPipedUpsert<T> extends CollectionPipedInsert<T> {
+
+  public CollectionPipedUpsert(String key, CollectionAttributes attribute,
+                               Transcoder<T> tc, int itemCount) {
+    super(key, attribute, tc, itemCount);
+  }
+
+  public static class BTreePipedUpsert<T> extends BTreePipedInsert<T> {
+    private static final String COMMAND = "bop upsert";
+
+    public BTreePipedUpsert(String key, Map<Long, T> map,
+                            CollectionAttributes attr, Transcoder<T> tc) {
+      super(key, map, attr, tc);
+    }
+
+    @Override
+    public String getCommand() {
+      return COMMAND;
+    }
+  }
+
+  public static class ByteArrayBTreePipedUpsert<T> extends ByteArraysBTreePipedInsert<T> {
+    private static final String COMMAND = "bop upsert";
+
+    public ByteArrayBTreePipedUpsert(String key, List<Element<T>> elements,
+                                     CollectionAttributes attr, Transcoder<T> tc) {
+      super(key, elements, attr, tc);
+    }
+
+    @Override
+    public String getCommand() {
+      return COMMAND;
+    }
+  }
+}

--- a/src/main/java/net/spy/memcached/protocol/ascii/CollectionPipedInsertOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/CollectionPipedInsertOperationImpl.java
@@ -49,6 +49,8 @@ public class CollectionPipedInsertOperationImpl extends OperationImpl
           true, "CREATED_STORED", CollectionResponse.CREATED_STORED);
   private static final OperationStatus STORED = new CollectionOperationStatus(
           true, "STORED", CollectionResponse.STORED);
+  private static final OperationStatus REPLACED = new CollectionOperationStatus(
+          true, "REPLACED", CollectionResponse.REPLACED);
   private static final OperationStatus NOT_FOUND = new CollectionOperationStatus(
           false, "NOT_FOUND", CollectionResponse.NOT_FOUND);
   private static final OperationStatus ELEMENT_EXISTS = new CollectionOperationStatus(
@@ -117,8 +119,8 @@ public class CollectionPipedInsertOperationImpl extends OperationImpl
 
     if (insert.isNotPiped()) {
       OperationStatus status = matchStatus(line, STORED, CREATED_STORED,
-              NOT_FOUND, ELEMENT_EXISTS, OVERFLOWED, OUT_OF_RANGE,
-              TYPE_MISMATCH, BKEY_MISMATCH);
+              REPLACED, NOT_FOUND, ELEMENT_EXISTS, OVERFLOWED,
+              OUT_OF_RANGE, TYPE_MISMATCH, BKEY_MISMATCH);
       if (status.isSuccess()) {
         cb.receivedStatus((successAll) ? END : FAILED_END);
       } else {
@@ -157,8 +159,8 @@ public class CollectionPipedInsertOperationImpl extends OperationImpl
       count = Integer.parseInt(stuff[1]);
     } else {
       OperationStatus status = matchStatus(line, STORED, CREATED_STORED,
-              NOT_FOUND, ELEMENT_EXISTS, OVERFLOWED, OUT_OF_RANGE,
-              TYPE_MISMATCH, BKEY_MISMATCH);
+              REPLACED, NOT_FOUND, ELEMENT_EXISTS, OVERFLOWED,
+              OUT_OF_RANGE, TYPE_MISMATCH, BKEY_MISMATCH);
 
       if (!status.isSuccess()) {
         cb.gotStatus(index, status);

--- a/src/test/manual/net/spy/memcached/bulkoperation/BopPipeUpsertTest.java
+++ b/src/test/manual/net/spy/memcached/bulkoperation/BopPipeUpsertTest.java
@@ -1,0 +1,277 @@
+package net.spy.memcached.bulkoperation;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+import java.util.concurrent.TimeUnit;
+
+import net.spy.memcached.collection.BaseIntegrationTest;
+import net.spy.memcached.collection.CollectionAttributes;
+import net.spy.memcached.collection.Element;
+import net.spy.memcached.collection.ElementFlagFilter;
+import net.spy.memcached.ops.CollectionOperationStatus;
+
+import org.junit.Assert;
+
+public class BopPipeUpsertTest extends BaseIntegrationTest {
+  private static final String KEY = BopPipeUpsertTest.class.getSimpleName();
+  private static final String WRONG_KEY = "WRONG_KEY";
+
+  @Override
+  protected void setUp() throws Exception {
+    super.setUp();
+    mc.delete(KEY).get();
+    Assert.assertNull(mc.asyncGetAttr(KEY).get());
+  }
+
+  @Override
+  protected void tearDown() throws Exception {
+    mc.delete(KEY).get();
+    super.tearDown();
+  }
+
+  public void testAsyncBopPipedUpsertBulkSuccess() throws Exception {
+    //given
+    Map<Integer, CollectionOperationStatus> result;
+    int elementCount = 1000;
+    Map<Long, Object> insertElem = new TreeMap<Long, Object>();
+    Map<Long, Object> upsertElem = new TreeMap<Long, Object>();
+    for (long i = 0; i < elementCount; i++) {
+      if (i % 2 == 0) {
+        insertElem.put(i, "value" + i);
+      }
+      upsertElem.put(i, "upsertValue" + i);
+    }
+    CollectionAttributes attr = new CollectionAttributes();
+    mc.asyncBopPipedInsertBulk(KEY, insertElem, attr).get();
+
+    //when
+    result = mc.asyncBopPipedUpsertBulk(KEY, upsertElem, attr).get();
+
+    //then
+    Assert.assertTrue(result.isEmpty());
+  }
+
+  public void testWrongKeyFail() throws Exception {
+    //given
+    Map<Integer, CollectionOperationStatus> result;
+    int elementCount = 100;
+    Map<Long, Object> insertElem = new TreeMap<Long, Object>();
+    Map<Long, Object> upsertElem = new TreeMap<Long, Object>();
+    for (long i = 0; i < elementCount; i++) {
+      if (i % 2 == 0) {
+        insertElem.put(i, "value" + i);
+      }
+      upsertElem.put(i, "upsertValue" + i);
+    }
+    mc.asyncBopPipedInsertBulk(KEY, insertElem, new CollectionAttributes()).get();
+
+    //when
+    result = mc.asyncBopPipedUpsertBulk(WRONG_KEY, upsertElem, null).get();
+
+    //then
+    Assert.assertFalse(result.isEmpty());
+    for (CollectionOperationStatus status : result.values()) {
+      Assert.assertFalse(status.isSuccess());
+      Assert.assertEquals(status.getMessage(), "NOT_FOUND");
+    }
+  }
+
+  public void testWrongTypeFail() throws Exception {
+    //given
+    Map<Integer, CollectionOperationStatus> result;
+    int elementCount = 100;
+    Map<String, Object> insertElem = new TreeMap<String, Object>();
+    Map<Long, Object> upsertElem = new TreeMap<Long, Object>();
+    for (long i = 0; i < elementCount; i++) {
+      if (i % 2 == 0) {
+        insertElem.put("MKey" + i, i);
+      }
+      upsertElem.put(i, "value" + i);
+    }
+
+    CollectionAttributes collectionAttributes = new CollectionAttributes();
+    mc.asyncMopPipedInsertBulk(KEY, insertElem, collectionAttributes).get();
+
+    //when
+    result = mc.asyncBopPipedUpsertBulk(KEY, upsertElem, collectionAttributes).get();
+
+    //then
+    Assert.assertFalse(result.isEmpty());
+    for (CollectionOperationStatus status : result.values()) {
+      Assert.assertFalse(status.isSuccess());
+      Assert.assertEquals(status.getMessage(), "TYPE_MISMATCH");
+    }
+  }
+
+  public void testWrongBKeyTypeFail() throws Exception {
+    //given
+    Map<Integer, CollectionOperationStatus> result;
+    int elementCount = 100;
+    List<Element<Object>> insertElem = new ArrayList<Element<Object>>();
+    List<Element<Object>> upsertElem = new ArrayList<Element<Object>>();
+    for (int i = 0; i < elementCount; i++) {
+      if (i % 2 == 0) {
+        insertElem.add(new Element<Object>(new byte[]{(byte) i},
+                "value" + i,
+                new byte[]{(byte) 1}));
+      }
+      upsertElem.add(new Element<Object>(i, "upsertValue" + i, new byte[]{(byte) 1}));
+    }
+
+    CollectionAttributes collectionAttributes = new CollectionAttributes();
+    mc.asyncBopPipedUpsertBulk(KEY, insertElem, collectionAttributes).get();
+
+    //when
+    result = mc.asyncBopPipedUpsertBulk(KEY, upsertElem, collectionAttributes).get();
+
+    //then
+    Assert.assertFalse(result.isEmpty());
+    for (CollectionOperationStatus status : result.values()) {
+      Assert.assertFalse(status.isSuccess());
+      Assert.assertEquals(status.getMessage(), "BKEY_MISMATCH");
+    }
+  }
+
+
+  public void testBopGetByList() throws Exception {
+    //given
+    int elementCount = 1000;
+    List<Element<Object>> insertElem = new ArrayList<Element<Object>>();
+    List<Element<Object>> upsertElem = new ArrayList<Element<Object>>();
+    for (int i = 0; i < elementCount; i++) {
+      if (i % 2 == 0) {
+        insertElem.add(new Element<Object>(i, "value" + i, new byte[]{(byte) 1}));
+      }
+      upsertElem.add(new Element<Object>(i, "upsertValue" + i, new byte[]{(byte) 1}));
+    }
+    CollectionAttributes attr = new CollectionAttributes();
+    mc.asyncBopPipedInsertBulk(KEY, insertElem, attr).get();
+
+    //when
+    mc.asyncBopPipedUpsertBulk(KEY, upsertElem, attr).get();
+
+    //then
+    Map<Long, Element<Object>> upsertResult = mc.asyncBopGet(
+                    KEY, 0, elementCount,
+                    ElementFlagFilter.DO_NOT_FILTER,
+                    0, 0, false, false)
+            .get();
+    Assert.assertEquals(elementCount, upsertResult.size());
+    int idx = 0;
+    for (Element<Object> elem : upsertResult.values()) {
+      Assert.assertEquals(elem.getLongBkey(), idx);
+      Assert.assertEquals(elem.getValue(), "upsertValue" + idx);
+      idx++;
+    }
+  }
+
+
+  public void testAllInsertByMap() throws Exception {
+    //given
+    int elementCount = 4000;
+    Map<Long, Object> elements = new TreeMap<Long, Object>();
+    for (long i = 0; i < elementCount; i++) {
+      elements.put(i, "value" + i);
+    }
+    CollectionAttributes attr = new CollectionAttributes();
+
+    //when
+    mc.asyncBopPipedUpsertBulk(KEY, elements, attr).get();
+
+    //then
+    Map<Long, Element<Object>> resultMap
+            = mc.asyncBopGet(KEY, 0, 5000,
+            ElementFlagFilter.DO_NOT_FILTER, 0,
+            0, false, false).get();
+    Long idx = 0L;
+    for (Map.Entry<Long, Element<Object>> entry : resultMap.entrySet()) {
+      Assert.assertEquals(idx, entry.getKey());
+      Assert.assertEquals("value" + idx, entry.getValue().getValue());
+      idx++;
+    }
+  }
+
+  public void testAllInsertByList() throws Exception {
+    //given
+    int elementCount = 4000;
+    List<Element<Object>> elements = new ArrayList<Element<Object>>();
+    for (int i = 0; i < elementCount; i++) {
+      elements.add(new Element<Object>(i, "value" + i, new byte[]{(byte) 1}));
+    }
+    CollectionAttributes attr = new CollectionAttributes();
+
+    //when
+    mc.asyncBopPipedUpsertBulk(KEY, elements, attr).get();
+
+    //then
+    Map<Long, Element<Object>> resultMap
+            = mc.asyncBopGet(KEY, 0, 5000,
+            ElementFlagFilter.DO_NOT_FILTER, 0,
+            0, false, false).get();
+    Long idx = 0L;
+    for (Map.Entry<Long, Element<Object>> entry : resultMap.entrySet()) {
+      Assert.assertEquals(idx, entry.getKey());
+      Assert.assertEquals("value" + idx, entry.getValue().getValue());
+      idx++;
+    }
+  }
+
+  public void testAllUpdateByMap() throws Exception {
+    //given
+    int elementCount = 500;
+    Map<Long, Object> insertElem = new TreeMap<Long, Object>();
+    Map<Long, Object> upsertElem = new TreeMap<Long, Object>();
+
+    for (long i = 0; i < elementCount; i++) {
+      insertElem.put(i, "value" + i);
+      upsertElem.put(i, "upsertValue" + i);
+    }
+
+    CollectionAttributes attr = new CollectionAttributes();
+    mc.asyncBopPipedInsertBulk(KEY, insertElem, attr).get(5000L, TimeUnit.MILLISECONDS);
+
+    //when
+    mc.asyncBopPipedUpsertBulk(KEY, upsertElem, attr);
+    Map<Long, Element<Object>> resultMap
+            = mc.asyncBopGet(KEY, 0, 5000,
+                    ElementFlagFilter.DO_NOT_FILTER, 0,
+                    0, false, false)
+            .get();
+    int idx = 0;
+    for (Element<Object> elem : resultMap.values()) {
+      Assert.assertEquals(elem.getLongBkey(), idx);
+      Assert.assertEquals(elem.getValue(), "upsertValue" + idx);
+      idx++;
+    }
+  }
+
+  public void testAllUpdateByList() throws Exception {
+    int elementCount = 500;
+    List<Element<Object>> insertElem = new ArrayList<Element<Object>>();
+    List<Element<Object>> upsertElem = new ArrayList<Element<Object>>();
+
+    for (int i = 0; i < elementCount; i++) {
+      insertElem.add(new Element<Object>(i, "value" + i, new byte[]{(byte) 1}));
+      upsertElem.add(new Element<Object>(i, "upsertValue" + i, new byte[]{(byte) 1}));
+    }
+
+    CollectionAttributes attr = new CollectionAttributes();
+    mc.asyncBopPipedInsertBulk(KEY, insertElem, attr).get(5000L, TimeUnit.MILLISECONDS);
+
+    //when
+    mc.asyncBopPipedUpsertBulk(KEY, upsertElem, attr);
+    Map<Long, Element<Object>> resultMap
+            = mc.asyncBopGet(KEY, 0, 5000,
+            ElementFlagFilter.DO_NOT_FILTER, 0,
+                    0, false, false)
+            .get();
+    int idx = 0;
+    for (Element<Object> elem : resultMap.values()) {
+      Assert.assertEquals(elem.getLongBkey(), idx);
+      Assert.assertEquals(elem.getValue(), "upsertValue" + idx);
+      idx++;
+    }
+  }
+}


### PR DESCRIPTION
## Motivation
아래 캐시 동기화에 필요한 기능 이슈를 해결하기 위해 구현한다.
https://github.com/jam2in/arcus-works/issues/426

## 구현 로직
캐시 서버는 bop insert와 bop upsert 요청에 대해
아래와 같이 동일한 인자와 형식을 가지고 있습니다.

```
bop insert <key> <bkey> [<eflag>] <bytes> [create <attributes>] [noreply|pipe|getrim]\r\n<data>\r\n
bop upsert <key> <bkey> [<eflag>] <bytes> [create <attributes>] [noreply|pipe|getrim]\r\n<data>\r\n
```

그래서 기존의 asyncCollectionPipedInsert()를 활용하여
piped upsert를 가능하도록 구현하였습니다.

단건 upsert의 경우도 아래와 같이 `asyncCollectionInsert`를 
사용하여 구현되어 있습니다.

```java
@Override
  public CollectionFuture<Boolean> asyncBopUpsert(String key, long bkey,
                                                  byte[] elementFlag, Object value,
                                                  CollectionAttributes attributesForCreate) {

    BTreeUtil.validateBkey(bkey);
    BTreeUpsert<Object> bTreeUpsert = new BTreeUpsert<Object>(value, elementFlag, null, attributesForCreate);

    return asyncCollectionInsert(key, String.valueOf(bkey), bTreeUpsert,
            collectionTranscoder);
  }
```

즉, 이러한 구현이 단건과 다건 api에 대한 일관적으로 구현된 형태입니다.