### PR TITLE
CLEANUP: Refactored parameter of smget()

### DIFF
--- a/src/main/java/net/spy/memcached/ArcusClient.java
+++ b/src/main/java/net/spy/memcached/ArcusClient.java
@@ -2032,7 +2032,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
       smGetList.add(new BTreeSMGetWithLongTypeBkey<Object>(entry.getKey(),
             entry.getValue(), from, to, eFlagFilter, count, smgetMode));
     }
-    return smget(smGetList, count, (from > to), collectionTranscoder, smgetMode);
+    return smget(smGetList, count, smgetMode == SMGetMode.UNIQUE, (from > to), collectionTranscoder);
   }
 
   /**
@@ -2147,12 +2147,12 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
   }
 
   private <T> SMGetFuture<List<SMGetElement<T>>> smget(
-          final List<BTreeSMGet<T>> smGetList, final int count,
-          final boolean reverse, final Transcoder<T> tc, final SMGetMode smgetMode) {
+          final List<BTreeSMGet<T>> smGetList, final int count, final boolean unique,
+          final boolean reverse, final Transcoder<T> tc) {
 
     final CountDownLatch blatch = new CountDownLatch(smGetList.size());
     final ConcurrentLinkedQueue<Operation> ops = new ConcurrentLinkedQueue<Operation>();
-    final SMGetResultImpl<T> result = new SMGetResultImpl<T>(count, smgetMode, reverse);
+    final SMGetResultImpl<T> result = new SMGetResultImpl<T>(count, unique, reverse);
 
     // if processedSMGetCount is 0, then all smget is done.
     final AtomicInteger processedSMGetCount = new AtomicInteger(smGetList.size());
@@ -3297,8 +3297,8 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
             entry.getValue(), from, to, eFlagFilter, count, smgetMode));
     }
 
-    return smget(smGetList, count, (BTreeUtil.compareByteArraysInLexOrder(from, to) > 0),
-            collectionTranscoder, smgetMode);
+    return smget(smGetList, count, smgetMode == SMGetMode.UNIQUE,
+            (BTreeUtil.compareByteArraysInLexOrder(from, to) > 0), collectionTranscoder);
   }
 
   /**

--- a/src/main/java/net/spy/memcached/internal/result/SMGetResultImpl.java
+++ b/src/main/java/net/spy/memcached/internal/result/SMGetResultImpl.java
@@ -3,19 +3,18 @@ package net.spy.memcached.internal.result;
 import java.util.List;
 
 import net.spy.memcached.collection.SMGetElement;
-import net.spy.memcached.collection.SMGetMode;
 import net.spy.memcached.collection.SMGetTrimKey;
 import net.spy.memcached.ops.OperationStatus;
 
 public final class SMGetResultImpl<T> extends SMGetResult<T> {
   private final int count;
-  private final SMGetMode smGetMode;
+  private final boolean unique;
 
-  public SMGetResultImpl(int count, SMGetMode smGetMode, boolean reverse) {
+  public SMGetResultImpl(int count, boolean unique, boolean reverse) {
     super(count, reverse);
 
     this.count = count;
-    this.smGetMode = smGetMode;
+    this.unique = unique;
   }
 
   @Override
@@ -54,12 +53,12 @@ public final class SMGetResultImpl<T> extends SMGetResult<T> {
           if (comp == 0) { // compare key string
             int keyComp = result.compareKeyTo(mergedResult.get(pos));
             if ((reverse) ? (0 < keyComp) : (0 > keyComp)) {
-              if (smGetMode == SMGetMode.UNIQUE) {
+              if (unique) {
                 mergedResult.remove(pos); // remove dup bkey
               }
               break;
             } else {
-              if (smGetMode == SMGetMode.UNIQUE) {
+              if (unique) {
                 duplicated = true;
                 break;
               }
@@ -126,7 +125,7 @@ public final class SMGetResultImpl<T> extends SMGetResult<T> {
       }
     }
 
-    if (smGetMode == SMGetMode.UNIQUE) {
+    if (unique) {
       resultOperationStatus.add(new OperationStatus(true, "END"));
     } else {
       boolean isDuplicated = false;


### PR DESCRIPTION
https://github.com/jam2in/arcus-works/issues/482

위 이슈 일부를 반영했습니다.
1. 인자 순서 변경
2. smgetMode => boolean unique
3. ~hasDuplicateBKeyResult() 메소드 추가~
4. ~EachResult가 empty result인 경우 고려~