### PR TITLE
FIX: Consider emptiness of each result when merge in old SMGetResult.

### DIFF
--- a/src/main/java/net/spy/memcached/internal/result/SMGetResultOldImpl.java
+++ b/src/main/java/net/spy/memcached/internal/result/SMGetResultOldImpl.java
@@ -79,7 +79,7 @@ public final class SMGetResultOldImpl<T> extends SMGetResult<T> {
         }
         pos += 1;
       }
-      if (isTrimmed && addAll) {
+      if (isTrimmed && addAll && pos > 0) {
         while (pos < mergedResult.size()) {
           if (mergedResult.get(pos).compareBkeyTo(mergedResult.get(pos - 1)) == 0) {
             pos += 1;


### PR DESCRIPTION
https://github.com/jam2in/arcus-works/issues/482

위 이슈 일부를 반영했습니다.
- EachResult가 empty result인 경우 고려