### PR TITLE
FEATURE: Add TCP connection keep-alive option.

### DIFF
--- a/src/main/java/net/spy/memcached/ConnectionFactory.java
+++ b/src/main/java/net/spy/memcached/ConnectionFactory.java
@@ -108,6 +108,15 @@ public interface ConnectionFactory {
   boolean useNagleAlgorithm();
 
   /**
+   * If true, keep alive will be used on connected sockets.
+   *
+   * <p>
+   * See {@link java.net.Socket#setKeepAlive(boolean)} for more information.
+   * </p>
+   */
+  boolean getKeepAlive();
+
+  /**
    * Observers that should be established at the time of connection
    * instantiation.
    *

--- a/src/main/java/net/spy/memcached/ConnectionFactoryBuilder.java
+++ b/src/main/java/net/spy/memcached/ConnectionFactoryBuilder.java
@@ -59,6 +59,7 @@ public class ConnectionFactoryBuilder {
   private boolean isDaemon = true;
   private boolean shouldOptimize = false;
   private boolean useNagle = false;
+  private boolean keepAlive = false;
   //private long maxReconnectDelay =
   //DefaultConnectionFactory.DEFAULT_MAX_RECONNECT_DELAY;
   private long maxReconnectDelay = 1;
@@ -467,6 +468,10 @@ public class ConnectionFactoryBuilder {
   }
   /* ENABLE_REPLICATION end */
 
+  public ConnectionFactoryBuilder setKeepAlive(boolean on) {
+    keepAlive = on;
+    return this;
+  }
   /**
    * Get the ConnectionFactory set up with the provided parameters.
    */
@@ -589,6 +594,11 @@ public class ConnectionFactoryBuilder {
       @Override
       public boolean useNagleAlgorithm() {
         return useNagle;
+      }
+
+      @Override
+      public boolean getKeepAlive() {
+        return keepAlive;
       }
 
       @Override

--- a/src/main/java/net/spy/memcached/DefaultConnectionFactory.java
+++ b/src/main/java/net/spy/memcached/DefaultConnectionFactory.java
@@ -318,7 +318,10 @@ public class DefaultConnectionFactory extends SpyObject
   public boolean useNagleAlgorithm() {
     return false;
   }
-
+  @Override
+  public boolean getKeepAlive() {
+    return false;
+  }
   public boolean shouldOptimize() {
     return true;
   }

--- a/src/main/java/net/spy/memcached/MemcachedConnection.java
+++ b/src/main/java/net/spy/memcached/MemcachedConnection.java
@@ -630,6 +630,7 @@ public final class MemcachedConnection extends SpyObject {
     SocketChannel ch = SocketChannel.open();
     ch.configureBlocking(false);
     ch.socket().setTcpNoDelay(!connFactory.useNagleAlgorithm());
+    ch.socket().setKeepAlive(connFactory.getKeepAlive());
     ch.socket().setReuseAddress(true);
     /* The codes above can be replaced by the codes below since java 1.7 */
     // ch.setOption(StandardSocketOptions.TCP_NODELAY, !f.useNagleAlgorithm());
@@ -1307,6 +1308,7 @@ public final class MemcachedConnection extends SpyObject {
         ch = SocketChannel.open();
         ch.configureBlocking(false);
         ch.socket().setTcpNoDelay(!connFactory.useNagleAlgorithm());
+        ch.socket().setKeepAlive(connFactory.getKeepAlive());
         ch.socket().setReuseAddress(true);
         /* The codes above can be replaced by the codes below since java 1.7 */
         // ch.setOption(StandardSocketOptions.TCP_NODELAY, !f.useNagleAlgorithm());

--- a/src/test/java/net/spy/memcached/ClientBaseCase.java
+++ b/src/test/java/net/spy/memcached/ClientBaseCase.java
@@ -153,6 +153,11 @@ public abstract class ClientBaseCase extends TestCase {
         }
 
         @Override
+        public boolean getKeepAlive() {
+          return inner.getKeepAlive();
+        }
+
+        @Override
         public Collection<ConnectionObserver> getInitialObservers() {
           return observers;
         }

--- a/src/test/java/net/spy/memcached/ConnectionFactoryBuilderTest.java
+++ b/src/test/java/net/spy/memcached/ConnectionFactoryBuilderTest.java
@@ -93,6 +93,7 @@ public class ConnectionFactoryBuilderTest extends BaseMockCase {
     assertTrue(f.isDaemon());
     assertFalse(f.shouldOptimize());
     assertFalse(f.useNagleAlgorithm());
+    assertFalse(f.getKeepAlive());
     assertEquals(f.getOpQueueMaxBlockTime(),
             DefaultConnectionFactory.DEFAULT_OP_QUEUE_MAX_BLOCK_TIME);
   }
@@ -130,6 +131,7 @@ public class ConnectionFactoryBuilderTest extends BaseMockCase {
             .setReadBufferSize(19)
             .setTranscoder(new WhalinTranscoder())
             .setUseNagleAlgorithm(true)
+            .setKeepAlive(true)
             .setLocatorType(Locator.CONSISTENT)
             .setOpQueueMaxBlockTime(19)
             .setAuthDescriptor(anAuthDescriptor)
@@ -149,6 +151,7 @@ public class ConnectionFactoryBuilderTest extends BaseMockCase {
     assertTrue(f.isDaemon());
     assertFalse(f.shouldOptimize());
     assertTrue(f.useNagleAlgorithm());
+    assertTrue(f.getKeepAlive());
     assertEquals(f.getOpQueueMaxBlockTime(), 19);
     assertSame(anAuthDescriptor, f.getAuthDescriptor());
 


### PR DESCRIPTION
## 관련 이슈
https://github.com/jam2in/arcus-works/issues/441

## Motivation
기존 구현은 사용자가 TCP Keep Alive 옵션을 설정하는 인터페이스를 제공하지 않는다.
이를 `ConnectionFactoryBuilder`를 통해 사용자가 설정할 수 있도록 제공한다.
keepAlive의 기본 옵션은 `false`이다.