### PR TITLE
INTRENAL: Refactor asyncCollectionExist api.

### DIFF
--- a/src/main/java/net/spy/memcached/ArcusClient.java
+++ b/src/main/java/net/spy/memcached/ArcusClient.java
@@ -551,13 +551,13 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
   public <T> CollectionFuture<Boolean> asyncSopExist(String key, T value,
                                                      Transcoder<T> tc) {
     SetExist<T> exist = new SetExist<T>(value, tc);
-    return asyncCollectionExist(key, "", exist, tc);
+    return asyncCollectionExist(key, "", exist);
   }
 
   @Override
   public CollectionFuture<Boolean> asyncSopExist(String key, Object value) {
     SetExist<Object> exist = new SetExist<Object>(value, collectionTranscoder);
-    return asyncCollectionExist(key, "", exist, collectionTranscoder);
+    return asyncCollectionExist(key, "", exist);
   }
 
   /**
@@ -961,12 +961,10 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
    * @param key             collection item's key
    * @param subkey          element key (list index, b+tree bkey)
    * @param collectionExist operation parameters (element value and so on)
-   * @param tc              transcoder to serialize and unserialize value
    * @return future holding the success/failure of the operation
    */
-  private <T> CollectionFuture<Boolean> asyncCollectionExist(
-          final String key, final String subkey,
-          final CollectionExist collectionExist, Transcoder<T> tc) {
+  private <T> CollectionFuture<Boolean> asyncCollectionExist(final String key, final String subkey,
+                                                             final CollectionExist collectionExist) {
     final CountDownLatch latch = new CountDownLatch(1);
     final CollectionFuture<Boolean> rv = new CollectionFuture<Boolean>(
             latch, operationTimeout);
@@ -981,8 +979,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
               getLogger().warn("Unhandled state: " + status);
               cstatus = new CollectionOperationStatus(status);
             }
-            boolean isExist = (CollectionResponse.EXIST == cstatus.getResponse())
-                            ? true : false;
+            boolean isExist = CollectionResponse.EXIST == cstatus.getResponse();
             rv.set(isExist, cstatus);
             if (!cstatus.isSuccess()) {
               getLogger().debug("Exist command to the collection failed : %s (type=%s, key=%s, subkey=%s)",


### PR DESCRIPTION
## Motivation
asyncCollectionExist의 경우 현재 Transcoder를 인자로 사용한다.
asyncCollectionExist 내에서는 tc가 사용되지 않고 wrapper 메서드인 
asyncSopExist 내의 SetExist 생성자를 통해 tc.encode를 수행한다.

 
추후 다른 자료구조들의 Exist api 확장을 고려한다해도
encode는 현재와 마찬가지로 asyncLopExist, asyncBopExist 등에서 수행시키면 된다.
asyncCollectionExist내에서는 decode를 수행하는 경우를 고려할 수 있는데
서버로부터의 응답값이 자료구조 내의 value가 아닌 EXIST, NOT_EXIST이기 때문에
docode로직 또한 사용되지 않는다고 예상할 수 있다.

결론적으로 Transcoder 인자를 제거할 수 있다.

그 외 사항으로는 삼항 연산자 로직을 간결하게 변경한다.
