### PR TITLE
INTERNAL: Refactor BTreeInsertAndGet to extend CollectionGet.

### DIFF
--- a/src/main/java/net/spy/memcached/ArcusClient.java
+++ b/src/main/java/net/spy/memcached/ArcusClient.java
@@ -3302,8 +3302,8 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
   public BTreeStoreAndGetFuture<Boolean, Object> asyncBopInsertAndGetTrimmed(
           String key, long bkey, byte[] eFlag, Object value,
           CollectionAttributes attributesForCreate) {
-    BTreeInsertAndGet<Object> insertAndGet = new BTreeInsertAndGet<Object>(
-            BTreeInsertAndGet.Command.INSERT, bkey, eFlag, value, attributesForCreate);
+    BTreeInsertAndGet<Object> insertAndGet
+            = new BTreeInsertAndGet<Object>(bkey, eFlag, value, false, attributesForCreate);
     return asyncBTreeInsertAndGet(key, insertAndGet, collectionTranscoder);
   }
 
@@ -3311,8 +3311,8 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
   public <E> BTreeStoreAndGetFuture<Boolean, E> asyncBopInsertAndGetTrimmed(
           String key, long bkey, byte[] eFlag, E value,
           CollectionAttributes attributesForCreate, Transcoder<E> transcoder) {
-    BTreeInsertAndGet<E> insertAndGet = new BTreeInsertAndGet<E>(
-            BTreeInsertAndGet.Command.INSERT, bkey, eFlag, value, attributesForCreate);
+    BTreeInsertAndGet<E> insertAndGet
+            = new BTreeInsertAndGet<E>(bkey, eFlag, value, false, attributesForCreate);
     return asyncBTreeInsertAndGet(key, insertAndGet, transcoder);
   }
 
@@ -3320,8 +3320,8 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
   public BTreeStoreAndGetFuture<Boolean, Object> asyncBopInsertAndGetTrimmed(
           String key, byte[] bkey, byte[] eFlag, Object value,
           CollectionAttributes attributesForCreate) {
-    BTreeInsertAndGet<Object> insertAndGet = new BTreeInsertAndGet<Object>(
-            BTreeInsertAndGet.Command.INSERT, bkey, eFlag, value, attributesForCreate);
+    BTreeInsertAndGet<Object> insertAndGet
+            = new BTreeInsertAndGet<Object>(bkey, eFlag, value, false, attributesForCreate);
     return asyncBTreeInsertAndGet(key, insertAndGet, collectionTranscoder);
   }
 
@@ -3329,8 +3329,8 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
   public <E> BTreeStoreAndGetFuture<Boolean, E> asyncBopInsertAndGetTrimmed(
           String key, byte[] bkey, byte[] eFlag, E value,
           CollectionAttributes attributesForCreate, Transcoder<E> transcoder) {
-    BTreeInsertAndGet<E> insertAndGet = new BTreeInsertAndGet<E>(
-            BTreeInsertAndGet.Command.INSERT, bkey, eFlag, value, attributesForCreate);
+    BTreeInsertAndGet<E> insertAndGet
+            = new BTreeInsertAndGet<E>(bkey, eFlag, value, false, attributesForCreate);
     return asyncBTreeInsertAndGet(key, insertAndGet, transcoder);
   }
 
@@ -3338,8 +3338,8 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
   public BTreeStoreAndGetFuture<Boolean, Object> asyncBopUpsertAndGetTrimmed(
           String key, long bkey, byte[] eFlag, Object value,
           CollectionAttributes attributesForCreate) {
-    BTreeInsertAndGet<Object> insertAndGet = new BTreeInsertAndGet<Object>(
-            BTreeInsertAndGet.Command.UPSERT, bkey, eFlag, value, attributesForCreate);
+    BTreeInsertAndGet<Object> insertAndGet
+            = new BTreeInsertAndGet<Object>(bkey, eFlag, value, true, attributesForCreate);
     return asyncBTreeInsertAndGet(key, insertAndGet, collectionTranscoder);
   }
 
@@ -3347,8 +3347,8 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
   public <E> BTreeStoreAndGetFuture<Boolean, E> asyncBopUpsertAndGetTrimmed(
           String key, long bkey, byte[] eFlag, E value,
           CollectionAttributes attributesForCreate, Transcoder<E> transcoder) {
-    BTreeInsertAndGet<E> insertAndGet = new BTreeInsertAndGet<E>(
-            BTreeInsertAndGet.Command.UPSERT, bkey, eFlag, value, attributesForCreate);
+    BTreeInsertAndGet<E> insertAndGet
+            = new BTreeInsertAndGet<E>(bkey, eFlag, value, true, attributesForCreate);
     return asyncBTreeInsertAndGet(key, insertAndGet, transcoder);
   }
 
@@ -3356,8 +3356,8 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
   public BTreeStoreAndGetFuture<Boolean, Object> asyncBopUpsertAndGetTrimmed(
           String key, byte[] bkey, byte[] eFlag, Object value,
           CollectionAttributes attributesForCreate) {
-    BTreeInsertAndGet<Object> insertAndGet = new BTreeInsertAndGet<Object>(
-            BTreeInsertAndGet.Command.UPSERT, bkey, eFlag, value, attributesForCreate);
+    BTreeInsertAndGet<Object> insertAndGet
+            = new BTreeInsertAndGet<Object>(bkey, eFlag, value, true, attributesForCreate);
     return asyncBTreeInsertAndGet(key, insertAndGet, collectionTranscoder);
   }
 
