### PR TITLE
CLEANUP: Remove TranscoderService from asyncGet()

### DIFF
--- a/src/main/java/net/spy/memcached/internal/GetFuture.java
+++ b/src/main/java/net/spy/memcached/internal/GetFuture.java
@@ -6,6 +6,7 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
+import net.spy.memcached.internal.result.GetResult;
 import net.spy.memcached.ops.Operation;
 import net.spy.memcached.ops.OperationStatus;
 
@@ -18,10 +19,10 @@ import net.spy.memcached.ops.OperationStatus;
  */
 public class GetFuture<T> implements Future<T> {
 
-  private final OperationFuture<Future<T>> rv;
+  private final OperationFuture<GetResult<T>> rv;
 
   public GetFuture(CountDownLatch l, long opTimeout) {
-    this.rv = new OperationFuture<Future<T>>(l, opTimeout);
+    this.rv = new OperationFuture<GetResult<T>>(l, opTimeout);
   }
 
   public GetFuture(GetFuture<T> parent) {
@@ -33,22 +34,22 @@ public class GetFuture<T> implements Future<T> {
   }
 
   public T get() throws InterruptedException, ExecutionException {
-    Future<T> decodedTask = rv.get();
-    return decodedTask == null ? null : decodedTask.get();
+    GetResult<T> result = rv.get();
+    return result == null ? null : result.getDecodedValue();
   }
 
   public T get(long duration, TimeUnit units)
           throws InterruptedException, TimeoutException, ExecutionException {
-    Future<T> decodedTask = rv.get(duration, units);
-    return decodedTask == null ? null : decodedTask.get();
+    GetResult<T> result = rv.get(duration, units);
+    return result == null ? null : result.getDecodedValue();
   }
 
   public OperationStatus getStatus() {
     return rv.getStatus();
   }
 
-  public void set(Future<T> decodedTask, OperationStatus status) {
-    rv.set(decodedTask, status);
+  public void set(GetResult<T> result, OperationStatus status) {
+    rv.set(result, status);
   }
 
   public void setOperation(Operation to) {

--- a/src/main/java/net/spy/memcached/internal/result/GetResult.java
+++ b/src/main/java/net/spy/memcached/internal/result/GetResult.java
@@ -1,0 +1,31 @@
+package net.spy.memcached.internal.result;
+
+import net.spy.memcached.CachedData;
+import net.spy.memcached.transcoders.Transcoder;
+
+public final class GetResult<T> {
+  private final Transcoder<T> transcoder;
+
+  private volatile CachedData cachedData = null;
+  private volatile T decodedValue = null;
+
+  public GetResult(Transcoder<T> transcoder) {
+    this.transcoder = transcoder;
+  }
+
+  public void setCachedData(CachedData cachedData) {
+    this.cachedData = cachedData;
+  }
+
+  public T getDecodedValue() {
+    if (cachedData == null) {
+      return null;
+    }
+
+    if (decodedValue == null) {
+      decodedValue = transcoder.decode(cachedData);
+    }
+
+    return decodedValue;
+  }
+}


### PR DESCRIPTION
TranscoderService는 별도의 Thread Pool에서 비동기적으로 decode를 수행합니다.
TranscoderService의 Thread Pool은 coreSize 1, maxSize 10으로 되어 있습니다.

CPU 리소스가 부족하거나, 동시에 decode 해야 할 데이터가 너무 많이 쌓이면 TranscoderService의 Thread Pool이 제시간 내에 decode를 수행하지 못할 수 있습니다.
따라서 TranscoderService를 통해 decode 하는 것이 아니라, 응용의 Worker Thread가 get 연산의 결과를 가져가려고 하는 순간에 decode를 수행하도록 변경했습니다.

변경 사항으로 인한 기대 효과는 get 연산의 성능 향상 및 CPU 리소스 부족 혹은 동시에 decode 해야 하는 대상이 너무 많아서 생기는 Timeout 오류 빈도 감소입니다.