### PR TITLE
FIX: apply limits of count and offset to bop bulk methods

### DIFF
--- a/docs/07-btree-API.md
+++ b/docs/07-btree-API.md
@@ -1070,11 +1070,11 @@ asyncBopPipedUpdateBulk(String key, List<Element<Object>> elements)
 
 ## B+Tree Element 일괄 조회
 
-다수의 b+tree들 각각에 대해 from부터 to까지의 bkey를 가진 elements를 탐색하면서,
-eFlagFilter 조건을 만족하는 elements 중 offset 위치부터 count 개수만큼 조회한다.
+다수의 b+tree들 각각에 대해 from ~ to 범위에 속한 bkey를 가지면서 eFlagFilter 조건을 만족하는 elements 중 offset 위치에서 count 개를 조회한다.
+각 b+tree에서 조회한 element는 최대 count개이며, 주어진 b+tree들에서 조회한 element 개수의 총합은 최대 (count * keyList.size())개이다.
 
 ```java
-CollectionGetBulkFuturee<Map<String, BTreeGetResult<Long, Object>>>
+CollectionGetBulkFuture<Map<String, BTreeGetResult<Long, Object>>>
 asyncBopGetBulk(List<String> keyList, long from, long to, ElementFlagFilter eFlagFilter, int offset, int count)
 CollectionGetBulkFuture<Map<String, BTreeGetResult<ByteArrayBKey, Object>>>
 asyncBopGetBulk(List<String> keyList, byte[] from, byte[] to, ElementFlagFilter eFlagFilter, int offset, int count)
@@ -1085,6 +1085,7 @@ asyncBopGetBulk(List<String> keyList, byte[] from, byte[] to, ElementFlagFilter 
 - eFlagFilter: eflag에 대한 filter 조건
   - eflag filter 조건을 지정하지 않으려면, ElementFlagFilter.DO_NOT_FILTER를 입력한다.
 - offset, count: bkey range와 eflag filter 조건을 만족하는 elements에서 실제 조회할 element의 offset과 count 지정
+  - **count 값은 1 이상 50 이하여야 한다.**
 
 
 수행 결과는 future 객체를 통해 Map\<Stirng, BTreeGetResult\<Bkey, Object\>\>을 얻으며,
@@ -1212,9 +1213,8 @@ missed keys에 대한 DB 조회가 offset으로 skip된 element를 가지는 경
 이전의 조회 결과에 이어서 추가로 조회하고자 하는 경우,
 이전에 조회된 bkey 값을 바탕으로 bkey range를 재조정하여 사용할 수 있다.
 
-여러 b+tree들에 대해 sort-merge get을 수행하는 함수는 아래와 같다.
-여러 b+tree들로 부터 from부터 to까지의 bkey를 가지고 있으면서 eflag filter조건을 만족하는 element를 찾아
-sort merge하면서, count개의 element를 조회한다. 
+sort-merge get을 수행하는 함수는 아래와 같다.
+여러 b+tree들에서 from ~ to 범위에 속한 bkey를 가지면서 eFlagFilter 조건을 만족하는 elements들을 sort merge하며 count개를 조회한다.
 
 ```java
 SMGetFuture<List<SMGetElement<Object>>>
