### PR TITLE
INTERNAL: Refactor collectionGetOp and BTreeGet.

### DIFF
--- a/src/main/java/net/spy/memcached/collection/CollectionGet.java
+++ b/src/main/java/net/spy/memcached/collection/CollectionGet.java
@@ -57,14 +57,6 @@ public abstract class CollectionGet {
     return headerCount == spaceCount;
   }
 
-  public void setHeaderCount(int headerCount) {
-    this.headerCount = headerCount;
-  }
-
-  public int getHeaderCount() {
-    return headerCount;
-  }
-
   public boolean eachRecordParseCompleted() {
     return true;
   }

--- a/src/main/java/net/spy/memcached/protocol/ascii/CollectionGetOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/CollectionGetOperationImpl.java
@@ -147,7 +147,7 @@ public class CollectionGetOperationImpl extends OperationImpl
   public final void handleRead(ByteBuffer bb) {
     // Decode a collection data header.
     if (lookingFor == '\0' && data == null) {
-      for (int i = 0; bb.remaining() > 0; i++) {
+      while (bb.hasRemaining()) {
         byte b = bb.get();
 
         // Handle spaces.
@@ -160,15 +160,10 @@ public class CollectionGetOperationImpl extends OperationImpl
               set:   <bytes> <data>\r\n
               map:   <field> <bytes> <data>\r\n
              */
-            collectionGet.decodeItemHeader(new String(byteBuffer.toByteArray()));
+            collectionGet.decodeItemHeader(byteBuffer.toString());
             byteBuffer.reset();
 
-            if (collectionGet.headerReady(spaceCount)
-                    && collectionGet.eachRecordParseCompleted()) {
-//              if (collectionGet.getElementFlag() != null) {
-//                  collectionGet.setHeaderCount(collectionGet
-//                      .getHeaderCount() - 1);
-//               }
+            if (collectionGet.headerReady(spaceCount) && collectionGet.eachRecordParseCompleted()) {
               data = new byte[collectionGet.getDataLength()];
               spaceCount = 0;
               break;


### PR DESCRIPTION
## Motivation
smget, bopBulkGet 등의 bop Get api들의 
서버 응답을 파싱하는 로직을 리팩토링 하기 위해
가장 간단한 형태의 api인 bop get의 로직을 분석하고 리팩토링한다.

기존의 로직은 decodingItemHeader 메서드에는
 의미가 불분명한 변수명과 하드코딩된 상수값들이 존재한다.
코드를 읽기 쉽게 하기 위해 이러한 값들을
적절히 변경한다.
또한 handleRead 메서드 내에 사용되지 않는 변수 제거 및
String 객체 사용 최적화를 진행한다.
