### PR TITLE
INTERNAL: Add new merge method with improved performance to old SMGetResult.

### DIFF
--- a/src/main/java/net/spy/memcached/internal/result/SMGetResult.java
+++ b/src/main/java/net/spy/memcached/internal/result/SMGetResult.java
@@ -18,7 +18,7 @@ public abstract class SMGetResult<T>  {
   protected final Map<String, CollectionOperationStatus> missedKeyMap;
   protected final List<SMGetTrimKey> mergedTrimmedKeys;
 
-  protected final List<SMGetElement<T>> mergedResult;
+  protected volatile List<SMGetElement<T>> mergedResult;
   protected volatile CollectionOperationStatus resultOperationStatus = null;
   protected volatile CollectionOperationStatus failedOperationStatus = null;
 


### PR DESCRIPTION
https://github.com/jam2in/arcus-works/issues/482

SMGetResultOldImpl 클래스에 성능이 개선된 merge 메소드를 추가했습니다.
git diff 결과에 기존 코드와 새 코드가 섞이지 않도록 메소드를 추가하는 방식으로 작업했습니다.

기존 코드 : 기존에 갖고 있던 결과에 입력된 결과의 요소들을 중간에 끼워 넣는 방식입니다.
개선된 코드 : 기존에 갖고 있던 결과와 입력된 결과를 새로운 결과에 하나씩 넣는 방식입니다.