### PR TITLE
CLEANUP: rename variable clearer in futures

### DIFF
--- a/src/main/java/net/spy/memcached/ArcusClient.java
+++ b/src/main/java/net/spy/memcached/ArcusClient.java
@@ -1005,7 +1005,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
           });
       opMap.put(key, op);
     }
-    rv.setOperations(opMap.values());
+    rv.addOperations(opMap.values());
     addOpMap(opMap);
     return rv;
   }
@@ -1053,7 +1053,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
             });
       opMap.put(key, op);
     }
-    rv.setOperations(opMap.values());
+    rv.addOperations(opMap.values());
     addOpMap(opMap);
     return rv;
   }
@@ -1093,7 +1093,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
             });
       opMap.put(key, op);
     }
-    rv.setOperations(opMap.values());
+    rv.addOperations(opMap.values());
     addOpMap(opMap);
     return rv;
   }
@@ -1140,7 +1140,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
           });
       opMap.put(key, op);
     }
-    rv.setOperations(opMap.values());
+    rv.addOperations(opMap.values());
     addOpMap(opMap);
     return rv;
   }
@@ -1174,7 +1174,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
       });
       opMap.put(key, op);
     }
-    rv.setOperations(opMap.values());
+    rv.addOperations(opMap.values());
     addOpMap(opMap);
     return rv;
   }

--- a/src/main/java/net/spy/memcached/internal/BulkOperationFuture.java
+++ b/src/main/java/net/spy/memcached/internal/BulkOperationFuture.java
@@ -104,7 +104,7 @@ public class BulkOperationFuture<T> implements Future<Map<String, T>> {
     failedResult.put(key, value);
   }
 
-  public void setOperations(Collection<Operation> ops) {
+  public void addOperations(Collection<Operation> ops) {
     this.ops.addAll(ops);
   }
 

--- a/src/main/java/net/spy/memcached/internal/PipedCollectionFuture.java
+++ b/src/main/java/net/spy/memcached/internal/PipedCollectionFuture.java
@@ -22,7 +22,7 @@ public class PipedCollectionFuture<K, V>
   private final AtomicReference<CollectionOperationStatus> operationStatus
           = new AtomicReference<CollectionOperationStatus>(null);
 
-  private final Map<K, V> mergedResult =
+  private final Map<K, V> failedResult =
           new ConcurrentHashMap<K, V>();
 
   public PipedCollectionFuture(CountDownLatch l, long opTimeout) {
@@ -90,7 +90,7 @@ public class PipedCollectionFuture<K, V>
       }
     }
 
-    return mergedResult;
+    return failedResult;
   }
 
   @Override
@@ -110,7 +110,7 @@ public class PipedCollectionFuture<K, V>
   }
 
   public void addEachResult(K index, V status) {
-    mergedResult.put(index, status);
+    failedResult.put(index, status);
   }
 
   public void addOperation(Operation op) {


### PR DESCRIPTION
- future에 있는 변수명과 함수명을 이해하기 쉽게 변경합니다.
- PipedCollectionFuture에서 mergedResult에 항상 실패한 Operation에 대한 상태만 들어있기 때문에 failedResult로 변경합니다.
- BulkOperationFuture 에서 setOperations 메서드는 새로운 값을 필드에 할당하는 것이 아닌 기존 필드에 데이터를 추가(add)하는 로직이기 때문에 addOperations 로 변경합니다.