### PR TITLE
FIX: Handling interrupt exception when blocking by future get invoked.

### DIFF
--- a/src/main/java/net/spy/memcached/MemcachedClient.java
+++ b/src/main/java/net/spy/memcached/MemcachedClient.java
@@ -616,6 +616,7 @@ public class MemcachedClient extends SpyThread
     try {
       return future.get(operationTimeout, TimeUnit.MILLISECONDS);
     } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
       future.cancel(true);
       throw new RuntimeException("Interrupted waiting for value", e);
     } catch (ExecutionException e) {
@@ -996,6 +997,7 @@ public class MemcachedClient extends SpyThread
     try {
       return future.get(operationTimeout, TimeUnit.MILLISECONDS);
     } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
       future.cancel(true);
       throw new RuntimeException("Interrupted waiting for value", e);
     } catch (ExecutionException e) {
@@ -1038,6 +1040,7 @@ public class MemcachedClient extends SpyThread
     try {
       return future.get(operationTimeout, TimeUnit.MILLISECONDS);
     } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
       future.cancel(true);
       throw new RuntimeException("Interrupted waiting for value", e);
     } catch (ExecutionException e) {
@@ -1387,6 +1390,7 @@ public class MemcachedClient extends SpyThread
     try {
       return future.get(operationTimeout, TimeUnit.MILLISECONDS);
     } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
       future.cancel(true);
       throw new RuntimeException("Interrupted getting bulk values", e);
     } catch (ExecutionException e) {
@@ -1460,6 +1464,7 @@ public class MemcachedClient extends SpyThread
     try {
       return future.get(operationTimeout, TimeUnit.MILLISECONDS);
     } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
       future.cancel(true);
       throw new RuntimeException("Interrupted getting bulk values", e);
     } catch (ExecutionException e) {
@@ -1555,6 +1560,7 @@ public class MemcachedClient extends SpyThread
     try {
       rv = future.get(operationTimeout, TimeUnit.MILLISECONDS);
     } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
       throw new RuntimeException("Interrupted waiting for versions", e);
     } catch (ExecutionException e) {
       throw new RuntimeException(e);
@@ -1628,6 +1634,7 @@ public class MemcachedClient extends SpyThread
     try {
       rv = future.get(operationTimeout, TimeUnit.MILLISECONDS);
     } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
       throw new RuntimeException("Interrupted waiting for stats", e);
     } catch (ExecutionException e) {
       throw new RuntimeException(e);
@@ -1658,6 +1665,7 @@ public class MemcachedClient extends SpyThread
         throw new OperationTimeoutException(operationTimeout, TimeUnit.MILLISECONDS, op);
       }
     } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
       op.cancel("by applcation.");
       throw new RuntimeException("Interrupted", e);
     }
@@ -1762,6 +1770,7 @@ public class MemcachedClient extends SpyThread
           assert rv != -1 : "Failed to mutate or init value";
         }
       } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
         f.cancel(true);
         throw new RuntimeException("Interrupted waiting for store", e);
       } catch (ExecutionException e) {
@@ -2132,6 +2141,7 @@ public class MemcachedClient extends SpyThread
       // and the check retried.
       return latch.await(timeout, unit);
     } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
       throw new RuntimeException("Interrupted waiting for queues", e);
     }
   }

--- a/src/main/java/net/spy/memcached/internal/BTreeStoreAndGetFuture.java
+++ b/src/main/java/net/spy/memcached/internal/BTreeStoreAndGetFuture.java
@@ -50,6 +50,7 @@ public class BTreeStoreAndGetFuture<T, E> extends CollectionFuture<T> {
     } catch (ExecutionException e) {
       throw new RuntimeException(e);
     } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
       throw new RuntimeException(e);
     } catch (TimeoutException e) {
       throw new OperationTimeoutException(e);


### PR DESCRIPTION
## Motivation
기존 arcusClient의 경우 동기 api와 몇몇의 broadcast api는
내부에서 Future.get을 호출한 다음 해당 결과를 리턴한다.

이러한 api들의 interrupt Exception Handling 방식을 
`Thread.currentThread().interrupt();`를 
호출하도록 통일한다.