### PR TITLE
FEATURE: Add overriden method "shutdown(long, TimeUnit)" to ArcusClient.

### DIFF
--- a/src/main/java/net/spy/memcached/ArcusClient.java
+++ b/src/main/java/net/spy/memcached/ArcusClient.java
@@ -363,8 +363,8 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
   }
 
   @Override
-  public void shutdown() {
-    super.shutdown(SHUTDOWN_TIMEOUT_MILLISECONDS, TimeUnit.MILLISECONDS);
+  public boolean shutdown(long timeout, TimeUnit unit) {
+    final boolean result = super.shutdown(timeout, unit);
     // Connect to Arcus server directly, cache manager may be null.
     if (cacheManager != null) {
       cacheManager.shutdown();
@@ -373,6 +373,12 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
     // if (bulkService != null) {
     //  bulkService.shutdown();
     // }
+    return result;
+  }
+
+  @Override
+  public void shutdown() {
+    this.shutdown(SHUTDOWN_TIMEOUT_MILLISECONDS, TimeUnit.MILLISECONDS);
   }
 
   private void validateMKey(String mkey) {


### PR DESCRIPTION
네트워크 지연이 있는 상태에서, ArcusClint 객체의 Operation Queue에 많은 Operation이 쌓여 있는 경우, 기존의 ArcusClient.shutdown()을 수행하면 반드시 2초(SHUTDOWN_TIMEOUT_MILLISECONDS)를 기다려야 합니다.
ArcusClient의 부모 클래스인 MemcachedClient 클래스의 shutdown(long, TimeUnit)을 통해 기다리는 시간을 조절할 수 있으나, CacheManager.shutdown()를 수행할 수 없다는 문제가 있습니다.
따라서 ArcusClient.shutdown(long, TimeUnit)을 추가하여 기다리는 시간도 조절하고, CacheManager.shutdown()도 수행할 수 있도록 했습니다.