### PR TITLE
INTERNAL: Change decode logic in collection Get apis.

### DIFF
--- a/src/main/java/net/spy/memcached/ArcusClient.java
+++ b/src/main/java/net/spy/memcached/ArcusClient.java
@@ -25,7 +25,6 @@ import java.util.AbstractMap;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -33,8 +32,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
-import java.util.TreeMap;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Future;
@@ -70,7 +67,6 @@ import net.spy.memcached.collection.BTreeSMGetWithLongTypeBkeyOld;
 import net.spy.memcached.collection.BTreeUpdate;
 import net.spy.memcached.collection.BTreeUpsert;
 import net.spy.memcached.collection.ByteArrayBKey;
-import net.spy.memcached.collection.ByteArrayTreeMap;
 import net.spy.memcached.collection.CollectionAttributes;
 import net.spy.memcached.collection.CollectionBulkInsert;
 import net.spy.memcached.collection.CollectionCount;
@@ -123,8 +119,16 @@ import net.spy.memcached.internal.CollectionGetFuture;
 import net.spy.memcached.internal.OperationFuture;
 import net.spy.memcached.internal.PipedCollectionFuture;
 import net.spy.memcached.internal.SMGetFuture;
+import net.spy.memcached.internal.result.BopGetBulkResultImpl;
+import net.spy.memcached.internal.result.BopGetByPositionResultImpl;
+import net.spy.memcached.internal.result.BopGetResultImpl;
+import net.spy.memcached.internal.result.BopStoreAndGetResultImpl;
+import net.spy.memcached.internal.result.GetResult;
+import net.spy.memcached.internal.result.LopGetResultImpl;
+import net.spy.memcached.internal.result.MopGetResultImpl;
 import net.spy.memcached.internal.result.SMGetResultImpl;
 import net.spy.memcached.internal.result.SMGetResultOldImpl;
+import net.spy.memcached.internal.result.SopGetResultImpl;
 import net.spy.memcached.ops.BTreeFindPositionOperation;
 import net.spy.memcached.ops.BTreeFindPositionWithGetOperation;
 import net.spy.memcached.ops.BTreeGetBulkOperation;
