### PR TITLE
ENHANCE: Change creating callback objects multiple times in pipe operation.

### DIFF
--- a/src/main/java/net/spy/memcached/collection/CollectionPipedInsert.java
+++ b/src/main/java/net/spy/memcached/collection/CollectionPipedInsert.java
@@ -36,12 +36,19 @@ public abstract class CollectionPipedInsert<T> extends CollectionPipe {
   protected final CollectionAttributes attribute;
   protected final Transcoder<T> tc;
 
-  protected CollectionPipedInsert(String key, CollectionAttributes attribute,
+  private final int opIdx;
+
+  protected CollectionPipedInsert(String key, int opIdx, CollectionAttributes attribute,
                                   Transcoder<T> tc, int itemCount) {
     super(itemCount);
     this.key = key;
+    this.opIdx = opIdx;
     this.attribute = attribute;
     this.tc = tc;
+  }
+
+  public int getOpIdx() {
+    return opIdx;
   }
 
   /**
@@ -53,9 +60,9 @@ public abstract class CollectionPipedInsert<T> extends CollectionPipe {
     private final Collection<T> list;
     private final int index;
 
-    public ListPipedInsert(String key, int index, Collection<T> list,
+    public ListPipedInsert(String key, int index, Collection<T> list, int opIdx,
                            CollectionAttributes attr, Transcoder<T> tc) {
-      super(key, attr, tc, list.size());
+      super(key, opIdx, attr, tc, list.size());
       if (attr != null) { /* item creation option */
         CollectionCreate.checkOverflowAction(CollectionType.list, attr.getOverflowAction());
       }
@@ -115,9 +122,9 @@ public abstract class CollectionPipedInsert<T> extends CollectionPipe {
     private static final String COMMAND = "sop insert";
     private final Collection<T> set;
 
-    public SetPipedInsert(String key, Collection<T> set,
+    public SetPipedInsert(String key, Collection<T> set, int opIdx,
                           CollectionAttributes attr, Transcoder<T> tc) {
-      super(key, attr, tc, set.size());
+      super(key, opIdx, attr, tc, set.size());
       if (attr != null) { /* item creation option */
         CollectionCreate.checkOverflowAction(CollectionType.set, attr.getOverflowAction());
       }
@@ -172,9 +179,9 @@ public abstract class CollectionPipedInsert<T> extends CollectionPipe {
     private static final String COMMAND = "bop insert";
     private final Map<Long, T> map;
 
-    public BTreePipedInsert(String key, Map<Long, T> map,
+    public BTreePipedInsert(String key, Map<Long, T> map, int opIdx,
                             CollectionAttributes attr, Transcoder<T> tc) {
-      super(key, attr, tc, map.size());
+      super(key, opIdx, attr, tc, map.size());
       if (attr != null) { /* item creation option */
         CollectionCreate.checkOverflowAction(CollectionType.btree, attr.getOverflowAction());
       }
@@ -234,9 +241,9 @@ public abstract class CollectionPipedInsert<T> extends CollectionPipe {
     private static final String COMMAND = "bop insert";
     private final List<Element<T>> elements;
 
-    public ByteArraysBTreePipedInsert(String key, List<Element<T>> elements,
+    public ByteArraysBTreePipedInsert(String key, List<Element<T>> elements, int opIdx,
                                       CollectionAttributes attr, Transcoder<T> tc) {
-      super(key, attr, tc, elements.size());
+      super(key, opIdx, attr, tc, elements.size());
       if (attr != null) { /* item creation option */
         CollectionCreate.checkOverflowAction(CollectionType.btree, attr.getOverflowAction());
       }
@@ -296,9 +303,9 @@ public abstract class CollectionPipedInsert<T> extends CollectionPipe {
     private static final String COMMAND = "mop insert";
     private final Map<String, T> map;
 
-    public MapPipedInsert(String key, Map<String, T> map,
+    public MapPipedInsert(String key, Map<String, T> map, int opIdx,
                           CollectionAttributes attr, Transcoder<T> tc) {
-      super(key, attr, tc, map.size());
+      super(key, opIdx, attr, tc, map.size());
       if (attr != null) { /* item creation option */
         CollectionCreate.checkOverflowAction(CollectionType.map, attr.getOverflowAction());
       }

--- a/src/main/java/net/spy/memcached/collection/CollectionPipedUpdate.java
+++ b/src/main/java/net/spy/memcached/collection/CollectionPipedUpdate.java
@@ -34,10 +34,17 @@ public abstract class CollectionPipedUpdate<T> extends CollectionPipe {
   protected final String key;
   protected final Transcoder<T> tc;
 
-  protected CollectionPipedUpdate(String key, Transcoder<T> tc, int itemCount) {
+  private final int opIdx;
+
+  protected CollectionPipedUpdate(String key, int opIdx, Transcoder<T> tc, int itemCount) {
     super(itemCount);
+    this.opIdx = opIdx;
     this.key = key;
     this.tc = tc;
+  }
+
+  public int getOpIdx() {
+    return opIdx;
   }
 
   public static class BTreePipedUpdate<T> extends CollectionPipedUpdate<T> {
@@ -46,8 +53,8 @@ public abstract class CollectionPipedUpdate<T> extends CollectionPipe {
     private final List<Element<T>> elements;
 
     public BTreePipedUpdate(String key, List<Element<T>> elements,
-                            Transcoder<T> tc) {
-      super(key, tc, elements.size());
+                            int opIdx, Transcoder<T> tc) {
+      super(key, opIdx, tc, elements.size());
       this.elements = elements;
     }
 
@@ -140,8 +147,8 @@ public abstract class CollectionPipedUpdate<T> extends CollectionPipe {
     private final Map<String, T> elements;
 
     public MapPipedUpdate(String key, Map<String, T> elements,
-                          Transcoder<T> tc) {
-      super(key, tc, elements.size());
+                          int opIdx, Transcoder<T> tc) {
+      super(key, opIdx, tc, elements.size());
       this.elements = elements;
     }
 

--- a/src/main/java/net/spy/memcached/ops/CollectionPipedInsertOperation.java
+++ b/src/main/java/net/spy/memcached/ops/CollectionPipedInsertOperation.java
@@ -26,7 +26,7 @@ public interface CollectionPipedInsertOperation extends KeyedOperation {
   CollectionPipedInsert<?> getInsert();
 
   interface Callback extends OperationCallback {
-    void gotStatus(Integer index, OperationStatus status);
+    void gotStatus(Integer index, int opIdx, OperationStatus status);
   }
 
 }

--- a/src/main/java/net/spy/memcached/ops/CollectionPipedUpdateOperation.java
+++ b/src/main/java/net/spy/memcached/ops/CollectionPipedUpdateOperation.java
@@ -26,7 +26,7 @@ public interface CollectionPipedUpdateOperation extends KeyedOperation {
   CollectionPipedUpdate<?> getUpdate();
 
   interface Callback extends OperationCallback {
-    void gotStatus(Integer index, OperationStatus status);
+    void gotStatus(Integer index, int opIdx, OperationStatus status);
   }
 
 }

--- a/src/main/java/net/spy/memcached/protocol/ascii/CollectionPipedInsertOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/CollectionPipedInsertOperationImpl.java
@@ -122,7 +122,7 @@ public class CollectionPipedInsertOperationImpl extends OperationImpl
       if (status.isSuccess()) {
         cb.receivedStatus((successAll) ? END : FAILED_END);
       } else {
-        cb.gotStatus(index, status);
+        cb.gotStatus(index, insert.getOpIdx(), status);
         cb.receivedStatus(FAILED_END);
       }
       transitionState(OperationState.COMPLETE);
@@ -161,7 +161,7 @@ public class CollectionPipedInsertOperationImpl extends OperationImpl
               TYPE_MISMATCH, BKEY_MISMATCH);
 
       if (!status.isSuccess()) {
-        cb.gotStatus(index, status);
+        cb.gotStatus(index, insert.getOpIdx(), status);
         successAll = false;
       }
       index++;

--- a/src/main/java/net/spy/memcached/protocol/ascii/CollectionPipedUpdateOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/CollectionPipedUpdateOperationImpl.java
@@ -118,7 +118,7 @@ public class CollectionPipedUpdateOperationImpl extends OperationImpl implements
       if (status.isSuccess()) {
         cb.receivedStatus((successAll) ? END : FAILED_END);
       } else {
-        cb.gotStatus(index, status);
+        cb.gotStatus(index, update.getOpIdx(), status);
         cb.receivedStatus(FAILED_END);
       }
       transitionState(OperationState.COMPLETE);
@@ -157,7 +157,7 @@ public class CollectionPipedUpdateOperationImpl extends OperationImpl implements
               BKEY_MISMATCH, EFLAG_MISMATCH, SERVER_ERROR);
 
       if (!status.isSuccess()) {
-        cb.gotStatus(index, status);
+        cb.gotStatus(index, update.getOpIdx(), status);
         successAll = false;
       }
       index++;

--- a/src/test/manual/net/spy/memcached/MultibyteKeyTest.java
+++ b/src/test/manual/net/spy/memcached/MultibyteKeyTest.java
@@ -344,7 +344,7 @@ public class MultibyteKeyTest {
     CollectionPipedInsertOperation.Callback cpsCallback =
         new CollectionPipedInsertOperation.Callback() {
           @Override
-          public void gotStatus(Integer index, OperationStatus status) {
+          public void gotStatus(Integer index, int opIdx, OperationStatus status) {
           }
 
           @Override
@@ -362,7 +362,7 @@ public class MultibyteKeyTest {
     }
     CollectionPipedInsert<Integer> insert =
         new CollectionPipedInsert.ByteArraysBTreePipedInsert<Integer>(
-            MULTIBYTE_KEY, elements, new CollectionAttributes(), new IntegerTranscoder());
+            MULTIBYTE_KEY, elements, 0, new CollectionAttributes(), new IntegerTranscoder());
     try {
       opFact.collectionPipedInsert(MULTIBYTE_KEY, insert, cpsCallback).initialize();
     } catch (java.nio.BufferOverflowException e) {
@@ -374,7 +374,7 @@ public class MultibyteKeyTest {
       elementsMap.put(Long.valueOf(i), new Random().nextInt());
     }
     insert = new CollectionPipedInsert.BTreePipedInsert<Integer>(
-            MULTIBYTE_KEY, elementsMap, new CollectionAttributes(), new IntegerTranscoder());
+            MULTIBYTE_KEY, elementsMap, 0, new CollectionAttributes(), new IntegerTranscoder());
     try {
       opFact.collectionPipedInsert(MULTIBYTE_KEY, insert, cpsCallback).initialize();
     } catch (java.nio.BufferOverflowException e) {
@@ -386,7 +386,7 @@ public class MultibyteKeyTest {
       elementsList.add(new Random().nextInt());
     }
     insert = new CollectionPipedInsert.ListPipedInsert<Integer>(
-            MULTIBYTE_KEY, 0, elementsList, new CollectionAttributes(),
+            MULTIBYTE_KEY, 0, elementsList, 0, new CollectionAttributes(),
             new IntegerTranscoder());
     try {
       opFact.collectionPipedInsert(MULTIBYTE_KEY, insert, cpsCallback).initialize();
@@ -399,7 +399,7 @@ public class MultibyteKeyTest {
       elementsSet.add(new Random().nextInt());
     }
     insert = new CollectionPipedInsert.SetPipedInsert<Integer>(
-            MULTIBYTE_KEY, elementsSet, new CollectionAttributes(), new IntegerTranscoder());
+            MULTIBYTE_KEY, elementsSet, 0, new CollectionAttributes(), new IntegerTranscoder());
     try {
       opFact.collectionPipedInsert(MULTIBYTE_KEY, insert, cpsCallback).initialize();
     } catch (java.nio.BufferOverflowException e) {
@@ -583,10 +583,10 @@ public class MultibyteKeyTest {
     try {
       opFact.collectionPipedUpdate(MULTIBYTE_KEY,
           new CollectionPipedUpdate.BTreePipedUpdate<Integer>(
-              MULTIBYTE_KEY, elementsList, new IntegerTranscoder()),
+              MULTIBYTE_KEY, elementsList, 0, new IntegerTranscoder()),
           new CollectionPipedUpdateOperation.Callback() {
             @Override
-            public void gotStatus(Integer index, OperationStatus status) {
+            public void gotStatus(Integer index, int opIdx, OperationStatus status) {
             }
 
             @Override


### PR DESCRIPTION
## 관련 이슈
https://github.com/jam2in/arcus-works/issues/515

## 작업 내용
Piped 연산 시 op 인스턴스는 여러개 생성된다.
이와 동시에 callback 인스턴스도 여러개 생성된다.

하나의 콜백 인스턴스를 복수개의 op 인스턴스가 공유해서 사용하도록 변경한다.
