### PR TITLE
CLEANUP: Refactored SMGetFuture.

### DIFF
--- a/src/main/java/net/spy/memcached/internal/result/SMGetResult.java
+++ b/src/main/java/net/spy/memcached/internal/result/SMGetResult.java
@@ -1,0 +1,66 @@
+package net.spy.memcached.internal.result;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import net.spy.memcached.collection.SMGetElement;
+import net.spy.memcached.collection.SMGetTrimKey;
+import net.spy.memcached.ops.CollectionOperationStatus;
+import net.spy.memcached.ops.OperationStatus;
+
+public abstract class SMGetResult<T>  {
+  protected final int totalResultElementCount;
+  protected final boolean reverse;
+
+  protected final List<String> missedKeyList;
+  protected final Map<String, CollectionOperationStatus> missedKeyMap;
+  protected final List<SMGetTrimKey> mergedTrimmedKeys;
+
+  protected final List<SMGetElement<T>> mergedResult;
+  protected final List<OperationStatus> resultOperationStatus;
+  protected final List<OperationStatus> failedOperationStatus;
+
+  public SMGetResult(int totalResultElementCount, boolean reverse) {
+    this.totalResultElementCount = totalResultElementCount;
+    this.reverse = reverse;
+
+    this.missedKeyList = Collections.synchronizedList(new ArrayList<String>());
+    this.missedKeyMap
+            = Collections.synchronizedMap(new HashMap<String, CollectionOperationStatus>());
+    this.mergedTrimmedKeys = Collections.synchronizedList(new ArrayList<SMGetTrimKey>());
+
+    this.mergedResult = new ArrayList<SMGetElement<T>>(totalResultElementCount);
+    this.resultOperationStatus = Collections.synchronizedList(new ArrayList<OperationStatus>(1));
+    this.failedOperationStatus = Collections.synchronizedList(new ArrayList<OperationStatus>(1));
+  }
+
+  public List<String> getMissedKeyList() {
+    return missedKeyList;
+  }
+
+  public Map<String, CollectionOperationStatus> getMissedKeyMap() {
+    return missedKeyMap;
+  }
+
+  public List<SMGetTrimKey> getMergedTrimmedKeys() {
+    return mergedTrimmedKeys;
+  }
+
+  public void addMissedKey(String key, CollectionOperationStatus cstatus) {
+    missedKeyList.add(key);
+    missedKeyMap.put(key, cstatus);
+  }
+
+  public CollectionOperationStatus getOperationStatus() {
+    if (!failedOperationStatus.isEmpty()) {
+      return new CollectionOperationStatus(failedOperationStatus.get(0));
+    }
+    return new CollectionOperationStatus(resultOperationStatus.get(0));
+  }
+
+  public abstract List<SMGetElement<T>> getFinalResult();
+  public abstract void makeResultOperationStatus();
+}

