### PR TITLE
TEST: Cancel previous CI when PR or branch is pushed.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,10 @@ on:
     branches:
     - develop
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     runs-on: ubuntu-20.04


### PR DESCRIPTION
<img width="468" alt="image" src="https://github.com/naver/arcus-java-client/assets/51937838/7f66cf78-14f7-4fc4-929f-e78e65b46b27">

동일한 PR 혹은 브랜치에 새로 커밋이 Push 되었을 때, 이전에 CI가 돌아가는 중이었다면 이전 CI를 자동으로 취소합니다.

# group

- 돌아가고 있는 Github Action을 서로 구분할 논리적 이름입니다.
- 동일한 group을 갖고 있으면 `cancel-in-progress` 값의 여부에 따라 이전 Github Action을 취소할 수 있습니다.

## github.workflow

- 현재 돌아가는 Github Action의 이름입니다. 
- ci.yml 파일에 `name: CI`로 되어 있으므로, `CI` 값이 들어갑니다.

## github.event.pull_request.number

- PR의 번호입니다. 
- 예를 들어 https://github.com/naver/arcus-java-client/pull/691 PR 같은 경우, `691` 값이 들어갑니다.

## github.ref

- PR이 아닌 경우에 사용되는 브랜치 이름, 혹은 태그 이름입니다.
- master 브랜치에 Push 했다면 `master` 값이 들어갑니다.
- Push에 태그 이름이 함께 특정되었을 경우, 예를 들어 태그가 `1.13.5`라면 `1.13.5` 값이 들어갑니다.

# cancel-in-progress: true

- 이전에 돌아가던 Github Action 중, 새로 돌아가야 하는 Github Action의 그룹과 동일한 그룹이 있으면 이전 Github Action을 취소합니다.
- false이면 취소하지 않습니다.