### PR TITLE
TEST: Add Socket keepAlive option test.

### DIFF
--- a/src/test/java/net/spy/memcached/SocketTest.java
+++ b/src/test/java/net/spy/memcached/SocketTest.java
@@ -1,0 +1,30 @@
+package net.spy.memcached;
+
+import java.net.SocketException;
+import java.util.Collection;
+
+import junit.framework.TestCase;
+
+import org.junit.Assert;
+
+public class SocketTest extends TestCase {
+  private ArcusClient client;
+  private final String ZK_STRING = "127.0.0.1:2181";
+  private final String SERVICE_CODE = "test";
+
+  @Override
+  protected void setUp() throws Exception {
+    super.setUp();
+    ConnectionFactoryBuilder connectionFactoryBuilder = new ConnectionFactoryBuilder();
+    connectionFactoryBuilder.setKeepAlive(true);
+    client = ArcusClient.createArcusClient(ZK_STRING, SERVICE_CODE, connectionFactoryBuilder);
+  }
+
+  public void testSocketKeepAliveTest() throws SocketException {
+    Collection<MemcachedNode> allNodes =
+            client.getAllNodes();
+    for (MemcachedNode node : allNodes) {
+      Assert.assertTrue(node.getChannel().socket().getKeepAlive());
+    }
+  }
+}


### PR DESCRIPTION
## 관련 이슈
https://github.com/jam2in/arcus-works/issues/441

## Motivation
아래와 같이 생성된 소켓에 대해 keepAlive 옵션의 
활성화 여부를 가져올 수 있다.

이를 통해 해당 TCP 연결에 keepAlive 옵션이 적절히 적용되었는지 테스트 가능하다.
