### PR TITLE
INTERNAL: Change asyncGets return future type.

### DIFF
--- a/src/main/java/net/spy/memcached/ArcusClientPool.java
+++ b/src/main/java/net/spy/memcached/ArcusClientPool.java
@@ -234,12 +234,12 @@ public class ArcusClientPool implements MemcachedClientIF, ArcusClientIF {
   }
 
   @Override
-  public <T> OperationFuture<CASValue<T>> asyncGets(String key, Transcoder<T> tc) {
+  public <T> GetFuture<CASValue<T>> asyncGets(String key, Transcoder<T> tc) {
     return this.getClient().asyncGets(key, tc);
   }
 
   @Override
-  public OperationFuture<CASValue<Object>> asyncGets(String key) {
+  public GetFuture<CASValue<Object>> asyncGets(String key) {
     return this.getClient().asyncGets(key);
   }
 

--- a/src/main/java/net/spy/memcached/internal/GetFuture.java
+++ b/src/main/java/net/spy/memcached/internal/GetFuture.java
@@ -2,12 +2,10 @@ package net.spy.memcached.internal;
 
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
 import net.spy.memcached.internal.result.GetResult;
-import net.spy.memcached.ops.Operation;
 import net.spy.memcached.ops.OperationStatus;
 
 /**
@@ -17,51 +15,22 @@ import net.spy.memcached.ops.OperationStatus;
  *
  * @param <T> Type of object returned from the get
  */
-public class GetFuture<T> implements Future<T> {
-
-  private final OperationFuture<GetResult<T>> rv;
+public class GetFuture<T> extends OperationFuture<T> {
+  private GetResult<T> result;
 
   public GetFuture(CountDownLatch l, long opTimeout) {
-    this.rv = new OperationFuture<GetResult<T>>(l, opTimeout);
+    super(l, opTimeout);
   }
 
-  public GetFuture(GetFuture<T> parent) {
-    this.rv = parent.rv;
-  }
-
-  public boolean cancel(boolean ign) {
-    return rv.cancel(ign);
-  }
-
-  public T get() throws InterruptedException, ExecutionException {
-    GetResult<T> result = rv.get();
-    return result == null ? null : result.getDecodedValue();
-  }
-
+  @Override
   public T get(long duration, TimeUnit units)
           throws InterruptedException, TimeoutException, ExecutionException {
-    GetResult<T> result = rv.get(duration, units);
+    super.get(duration, units); // for waiting latch.
     return result == null ? null : result.getDecodedValue();
-  }
-
-  public OperationStatus getStatus() {
-    return rv.getStatus();
   }
 
   public void set(GetResult<T> result, OperationStatus status) {
-    rv.set(result, status);
+    super.set(null, status);
+    this.result = result;
   }
-
-  public void setOperation(Operation to) {
-    rv.setOperation(to);
-  }
-
-  public boolean isCancelled() {
-    return rv.isCancelled();
-  }
-
-  public boolean isDone() {
-    return rv.isDone();
-  }
-
 }

--- a/src/main/java/net/spy/memcached/internal/result/GetsResultImpl.java
+++ b/src/main/java/net/spy/memcached/internal/result/GetsResultImpl.java
@@ -1,0 +1,26 @@
+package net.spy.memcached.internal.result;
+
+import net.spy.memcached.CASValue;
+import net.spy.memcached.CachedData;
+import net.spy.memcached.transcoders.Transcoder;
+
+public class GetsResultImpl<T> implements GetResult<CASValue<T>> {
+  private final long cas;
+  private final CachedData cachedData;
+  private final Transcoder<T> transcoder;
+  private volatile CASValue<T> decodedValue = null;
+
+  public GetsResultImpl(long cas, CachedData cachedData, Transcoder<T> transcoder) {
+    this.cas = cas;
+    this.cachedData = cachedData;
+    this.transcoder = transcoder;
+  }
+
+  @Override
+  public CASValue<T> getDecodedValue() {
+    if (decodedValue == null) {
+      decodedValue = new CASValue<T>(cas, transcoder.decode(cachedData));
+    }
+    return decodedValue;
+  }
+}


### PR DESCRIPTION
## 변경 사항
- 오전에 오프라인으로 논의된 asyncGets API의 Future 리턴 타입을 `OperationFuture` -> `GetFuture`로 변경하였습니다.
- 아래의 코멘트의 Transcoder 문제 때문에 `CASGetResult<T>`를 사용해서 구현하였습니다.
  - https://github.com/naver/arcus-java-client/pull/710#discussion_r1437921170
- GetResult 인터페이스를 통해 아래 문제를 해결하였습니다.
- ~~이를 해결하기 위해 해당 PR은 생성자 내에서 `super(null)`을 사용하였습니다. 아래 코멘트는 다른 방안들입니다.~~
  - https://github.com/naver/arcus-java-client/pull/710#discussion_r1439119905
- `@Deprecated`를 사용하려면 `asyncGetsNew()` 와 같은 새로운 함수를 정의하고 기존`asyncGets()`에 `@Deprecated`을 붙여줘야합니다. 메서드의 리턴값만 다를 경우 오버로딩이 적용되지 않기 때문입니다. 우선은 로직에 대한 리뷰를 먼저 받기 위해 기존 메서드의 리턴값을 바로 변경하였습니다. 

- ~~GetResult 생성자에서 CachedData를 외부로부터 주입 받는 로직은 별도의 PR로 반영하겠습니다.~~