### PR TITLE
TEST: Remove duplicated test case regardless ZK is running or not.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
 
       - name: Build ARCUS Client
         run: mvn install -DskipTests
-      - name: Test ARCUS Client -DUSE_ZK=false -DARCUS_HOST=127.0.0.1:11212
-        run: mvn test -DUSE_ZK=false -DARCUS_HOST=127.0.0.1:11212
-      - name: Test ARCUS Client -DUSE_ZK=true
+      - name: Test ARCUS Client Without ZK
+        run: mvn test -DUSE_ZK=false -Dtest=ObserverTest
+      - name: Test ARCUS Client With ZK
         run: mvn test -DUSE_ZK=true


### PR DESCRIPTION
아래 테스트는 ZK와 함께 구동될 경우 Skip 되는 테스트 클래스입니다.
(assumeTrue 사용)

- ObserverTest

ZK 없이 테스트하는 경우 Single cached node에 테스트 코드를 수행하는 경우라서
클러스터 환경에서 나머지 테스트 케이스들을 커버합니다.

위 테스트를 제외한 나머지 테스트 케이스들의 중복 수행을 수정하는 PR입니다.
(6min -> 3min 으로 CI 시간 단축)

아래는 기존에 실행되던 테스트 방식에서 skip 되는 테스트 케이스들에 대한 정리입니다.
https://www.notion.so/jam2in/skip-test-case-94ac9e83e6024ec68e722b3ac67a287f?pvs=4