### PR TITLE
INTERNAL: Remove unintentionally exposed public method, GetFuture.getRv()

### DIFF
--- a/src/main/java/net/spy/memcached/internal/GetFuture.java
+++ b/src/main/java/net/spy/memcached/internal/GetFuture.java
@@ -25,7 +25,7 @@ public class GetFuture<T> implements Future<T> {
   }
 
   public GetFuture(GetFuture<T> parent) {
-    this.rv = parent.getRv();
+    this.rv = parent.rv;
   }
 
   public boolean cancel(boolean ign) {
@@ -61,10 +61,6 @@ public class GetFuture<T> implements Future<T> {
 
   public boolean isDone() {
     return rv.isDone();
-  }
-
-  public OperationFuture<Future<T>> getRv() {
-    return rv;
   }
 
 }


### PR DESCRIPTION
GetFuture.rv 필드는 내부적으로만 사용해야 하는 객체입니다.
그럼에도 getter 메소드가 있었던 것은 `public GetFuture(GetFuture parent)` 생성자에서 `this.rv = parent.getRv()`를 호출하기 위함인 것으로 보입니다.
그러나 GetFuture.rv 필드는 GetFuture 클래스 내부라면 서로 다른 객체 간이라도 접근이 가능하므로, getter가 필요 없습니다.