### PR TITLE
INTERNAL: Use GetResult interface in asyncGet api.

### DIFF
--- a/src/main/java/net/spy/memcached/MemcachedClient.java
+++ b/src/main/java/net/spy/memcached/MemcachedClient.java
@@ -52,6 +52,7 @@ import net.spy.memcached.internal.GetFuture;
 import net.spy.memcached.internal.OperationFuture;
 import net.spy.memcached.internal.SingleElementInfiniteIterator;
 import net.spy.memcached.internal.result.GetResult;
+import net.spy.memcached.internal.result.GetResultImpl;
 import net.spy.memcached.ops.CASOperationStatus;
 import net.spy.memcached.ops.CancelledOperationStatus;
 import net.spy.memcached.ops.ConcatenationType;
@@ -892,7 +893,7 @@ public class MemcachedClient extends SpyThread
 
     Operation op = opFact.get(key,
         new GetOperation.Callback() {
-          private final GetResult<T> result = new GetResult<T>(tc);
+          private GetResult<T> result = null;
 
           public void receivedStatus(OperationStatus status) {
             future.set(result, status);
@@ -900,7 +901,7 @@ public class MemcachedClient extends SpyThread
 
           public void gotData(String k, int flags, byte[] data) {
             assert key.equals(k) : "Wrong key returned";
-            result.setCachedData(new CachedData(flags, data, tc.getMaxSize()));
+            result = new GetResultImpl<T>(new CachedData(flags, data, tc.getMaxSize()), tc);
           }
 
           public void complete() {

--- a/src/main/java/net/spy/memcached/internal/result/GetResult.java
+++ b/src/main/java/net/spy/memcached/internal/result/GetResult.java
@@ -1,31 +1,5 @@
 package net.spy.memcached.internal.result;
 
-import net.spy.memcached.CachedData;
-import net.spy.memcached.transcoders.Transcoder;
-
-public final class GetResult<T> {
-  private final Transcoder<T> transcoder;
-
-  private volatile CachedData cachedData = null;
-  private volatile T decodedValue = null;
-
-  public GetResult(Transcoder<T> transcoder) {
-    this.transcoder = transcoder;
-  }
-
-  public void setCachedData(CachedData cachedData) {
-    this.cachedData = cachedData;
-  }
-
-  public T getDecodedValue() {
-    if (cachedData == null) {
-      return null;
-    }
-
-    if (decodedValue == null) {
-      decodedValue = transcoder.decode(cachedData);
-    }
-
-    return decodedValue;
-  }
+public interface GetResult<T> {
+  T getDecodedValue();
 }

--- a/src/main/java/net/spy/memcached/internal/result/GetResultImpl.java
+++ b/src/main/java/net/spy/memcached/internal/result/GetResultImpl.java
@@ -1,0 +1,23 @@
+package net.spy.memcached.internal.result;
+
+import net.spy.memcached.CachedData;
+import net.spy.memcached.transcoders.Transcoder;
+
+public final class GetResultImpl<T> implements GetResult<T> {
+  private final CachedData cachedData;
+  private final Transcoder<T> transcoder;
+  private volatile T decodedValue = null;
+
+  public GetResultImpl(CachedData cachedData, Transcoder<T> transcoder) {
+    this.cachedData = cachedData;
+    this.transcoder = transcoder;
+  }
+
+  @Override
+  public T getDecodedValue() {
+    if (decodedValue == null) {
+      decodedValue = transcoder.decode(cachedData);
+    }
+    return decodedValue;
+  }
+}


### PR DESCRIPTION
아래 PR로부터 파생된 PR입니다.
https://github.com/naver/arcus-java-client/pull/711

인터페이스 기반의 GetReuslt 사용을 위해 기존의 GetResult 구현을 변경하였습니다.
CachedData 레퍼런스를 외부에서 생성자 주입을 통해 전달하도록 변경했습니다.(기존에는 setter 주입)