### PR TITLE
ENHANCE: Change decode logic in BTreeGetBulk api.

### DIFF
--- a/src/main/java/net/spy/memcached/collection/BTreeGetResult.java
+++ b/src/main/java/net/spy/memcached/collection/BTreeGetResult.java
@@ -16,10 +16,13 @@
  */
 package net.spy.memcached.collection;
 
+import java.util.List;
 import java.util.Map;
 import java.util.SortedMap;
 
+import net.spy.memcached.CachedData;
 import net.spy.memcached.ops.CollectionOperationStatus;
+import net.spy.memcached.transcoders.Transcoder;
 
 public class BTreeGetResult<K, V> {
 
@@ -40,7 +43,13 @@ public class BTreeGetResult<K, V> {
     return opStatus;
   }
 
-  public void addElement(BTreeElement<K, V> element) {
-    this.elements.put(element.getBkey(), element);
+  public void addElements(List<BTreeElement<K, CachedData>> cachedData, Transcoder<V> tc) {
+    if (elements != null && elements.isEmpty()) {
+      for (BTreeElement<K, CachedData> elem : cachedData) {
+        BTreeElement<K, V> decodedElem =
+                new BTreeElement<K, V>(elem.getBkey(), elem.getEflag(), tc.decode(elem.getValue()));
+        elements.put(decodedElem.getBkey(), decodedElem);
+      }
+    }
   }
 }

--- a/src/main/java/net/spy/memcached/internal/CollectionGetBulkFuture.java
+++ b/src/main/java/net/spy/memcached/internal/CollectionGetBulkFuture.java
@@ -26,6 +26,7 @@ import java.util.concurrent.TimeoutException;
 
 import net.spy.memcached.MemcachedConnection;
 import net.spy.memcached.OperationTimeoutException;
+import net.spy.memcached.ops.CollectionGetOpCallback;
 import net.spy.memcached.ops.CollectionOperationStatus;
 import net.spy.memcached.ops.Operation;
 import net.spy.memcached.ops.OperationState;
@@ -83,6 +84,10 @@ public class CollectionGetBulkFuture<T> implements Future<T> {
       if (op != null && op.isCancelled()) {
         throw new ExecutionException(new RuntimeException(op.getCancelCause()));
       }
+    }
+    for (Operation op : ops) {
+      CollectionGetOpCallback callback = (CollectionGetOpCallback) op.getCallback();
+      callback.addResult();
     }
 
     return result;

--- a/src/main/java/net/spy/memcached/ops/BTreeGetBulkOperation.java
+++ b/src/main/java/net/spy/memcached/ops/BTreeGetBulkOperation.java
@@ -21,7 +21,7 @@ import net.spy.memcached.collection.BTreeGetBulk;
 public interface BTreeGetBulkOperation extends KeyedOperation {
   BTreeGetBulk<?> getBulk();
 
-  interface Callback extends OperationCallback {
+  interface Callback extends CollectionGetOpCallback {
     void gotElement(String key, int flags, Object subkey, byte[] eflag, byte[] data);
 
     void gotKey(String key, int elementCount, OperationStatus status);

--- a/src/main/java/net/spy/memcached/ops/MultiBTreeGetBulkOperationCallback.java
+++ b/src/main/java/net/spy/memcached/ops/MultiBTreeGetBulkOperationCallback.java
@@ -33,5 +33,10 @@ public class MultiBTreeGetBulkOperationCallback extends MultiOperationCallback
   public void gotKey(String key, int elementCount, OperationStatus status) {
     ((BTreeGetBulkOperation.Callback) originalCallback).gotKey(key, elementCount, status);
   }
+
+  @Override
+  public void addResult() {
+    ((BTreeGetBulkOperation.Callback) originalCallback).addResult();
+  }
 }
 

--- a/src/test/manual/net/spy/memcached/MultibyteKeyTest.java
+++ b/src/test/manual/net/spy/memcached/MultibyteKeyTest.java
@@ -540,6 +540,10 @@ public class MultibyteKeyTest {
             @Override
             public void complete() {
             }
+
+            @Override
+            public void addResult() {
+            }
           }).initialize();
     } catch (java.nio.BufferOverflowException e) {
       Assert.fail();


### PR DESCRIPTION
## 관련 이슈
https://github.com/jam2in/arcus-works/issues/406

## Motivation
BopGetBulk 연산의 경우에도 읽어야하는 Value의 decode() 수행은 IO 쓰레드가 담당한다.
이러한 로직을 addResult() 메서드를 통해 WAS의 worker 쓰레드가 담당하도록 변경한다.

해당 연산의 경우, 사용자가 받게 될 result는 아래와 같은 구조이다.
```
----------------------------------------
BTreeKey1(not BKey) | BTreeGetResult1
BTreeKey2(not BKey) | BTreeGetResult2
BTreeKey3(not BKey) | BTreeGetResult3
----------------------------------------
```

BTreeGetResult 객체의 내부에 TreeMap이 null이 아닌 경우는 
서버로부터 받은 elem이 존재하고 null인 경우는 elem이 없는 BTree를 조회한것이다.
**즉, TreeMap이 null인 경우는 addResult()를 수행하지 않아도 된다.**
참고로 해당 로직은 콜백의 gotKey()의 elemCount 파라미터를 통해 수행된다.

그외, TreeMap이 null이 아닌 경우는 첫번째 get() 호출에서만 
addResult() 로직을 수행하기 위해 isEmpty 검사를 진행한다.

결론적으로 기존의 addResult 메서드 구현보다 검증해야할 부분이 많이 존재한다.

그 외 나머지 사항은 기존의 Decode 로직 변경 PR들과 유사하다.
아래 PR을 참고 할 수 있다.
- https://github.com/naver/arcus-java-client/pull/653