--- a/src/main/java/net/spy/memcached/internal/result/SMGetResultImpl.java
+++ b/src/main/java/net/spy/memcached/internal/result/SMGetResultImpl.java
@@ -1,0 +1,146 @@
+package net.spy.memcached.internal.result;
+
+import java.util.List;
+
+import net.spy.memcached.collection.SMGetElement;
+import net.spy.memcached.collection.SMGetMode;
+import net.spy.memcached.collection.SMGetTrimKey;
+import net.spy.memcached.ops.OperationStatus;
+
+public final class SMGetResultImpl<T> extends SMGetResult<T> {
+  private final int count;
+  private final SMGetMode smGetMode;
+
+  public SMGetResultImpl(int count, SMGetMode smGetMode, boolean reverse) {
+    super(count, reverse);
+
+    this.count = count;
+    this.smGetMode = smGetMode;
+  }
+
+  @Override
+  public List<SMGetElement<T>> getFinalResult() {
+    return mergedResult;
+  }
+
+  public void addFailedOperationStatus(OperationStatus status) {
+    failedOperationStatus.add(status);
+    mergedResult.clear();
+    mergedTrimmedKeys.clear();
+  }
+
+  public void mergeSMGetElements(final List<SMGetElement<T>> eachResult,
+                                 final List<SMGetTrimKey> eachTrimmedResult) {
+
+    if (mergedResult.isEmpty()) {
+      // merged result is empty, add all.
+      mergedResult.addAll(eachResult);
+
+      while (mergedResult.size() > count) {
+        mergedResult.remove(count);
+      }
+    } else {
+      // do sort merge
+      boolean duplicated;
+      int comp, pos = 0;
+      for (SMGetElement<T> result : eachResult) {
+        duplicated = false;
+        for (; pos < mergedResult.size(); pos++) {
+          // compare b+tree key
+          comp = result.compareBkeyTo(mergedResult.get(pos));
+          if ((reverse) ? (0 < comp) : (0 > comp)) {
+            break;
+          }
+          if (comp == 0) { // compare key string
+            int keyComp = result.compareKeyTo(mergedResult.get(pos));
+            if ((reverse) ? (0 < keyComp) : (0 > keyComp)) {
+              if (smGetMode == SMGetMode.UNIQUE) {
+                mergedResult.remove(pos); // remove dup bkey
+              }
+              break;
+            } else {
+              if (smGetMode == SMGetMode.UNIQUE) {
+                duplicated = true;
+                break;
+              }
+            }
+          }
+        }
+        if (duplicated) { // UNIQUE
+          continue;
+        }
+        if (pos >= count) {
+          // At this point, following conditions are met.
+          //   - mergedResult.size() == totalResultElementCount &&
+          //   - The current <bkey, key> of eachResult is
+          //     behind of the last <bkey, key> of mergedResult.
+          // Then, all the next <bkey, key> elements of eachResult are
+          // definitely behind of the last <bkey, bkey> of mergedResult.
+          // So, stop the current sort-merge.
+          break;
+        }
+        mergedResult.add(pos, result);
+        if (mergedResult.size() > count) {
+          // Remove elements that exceed the requested count.
+          mergedResult.remove(count);
+        }
+        pos += 1;
+      }
+    }
+
+    if (!eachTrimmedResult.isEmpty()) {
+      if (mergedTrimmedKeys.isEmpty()) {
+        mergedTrimmedKeys.addAll(eachTrimmedResult);
+      } else {
+        // do sort merge trimmed list
+        int pos = 0;
+        for (SMGetTrimKey result : eachTrimmedResult) {
+          for (; pos < mergedTrimmedKeys.size(); pos++) {
+            if ((reverse) ? (0 < result.compareTo(mergedTrimmedKeys.get(pos)))
+                          : (0 > result.compareTo(mergedTrimmedKeys.get(pos)))) {
+              break;
+            }
+          }
+          mergedTrimmedKeys.add(pos, result);
+          pos += 1;
+        }
+      }
+    }
+  }
+
+  @Override
+  public void makeResultOperationStatus() {
+    if (!mergedTrimmedKeys.isEmpty() && count <= mergedResult.size()) {
+      // remove trimed keys whose bkeys are behind of the last element.
+      SMGetElement<T> lastElement = mergedResult.get(mergedResult.size() - 1);
+      SMGetTrimKey lastTrimKey = new SMGetTrimKey(lastElement.getKey(),
+              lastElement.getBkeyObject());
+      for (int i = mergedTrimmedKeys.size() - 1; i >= 0; i--) {
+        SMGetTrimKey me = mergedTrimmedKeys.get(i);
+        if ((reverse) ? (0 >= me.compareTo(lastTrimKey))
+                      : (0 <= me.compareTo(lastTrimKey))) {
+          mergedTrimmedKeys.remove(i);
+        } else {
+          break;
+        }
+      }
+    }
+
+    if (smGetMode == SMGetMode.UNIQUE) {
+      resultOperationStatus.add(new OperationStatus(true, "END"));
+    } else {
+      boolean isDuplicated = false;
+      for (int i = 1; i < mergedResult.size(); i++) {
+        if (mergedResult.get(i).compareBkeyTo(mergedResult.get(i - 1)) == 0) {
+          isDuplicated = true;
+          break;
+        }
+      }
+      if (isDuplicated) {
+        resultOperationStatus.add(new OperationStatus(true, "DUPLICATED"));
+      } else {
+        resultOperationStatus.add(new OperationStatus(true, "END"));
+      }
+    }
+  }
+}