@@ -3365,8 +3365,8 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
   public <E> BTreeStoreAndGetFuture<Boolean, E> asyncBopUpsertAndGetTrimmed(
           String key, byte[] bkey, byte[] eFlag, E value,
           CollectionAttributes attributesForCreate, Transcoder<E> transcoder) {
-    BTreeInsertAndGet<E> insertAndGet = new BTreeInsertAndGet<E>(
-            BTreeInsertAndGet.Command.UPSERT, bkey, eFlag, value, attributesForCreate);
+    BTreeInsertAndGet<E> insertAndGet
+            = new BTreeInsertAndGet<E>(bkey, eFlag, value, true, attributesForCreate);
     return asyncBTreeInsertAndGet(key, insertAndGet, transcoder);
   }
 

--- a/src/main/java/net/spy/memcached/protocol/ascii/BTreeInsertAndGetOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/BTreeInsertAndGetOperationImpl.java
@@ -99,10 +99,10 @@ public class BTreeInsertAndGetOperationImpl extends OperationImpl implements
     this.key = key;
     this.get = get;
     this.dataToStore = dataToStore;
-    if (get.getCmd() == BTreeInsertAndGet.Command.INSERT) {
-      setAPIType(APIType.BOP_INSERT);
-    } else if (get.getCmd() == BTreeInsertAndGet.Command.UPSERT) {
+    if (get.isUpdateIfExist()) {
       setAPIType(APIType.BOP_UPSERT);
+    } else {
+      setAPIType(APIType.BOP_INSERT);
     }
     setOperationType(OperationType.WRITE);
   }
@@ -149,15 +149,10 @@ public class BTreeInsertAndGetOperationImpl extends OperationImpl implements
       }
     } else {
       OperationStatus status = null;
-      switch (get.getCmd()) {
-        case INSERT:
-          status = matchStatus(line, INSERT_AND_GET_STATUS_ON_LINE);
-          break;
-        case UPSERT:
-          status = matchStatus(line, UPSERT_AND_GET_STATUS_ON_LINE);
-          break;
-        default:
-          status = UNDEFINED_OPERATION;
+      if (get.isUpdateIfExist()) {
+        status = matchStatus(line, UPSERT_AND_GET_STATUS_ON_LINE);
+      } else {
+        status = matchStatus(line, INSERT_AND_GET_STATUS_ON_LINE);
       }
       getLogger().debug(status);
       getCallback().receivedStatus(status);

--- a/src/test/manual/net/spy/memcached/MultibyteKeyTest.java
+++ b/src/test/manual/net/spy/memcached/MultibyteKeyTest.java
@@ -666,8 +666,8 @@ public class MultibyteKeyTest {
   public void BTreeInsertAndGetOperationImplTest() {
     try {
       opFact.bopInsertAndGet(MULTIBYTE_KEY,
-          new BTreeInsertAndGet<Integer>(BTreeInsertAndGet.Command.INSERT, 1L, new byte[]{0, 0},
-                  new Random().nextInt(), new CollectionAttributes()),
+          new BTreeInsertAndGet<Integer>(1L, new byte[]{0, 0}, new Random().nextInt(),
+                  false,  new CollectionAttributes()),
           testData, new BTreeInsertAndGetOperation.Callback() {
             @Override
             public void gotData(int flags, BKeyObject bkeyObject, byte[] elementFlag, byte[] data) {

--- a/src/test/manual/net/spy/memcached/collection/btree/BopInsertAndGetTest.java
+++ b/src/test/manual/net/spy/memcached/collection/btree/BopInsertAndGetTest.java
@@ -49,6 +49,23 @@ public class BopInsertAndGetTest extends BaseIntegrationTest {
     mc.delete(kvKey).get();
   }
 
+  public void testInsertAndGetNotTrimmed() throws Exception {
+    //given
+    CollectionAttributes attrs = new CollectionAttributes();
+    attrs.setMaxCount(longBkeys.length + 1);
+
+    //when
+    for (long each : longBkeys) {
+      mc.asyncBopInsert(key, each, null, "val", attrs).get();
+    }
+
+    //then
+    BTreeStoreAndGetFuture<Boolean, Object> f = mc
+            .asyncBopInsertAndGetTrimmed(key, 2000, null, "val", null);
+    assertTrue(f.get());
+    assertNull(f.getElement());
+  }
+
   public void testInsertAndGetTrimmedLongBKey() throws Exception {
     // insert test data
     CollectionAttributes attrs = new CollectionAttributes();


### PR DESCRIPTION
## Motivation 및 변경 지점

기존 `BTreeInsertAndGet`의 경우 
`CollectionInsert<T>`를 상속 받아 구현된다.

이러한 점은 아래와 같이 서버로부터 Data를 read하는 연산들과 일관성이 없는 구현이다.
- collectionGet
- BTreeGetByPosition
- BTreeFindPositionWithGet

그래서 상속 대신 구성을 통해 `CollectionInsert<T>`의 기능을 그대로 가져오는 구현으로 변경한다.
이러한 변경은 자식 클래스가 사용하지 않는 부모 클래스의 기능들을 상속받지 않아도 되며,
다른 api들과의 일관성 또한 가질 수 있다.

또한 내부적으로 사용되던 enum 타입이 존재하는데
이는 코드의 가독성을 감소시키고 구현을 복잡하게 만든다.
이를 외부에서 선언하여 간결하게 변경한다.

마지막으로 not trimmed인 경우에 대한 테스트 케이스를 추가하였다.


## 추후 변경 예정

아래 PR이 merge 되고
- https://github.com/naver/arcus-java-client/pull/661

해당 PR이 approve 되면 BTreeInsertAndGet의 
handleRead() 로직을 변경하는 구현에 대한 PR 올리겠습니다.