@@ -1228,8 +1228,8 @@ asyncBopSortMergeGet(List<String> keyList, byte[] from, byte[] to, ElementFlagFi
 - eFlagFilter: eflag에 대한 filter 조건
   - eflag filter 조건을 지정하지 않으려면, ElementFlagFilter.DO_NOT_FILTER를 입력한다.
 - count: bkey range와 eflag filter 조건을 만족하는 elements에서 실제 조회할 element의 count 지정
-  - **제약 조건으로 1000이하이어야 한다.**
-  - 이는 sort-merge get 연산이 부담이 너무 크지 않은 연산으로 제한하기 위한 것이다.
+  - **count 값은 1 이상 1000이하이어야 한다.**
+  - 이는 sort-merge get 연산을 부담이 너무 크지 않은 연산으로 제한하기 위해서이다.
 - smgetMode: smget에 대해서 mode를 지정하는 flag
   - unique 조회 또는 duplicate 조회를 지정한다.
 

--- a/src/main/java/net/spy/memcached/ArcusClient.java
+++ b/src/main/java/net/spy/memcached/ArcusClient.java
@@ -3923,6 +3923,9 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
     if (offset < 0) {
       throw new IllegalArgumentException("Offset must be 0 or positive integer.");
     }
+    if (count < 1) {
+      throw new IllegalArgumentException("Count must be larger than 0.");
+    }
     if (count > MAX_GETBULK_ELEMENT_COUNT) {
       throw new IllegalArgumentException("Count must not exceed a maximum of "
           + MAX_GETBULK_ELEMENT_COUNT + ".");
@@ -3960,6 +3963,9 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
 
     if (offset < 0) {
       throw new IllegalArgumentException("Offset must be 0 or positive integer.");
+    }
+    if (count < 1) {
+      throw new IllegalArgumentException("Count must be larger than 0.");
     }
     if (count > MAX_GETBULK_ELEMENT_COUNT) {
       throw new IllegalArgumentException("Count must not exceed a maximum of "

--- a/src/main/java/net/spy/memcached/ArcusClientIF.java
+++ b/src/main/java/net/spy/memcached/ArcusClientIF.java
@@ -1403,7 +1403,8 @@ public interface ArcusClientIF {
    * @param to          bkey index to
    * @param eFlagFilter element flag filter
    * @param offset      0-base offset
-   * @param count       number of returning values (0 to all)
+   * @param count       number of returning values. must be larger than 0.
+   *                    {@code offset + count} must not be more than 1000.
    * @return a future that will hold the return value list of the fetch.
    */
   SMGetFuture<List<SMGetElement<Object>>> asyncBopSortMergeGet(
@@ -1418,7 +1419,7 @@ public interface ArcusClientIF {
    * @param from        bkey index from
    * @param to          bkey index to
    * @param eFlagFilter element flag filter
-   * @param count       number of returning values (0 to all)
+   * @param count       number of returning values. must be larger than 0 and not more than 1000.
    * @param smgetMode   smgetMode
    * @return a future that will hold the return value list of the fetch.
    */
@@ -1913,7 +1914,8 @@ public interface ArcusClientIF {
    * @param to          bkey index to
    * @param eFlagFilter element flag filter
    * @param offset      0-base offset
-   * @param count       number of returning values (0 to all)
+   * @param count       number of returning values. must be larger than 0.
+   *                    {@code offset + count} must not be more than 1000.
    * @return a future that will hold the return value list of the fetch.
    */
   SMGetFuture<List<SMGetElement<Object>>> asyncBopSortMergeGet(
@@ -1928,7 +1930,7 @@ public interface ArcusClientIF {
    * @param from        bkey index from
    * @param to          bkey index to
    * @param eFlagFilter element flag filter
-   * @param count       number of returning values (0 to all)
+   * @param count       number of returning values. must be larger than 0 and not more than 1000.
    * @param smgetMode   smgetMode
    * @return a future that will hold the return value list of the fetch.
    */
@@ -1971,14 +1973,16 @@ public interface ArcusClientIF {
           byte[] eFlag, T value, CollectionAttributes attributesForCreate, Transcoder<T> tc);
 
   /**
-   * Get elements from each b+tree.
+   * Get elements from multiple b+trees.
    *
    * @param keyList     key list of b+tree
    * @param from        bkey from
    * @param to          bkey to
    * @param eFlagFilter element flag filter
-   * @param offset      0-based offset (max = 50)
-   * @param count       number of returning values (0 to all) (max = 200)
+   * @param offset      0-based offset. must be 0 or positive.
+   * @param count       number of elements to retrieve from each b+tree.
+   *                    must be larger than 0 and not more than 50.
+   *                    total number of returning elements could be 0 to (count * keyList.size()).
    * @return future indicating result of each b+tree
    */
   CollectionGetBulkFuture<Map<String, BTreeGetResult<ByteArrayBKey, Object>>>
@@ -1987,15 +1991,17 @@ public interface ArcusClientIF {
           ElementFlagFilter eFlagFilter, int offset, int count);
 
   /**
-   * Get elements from each b+tree.
+   * Get elements from multiple b+trees.
    *
    * @param <T>         the expected class of the value
    * @param keyList     key list of b+tree
    * @param from        bkey from
    * @param to          bkey to
    * @param eFlagFilter element flag filter
-   * @param offset      0-based offset (max = 50)
-   * @param count       number of returning values (0 to all) (max = 200)
+   * @param offset      0-based offset. must be 0 or positive.
+   * @param count       number of elements to retrieve from each b+tree.
+   *                    must be larger than 0 and not more than 50.
+   *                    total number of returning elements could be 0 to (count * keyList.size()).
    * @param tc          transcoder to decode value
    * @return future indicating result of each b+tree
    */
@@ -2005,14 +2011,16 @@ public interface ArcusClientIF {
           Transcoder<T> tc);
 
   /**
-   * Get elements from each b+tree.
+   * Get elements from multiple b+trees.
    *
    * @param keyList     key list of b+tree
    * @param from        bkey from
    * @param to          bkey to
    * @param eFlagFilter element flag filter
-   * @param offset      0-based offset (max = 50)
-   * @param count       number of returning values (0 to all) (max = 200)
+   * @param offset      0-based offset. must be 0 or positive.
+   * @param count       number of elements to retrieve from each b+tree.
+   *                    must be larger than 0 and not more than 50.
+   *                    total number of returning elements could be 0 to (count * keyList.size()).
    * @return future indicating result of each b+tree
    */
   CollectionGetBulkFuture<Map<String, BTreeGetResult<Long, Object>>> asyncBopGetBulk(
@@ -2020,15 +2028,17 @@ public interface ArcusClientIF {
           ElementFlagFilter eFlagFilter, int offset, int count);
 
   /**
-   * Get elements from each b+tree.
+   * Get elements from multiple b+trees.
    *
    * @param <T>         the expected class of the value
    * @param keyList     key list of b+tree
    * @param from        bkey from
    * @param to          bkey to
    * @param eFlagFilter element flag filter
-   * @param offset      0-based offset (max = 50)
-   * @param count       number of returning values (0 to all) (max = 200)
+   * @param offset      0-based offset. must be 0 or positive.
+   * @param count       number of elements to retrieve from each b+tree.
+   *                    must be larger than 0 and not more than 50.
+   *                    total number of returning elements could be 0 to (count * keyList.size()).
    * @param tc          transcoder to decode value
    * @return future indicating result of each b+tree
    */


### PR DESCRIPTION
- asyncBopGetBulk 메서드와 asyncBopSortMergeGet 메서드의 count, offset에 대한 조건이 잘못 명시되어 있던 것을 수정합니다.