### PR TITLE
FIX: getElement logic in BTreeStoreAndGetFuture.

### DIFF
--- a/src/main/java/net/spy/memcached/internal/BTreeStoreAndGetFuture.java
+++ b/src/main/java/net/spy/memcached/internal/BTreeStoreAndGetFuture.java
@@ -17,8 +17,12 @@
 package net.spy.memcached.internal;
 
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicReference;
 
+import net.spy.memcached.OperationTimeoutException;
 import net.spy.memcached.collection.Element;
 import net.spy.memcached.ops.CollectionGetOpCallback;
 
@@ -41,6 +45,15 @@ public class BTreeStoreAndGetFuture<T, E> extends CollectionFuture<T> {
   }
 
   public Element<E> getElement() {
+    try {
+      super.get(super.timeout, TimeUnit.MILLISECONDS);
+    } catch (ExecutionException e) {
+      throw new RuntimeException(e);
+    } catch (InterruptedException e) {
+      throw new RuntimeException(e);
+    } catch (TimeoutException e) {
+      throw new OperationTimeoutException(e);
+    }
     CollectionGetOpCallback callback = (CollectionGetOpCallback) op.getCallback();
     callback.addResult();
     return element;


### PR DESCRIPTION
## Motivation
기존 BTreeStoreAndGetFuture의 getElement 동작은 
곧바로 element 변수를 리턴하는 로직인데
이는 Future의 get()이 완료되지 않을 경우 
리턴되는 결과가 부정확하다.

**즉, 응용의 Worker Thread가 Blocking되어 정확한 결과값을 리턴받도록 변경**해야한다.

getElement() 내부적으로 get()을 호출하여
정확한 element를 리턴하도록 변경한다.