--- a/src/main/java/net/spy/memcached/internal/result/SMGetResultOldImpl.java
+++ b/src/main/java/net/spy/memcached/internal/result/SMGetResultOldImpl.java
@@ -1,0 +1,121 @@
+package net.spy.memcached.internal.result;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import net.spy.memcached.collection.SMGetElement;
+import net.spy.memcached.ops.OperationStatus;
+
+public final class SMGetResultOldImpl<T> extends SMGetResult<T> {
+  private final AtomicBoolean mergedTrim = new AtomicBoolean(false);
+  private final int offset;
+  private final boolean isMultiNode;
+
+  private List<SMGetElement<T>> finalResult = null;
+
+  public SMGetResultOldImpl(int offset, int count, boolean reverse, boolean isMultiNode) {
+    super(offset + count, reverse);
+
+    this.offset = offset;
+    this.isMultiNode = isMultiNode;
+  }
+
+  @Override
+  public List<SMGetElement<T>> getFinalResult() {
+    if (finalResult == null) {
+      if (isMultiNode && offset > 0) {
+        if (offset < mergedResult.size()) {
+          finalResult = mergedResult.subList(offset, mergedResult.size());
+        } else {
+          finalResult = Collections.emptyList();
+        }
+      } else {
+        finalResult = mergedResult;
+      }
+    }
+
+    return finalResult;
+  }
+
+  public void addFailedOperationStatus(OperationStatus status) {
+    failedOperationStatus.add(status);
+    mergedResult.clear();
+  }
+
+  public void mergeSMGetElements(final List<SMGetElement<T>> eachResult,
+                                 final boolean isTrimmed) {
+
+    if (mergedResult.isEmpty()) {
+      // merged result is empty, add all.
+      mergedResult.addAll(eachResult);
+      mergedTrim.set(isTrimmed);
+
+      while (mergedResult.size() > totalResultElementCount) {
+        mergedResult.remove(totalResultElementCount);
+      }
+    } else {
+      boolean addAll = true;
+      int pos = 0;
+      for (SMGetElement<T> result : eachResult) {
+        for (; pos < mergedResult.size(); pos++) {
+          if ((reverse) ? (0 < result.compareTo(mergedResult.get(pos)))
+                        : (0 > result.compareTo(mergedResult.get(pos)))) {
+            break;
+          }
+        }
+        if (pos >= totalResultElementCount) {
+          addAll = false;
+          break;
+        }
+        if (pos >= mergedResult.size() && mergedTrim.get() &&
+                result.compareBkeyTo(mergedResult.get(pos - 1)) != 0) {
+          addAll = false;
+          break;
+        }
+        mergedResult.add(pos, result);
+        if (mergedResult.size() > totalResultElementCount) {
+          mergedResult.remove(totalResultElementCount);
+        }
+        pos += 1;
+      }
+      if (isTrimmed && addAll) {
+        while (pos < mergedResult.size()) {
+          if (mergedResult.get(pos).compareBkeyTo(mergedResult.get(pos - 1)) == 0) {
+            pos += 1;
+          } else {
+            mergedResult.remove(pos);
+          }
+        }
+        mergedTrim.set(true);
+      }
+      if (mergedResult.size() >= totalResultElementCount) {
+        mergedTrim.set(false);
+      }
+    }
+  }
+
+  @Override
+  public void makeResultOperationStatus() {
+    boolean isDuplicated = false;
+    for (int i = 1; i < mergedResult.size(); i++) {
+      if (mergedResult.get(i).compareBkeyTo(mergedResult.get(i - 1)) == 0) {
+        isDuplicated = true;
+        break;
+      }
+    }
+    if (mergedTrim.get()) {
+      if (isDuplicated) {
+        resultOperationStatus.add(new OperationStatus(true, "DUPLICATED_TRIMMED"));
+      } else {
+        resultOperationStatus.add(new OperationStatus(true, "TRIMMED"));
+      }
+    } else {
+      if (isDuplicated) {
+        resultOperationStatus.add(new OperationStatus(true, "DUPLICATED"));
+      } else {
+        resultOperationStatus.add(new OperationStatus(true, "END"));
+      }
+    }
+  }
+}


### PR DESCRIPTION
SMGetFuture를 추상 클래스에서 일반 클래스로 변경했습니다.
일반 클래스로 변경하면서 각 smget 메소드에서 구현했던 추상 메소드를 SMGetFuture 내로 옮겼습니다.

SMGetFuture를 통해 접근 가능한 여러 필드들은 SMGetResult 클래스를 만들어 접근하도록 했습니다.
SMGetResult 객체에 직접 참조를 통해 필드에 Write 하게 했는데, 간접 참조로 바꿔야 더 명확하다면 간접 참조로 바꾸겠습니다.
  - 직접 참조 예시 : `r.addToMergedResult(eachResult);`
  - 간접 참조 예시 : `r.getMergedResult().addAll(eachResult)`

SMGetFuture 내의 필드로 `SMGetResult<?> smGetResult`를 두었는데, `SMGetResult<T>`가 아닌 이유는 smget 메소드의 return type이 `SMGetFuture<List<SMGetElement<G>>>`이기 때문입니다.
`class SMGetFuture<T>`에서 `T = List<SMGetElement<G>>`로부터 내부의 `<G>`를 가져올 수 없어 `SMGetResult<?>` 형태의 필드를 둔 것입니다.

# 추가 기대 효과

또한 현재 형태의 리팩토링은 Future 클래스에서 public으로 노출하는 메소드를 getter에 한정하게 되어 다음의 이슈를 해결할 수 있는 방안 중 하나가 될 것 같습니다.
- https://github.com/naver/arcus-java-client/issues/632