### PR TITLE
INTERNAL: Remove transcoder service logic in bulkGet apis.

### DIFF
--- a/src/main/java/net/spy/memcached/internal/BulkGetFuture.java
+++ b/src/main/java/net/spy/memcached/internal/BulkGetFuture.java
@@ -22,13 +22,13 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
 import net.spy.memcached.MemcachedConnection;
 import net.spy.memcached.OperationTimeoutException;
 import net.spy.memcached.compat.log.LoggerFactory;
+import net.spy.memcached.internal.result.GetResult;
 import net.spy.memcached.ops.Operation;
 import net.spy.memcached.ops.OperationState;
 
@@ -40,13 +40,13 @@ import net.spy.memcached.ops.OperationState;
  * @param <T> types of objects returned from the GET
  */
 public class BulkGetFuture<T> implements BulkFuture<Map<String, T>> {
-  private final Map<String, Future<T>> rvMap;
+  private final Map<String, GetResult<T>> rvMap;
   private final Collection<Operation> ops;
   private final CountDownLatch latch;
   private final long timeout;
   private boolean isTimeout = false;
 
-  public BulkGetFuture(Map<String, Future<T>> rvMap, Collection<Operation> ops,
+  public BulkGetFuture(Map<String, GetResult<T>> rvMap, Collection<Operation> ops,
                        CountDownLatch latch, Long timeout) {
     super();
     this.rvMap = rvMap;
@@ -164,10 +164,9 @@ public class BulkGetFuture<T> implements BulkFuture<Map<String, T>> {
     }
 
     Map<String, T> resultMap = new HashMap<String, T>();
-    for (Map.Entry<String, Future<T>> me : rvMap.entrySet()) {
+    for (Map.Entry<String, GetResult<T>> me : rvMap.entrySet()) {
       String key = me.getKey();
-      Future<T> future = me.getValue();
-      T value = future.get();
+      T value = me.getValue().getDecodedValue();
 
       // put the key into the result map.
       resultMap.put(key, value);

--- a/src/test/java/net/spy/memcached/ProtocolBaseCase.java
+++ b/src/test/java/net/spy/memcached/ProtocolBaseCase.java
@@ -453,8 +453,8 @@ public abstract class ProtocolBaseCase extends ClientBaseCase {
     tcs.add(0, decodeTranscoder);
     try {
       client.asyncGetBulk(keys, tcs.listIterator()).get();
-      fail("Expected ExecutionException caused by key mismatch");
-    } catch (java.util.concurrent.ExecutionException e) {
+      fail("Expected AssertionError caused by key mismatch");
+    } catch (AssertionError e) {
       // pass
     }
   }
@@ -552,8 +552,8 @@ public abstract class ProtocolBaseCase extends ClientBaseCase {
     tcs.add(0, decodeTranscoder);
     try {
       client.asyncGetsBulk(keys, tcs.listIterator()).get();
-      fail("Expected ExecutionException caused by key mismatch");
-    } catch (java.util.concurrent.ExecutionException e) {
+      fail("Expected AssertionError caused by key mismatch");
+    } catch (AssertionError e) {
       // pass
     }
   }


### PR DESCRIPTION
## 변경 사항
asyncGetBulk, asyncGetsBulk 연산에서 TranscoderService를 사용하지 않고
decode()를 WAS의 worker thread 수행하도록 변경하였습니다.

기존 테스트 코드에서는 테스트 코드의 메인 쓰레드가 decode될 동안 Blocking이 되어 IO 스레드로부터예외인 `ExecutionException e`이 발생하였고, 
현재 구현에서는 테스트 메인 쓰레드가 Decode 작업을 수행하여 AssertionError가 발생하기 때문에 Throwable를 인자로 받도록 변경하였습니다.