@@ -459,12 +463,13 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
                                                     final CollectionGet collectionGet,
                                                     final Transcoder<T> tc) {
     final CountDownLatch latch = new CountDownLatch(1);
-    final CollectionGetFuture<List<T>> rv = new CollectionGetFuture<List<T>>(latch, operationTimeout);
+    final CollectionGetFuture<List<T>> rv =
+            new CollectionGetFuture<List<T>>(latch, operationTimeout);
 
     Operation op = opFact.collectionGet(k, collectionGet,
         new CollectionGetOperation.Callback() {
-          private final List<T> result = new ArrayList<T>();
           private final List<CachedData> cachedDataList = new ArrayList<CachedData>();
+          private final GetResult<List<T>> result = new LopGetResultImpl<T>(cachedDataList, tc);
 
           public void receivedStatus(OperationStatus status) {
             CollectionOperationStatus cstatus;
@@ -475,28 +480,28 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
               cstatus = new CollectionOperationStatus(status);
             }
             if (cstatus.isSuccess()) {
-              rv.set(result, cstatus);
+              rv.setResult(result, cstatus);
               return;
             }
             switch (cstatus.getResponse()) {
               case NOT_FOUND:
-                rv.set(null, cstatus);
+                rv.setResult(null, cstatus);
                 getLogger().debug("Key(%s) not found : %s", k, cstatus);
                 break;
               case NOT_FOUND_ELEMENT:
-                rv.set(result, cstatus);
+                rv.setResult(result, cstatus);
                 getLogger().debug("Element(%s) not found : %s", k, cstatus);
                 break;
               case OUT_OF_RANGE:
-                rv.set(result, cstatus);
+                rv.setResult(result, cstatus);
                 getLogger().debug("Element(%s) not found in condition : %s", k, cstatus);
                 break;
               case UNREADABLE:
-                rv.set(null, cstatus);
+                rv.setResult(null, cstatus);
                 getLogger().debug("Element(%s) is not readable : %s", k, cstatus);
                 break;
               default:
-                rv.set(null, cstatus);
+                rv.setResult(null, cstatus);
                 getLogger().debug("Key(%s) unknown status : %s", k, cstatus);
                 break;
             }
@@ -508,15 +513,6 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
 
           public void gotData(String subkey, int flags, byte[] data, byte[] eflag) {
             cachedDataList.add(new CachedData(flags, data, tc.getMaxSize()));
-          }
-
-          @Override
-          public void addResult() {
-            if (result.isEmpty() && !cachedDataList.isEmpty()) {
-              for (CachedData cachedData : cachedDataList) {
-                result.add(tc.decode(cachedData));
-              }
-            }
           }
         });
     rv.setOperation(op);
@@ -554,10 +550,8 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
 
     Operation op = opFact.collectionGet(k, collectionGet,
         new CollectionGetOperation.Callback() {
-
-          private final HashSet<T> result = new HashSet<T>();
           private final HashSet<CachedData> cachedDataSet = new HashSet<CachedData>();
-
+          private final GetResult<Set<T>> result = new SopGetResultImpl<T>(cachedDataSet, tc);
 
           public void receivedStatus(OperationStatus status) {
             CollectionOperationStatus cstatus;
@@ -568,25 +562,25 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
               cstatus = new CollectionOperationStatus(status);
             }
             if (cstatus.isSuccess()) {
-              rv.set(result, cstatus);
+              rv.setResult(result, cstatus);
               return;
             }
 
             switch (cstatus.getResponse()) {
               case NOT_FOUND:
-                rv.set(null, cstatus);
+                rv.setResult(null, cstatus);
                 getLogger().debug("Key(%s) not found : %s", k, cstatus);
                 break;
               case NOT_FOUND_ELEMENT:
-                rv.set(result, cstatus);
+                rv.setResult(result, cstatus);
                 getLogger().debug("Element(%s) not found : %s", k, cstatus);
                 break;
               case UNREADABLE:
-                rv.set(null, cstatus);
+                rv.setResult(null, cstatus);
                 getLogger().debug("Collection(%s) is not readable : %s", k, cstatus);
                 break;
               default:
-                rv.set(null, cstatus);
+                rv.setResult(null, cstatus);
                 getLogger().debug("Key(%s) unknown status : %s", k, cstatus);
                 break;
             }
@@ -598,15 +592,6 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
 
           public void gotData(String subkey, int flags, byte[] data, byte[] eflag) {
             cachedDataSet.add(new CachedData(flags, data, tc.getMaxSize()));
-          }
-
-          @Override
-          public void addResult() {
-            if (result.isEmpty() && !cachedDataSet.isEmpty()) {
-              for (CachedData cachedData : cachedDataSet) {
-                result.add(tc.decode(cachedData));
-              }
-            }
           }
         });
 
@@ -630,11 +615,13 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
     final CountDownLatch latch = new CountDownLatch(1);
     final CollectionGetFuture<Map<Long, Element<T>>> rv =
             new CollectionGetFuture<Map<Long, Element<T>>>(latch, operationTimeout);
+
     Operation op = opFact.collectionGet(k, collectionGet,
         new CollectionGetOperation.Callback() {
-          private final TreeMap<Long, Element<T>> result =
-                  new TreeMap<Long, Element<T>>((reverse) ? Collections.reverseOrder() : null);
           private final HashMap<Long, CachedData> cachedDataMap = new HashMap<Long, CachedData>();
+          private final GetResult<Map<Long, Element<T>>> result =
+                  new BopGetResultImpl<Long, T>(cachedDataMap, reverse, tc);
+
           public void receivedStatus(OperationStatus status) {
             CollectionOperationStatus cstatus;
             if (status instanceof CollectionOperationStatus) {
@@ -644,24 +631,24 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
               cstatus = new CollectionOperationStatus(status);
             }
             if (cstatus.isSuccess()) {
-              rv.set(result, cstatus);
+              rv.setResult(result, cstatus);
               return;
             }
             switch (cstatus.getResponse()) {
               case NOT_FOUND:
-                rv.set(null, cstatus);
+                rv.setResult(null, cstatus);
                 getLogger().debug("Key(%s) not found : %s", k, cstatus);
                 break;
               case NOT_FOUND_ELEMENT:
-                rv.set(result, cstatus);
+                rv.setResult(result, cstatus);
                 getLogger().debug("Element(%s) not found : %s", k, cstatus);
                 break;
               case UNREADABLE:
-                rv.set(null, cstatus);
+                rv.setResult(null, cstatus);
                 getLogger().debug("Element(%s) is not readable : %s", k, cstatus);
                 break;
               default:
-                rv.set(null, cstatus);
+                rv.setResult(null, cstatus);
                 getLogger().debug("Key(%s) Unknown response : %s", k, cstatus);
                 break;
             }
@@ -673,17 +660,6 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
 
           public void gotData(String bKey, int flags, byte[] data, byte[] eflag) {
             cachedDataMap.put(Long.parseLong(bKey), new CachedData(flags, data, eflag, tc.getMaxSize()));
-          }
-
-          @Override
-          public void addResult() {
-            if (result.isEmpty() && !cachedDataMap.isEmpty()) {
-              for (Entry<Long, CachedData> cachedDataEntry : this.cachedDataMap.entrySet()) {
-                Long bKey = cachedDataEntry.getKey();
-                CachedData cachedData = cachedDataEntry.getValue();
-                result.put(bKey, new Element<T>(bKey, tc.decode(cachedData), cachedData.getEFlag()));
-              }
-            }
           }
         });
     rv.setOperation(op);
@@ -704,11 +680,13 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
     final CountDownLatch latch = new CountDownLatch(1);
     final CollectionGetFuture<Map<String, T>> rv =
             new CollectionGetFuture<Map<String, T>>(latch, operationTimeout);
+
     Operation op = opFact.collectionGet(k, collectionGet,
         new CollectionGetOperation.Callback() {
-
-          private final HashMap<String, T> result = new HashMap<String, T>();
           private final HashMap<String, CachedData> cachedDataMap = new HashMap<String, CachedData>();
+          private final GetResult<Map<String, T>> result
+                  = new MopGetResultImpl<T>(cachedDataMap, tc);
+
           public void receivedStatus(OperationStatus status) {
             CollectionOperationStatus cstatus;
             if (status instanceof CollectionOperationStatus) {
@@ -718,24 +696,24 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
               cstatus = new CollectionOperationStatus(status);
             }
             if (cstatus.isSuccess()) {
-              rv.set(result, cstatus);
+              rv.setResult(result, cstatus);
               return;
             }
             switch (cstatus.getResponse()) {
               case NOT_FOUND:
-                rv.set(null, cstatus);
+                rv.setResult(null, cstatus);
                 getLogger().debug("Key(%s) not found : %s", k, cstatus);
                 break;
               case NOT_FOUND_ELEMENT:
-                rv.set(result, cstatus);
+                rv.setResult(result, cstatus);
                 getLogger().debug("Element(%s) not found : %s", k, cstatus);
                 break;
               case UNREADABLE:
-                rv.set(null, cstatus);
+                rv.setResult(null, cstatus);
                 getLogger().debug("Element(%s) is not readable : %s", k, cstatus);
                 break;
               default:
-                rv.set(null, cstatus);
+                rv.setResult(null, cstatus);
                 getLogger().debug("Key(%s) Unknown response : %s", k, cstatus);
                 break;
             }
@@ -747,17 +725,6 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
 
           public void gotData(String mkey, int flags, byte[] data, byte[] eflag) {
             cachedDataMap.put(mkey, new CachedData(flags, data, eflag, tc.getMaxSize()));
-          }
-
-          @Override
-          public void addResult() {
-            if (result.isEmpty() && !cachedDataMap.isEmpty()) {
-              for (Entry<String, CachedData> cachedDataEntry : this.cachedDataMap.entrySet()) {
-                String mKey = cachedDataEntry.getKey();
-                CachedData cachedData = cachedDataEntry.getValue();
-                result.put(mKey, tc.decode(cachedData));
-              }
-            }
           }
         });
     rv.setOperation(op);
@@ -2505,9 +2472,10 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
 
     Operation op = opFact.collectionGet(k, collectionGet,
         new CollectionGetOperation.Callback() {
-          private final TreeMap<ByteArrayBKey, Element<T>> result
-                  = new ByteArrayTreeMap<ByteArrayBKey, Element<T>>((reverse) ? Collections.reverseOrder() : null);
           private final HashMap<ByteArrayBKey, CachedData> cachedDataMap = new HashMap<ByteArrayBKey, CachedData>();
+          private final GetResult<Map<ByteArrayBKey, Element<T>>> result =
+                  new BopGetResultImpl<ByteArrayBKey, T>(cachedDataMap, reverse, tc);
+
           public void receivedStatus(OperationStatus status) {
             CollectionOperationStatus cstatus;
             if (status instanceof CollectionOperationStatus) {
@@ -2517,24 +2485,24 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
               cstatus = new CollectionOperationStatus(status);
             }
             if (cstatus.isSuccess()) {
-              rv.set(result, cstatus);
+              rv.setResult(result, cstatus);
               return;
             }
             switch (cstatus.getResponse()) {
               case NOT_FOUND:
-                rv.set(null, cstatus);
+                rv.setResult(null, cstatus);
                 getLogger().debug("Key(%s) not found : %s", k, cstatus);
                 break;
               case NOT_FOUND_ELEMENT:
-                rv.set(result, cstatus);
+                rv.setResult(result, cstatus);
                 getLogger().debug("Element(%s) not found : %s", k, cstatus);
                 break;
               case UNREADABLE:
-                rv.set(null, cstatus);
+                rv.setResult(null, cstatus);
                 getLogger().debug("Collection(%s) is not readable : %s", k, cstatus);
                 break;
               default:
-                rv.set(null, cstatus);
+                rv.setResult(null, cstatus);
                 getLogger().debug("Key(%s) Unknown response : %s", k, cstatus);
                 break;
             }
@@ -2547,17 +2515,6 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
           public void gotData(String bkey, int flags, byte[] data, byte[] eflag) {
             cachedDataMap.put(new ByteArrayBKey(BTreeUtil.hexStringToByteArrays(bkey)),
                     new CachedData(flags, data, eflag, tc.getMaxSize()));
-          }
-
-          @Override
-          public void addResult() {
-            if (result.isEmpty() && !cachedDataMap.isEmpty()) {
-              for (Entry<ByteArrayBKey, CachedData> cachedDataEntry : this.cachedDataMap.entrySet()) {
-                ByteArrayBKey bKey = cachedDataEntry.getKey();
-                CachedData cachedData = cachedDataEntry.getValue();
-                result.put(bKey, new Element<T>(bKey.getBytes(), tc.decode(cachedData), cachedData.getEFlag()));
-              }
-            }
           }
         });
     rv.setOperation(op);
@@ -2623,11 +2580,10 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
         new CollectionGetFuture<Map<Integer, Element<T>>>(latch, operationTimeout);
 
     Operation op = opFact.bopGetByPosition(k, get, new BTreeGetByPositionOperation.Callback() {
-
-      private final TreeMap<Integer, Element<T>> result =
-              new TreeMap<Integer, Element<T>>((reverse) ? Collections.reverseOrder() : null);
-      private final HashMap<Integer, Entry<BKeyObject, CachedData>> cachedDataMap
-              = new HashMap<Integer, Entry<BKeyObject, CachedData>>();
+      private final HashMap<Integer, Entry<BKeyObject, CachedData>> cachedDataMap =
+              new HashMap<Integer, Entry<BKeyObject, CachedData>>();
+      private final GetResult<Map<Integer, Element<T>>> result =
+              new BopGetByPositionResultImpl<T>(cachedDataMap, reverse, tc);
 
       public void receivedStatus(OperationStatus status) {
         CollectionOperationStatus cstatus;
@@ -2638,24 +2594,24 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
           cstatus = new CollectionOperationStatus(status);
         }
         if (cstatus.isSuccess()) {
-          rv.set(result, cstatus);
+          rv.setResult(result, cstatus);
           return;
         }
         switch (cstatus.getResponse()) {
           case NOT_FOUND:
-            rv.set(null, cstatus);
+            rv.setResult(null, cstatus);
             getLogger().debug("Key(%s) not found : %s", k, cstatus);
             break;
           case NOT_FOUND_ELEMENT:
-            rv.set(result, cstatus);
+            rv.setResult(result, cstatus);
             getLogger().debug("Element(%s) not found : %s", k, cstatus);
             break;
           case UNREADABLE:
-            rv.set(null, cstatus);
+            rv.setResult(null, cstatus);
             getLogger().debug("Collection(%s) is not readable : %s", k, cstatus);
             break;
           case TYPE_MISMATCH:
-            rv.set(null, cstatus);
+            rv.setResult(null, cstatus);
             getLogger().debug("Collection(%s) is not a B+Tree : %s", k, cstatus);
             break;
           default:
@@ -2672,16 +2628,6 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
       public void gotData(int pos, int flags, BKeyObject bkeyObject, byte[] eflag, byte[] data) {
         CachedData cachedData = new CachedData(flags, data, eflag, tc.getMaxSize());
         cachedDataMap.put(pos, new AbstractMap.SimpleEntry<BKeyObject, CachedData>(bkeyObject, cachedData));
-      }
-
-      @Override
-      public void addResult() {
-        if (result.isEmpty() && !cachedDataMap.isEmpty()) {
-          for (Entry<Integer, Entry<BKeyObject, CachedData>> entry : cachedDataMap.entrySet()) {
-            Entry<BKeyObject, CachedData> cachedDataEntry = entry.getValue();
-            result.put(entry.getKey(), makeBTreeElement(cachedDataEntry.getKey(), cachedDataEntry.getValue(), tc));
-          }
-        }
       }
     });
     rv.setOperation(op);
@@ -2832,11 +2778,10 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
 
     Operation op = opFact.bopFindPositionWithGet(k, get,
         new BTreeFindPositionWithGetOperation.Callback() {
-
-          private final TreeMap<Integer, Element<T>> result
-                  = new TreeMap<Integer, Element<T>>();
           private final HashMap<Integer, Entry<BKeyObject, CachedData>> cachedDataMap
                   = new HashMap<Integer, Entry<BKeyObject, CachedData>>();
+          private final GetResult<Map<Integer, Element<T>>> result
+                  = new BopGetByPositionResultImpl<T>(cachedDataMap, false, tc);
 
           public void receivedStatus(OperationStatus status) {
             CollectionOperationStatus cstatus;
@@ -2847,29 +2792,29 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
               cstatus = new CollectionOperationStatus(status);
             }
             if (cstatus.isSuccess()) {
-              rv.set(result, cstatus);
+              rv.setResult(result, cstatus);
               return;
             }
             switch (cstatus.getResponse()) {
               case NOT_FOUND:
-                rv.set(null, cstatus);
+                rv.setResult(null, cstatus);
                 getLogger().debug("Key(%s) not found : %s", k, cstatus);
                 break;
               case NOT_FOUND_ELEMENT:
-                rv.set(null, cstatus);
+                rv.setResult(null, cstatus);
                 getLogger().debug("Element(%s) not found : %s", k, cstatus);
                 break;
               case UNREADABLE:
-                rv.set(null, cstatus);
+                rv.setResult(null, cstatus);
                 getLogger().debug("Collection(%s) is not readable : %s", k, cstatus);
                 break;
               case BKEY_MISMATCH:
-                rv.set(null, cstatus);
+                rv.setResult(null, cstatus);
                 getLogger().debug("Collection(%s) has wrong bkey : %s(%s)", k, cstatus,
                     get.getBkeyObject().getType());
                 break;
               case TYPE_MISMATCH:
-                rv.set(null, cstatus);
+                rv.setResult(null, cstatus);
                 getLogger().debug("Collection(%s) is not a B+Tree : %s", k, cstatus);
                 break;
               default:
@@ -2885,16 +2830,6 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
           public void gotData(int pos, int flags, BKeyObject bkeyObject, byte[] eflag, byte[] data) {
             CachedData cachedData = new CachedData(flags, data, eflag, tc.getMaxSize());
             cachedDataMap.put(pos, new AbstractMap.SimpleEntry<BKeyObject, CachedData>(bkeyObject, cachedData));
-          }
-
-          @Override
-          public void addResult() {
-            if (result.isEmpty() && !cachedDataMap.isEmpty()) {
-              for (Map.Entry<Integer, Map.Entry<BKeyObject, CachedData>> entry : cachedDataMap.entrySet()) {
-                Entry<BKeyObject, CachedData> cachedDataEntry = entry.getValue();
-                result.put(entry.getKey(), makeBTreeElement(cachedDataEntry.getKey(), cachedDataEntry.getValue(), tc));
-              }
-            }
           }
         }
     );
@@ -2989,14 +2924,11 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
     get.setFlags(co.getFlags());
 
     final CountDownLatch latch = new CountDownLatch(1);
-    final BTreeStoreAndGetFuture<Boolean, E> rv
-            = new BTreeStoreAndGetFuture<Boolean, E>(latch, operationTimeout);
+    final BTreeStoreAndGetFuture<Boolean, E> rv =
+            new BTreeStoreAndGetFuture<Boolean, E>(latch, operationTimeout);
 
     Operation op = opFact.bopInsertAndGet(k, get, co.getData(),
         new BTreeInsertAndGetOperation.Callback() {
-          private Element<E> element = null;
-          private CachedData cachedData = null;
-          private BKeyObject bKeyObject = null;
 
           public void receivedStatus(OperationStatus status) {
             CollectionOperationStatus cstatus;
@@ -3031,46 +2963,13 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
 
           @Override
           public void gotData(int flags, BKeyObject bkeyObject, byte[] eflag, byte[] data) {
-            this.bKeyObject = bkeyObject;
-            cachedData = new CachedData(flags, data, eflag, tc.getMaxSize());
-          }
-
-          @Override
-          public void addResult() {
-            if (cachedData != null && element == null) {
-              element = makeBTreeElement(bKeyObject, cachedData, tc);
-              rv.setElement(element);
-            }
+            rv.setElement(new BopStoreAndGetResultImpl<E>(bkeyObject,
+                    new CachedData(flags, data, eflag, tc.getMaxSize()), tc));
           }
         });
     rv.setOperation(op);
     addOp(k, op);
     return rv;
-  }
-
-  /**
-   * Utility method to create a b+tree element from individual parameters.
-   *
-   * @param bkey  element key
-   * @param cachedData element data
-   * @param tc    transcoder to serialize and unserialize value
-   * @return element object containing all the parameters and transcoded value
-   */
-  private <T> Element<T> makeBTreeElement(BKeyObject bkey, CachedData cachedData, Transcoder<T> tc) {
-    Element<T> element = null;
-    T value = tc.decode(cachedData);
-
-    switch (bkey.getType()) {
-      case LONG:
-        element = new Element<T>(bkey.getLongBKey(), value, cachedData.getEFlag());
-        break;
-      case BYTEARRAY:
-        element = new Element<T>(bkey.getByteArrayBKeyRaw(), value, cachedData.getEFlag());
-        break;
-      default:
-        getLogger().error("Unexpected bkey type : (bkey:" + bkey.toString() + ")");
-    }
-    return element;
   }
 
   @Override
@@ -3631,13 +3530,15 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
 
     final CountDownLatch latch = new CountDownLatch(getBulkList.size());
     final ConcurrentLinkedQueue<Operation> ops = new ConcurrentLinkedQueue<Operation>();
-    final Map<String, BTreeGetResult<Long, T>> result =
-        new ConcurrentHashMap<String, BTreeGetResult<Long, T>>();
+    final Map<String, List<BTreeElement<Long, CachedData>>> cachedDataMap =
+            new HashMap<String, List<BTreeElement<Long, CachedData>>>();
+    final Map<String, CollectionOperationStatus> opStatusMap =
+            new HashMap<String, CollectionOperationStatus>();
+    final GetResult<Map<String, BTreeGetResult<Long, T>>> result =
+            new BopGetBulkResultImpl<Long, T>(cachedDataMap, opStatusMap, reverse, tc);
 
     for (BTreeGetBulk<T> getBulk : getBulkList) {
-      Operation op = opFact.bopGetBulk(getBulk, new BTreeGetBulkOperation.Callback() {
-        private final Map<String, List<BTreeElement<Long, CachedData>>> cachedDataMap =
-                new HashMap<String, List<BTreeElement<Long, CachedData>>>();
+      final Operation op = opFact.bopGetBulk(getBulk, new BTreeGetBulkOperation.Callback() {
 
         @Override
         public void receivedStatus(OperationStatus status) {
@@ -3651,33 +3552,18 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
 
         @Override
         public void gotKey(String key, int elementCount, OperationStatus status) {
-          TreeMap<Long, BTreeElement<Long, T>> tree = null;
           if (elementCount > 0) {
-            tree = new TreeMap<Long, BTreeElement<Long, T>>(
-                    (reverse) ? Collections.reverseOrder() : null);
+            cachedDataMap.put(key, new ArrayList<BTreeElement<Long, CachedData>>(elementCount));
           }
-          result.put(key, new BTreeGetResult<Long, T>(tree, new CollectionOperationStatus(status)));
+          opStatusMap.put(key, (CollectionOperationStatus) status);
         }
 
         @Override
         public void gotElement(String key, int flags, Object bkey, byte[] eflag, byte[] data) {
-          List<BTreeElement<Long, CachedData>> elements = cachedDataMap.get(key);
-          if (elements == null) {
-            elements = new ArrayList<BTreeElement<Long, CachedData>>();
-            cachedDataMap.put(key, elements);
-          }
-          elements.add(new BTreeElement<Long, CachedData>((Long) bkey, eflag,
+          List<BTreeElement<Long, CachedData>> elems = cachedDataMap.get(key);
+          assert elems != null : "Element list not prepared in bopGetBulk";
+          elems.add(new BTreeElement<Long, CachedData>((Long) bkey, eflag,
                   new CachedData(flags, data, tc.getMaxSize())));
-        }
-
-        @Override
-        public void addResult() {
-          if (!cachedDataMap.isEmpty()) {
-            for (Entry<String, List<BTreeElement<Long, CachedData>>> entry : cachedDataMap.entrySet()) {
-              result.get(entry.getKey()).addElements(entry.getValue(), tc);
-            }
-            cachedDataMap.clear();
-          }
         }
       });
       ops.add(op);
@@ -3704,14 +3590,15 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
 
     final CountDownLatch latch = new CountDownLatch(getBulkList.size());
     final ConcurrentLinkedQueue<Operation> ops = new ConcurrentLinkedQueue<Operation>();
-    final Map<String, BTreeGetResult<ByteArrayBKey, T>> result =
-        new ConcurrentHashMap<String, BTreeGetResult<ByteArrayBKey, T>>();
+    final Map<String, List<BTreeElement<ByteArrayBKey, CachedData>>> cachedDataMap =
+            new HashMap<String, List<BTreeElement<ByteArrayBKey, CachedData>>>();
+    final Map<String, CollectionOperationStatus> opStatusMap =
+            new HashMap<String, CollectionOperationStatus>();
+    final GetResult<Map<String, BTreeGetResult<ByteArrayBKey, T>>> result =
+            new BopGetBulkResultImpl<ByteArrayBKey, T>(cachedDataMap, opStatusMap, reverse, tc);
 
     for (BTreeGetBulk<T> getBulk : getBulkList) {
       Operation op = opFact.bopGetBulk(getBulk, new BTreeGetBulkOperation.Callback() {
-        private final Map<String, List<BTreeElement<ByteArrayBKey, CachedData>>> cachedDataMap =
-                new HashMap<String, List<BTreeElement<ByteArrayBKey, CachedData>>>();
-
         @Override
         public void receivedStatus(OperationStatus status) {
         }
@@ -3723,35 +3610,19 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
 
         @Override
         public void gotKey(String key, int elementCount, OperationStatus status) {
-          TreeMap<ByteArrayBKey, BTreeElement<ByteArrayBKey, T>> tree = null;
           if (elementCount > 0) {
-            tree = new ByteArrayTreeMap<ByteArrayBKey, BTreeElement<ByteArrayBKey, T>>(
-                    (reverse) ? Collections.reverseOrder() : null);
+            cachedDataMap.put(key, new ArrayList<BTreeElement<ByteArrayBKey, CachedData>>(elementCount));
           }
-          result.put(key, new BTreeGetResult<ByteArrayBKey, T>(
-              tree, new CollectionOperationStatus(status)));
+          opStatusMap.put(key, (CollectionOperationStatus) status);
         }
 
         @Override
         public void gotElement(String key, int flags, Object bkey, byte[] eflag, byte[] data) {
-          List<BTreeElement<ByteArrayBKey, CachedData>> elements = cachedDataMap.get(key);
-          if (elements == null) {
-            elements = new ArrayList<BTreeElement<ByteArrayBKey, CachedData>>();
-            cachedDataMap.put(key, elements);
-          }
-          elements.add(new BTreeElement<ByteArrayBKey, CachedData>(
+          List<BTreeElement<ByteArrayBKey, CachedData>> elems = cachedDataMap.get(key);
+          assert elems != null : "Element list not prepared in bopGetBulk";
+          elems.add(new BTreeElement<ByteArrayBKey, CachedData>(
                   new ByteArrayBKey((byte[]) bkey), eflag,
                   new CachedData(flags, data, tc.getMaxSize())));
-        }
-
-        @Override
-        public void addResult() {
-          if (!cachedDataMap.isEmpty()) {
-            for (Entry<String, List<BTreeElement<ByteArrayBKey, CachedData>>> entry : cachedDataMap.entrySet()) {
-              result.get(entry.getKey()).addElements(entry.getValue(), tc);
-            }
-            cachedDataMap.clear();
-          }
         }
       });
       ops.add(op);

--- a/src/main/java/net/spy/memcached/internal/BTreeStoreAndGetFuture.java
+++ b/src/main/java/net/spy/memcached/internal/BTreeStoreAndGetFuture.java
@@ -24,7 +24,7 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import net.spy.memcached.OperationTimeoutException;
 import net.spy.memcached.collection.Element;
-import net.spy.memcached.ops.CollectionGetOpCallback;
+import net.spy.memcached.internal.result.GetResult;
 
 /**
  * Future object that contains an b+tree element object
@@ -34,7 +34,7 @@ import net.spy.memcached.ops.CollectionGetOpCallback;
  */
 public class BTreeStoreAndGetFuture<T, E> extends CollectionFuture<T> {
 
-  private Element<E> element;
+  private GetResult<Element<E>> element;
 
   public BTreeStoreAndGetFuture(CountDownLatch l, long opTimeout) {
     this(l, new AtomicReference<T>(null), opTimeout);
@@ -54,13 +54,10 @@ public class BTreeStoreAndGetFuture<T, E> extends CollectionFuture<T> {
     } catch (TimeoutException e) {
       throw new OperationTimeoutException(e);
     }
-    CollectionGetOpCallback callback = (CollectionGetOpCallback) op.getCallback();
-    callback.addResult();
-    return element;
+    return element == null ? null : element.getDecodedValue();
   }
 
-  public void setElement(Element<E> element) {
+  public void setElement(GetResult<Element<E>> element) {
     this.element = element;
   }
-
 }

--- a/src/main/java/net/spy/memcached/internal/CollectionGetBulkFuture.java
+++ b/src/main/java/net/spy/memcached/internal/CollectionGetBulkFuture.java
@@ -26,7 +26,7 @@ import java.util.concurrent.TimeoutException;
 
 import net.spy.memcached.MemcachedConnection;
 import net.spy.memcached.OperationTimeoutException;
-import net.spy.memcached.ops.CollectionGetOpCallback;
+import net.spy.memcached.internal.result.GetResult;
 import net.spy.memcached.ops.CollectionOperationStatus;
 import net.spy.memcached.ops.Operation;
 import net.spy.memcached.ops.OperationState;
@@ -37,9 +37,10 @@ public class CollectionGetBulkFuture<T> implements Future<T> {
   private final Collection<Operation> ops;
   private final long timeout;
   private final CountDownLatch latch;
-  private final T result;
+  private final GetResult<T> result;
 
-  public CollectionGetBulkFuture(CountDownLatch latch, Collection<Operation> ops, T result,
+  public CollectionGetBulkFuture(CountDownLatch latch, Collection<Operation> ops,
+                                 GetResult<T> result,
                                  long timeout) {
     this.latch = latch;
     this.ops = ops;
@@ -85,12 +86,7 @@ public class CollectionGetBulkFuture<T> implements Future<T> {
         throw new ExecutionException(new RuntimeException(op.getCancelCause()));
       }
     }
-    for (Operation op : ops) {
-      CollectionGetOpCallback callback = (CollectionGetOpCallback) op.getCallback();
-      callback.addResult();
-    }
-
-    return result;
+    return result == null ? null : result.getDecodedValue();
   }
 
   @Override

--- a/src/main/java/net/spy/memcached/internal/CollectionGetFuture.java
+++ b/src/main/java/net/spy/memcached/internal/CollectionGetFuture.java
@@ -1,13 +1,15 @@
 package net.spy.memcached.internal;
 
-import net.spy.memcached.ops.CollectionGetOpCallback;
-
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
+import net.spy.memcached.internal.result.GetResult;
+import net.spy.memcached.ops.CollectionOperationStatus;
+
 public class CollectionGetFuture<T> extends CollectionFuture<T> {
+  private GetResult<T> result;
 
   public CollectionGetFuture(CountDownLatch l, long opTimeout) {
     super(l, opTimeout);
@@ -16,12 +18,12 @@ public class CollectionGetFuture<T> extends CollectionFuture<T> {
   @Override
   public T get(long duration, TimeUnit units)
           throws InterruptedException, TimeoutException, ExecutionException {
+    super.get(duration, units); // for waiting latch.
+    return result == null ? null : result.getDecodedValue();
+  }
 
-    T result = super.get(duration, units);
-    if (result != null) {
-      CollectionGetOpCallback callback = (CollectionGetOpCallback) op.getCallback();
-      callback.addResult();
-    }
-    return result;
+  public void setResult(GetResult<T> result, CollectionOperationStatus status) {
+    super.set(null, status);
+    this.result = result;
   }
 }

--- a/src/main/java/net/spy/memcached/internal/result/BopGetBulkResultImpl.java
+++ b/src/main/java/net/spy/memcached/internal/result/BopGetBulkResultImpl.java
@@ -1,0 +1,43 @@
+package net.spy.memcached.internal.result;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import net.spy.memcached.CachedData;
+import net.spy.memcached.collection.BTreeElement;
+import net.spy.memcached.collection.BTreeGetResult;
+import net.spy.memcached.ops.CollectionOperationStatus;
+import net.spy.memcached.transcoders.Transcoder;
+
+public class BopGetBulkResultImpl<K, V> implements GetResult<Map<String, BTreeGetResult<K, V>>> {
+  private final Map<String, List<BTreeElement<K, CachedData>>> cachedDataMap;
+  private final Map<String, CollectionOperationStatus> opStatusMap;
+  private final boolean reverse;
+  private final Transcoder<V> transcoder;
+  private Map<String, BTreeGetResult<K, V>> result
+          = new HashMap<String, BTreeGetResult<K, V>>();
+
+  public BopGetBulkResultImpl(Map<String, List<BTreeElement<K, CachedData>>> cachedDataMap,
+                              Map<String, CollectionOperationStatus> opStatusMap,
+                              boolean reverse, Transcoder<V> transcoder) {
+    this.cachedDataMap = cachedDataMap;
+    this.opStatusMap = opStatusMap;
+    this.reverse = reverse;
+    this.transcoder = transcoder;
+  }
+
+  @Override
+  public Map<String, BTreeGetResult<K, V>> getDecodedValue() {
+    if (result.isEmpty() && !opStatusMap.isEmpty()) {
+      Map<String, BTreeGetResult<K, V>> temp = new HashMap<String, BTreeGetResult<K, V>>(result);
+      for (Map.Entry<String, CollectionOperationStatus> entry : opStatusMap.entrySet()) {
+        String key = entry.getKey();
+        temp.put(key, new BTreeGetResult<K, V>(cachedDataMap.get(key),
+                reverse, transcoder, entry.getValue()));
+      }
+      result = temp;
+    }
+    return result;
+  }
+}

--- a/src/main/java/net/spy/memcached/internal/result/BopGetByPositionResultImpl.java
+++ b/src/main/java/net/spy/memcached/internal/result/BopGetByPositionResultImpl.java
@@ -1,0 +1,40 @@
+package net.spy.memcached.internal.result;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.SortedMap;
+import java.util.TreeMap;
+
+import net.spy.memcached.CachedData;
+import net.spy.memcached.collection.BKeyObject;
+import net.spy.memcached.collection.Element;
+import net.spy.memcached.transcoders.Transcoder;
+import net.spy.memcached.util.BTreeUtil;
+
+public class BopGetByPositionResultImpl<T> implements GetResult<Map<Integer, Element<T>>> {
+  private final Map<Integer, Map.Entry<BKeyObject, CachedData>> cachedDataMap;
+  private final Transcoder<T> transcoder;
+  private SortedMap<Integer, Element<T>> result;
+
+  public BopGetByPositionResultImpl(Map<Integer, Map.Entry<BKeyObject, CachedData>> cachedDataMap,
+                                    boolean reverse,
+                                    Transcoder<T> transcoder) {
+    this.cachedDataMap = cachedDataMap;
+    this.result = new TreeMap<Integer, Element<T>>((reverse) ? Collections.reverseOrder() : null);
+    this.transcoder = transcoder;
+  }
+
+  @Override
+  public Map<Integer, Element<T>> getDecodedValue() {
+    if (result.isEmpty() && !cachedDataMap.isEmpty()) {
+      SortedMap<Integer, Element<T>> temp = new TreeMap<Integer, Element<T>>(result);
+      for (Map.Entry<Integer, Map.Entry<BKeyObject, CachedData>> entry : cachedDataMap.entrySet()) {
+        Map.Entry<BKeyObject, CachedData> cachedDataEntry = entry.getValue();
+        temp.put(entry.getKey(), BTreeUtil.makeBTreeElement(
+                cachedDataEntry.getKey(), cachedDataEntry.getValue(), transcoder));
+      }
+      result = temp;
+    }
+    return result;
+  }
+}

--- a/src/main/java/net/spy/memcached/internal/result/BopGetResultImpl.java
+++ b/src/main/java/net/spy/memcached/internal/result/BopGetResultImpl.java
@@ -1,0 +1,65 @@
+package net.spy.memcached.internal.result;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Set;
+import java.util.SortedMap;
+import java.util.TreeMap;
+
+import net.spy.memcached.CachedData;
+import net.spy.memcached.collection.BKeyObject;
+import net.spy.memcached.collection.ByteArrayBKey;
+import net.spy.memcached.collection.ByteArrayTreeMap;
+import net.spy.memcached.collection.Element;
+import net.spy.memcached.transcoders.Transcoder;
+import net.spy.memcached.util.BTreeUtil;
+
+public class BopGetResultImpl<K, V> implements GetResult<Map<K, Element<V>>> {
+  private final Map<K, CachedData> cachedDataMap;
+  private final boolean reverse;
+  private final Transcoder<V> transcoder;
+  private SortedMap<K, Element<V>> result;
+
+  public BopGetResultImpl(Map<K, CachedData> cachedDataMap,
+                          boolean reverse, Transcoder<V> transcoder) {
+    this.cachedDataMap = cachedDataMap;
+    this.result = new TreeMap<K, Element<V>>((reverse) ? Collections.reverseOrder() : null);
+    this.reverse = reverse;
+    this.transcoder = transcoder;
+  }
+
+  @Override
+  public Map<K, Element<V>> getDecodedValue() {
+    if (result.isEmpty() && !cachedDataMap.isEmpty()) {
+      Set<Map.Entry<K, CachedData>> entrySet = cachedDataMap.entrySet();
+      K bKey = entrySet.iterator().next().getKey();
+
+      boolean isByteBKey = (bKey instanceof ByteArrayBKey);
+      boolean isLongBKey = (bKey instanceof Long);
+
+      SortedMap<K, Element<V>> temp;
+
+      if (isByteBKey) {
+        temp = new ByteArrayTreeMap<K, Element<V>>(reverse ? Collections.<K>reverseOrder() : null);
+      } else if (isLongBKey) {
+        temp = new TreeMap<K, Element<V>>(reverse ? Collections.<K>reverseOrder() : null);
+      } else {
+        return result;
+      }
+
+      for (Map.Entry<K, CachedData> entry : cachedDataMap.entrySet()) {
+        bKey = entry.getKey();
+        CachedData cachedData = entry.getValue();
+        if (isByteBKey) {
+          temp.put(bKey, BTreeUtil.makeBTreeElement(
+                  new BKeyObject((ByteArrayBKey) bKey), cachedData, transcoder));
+        } else {
+          temp.put(bKey, BTreeUtil.makeBTreeElement(
+                  new BKeyObject((Long) bKey), cachedData, transcoder));
+        }
+      }
+      result = temp;
+    }
+    return result;
+  }
+}

--- a/src/main/java/net/spy/memcached/internal/result/BopStoreAndGetResultImpl.java
+++ b/src/main/java/net/spy/memcached/internal/result/BopStoreAndGetResultImpl.java
@@ -1,0 +1,30 @@
+package net.spy.memcached.internal.result;
+
+import net.spy.memcached.CachedData;
+import net.spy.memcached.collection.BKeyObject;
+import net.spy.memcached.collection.Element;
+import net.spy.memcached.transcoders.Transcoder;
+import net.spy.memcached.util.BTreeUtil;
+
+public class BopStoreAndGetResultImpl<T> implements GetResult<Element<T>> {
+  private final BKeyObject bKeyObject;
+  private final CachedData cachedData;
+  private final Transcoder<T> transcoder;
+  private Element<T> result = null;
+
+  public BopStoreAndGetResultImpl(BKeyObject bKeyObject,
+                                  CachedData cachedData,
+                                  Transcoder<T> transcoder) {
+    this.bKeyObject = bKeyObject;
+    this.cachedData = cachedData;
+    this.transcoder = transcoder;
+  }
+
+  @Override
+  public Element<T> getDecodedValue() {
+    if (cachedData != null && result == null) {
+      result = BTreeUtil.makeBTreeElement(bKeyObject, cachedData, transcoder);
+    }
+    return result;
+  }
+}

--- a/src/main/java/net/spy/memcached/internal/result/LopGetResultImpl.java
+++ b/src/main/java/net/spy/memcached/internal/result/LopGetResultImpl.java
@@ -1,0 +1,30 @@
+package net.spy.memcached.internal.result;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import net.spy.memcached.CachedData;
+import net.spy.memcached.transcoders.Transcoder;
+
+public class LopGetResultImpl<T> implements GetResult<List<T>> {
+  private final List<CachedData> cachedDataList;
+  private final Transcoder<T> transcoder;
+  private List<T> result = new ArrayList<T>();
+
+  public LopGetResultImpl(List<CachedData> cachedDataList, Transcoder<T> transcoder) {
+    this.cachedDataList = cachedDataList;
+    this.transcoder = transcoder;
+  }
+
+  @Override
+  public List<T> getDecodedValue() {
+    if (result.isEmpty() && !cachedDataList.isEmpty()) {
+      List<T> temp = new ArrayList<T>();
+      for (CachedData cachedData : cachedDataList) {
+        temp.add(transcoder.decode(cachedData));
+      }
+      result = temp;
+    }
+    return result;
+  }
+}

--- a/src/main/java/net/spy/memcached/internal/result/MopGetResultImpl.java
+++ b/src/main/java/net/spy/memcached/internal/result/MopGetResultImpl.java
@@ -1,0 +1,30 @@
+package net.spy.memcached.internal.result;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import net.spy.memcached.CachedData;
+import net.spy.memcached.transcoders.Transcoder;
+
+public class MopGetResultImpl<T> implements GetResult<Map<String, T>> {
+  private final Map<String, CachedData> cachedDataMap;
+  private final Transcoder<T> transcoder;
+  private Map<String, T> result = new HashMap<String, T>();
+
+  public MopGetResultImpl(Map<String, CachedData> cachedDataMap, Transcoder<T> transcoder) {
+    this.cachedDataMap = cachedDataMap;
+    this.transcoder = transcoder;
+  }
+
+  @Override
+  public Map<String, T> getDecodedValue() {
+    if (result.isEmpty() && !cachedDataMap.isEmpty()) {
+      Map<String, T> temp = new HashMap<String, T>();
+      for (Map.Entry<String, CachedData> entry : cachedDataMap.entrySet()) {
+        temp.put(entry.getKey(), transcoder.decode(entry.getValue()));
+      }
+      result = temp;
+    }
+    return result;
+  }
+}

--- a/src/main/java/net/spy/memcached/internal/result/SopGetResultImpl.java
+++ b/src/main/java/net/spy/memcached/internal/result/SopGetResultImpl.java
@@ -1,0 +1,30 @@
+package net.spy.memcached.internal.result;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import net.spy.memcached.CachedData;
+import net.spy.memcached.transcoders.Transcoder;
+
+public class SopGetResultImpl<T> implements GetResult<Set<T>> {
+  private final Set<CachedData> cachedDataSet;
+  private final Transcoder<T> transcoder;
+  private Set<T> result = new HashSet<T>();
+
+  public SopGetResultImpl(Set<CachedData> cachedDataSet, Transcoder<T> transcoder) {
+    this.cachedDataSet = cachedDataSet;
+    this.transcoder = transcoder;
+  }
+
+  @Override
+  public Set<T> getDecodedValue() {
+    if (result.isEmpty() && !cachedDataSet.isEmpty()) {
+      Set<T> temp = new HashSet<T>();
+      for (CachedData cachedData : cachedDataSet) {
+        temp.add(transcoder.decode(cachedData));
+      }
+      result = temp;
+    }
+    return result;
+  }
+}

--- a/src/main/java/net/spy/memcached/ops/BTreeFindPositionWithGetOperation.java
+++ b/src/main/java/net/spy/memcached/ops/BTreeFindPositionWithGetOperation.java
@@ -23,7 +23,7 @@ public interface BTreeFindPositionWithGetOperation extends KeyedOperation {
 
   BTreeFindPositionWithGet getGet();
 
-  interface Callback extends CollectionGetOpCallback {
+  interface Callback extends OperationCallback {
     void gotData(int pos, int flags, BKeyObject bkey, byte[] eflag, byte[] data);
   }
 }

--- a/src/main/java/net/spy/memcached/ops/BTreeGetBulkOperation.java
+++ b/src/main/java/net/spy/memcached/ops/BTreeGetBulkOperation.java
@@ -21,7 +21,7 @@ import net.spy.memcached.collection.BTreeGetBulk;
 public interface BTreeGetBulkOperation extends KeyedOperation {
   BTreeGetBulk<?> getBulk();
 
-  interface Callback extends CollectionGetOpCallback {
+  interface Callback extends OperationCallback {
     void gotElement(String key, int flags, Object subkey, byte[] eflag, byte[] data);
 
     void gotKey(String key, int elementCount, OperationStatus status);

--- a/src/main/java/net/spy/memcached/ops/BTreeGetByPositionOperation.java
+++ b/src/main/java/net/spy/memcached/ops/BTreeGetByPositionOperation.java
@@ -20,10 +20,9 @@ import net.spy.memcached.collection.BKeyObject;
 import net.spy.memcached.collection.BTreeGetByPosition;
 
 public interface BTreeGetByPositionOperation extends KeyedOperation {
-
   BTreeGetByPosition getGet();
 
-  interface Callback extends CollectionGetOpCallback {
+  interface Callback extends OperationCallback {
     void gotData(int pos, int flags, BKeyObject bkey, byte[] eflag, byte[] data);
   }
 }

--- a/src/main/java/net/spy/memcached/ops/BTreeInsertAndGetOperation.java
+++ b/src/main/java/net/spy/memcached/ops/BTreeInsertAndGetOperation.java
@@ -23,7 +23,7 @@ public interface BTreeInsertAndGetOperation extends KeyedOperation {
 
   BTreeInsertAndGet<?> getGet();
 
-  interface Callback extends CollectionGetOpCallback {
+  interface Callback extends OperationCallback {
     void gotData(int flags, BKeyObject bkeyObject, byte[] elementFlag, byte[] data);
   }
 

--- a/src/main/java/net/spy/memcached/ops/CollectionGetOpCallback.java
+++ b/src/main/java/net/spy/memcached/ops/CollectionGetOpCallback.java
@@ -1,5 +1,0 @@
-package net.spy.memcached.ops;
-
-public interface CollectionGetOpCallback extends OperationCallback {
-  void addResult();
-}

--- a/src/main/java/net/spy/memcached/ops/CollectionGetOperation.java
+++ b/src/main/java/net/spy/memcached/ops/CollectionGetOperation.java
@@ -25,7 +25,7 @@ public interface CollectionGetOperation extends KeyedOperation {
 
   CollectionGet getGet();
 
-  interface Callback extends CollectionGetOpCallback {
+  interface Callback extends OperationCallback {
     void gotData(String subkey, int flags, byte[] data, byte[] eflag);
   }
 }

--- a/src/main/java/net/spy/memcached/ops/MultiBTreeGetBulkOperationCallback.java
+++ b/src/main/java/net/spy/memcached/ops/MultiBTreeGetBulkOperationCallback.java
@@ -33,10 +33,5 @@ public class MultiBTreeGetBulkOperationCallback extends MultiOperationCallback
   public void gotKey(String key, int elementCount, OperationStatus status) {
     ((BTreeGetBulkOperation.Callback) originalCallback).gotKey(key, elementCount, status);
   }
-
-  @Override
-  public void addResult() {
-    ((BTreeGetBulkOperation.Callback) originalCallback).addResult();
-  }
 }
 

--- a/src/main/java/net/spy/memcached/util/BTreeUtil.java
+++ b/src/main/java/net/spy/memcached/util/BTreeUtil.java
@@ -18,6 +18,11 @@
 package net.spy.memcached.util;
 
 
+import net.spy.memcached.CachedData;
+import net.spy.memcached.collection.BKeyObject;
+import net.spy.memcached.collection.Element;
+import net.spy.memcached.transcoders.Transcoder;
+
 public final class BTreeUtil {
 
   private static final String HEXES = "0123456789ABCDEF";
@@ -100,5 +105,22 @@ public final class BTreeUtil {
                 String.format("not supported unsigned long bkey : %s, use byte array bkey", bkey));
       }
     }
+  }
+
+  public static <T> Element<T> makeBTreeElement(BKeyObject bkey,
+                                                CachedData cachedData,
+                                                Transcoder<T> tc) {
+    Element<T> element = null;
+    T value = tc.decode(cachedData);
+
+    switch (bkey.getType()) {
+      case LONG:
+        element = new Element<T>(bkey.getLongBKey(), value, cachedData.getEFlag());
+        break;
+      case BYTEARRAY:
+        element = new Element<T>(bkey.getByteArrayBKeyRaw(), value, cachedData.getEFlag());
+        break;
+    }
+    return element;
   }
 }

--- a/src/test/manual/net/spy/memcached/MultibyteKeyTest.java
+++ b/src/test/manual/net/spy/memcached/MultibyteKeyTest.java
@@ -176,10 +176,6 @@ public class MultibyteKeyTest {
         @Override
         public void complete() {
         }
-
-        @Override
-        public void addResult() {
-        }
       }).initialize();
     } catch (java.nio.BufferOverflowException e) {
       Assert.fail();
@@ -439,10 +435,6 @@ public class MultibyteKeyTest {
             @Override
             public void complete() {
             }
-
-            @Override
-            public void addResult() {
-            }
           }).initialize();
     } catch (java.nio.BufferOverflowException e) {
       Assert.fail();
@@ -540,10 +532,6 @@ public class MultibyteKeyTest {
             @Override
             public void complete() {
             }
-
-            @Override
-            public void addResult() {
-            }
           }).initialize();
     } catch (java.nio.BufferOverflowException e) {
       Assert.fail();
@@ -556,9 +544,6 @@ public class MultibyteKeyTest {
       opFact.bopGetByPosition(MULTIBYTE_KEY,
           new BTreeGetByPosition(BTreeOrder.ASC, 0),
           new BTreeGetByPositionOperation.Callback() {
-            @Override
-            public void addResult() {
-            }
 
             @Override
             public void gotData(int pos, int flags, BKeyObject bkey, byte[] eflag, byte[] data) {
@@ -683,10 +668,6 @@ public class MultibyteKeyTest {
 
             @Override
             public void complete() {
-            }
-
-            @Override
-            public void addResult() {
             }
           }).initialize();
     } catch (java.nio.BufferOverflowException e) {


### PR DESCRIPTION
## 이슈
https://github.com/jam2in/arcus-works/issues/486

## 변경 지점
1. 기존에 addResult 콜백을 사용하던 모든 api들의 `decode()` 로직 수행을 콜백 메서드가 아닌 XXXResult 객체를 통해 수행하도록 변경하였습니다.
2. ArcusClient에 존재하던 `makeBTreeElement` 메서드를 삭제하고 BTreeUtil 클래스의 static 메서드로 변경하였습니다.
3. `BopGetResultImpl`와 `BopGetBulkResultImpl`의 경우 BKey 타입에 따라 생성할 Tree 객체의 타입이 달라집니다. 그래서 해당 트리를 호출 api 내부에서 생성 후 Result 객체로 넘겨주도록 구현하였습니다.
    - bopGet은 `BopGetResultImpl`의 생성자의 인자로 넘겨줌
    - bopBulkGet은 `gotKey` 콜백 메서드 내부에서 `addEachBTree`의 인자로 넘겨줌

### 새롭게 생성된 Result 클래스
아래 청크 단위로 변경지점 파악하시면 리뷰하는데 수월할 것 같습니다.
### 1
- `LopGetResultImpl`
- `MopGetResultImpl`
- `SopGetResultImpl`
### 2
- `BopGetByPositoinResultImpl`
- `BopGetResultImpl`
### 3
- `BopGetBulkResultImpl`
### 4
- `BopStoreAndGetResultImpl`


