### PR TITLE
INTERNAL: Use isEmpty method to simplify empty checking

### DIFF
--- a/src/main/java/net/spy/memcached/ArcusClient.java
+++ b/src/main/java/net/spy/memcached/ArcusClient.java
@@ -2315,7 +2315,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
 
       @Override
       public CollectionOperationStatus getOperationStatus() {
-        if (failedOperationStatus.size() > 0) {
+        if (!failedOperationStatus.isEmpty()) {
           return new CollectionOperationStatus(failedOperationStatus.get(0));
         }
         return new CollectionOperationStatus(resultOperationStatus.get(0));
@@ -2588,7 +2588,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
 
       @Override
       public CollectionOperationStatus getOperationStatus() {
-        if (failedOperationStatus.size() > 0) {
+        if (!failedOperationStatus.isEmpty()) {
           return new CollectionOperationStatus(failedOperationStatus.get(0));
         }
         return new CollectionOperationStatus(resultOperationStatus.get(0));

--- a/src/main/java/net/spy/memcached/ArcusKetamaNodeLocator.java
+++ b/src/main/java/net/spy/memcached/ArcusKetamaNodeLocator.java
@@ -301,7 +301,7 @@ public class ArcusKetamaNodeLocator extends SpyObject implements NodeLocator {
         SortedSet<MemcachedNode> nodeSet = ketamaNodes.get(k);
         assert nodeSet != null;
         nodeSet.remove(node);
-        if (nodeSet.size() == 0) {
+        if (nodeSet.isEmpty()) {
           ketamaNodes.remove(k);
         }
       }
@@ -338,7 +338,7 @@ public class ArcusKetamaNodeLocator extends SpyObject implements NodeLocator {
         Long k = getKetamaHashPoint(digest, h);
         SortedSet<MemcachedNode> alterSet = ketamaAlterNodes.get(k);
         if (alterSet != null && alterSet.remove(node)) {
-          if (alterSet.size() == 0) {
+          if (alterSet.isEmpty()) {
             ketamaAlterNodes.remove(k);
           }
           SortedSet<MemcachedNode> existSet = ketamaNodes.get(k);

--- a/src/main/java/net/spy/memcached/ArcusReplKetamaNodeLocator.java
+++ b/src/main/java/net/spy/memcached/ArcusReplKetamaNodeLocator.java
@@ -410,7 +410,7 @@ public class ArcusReplKetamaNodeLocator extends SpyObject implements NodeLocator
         Long k = getKetamaHashPoint(digest, h);
         SortedSet<MemcachedReplicaGroup> nodeSet = ketamaGroups.get(k);
         nodeSet.remove(group);
-        if (nodeSet.size() == 0) {
+        if (nodeSet.isEmpty()) {
           ketamaGroups.remove(k);
         }
       }
@@ -444,7 +444,7 @@ public class ArcusReplKetamaNodeLocator extends SpyObject implements NodeLocator
         Long k = getKetamaHashPoint(digest, h);
         SortedSet<MemcachedReplicaGroup> alterSet = ketamaAlterGroups.get(k);
         if (alterSet != null && alterSet.remove(group)) {
-          if (alterSet.size() == 0) {
+          if (alterSet.isEmpty()) {
             ketamaAlterGroups.remove(k);
           }
           SortedSet<MemcachedReplicaGroup> existSet = ketamaGroups.get(k);

--- a/src/main/java/net/spy/memcached/CacheManager.java
+++ b/src/main/java/net/spy/memcached/CacheManager.java
@@ -439,7 +439,7 @@ public class CacheManager extends SpyThread implements Watcher,
    * @param children new children node list
    */
   public void commandCacheListChange(List<String> children) {
-    if (children.size() == 0) {
+    if (children.isEmpty()) {
       getLogger().error("Cannot find any cache nodes for your service code. " +
               "Please contact Arcus support to solve this problem. " +
               "[serviceCode=" + serviceCode + ", adminSessionId=0x" +
@@ -493,7 +493,7 @@ public class CacheManager extends SpyThread implements Watcher,
   @Override
   public boolean commandCloudStatChange(List<String> children) {
     // return true if STATE == PREPARED.
-    if (children.size() == 0) {
+    if (children.isEmpty()) {
       /*
        * case 1 : No child znode in clout_stat znode.
        * case 2 : Starting migration.

--- a/src/main/java/net/spy/memcached/collection/ElementMultiFlagsFilter.java
+++ b/src/main/java/net/spy/memcached/collection/ElementMultiFlagsFilter.java
@@ -67,7 +67,7 @@ public class ElementMultiFlagsFilter extends ElementFlagFilter {
                       + MAX_EFLAGS);
     }
 
-    if (this.compValue.size() > 0
+    if (!this.compValue.isEmpty()
             && this.compValue.get(0).length != compValue.length) {
       throw new IllegalArgumentException(
               "Length of comparison value must be same with "

--- a/src/main/java/net/spy/memcached/collection/MapDelete.java
+++ b/src/main/java/net/spy/memcached/collection/MapDelete.java
@@ -66,7 +66,7 @@ public class MapDelete extends CollectionDelete {
       return str;
     }
 
-    if (mkeyList.size() == 0) {
+    if (mkeyList.isEmpty()) {
       additionalArgs = null;
     } else {
       additionalArgs = getSpaceSeparatedMkeys().getBytes();

--- a/src/main/java/net/spy/memcached/collection/MapGet.java
+++ b/src/main/java/net/spy/memcached/collection/MapGet.java
@@ -67,7 +67,7 @@ public class MapGet extends CollectionGet {
       return str;
     }
 
-    if (mkeyList.size() == 0) {
+    if (mkeyList.isEmpty()) {
       additionalArgs = null;
     } else {
       additionalArgs = getSpaceSeparatedMkeys().getBytes();

--- a/src/main/java/net/spy/memcached/internal/BroadcastFuture.java
+++ b/src/main/java/net/spy/memcached/internal/BroadcastFuture.java
@@ -65,7 +65,7 @@ public class BroadcastFuture<T> extends OperationFuture<T> {
           MemcachedConnection.opSucceeded(op);
         }
       }
-      if (timedoutOps.size() > 0) {
+      if (!timedoutOps.isEmpty()) {
         throw new CheckedOperationTimeoutException(duration, units, timedoutOps);
       }
     } else {

--- a/src/main/java/net/spy/memcached/internal/BulkGetFuture.java
+++ b/src/main/java/net/spy/memcached/internal/BulkGetFuture.java
@@ -86,7 +86,7 @@ public class BulkGetFuture<T> implements BulkFuture<Map<String, T>> {
           throws InterruptedException, ExecutionException {
     Collection<Operation> timedoutOps = new HashSet<Operation>();
     Map<String, T> ret = internalGet(duration, units, timedoutOps);
-    if (timedoutOps.size() > 0) {
+    if (!timedoutOps.isEmpty()) {
       isTimeout = true;
       LoggerFactory.getLogger(getClass()).warn(
               new CheckedOperationTimeoutException(duration, units, timedoutOps).getMessage());
@@ -106,7 +106,7 @@ public class BulkGetFuture<T> implements BulkFuture<Map<String, T>> {
           throws InterruptedException, ExecutionException, TimeoutException {
     Collection<Operation> timedoutOps = new HashSet<Operation>();
     Map<String, T> ret = internalGet(duration, units, timedoutOps);
-    if (timedoutOps.size() > 0) {
+    if (!timedoutOps.isEmpty()) {
       isTimeout = true;
       throw new CheckedOperationTimeoutException(duration, units, timedoutOps);
     }
@@ -148,7 +148,7 @@ public class BulkGetFuture<T> implements BulkFuture<Map<String, T>> {
           MemcachedConnection.opSucceeded(op);
         }
       }
-      if (timedoutOps.size() > 0) {
+      if (!timedoutOps.isEmpty()) {
         MemcachedConnection.opsTimedOut(timedoutOps);
       }
     } else {

--- a/src/main/java/net/spy/memcached/internal/BulkOperationFuture.java
+++ b/src/main/java/net/spy/memcached/internal/BulkOperationFuture.java
@@ -78,7 +78,7 @@ public class BulkOperationFuture<T> implements Future<Map<String, T>> {
           MemcachedConnection.opSucceeded(op);
         }
       }
-      if (timedoutOps.size() > 0) {
+      if (!timedoutOps.isEmpty()) {
         MemcachedConnection.opsTimedOut(timedoutOps);
         throw new CheckedOperationTimeoutException(duration, units, timedoutOps);
       }

--- a/src/main/java/net/spy/memcached/internal/CollectionGetBulkFuture.java
+++ b/src/main/java/net/spy/memcached/internal/CollectionGetBulkFuture.java
@@ -67,7 +67,7 @@ public class CollectionGetBulkFuture<T> implements Future<T> {
           MemcachedConnection.opSucceeded(op);
         }
       }
-      if (timedoutOps.size() > 0) {
+      if (!timedoutOps.isEmpty()) {
         MemcachedConnection.opsTimedOut(timedoutOps);
         throw new CheckedOperationTimeoutException(duration, units, timedoutOps);
       }

--- a/src/main/java/net/spy/memcached/internal/PipedCollectionFuture.java
+++ b/src/main/java/net/spy/memcached/internal/PipedCollectionFuture.java
@@ -73,7 +73,7 @@ public class PipedCollectionFuture<K, V>
           MemcachedConnection.opSucceeded(op);
         }
       }
-      if (timedoutOps.size() > 0) {
+      if (!timedoutOps.isEmpty()) {
         MemcachedConnection.opTimedOut(timedoutOps.iterator().next());
         throw new CheckedOperationTimeoutException(duration, units, timedoutOps);
       }

--- a/src/main/java/net/spy/memcached/protocol/TCPMemcachedNodeImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/TCPMemcachedNodeImpl.java
@@ -626,7 +626,7 @@ public abstract class TCPMemcachedNodeImpl extends SpyObject
   }
 
   public final void authComplete() {
-    if (reconnectBlocked != null && reconnectBlocked.size() > 0) {
+    if (reconnectBlocked != null && !reconnectBlocked.isEmpty()) {
       inputQueue.addAll(reconnectBlocked);
     }
     authLatch.countDown();
@@ -635,12 +635,12 @@ public abstract class TCPMemcachedNodeImpl extends SpyObject
   public final void setupForAuth(String cause) {
     if (shouldAuth) {
       authLatch = new CountDownLatch(1);
-      if (inputQueue.size() > 0) {
+      if (!inputQueue.isEmpty()) {
         reconnectBlocked = new ArrayList<Operation>(
                 inputQueue.size() + 1);
         inputQueue.drainTo(reconnectBlocked);
       }
-      assert (inputQueue.size() == 0);
+      assert (inputQueue.isEmpty());
       setupResend(cause);
     } else {
       authLatch = new CountDownLatch(0);


### PR DESCRIPTION
자료형의 직접적인 사이즈 비교 대신 `isEmpty` 메서드를 사용하여 요소가 비었는지를 확인하도록 수정하였습니다.