### PR TITLE
INTERNAL: Change parsing itemHeader logic in CollectionGetOpImpl.

### DIFF
--- a/src/main/java/net/spy/memcached/collection/CollectionGet.java
+++ b/src/main/java/net/spy/memcached/collection/CollectionGet.java
@@ -16,6 +16,8 @@
  */
 package net.spy.memcached.collection;
 
+import java.util.List;
+
 public abstract class CollectionGet {
 
   protected boolean delete = false;
@@ -23,11 +25,12 @@ public abstract class CollectionGet {
 
   protected String range;
   protected String str;
-  protected int headerCount;
   protected String subkey;
   protected int dataLength;
 
   protected byte[] elementFlag;
+  protected int eHeadCount;
+  protected int eFlagIndex;
 
   public boolean isDelete() {
     return delete;
@@ -53,12 +56,12 @@ public abstract class CollectionGet {
     return elementFlag;
   }
 
-  public boolean headerReady(int spaceCount) {
-    return headerCount == spaceCount;
+  public int getEFlagIndex() {
+    return eFlagIndex;
   }
 
-  public boolean eachRecordParseCompleted() {
-    return true;
+  public int getEHeadCount() {
+    return eHeadCount;
   }
 
   public abstract byte[] getAddtionalArgs();
@@ -67,6 +70,5 @@ public abstract class CollectionGet {
 
   public abstract String getCommand();
 
-  public abstract void decodeItemHeader(String itemHeader);
-
+  public abstract void decodeElemHeader(List<String> tokens);
 }

--- a/src/main/java/net/spy/memcached/collection/ListGet.java
+++ b/src/main/java/net/spy/memcached/collection/ListGet.java
@@ -16,15 +16,18 @@
  */
 package net.spy.memcached.collection;
 
+import java.util.List;
+
 public class ListGet extends CollectionGet {
 
   private static final String command = "lop get";
 
   private ListGet(String range, boolean delete, boolean dropIfEmpty) {
-    this.headerCount = 1;
     this.range = range;
     this.delete = delete;
     this.dropIfEmpty = dropIfEmpty;
+    this.eHeadCount = 1;
+    this.eFlagIndex = -1;
   }
 
   public ListGet(int index, boolean delete, boolean dropIfEmpty) {
@@ -70,7 +73,8 @@ public class ListGet extends CollectionGet {
     return command;
   }
 
-  public void decodeItemHeader(String itemHeader) {
-    this.dataLength = Integer.parseInt(itemHeader);
+  @Override
+  public void decodeElemHeader(List<String> tokens) {
+    this.dataLength = Integer.parseInt(tokens.get(0));
   }
 }

--- a/src/main/java/net/spy/memcached/collection/MapGet.java
+++ b/src/main/java/net/spy/memcached/collection/MapGet.java
@@ -29,10 +29,11 @@ public class MapGet extends CollectionGet {
   protected byte[] additionalArgs;
 
   public MapGet(List<String> mkeyList, boolean delete, boolean dropIfEmpty) {
-    this.headerCount = 2;
     this.mkeyList = mkeyList;
     this.delete = delete;
     this.dropIfEmpty = dropIfEmpty;
+    this.eHeadCount = 2;
+    this.eFlagIndex = -1;
   }
 
   public void setKeySeparator(String keySeparator) {
@@ -95,9 +96,9 @@ public class MapGet extends CollectionGet {
     return command;
   }
 
-  public void decodeItemHeader(String itemHeader) {
-    String[] splited = itemHeader.split(" ");
-    this.subkey = splited[0];
-    this.dataLength = Integer.parseInt(splited[1]);
+  @Override
+  public void decodeElemHeader(List<String> tokens) {
+    this.subkey = tokens.get(0);
+    this.dataLength = Integer.parseInt(tokens.get(1));
   }
 }

--- a/src/main/java/net/spy/memcached/collection/SetGet.java
+++ b/src/main/java/net/spy/memcached/collection/SetGet.java
@@ -16,6 +16,8 @@
  */
 package net.spy.memcached.collection;
 
+import java.util.List;
+
 public class SetGet extends CollectionGet {
 
   private static final String command = "sop get";
@@ -23,10 +25,11 @@ public class SetGet extends CollectionGet {
   protected int count;
 
   public SetGet(int count, boolean delete, boolean dropIfEmpty) {
-    this.headerCount = 1;
     this.count = count;
     this.delete = delete;
     this.dropIfEmpty = dropIfEmpty;
+    this.eHeadCount = 1;
+    this.eFlagIndex = -1;
   }
 
   public int getCount() {
@@ -64,7 +67,8 @@ public class SetGet extends CollectionGet {
     return command;
   }
 
-  public void decodeItemHeader(String itemHeader) {
-    this.dataLength = Integer.parseInt(itemHeader);
+  @Override
+  public void decodeElemHeader(List<String> tokens) {
+    this.dataLength = Integer.parseInt(tokens.get(0));
   }
 }

--- a/src/test/manual/net/spy/memcached/MultibyteKeyTest.java
+++ b/src/test/manual/net/spy/memcached/MultibyteKeyTest.java
@@ -162,7 +162,7 @@ public class MultibyteKeyTest {
         }
 
         @Override
-        public void decodeItemHeader(String itemHeader) {
+        public void decodeElemHeader(List<String> tokens) {
         }
       }, new CollectionGetOperation.Callback() {
         @Override


### PR DESCRIPTION
## 관련 이슈
https://github.com/jam2in/arcus-works/issues/433

## Motivation
기존 item Header를 파싱하는 로직은
handleRead 내에서 eFlag 유무와 eachRecordParseCompleted()의 여부에 따라
decodeItemHeader를 2번 호출하는 복잡한 로직이다.
이러한 로직을 버퍼로부터 데이터를 받고 space를 만날 때 마다
파싱 대상을 String 단위로 `List<String>`에 추가해주고
해당 List의 길이를 통해 eFlag 여부를 확인하도록 변경한다.

## 주요 변경 사항
- 슈퍼 클래스인 CollectionGet에 추상 메서드 `decodeItemHeader(List<String>)` 생성
- 이의 구현체들 중 sopGet,bopGet,lopGet,MopGet은 위 함수를 통해 handleRead() 로직 수행
- 나머지 BTreeFPG 등은 위 함수의 구현 없이 기존 `decodeItemHeader(String)`를 통해 로직 수행
- BTreeFPG 등은 컴파일 에러 방지를 위해 함수 선언과 비어있는 body로 구현되어 있음
- 이는 해당 PR이 merge되고 나서 점진적으로 변경 예정