### PR TITLE
TEST: Fix expected result invoking getStat.

### DIFF
--- a/src/test/java/net/spy/memcached/ProtocolBaseCase.java
+++ b/src/test/java/net/spy/memcached/ProtocolBaseCase.java
@@ -53,7 +53,7 @@ public abstract class ProtocolBaseCase extends ClientBaseCase {
   public void testGetStats() throws Exception {
     Map<SocketAddress, Map<String, String>> stats = client.getStats();
     System.out.println("Stats:  " + stats);
-    assertEquals(1, stats.size());
+    assertEquals(client.getAllNodes().size(), stats.size());
     Map<String, String> oneStat = stats.values().iterator().next();
     assertTrue(oneStat.containsKey("total_items"));
   }
@@ -64,7 +64,7 @@ public abstract class ProtocolBaseCase extends ClientBaseCase {
     client.set("slabinitializer", 0, "hi");
     Map<SocketAddress, Map<String, String>> stats = client.getStats("slabs");
     System.out.println("Stats:  " + stats);
-    assertEquals(1, stats.size());
+    assertEquals(client.getAllNodes().size(), stats.size());
     Map<String, String> oneStat = stats.values().iterator().next();
     assertTrue(oneStat.containsKey("0:chunk_size"));
   }
@@ -79,7 +79,7 @@ public abstract class ProtocolBaseCase extends ClientBaseCase {
     client.set("sizeinitializer", 0, "hi");
     Map<SocketAddress, Map<String, String>> stats = client.getStats("sizes");
     System.out.println("Stats:  " + stats);
-    assertEquals(1, stats.size());
+    assertEquals(client.getAllNodes().size(), stats.size());
     Map<String, String> oneStat = stats.values().iterator().next();
     assertEquals("1", oneStat.get("96"));
   }
@@ -91,7 +91,7 @@ public abstract class ProtocolBaseCase extends ClientBaseCase {
     Map<SocketAddress, Map<String, String>> stats =
             client.getStats("cachedump 0 10000");
     System.out.println("Stats:  " + stats);
-    assertEquals(1, stats.size());
+    assertEquals(client.getAllNodes().size(), stats.size());
     Map<String, String> oneStat = stats.values().iterator().next();
     String val = oneStat.get("dumpinitializer");
     assertTrue(val + "doesn't match", val.matches("\\[acctime=\\d+, exptime=\\d+\\]"));


### PR DESCRIPTION
## motivation

현재 testGetStats 관련 테스트 코드들은
mc가 1개만 띄워져 있는 상황을 가정하여 테스트 코드가 작성되어있다.

mc가 여러개 띄워진 상태에서 해당 테스트 코드를 
수행할 시 fail이 발생한다.

그래서 연결된 client의 nodes 수만큼 검증하도록 변경한다.

추후 Github action을 3개의 mc가 띄워진 형태로 변경할 예정입니다.
현재 Local에서 3개의 mc을 띄우고 아래 테스트 코드를 실행하면 fail이 발생합니다.