### PR TITLE
TEST: Separate CI into 2 phases, NOT using ZK and using ZK.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,5 +31,7 @@ jobs:
 
       - name: Build ARCUS Client
         run: mvn install -DskipTests
-      - name: Test ARCUS Client
-        run: mvn test -DUSE_ZK=false -DARCUS_HOST=127.0.0.1:11212 && mvn test -DUSE_ZK=true
+      - name: Test ARCUS Client -DUSE_ZK=false -DARCUS_HOST=127.0.0.1:11212
+        run: mvn test -DUSE_ZK=false -DARCUS_HOST=127.0.0.1:11212
+      - name: Test ARCUS Client -DUSE_ZK=true
+        run: mvn test -DUSE_ZK=true


### PR DESCRIPTION
<img width="1249" alt="image" src="https://github.com/naver/arcus-java-client/assets/51937838/c62af951-786b-430a-9af0-42730f3d086b">


CI에서 2개의 테스트를 1개의 명령어로 수행하는 부분을 2개의 명령어로 분리했습니다.
1개의 명령어로 수행할 경우, 테스트 실패 메세지가 나왔을 때 어느 옵션의 테스트에서 비롯된 실패 메세지인지 파악하기 힘듭니다.
2개의 명령어로 분리할 경우, CI에서 각 테스트 단계가 분리되어 있기 때문에 어느 옵션의 테스트에서 비롯된 실패 메세지인지 파악하기 쉽습니다.
또한 2개의 명령어로 분리했더라도, 앞의 명령어가 실패하면 뒤의 명령어는 수행하지 않는 점은 동일합니다.