### PR TITLE
FEAT: Add check DNS cache ttl method.

### DIFF
--- a/src/main/java/net/spy/memcached/ConnectionFactory.java
+++ b/src/main/java/net/spy/memcached/ConnectionFactory.java
@@ -117,6 +117,11 @@ public interface ConnectionFactory {
   boolean getKeepAlive();
 
   /**
+   * If true, check DNS cache TTL when invoking ArcusClient constructor.
+   */
+  boolean getDnsCacheTtlCheck();
+
+  /**
    * Observers that should be established at the time of connection
    * instantiation.
    *

--- a/src/main/java/net/spy/memcached/ConnectionFactoryBuilder.java
+++ b/src/main/java/net/spy/memcached/ConnectionFactoryBuilder.java
@@ -60,6 +60,7 @@ public class ConnectionFactoryBuilder {
   private boolean shouldOptimize = false;
   private boolean useNagle = false;
   private boolean keepAlive = false;
+  private boolean dnsCacheTtlCheck = true;
   //private long maxReconnectDelay =
   //DefaultConnectionFactory.DEFAULT_MAX_RECONNECT_DELAY;
   private long maxReconnectDelay = 1;
@@ -448,6 +449,12 @@ public class ConnectionFactoryBuilder {
     keepAlive = on;
     return this;
   }
+
+  public ConnectionFactoryBuilder setDnsCacheTtlCheck(boolean dnsCacheTtlCheck) {
+    this.dnsCacheTtlCheck = dnsCacheTtlCheck;
+    return this;
+  }
+
   /**
    * Get the ConnectionFactory set up with the provided parameters.
    */
@@ -575,6 +582,11 @@ public class ConnectionFactoryBuilder {
       @Override
       public boolean getKeepAlive() {
         return keepAlive;
+      }
+
+      @Override
+      public boolean getDnsCacheTtlCheck() {
+        return dnsCacheTtlCheck;
       }
 
       @Override

--- a/src/main/java/net/spy/memcached/DefaultConnectionFactory.java
+++ b/src/main/java/net/spy/memcached/DefaultConnectionFactory.java
@@ -303,6 +303,12 @@ public class DefaultConnectionFactory extends SpyObject
   public boolean getKeepAlive() {
     return false;
   }
+
+  @Override
+  public boolean getDnsCacheTtlCheck() {
+    return true;
+  }
+
   public boolean shouldOptimize() {
     return false;
   }

--- a/src/test/java/net/spy/memcached/ClientBaseCase.java
+++ b/src/test/java/net/spy/memcached/ClientBaseCase.java
@@ -158,6 +158,11 @@ public abstract class ClientBaseCase extends TestCase {
         }
 
         @Override
+        public boolean getDnsCacheTtlCheck() {
+          return inner.getDnsCacheTtlCheck();
+        }
+
+        @Override
         public Collection<ConnectionObserver> getInitialObservers() {
           return observers;
         }

--- a/src/test/java/net/spy/memcached/ConnectionFactoryBuilderTest.java
+++ b/src/test/java/net/spy/memcached/ConnectionFactoryBuilderTest.java
@@ -94,6 +94,7 @@ public class ConnectionFactoryBuilderTest extends BaseMockCase {
     assertFalse(f.shouldOptimize());
     assertFalse(f.useNagleAlgorithm());
     assertFalse(f.getKeepAlive());
+    assertTrue(f.getDnsCacheTtlCheck());
     assertEquals(f.getOpQueueMaxBlockTime(),
             DefaultConnectionFactory.DEFAULT_OP_QUEUE_MAX_BLOCK_TIME);
   }
@@ -132,6 +133,7 @@ public class ConnectionFactoryBuilderTest extends BaseMockCase {
             .setTranscoder(new WhalinTranscoder())
             .setUseNagleAlgorithm(true)
             .setKeepAlive(true)
+            .setDnsCacheTtlCheck(false)
             .setLocatorType(Locator.CONSISTENT)
             .setOpQueueMaxBlockTime(19)
             .setAuthDescriptor(anAuthDescriptor)
@@ -152,6 +154,7 @@ public class ConnectionFactoryBuilderTest extends BaseMockCase {
     assertFalse(f.shouldOptimize());
     assertTrue(f.useNagleAlgorithm());
     assertTrue(f.getKeepAlive());
+    assertFalse(f.getDnsCacheTtlCheck());
     assertEquals(f.getOpQueueMaxBlockTime(), 19);
     assertSame(anAuthDescriptor, f.getAuthDescriptor());
 


### PR DESCRIPTION
### 관련 이슈
https://github.com/jam2in/arcus-works/issues/487

## 변경된 구현
### DNS cache TTL 값을 확인하는 법
1. Security.getProperty(...) -> "networkaddress.cache.ttl" 프로퍼티 사용
2. System.getProperty(...) -> "sun.net.inetaddr.ttl" 프로퍼티 사용
3. `CacheManger`객체 사용 여부 확인

### Invalid 기준
- 가져온 DnsCacheTtl 값이 0 < ttl or ttl > 300 면 invalid 판정

### ArcusClient 생성 시 DNS 검증 여부
default 값을 true로 설정해서 ArcusClient 인스턴스가 생성될 때매다
기본적으로 검증하도록 구현했습니다.

ArcusClientPool을 사용하더라도 getInstance를 통해 
본 PR에서 변경된 ArcusClient 생성자를 호출합니다.