### PR TITLE
CLEANUP: deprecate APIs using varargs

### DIFF
--- a/src/main/java/net/spy/memcached/ArcusClient.java
+++ b/src/main/java/net/spy/memcached/ArcusClient.java
@@ -1178,6 +1178,11 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
     return rv;
   }
 
+  /**
+   * @deprecated no longer support varargs as collection has the same role.
+   * use {@link ArcusClient#asyncDeleteBulk(List)} instead.
+   */
+  @Deprecated
   @Override
   public Future<Map<String, OperationStatus>> asyncDeleteBulk(String... key) {
     if (key == null) {

--- a/src/main/java/net/spy/memcached/ArcusClientPool.java
+++ b/src/main/java/net/spy/memcached/ArcusClientPool.java
@@ -282,12 +282,14 @@ public class ArcusClientPool implements MemcachedClientIF, ArcusClientIF {
     return this.getClient().asyncGetBulk(keys);
   }
 
+  @Deprecated
   @Override
   public <T> BulkFuture<Map<String, T>> asyncGetBulk(Transcoder<T> tc,
                                                      String... keys) {
     return this.getClient().asyncGetBulk(tc, keys);
   }
 
+  @Deprecated
   @Override
   public BulkFuture<Map<String, Object>> asyncGetBulk(String... keys) {
     return this.getClient().asyncGetBulk(keys);
@@ -310,12 +312,14 @@ public class ArcusClientPool implements MemcachedClientIF, ArcusClientIF {
     return this.getClient().asyncGetsBulk(keys);
   }
 
+  @Deprecated
   @Override
   public <T> BulkFuture<Map<String, CASValue<T>>> asyncGetsBulk(Transcoder<T> tc,
                                                                 String... keys) {
     return this.getClient().asyncGetsBulk(tc, keys);
   }
 
+  @Deprecated
   @Override
   public BulkFuture<Map<String, CASValue<Object>>> asyncGetsBulk(String... keys) {
     return this.getClient().asyncGetsBulk(keys);
@@ -333,12 +337,14 @@ public class ArcusClientPool implements MemcachedClientIF, ArcusClientIF {
     return this.getClient().getBulk(keys);
   }
 
+  @Deprecated
   @Override
   public <T> Map<String, T> getBulk(Transcoder<T> tc, String... keys)
           throws OperationTimeoutException {
     return this.getClient().getBulk(tc, keys);
   }
 
+  @Deprecated
   @Override
   public Map<String, Object> getBulk(String... keys)
           throws OperationTimeoutException {
@@ -357,12 +363,14 @@ public class ArcusClientPool implements MemcachedClientIF, ArcusClientIF {
     return this.getClient().getsBulk(keys);
   }
 
+  @Deprecated
   @Override
   public <T> Map<String, CASValue<T>> getsBulk(Transcoder<T> tc, String... keys)
           throws OperationTimeoutException {
     return this.getClient().getsBulk(tc, keys);
   }
 
+  @Deprecated
   @Override
   public Map<String, CASValue<Object>> getsBulk(String... keys)
           throws OperationTimeoutException {
@@ -553,6 +561,7 @@ public class ArcusClientPool implements MemcachedClientIF, ArcusClientIF {
     return this.getClient().asyncDeleteBulk(key);
   }
 
+  @Deprecated
   @Override
   public Future<Map<String, OperationStatus>> asyncDeleteBulk(
           String... key) {

--- a/src/main/java/net/spy/memcached/MemcachedClient.java
+++ b/src/main/java/net/spy/memcached/MemcachedClient.java
@@ -1177,7 +1177,10 @@ public class MemcachedClient extends SpyThread
    * @return the future values of those keys
    * @throws IllegalStateException in the rare circumstance where queue
    *                               is too full to accept any more requests
+   * @deprecated no longer support varargs as collection has the same role.
+   * use {@link MemcachedClient#asyncGetBulk(Collection, Transcoder)} instead.
    */
+  @Deprecated
   public <T> BulkFuture<Map<String, T>> asyncGetBulk(Transcoder<T> tc,
                                                      String... keys) {
     return asyncGetBulk(Arrays.asList(keys), tc);
@@ -1190,7 +1193,10 @@ public class MemcachedClient extends SpyThread
    * @return the future values of those keys
    * @throws IllegalStateException in the rare circumstance where queue
    *                               is too full to accept any more requests
+   * @deprecated no longer support varargs as collection has the same role.
+   * use {@link MemcachedClient#asyncGetBulk(Collection)} instead.
    */
+  @Deprecated
   public BulkFuture<Map<String, Object>> asyncGetBulk(String... keys) {
     return asyncGetBulk(Arrays.asList(keys), transcoder);
   }
@@ -1344,7 +1350,10 @@ public class MemcachedClient extends SpyThread
    * @return the future values of those keys
    * @throws IllegalStateException in the rare circumstance where queue
    *                               is too full to accept any more requests
+   * @deprecated no longer support varargs as collection has the same role.
+   * use {@link MemcachedClient#asyncGetsBulk(Collection, Transcoder)} instead.
    */
+  @Deprecated
   public <T> BulkFuture<Map<String, CASValue<T>>> asyncGetsBulk(Transcoder<T> tc,
                                                                 String... keys) {
     return asyncGetsBulk(Arrays.asList(keys), tc);
@@ -1357,7 +1366,10 @@ public class MemcachedClient extends SpyThread
    * @return the future values of those keys
    * @throws IllegalStateException in the rare circumstance where queue
    *                               is too full to accept any more requests
+   * @deprecated no longer support varargs as collection has the same role.
+   * use {@link MemcachedClient#asyncGetsBulk(Collection)} instead.
    */
+  @Deprecated
   public BulkFuture<Map<String, CASValue<Object>>> asyncGetsBulk(String... keys) {
     return asyncGetsBulk(Arrays.asList(keys), transcoder);
   }
@@ -1416,7 +1428,10 @@ public class MemcachedClient extends SpyThread
    *                                   exceeded
    * @throws IllegalStateException     in the rare circumstance where queue
    *                                   is too full to accept any more requests
+   * @deprecated no longer support varargs as collection has the same role.
+   * use {@link MemcachedClient#getBulk(Collection, Transcoder)} instead.
    */
+  @Deprecated
   public <T> Map<String, T> getBulk(Transcoder<T> tc, String... keys) {
     return getBulk(Arrays.asList(keys), tc);
   }
@@ -1430,7 +1445,10 @@ public class MemcachedClient extends SpyThread
    *                                   exceeded
    * @throws IllegalStateException     in the rare circumstance where queue
    *                                   is too full to accept any more requests
+   * @deprecated no longer support varargs as collection has the same role.
+   * use {@link MemcachedClient#getBulk(Collection)} instead.
    */
+  @Deprecated
   public Map<String, Object> getBulk(String... keys) {
     return getBulk(Arrays.asList(keys), transcoder);
   }
@@ -1489,7 +1507,10 @@ public class MemcachedClient extends SpyThread
    *                                   exceeded
    * @throws IllegalStateException     in the rare circumstance where queue
    *                                   is too full to accept any more requests
+   * @deprecated no longer support varargs as collection has the same role.
+   * use {@link MemcachedClient#getsBulk(Collection, Transcoder)} instead.
    */
+  @Deprecated
   public <T> Map<String, CASValue<T>> getsBulk(Transcoder<T> tc, String... keys) {
     return getsBulk(Arrays.asList(keys), tc);
   }
@@ -1503,7 +1524,10 @@ public class MemcachedClient extends SpyThread
    *                                   exceeded
    * @throws IllegalStateException     in the rare circumstance where queue
    *                                   is too full to accept any more requests
+   * @deprecated no longer support varargs as collection has the same role.
+   * use {@link MemcachedClient#getsBulk(Collection)} instead.
    */
+  @Deprecated
   public Map<String, CASValue<Object>> getsBulk(String... keys) {
     return getsBulk(Arrays.asList(keys), transcoder);
   }

--- a/src/test/java/net/spy/memcached/ArcusTimeoutTest.java
+++ b/src/test/java/net/spy/memcached/ArcusTimeoutTest.java
@@ -128,9 +128,9 @@ public class ArcusTimeoutTest extends TestCase {
           throws InterruptedException, ExecutionException, TimeoutException {
     int keySize = 100000;
 
-    String[] keys = new String[keySize];
-    for (int i = 0; i < keys.length; i++) {
-      keys[i] = "MyKey" + i;
+    List<String> keys = new ArrayList<String>(keySize);
+    for (int i = 0; i < keySize; i++) {
+      keys.add("MyKey" + i);
     }
 
     Future<Map<String, OperationStatus>> future = mc.asyncDeleteBulk(keys);
@@ -142,9 +142,9 @@ public class ArcusTimeoutTest extends TestCase {
           throws InterruptedException, ExecutionException, TimeoutException {
     int keySize = 100000;
 
-    String[] keys = new String[keySize];
-    for (int i = 0; i < keys.length; i++) {
-      keys[i] = "MyKey" + i;
+    List<String> keys = new ArrayList<String>(keySize);
+    for (int i = 0; i < keySize; i++) {
+      keys.add("MyKey" + i);
     }
 
     Future<Map<String, OperationStatus>> future = mc.asyncDeleteBulk(keys);

--- a/src/test/java/net/spy/memcached/BinaryClientTest.java
+++ b/src/test/java/net/spy/memcached/BinaryClientTest.java
@@ -38,21 +38,6 @@ public class BinaryClientTest extends ProtocolBaseCase {
   }
 
   @Override
-  public void testGetsBulkVararg() throws Exception {
-    assertTrue(true);
-  }
-
-  @Override
-  public void testGetsBulkVarargWithTranscoder() throws Exception {
-    assertTrue(true);
-  }
-
-  @Override
-  public void testAsyncGetsBulkVarargWithTranscoder() throws Exception {
-    assertTrue(true);
-  }
-
-  @Override
   public void testAsyncGetsBulkWithTranscoderIterator() throws Exception {
     assertTrue(true);
   }

--- a/src/test/java/net/spy/memcached/CancellationBaseCase.java
+++ b/src/test/java/net/spy/memcached/CancellationBaseCase.java
@@ -95,10 +95,6 @@ public abstract class CancellationBaseCase extends TestCase {
     tryTestSequence(client.asyncGetBulk(Arrays.asList("k", "k2")));
   }
 
-  public void testAsyncGetBulkCancellationVararg() throws Exception {
-    tryTestSequence(client.asyncGetBulk("k", "k2"));
-  }
-
   public void testDeleteCancellation() throws Exception {
     tryTestSequence(client.delete("x"));
   }

--- a/src/test/java/net/spy/memcached/DoLotsOfSets.java
+++ b/src/test/java/net/spy/memcached/DoLotsOfSets.java
@@ -30,8 +30,8 @@ public final class DoLotsOfSets {
     long end = System.currentTimeMillis();
     System.err.printf("Completed everything in %sms (%sms to flush)%n",
             end - start, end - added);
-    Map<String, Object> m = client.getBulk("k1", "k2", "k3", "k4", "k5",
-            "k299999", "k299998", "k299997", "k299996");
+    Map<String, Object> m = client.getBulk(Arrays.asList("k1", "k2", "k3", "k4", "k5",
+            "k299999", "k299998", "k299997", "k299996"));
     assert m.size() == 9 : "Expected 9 results, got " + m;
     client.shutdown();
   }

--- a/src/test/java/net/spy/memcached/ProtocolBaseCase.java
+++ b/src/test/java/net/spy/memcached/ProtocolBaseCase.java
@@ -238,7 +238,7 @@ public abstract class ProtocolBaseCase extends ClientBaseCase {
 
   public void testInvalidKeyBulk() throws Exception {
     try {
-      Object val = client.getBulk("Key key2");
+      Object val = client.getBulk(Collections.singletonList("Key key2"));
       fail("Expected IllegalArgumentException, got " + val);
     } catch (IllegalArgumentException e) {
       // pass
@@ -268,9 +268,9 @@ public abstract class ProtocolBaseCase extends ClientBaseCase {
           client.set("test" + i, 5, "value" + i);
           assertEquals("value" + i, client.get("test" + i));
         }
-        Map<String, Object> m = client.getBulk("test0", "test1", "test2",
+        Map<String, Object> m = client.getBulk(Arrays.asList("test0", "test1", "test2",
                 "test3", "test4", "test5", "test6", "test7", "test8",
-                "test9", "test10"); // Yes, I intentionally ran over.
+                "test9", "test10")); // Yes, I intentionally ran over.
         for (int i = 0; i < 10; i++) {
           assertEquals("value" + i, m.get("test" + i));
         }
@@ -384,39 +384,6 @@ public abstract class ProtocolBaseCase extends ClientBaseCase {
     assertEquals("val2", vals.get("test2"));
   }
 
-  public void testGetBulkVararg() throws Exception {
-    assertEquals(0, client.getBulk("test1", "test2", "test3").size());
-    client.set("test1", 5, "val1");
-    client.set("test2", 5, "val2");
-    Map<String, Object> vals = client.getBulk("test1", "test2", "test3");
-    assertEquals(2, vals.size());
-    assertEquals("val1", vals.get("test1"));
-    assertEquals("val2", vals.get("test2"));
-  }
-
-  public void testGetBulkVarargWithTranscoder() throws Exception {
-    Transcoder<String> t = new TestTranscoder();
-    assertEquals(0, client.getBulk(t, "test1", "test2", "test3").size());
-    client.set("test1", 5, "val1", t);
-    client.set("test2", 5, "val2", t);
-    Map<String, String> vals = client.getBulk(t, "test1", "test2", "test3");
-    assertEquals(2, vals.size());
-    assertEquals("val1", vals.get("test1"));
-    assertEquals("val2", vals.get("test2"));
-  }
-
-  public void testAsyncGetBulkVarargWithTranscoder() throws Exception {
-    Transcoder<String> t = new TestTranscoder();
-    assertEquals(0, client.getBulk(t, "test1", "test2", "test3").size());
-    client.set("test1", 5, "val1", t);
-    client.set("test2", 5, "val2", t);
-    Future<Map<String, String>> vals = client.asyncGetBulk(t,
-            "test1", "test2", "test3");
-    assertEquals(2, vals.get().size());
-    assertEquals("val1", vals.get().get("test1"));
-    assertEquals("val2", vals.get().get("test2"));
-  }
-
   public void testAsyncGetBulkWithTranscoderIterator() throws Exception {
     ArrayList<String> keys = new ArrayList<String>();
     keys.add("test1");
@@ -470,46 +437,6 @@ public abstract class ProtocolBaseCase extends ClientBaseCase {
     assertEquals("val2", vals.get("test2").getValue());
     assertEquals(client.gets("test1").getCas(), vals.get("test1").getCas());
     assertEquals(client.gets("test2").getCas(), vals.get("test2").getCas());
-  }
-
-  public void testGetsBulkVararg() throws Exception {
-    assertEquals(0, client.getsBulk("test1", "test2", "test3").size());
-    client.set("test1", 5, "val1");
-    client.set("test2", 5, "val2");
-    Map<String, CASValue<Object>> vals = client.getsBulk("test1", "test2", "test3");
-    assertEquals(2, vals.size());
-    assertEquals("val1", vals.get("test1").getValue());
-    assertEquals("val2", vals.get("test2").getValue());
-    assertEquals(client.gets("test1").getCas(), vals.get("test1").getCas());
-    assertEquals(client.gets("test2").getCas(), vals.get("test2").getCas());
-  }
-
-  public void testGetsBulkVarargWithTranscoder() throws Exception {
-    Transcoder<String> t = new TestTranscoder();
-    assertEquals(0, client.getsBulk(t, "test1", "test2", "test3").size());
-    client.set("test1", 5, "val1", t);
-    client.set("test2", 5, "val2", t);
-    Map<String, CASValue<String>> vals = client.getsBulk(t,
-            "test1", "test2", "test3");
-    assertEquals(2, vals.size());
-    assertEquals("val1", vals.get("test1").getValue());
-    assertEquals("val2", vals.get("test2").getValue());
-    assertEquals(client.gets("test1", t).getCas(), vals.get("test1").getCas());
-    assertEquals(client.gets("test2", t).getCas(), vals.get("test2").getCas());
-  }
-
-  public void testAsyncGetsBulkVarargWithTranscoder() throws Exception {
-    Transcoder<String> t = new TestTranscoder();
-    assertEquals(0, client.getsBulk(t, "test1", "test2", "test3").size());
-    client.set("test1", 5, "val1", t);
-    client.set("test2", 5, "val2", t);
-    BulkFuture<Map<String, CASValue<String>>> vals = client.asyncGetsBulk(t,
-            "test1", "test2", "test3");
-    assertEquals(2, vals.get().size());
-    assertEquals("val1", vals.get().get("test1").getValue());
-    assertEquals("val2", vals.get().get("test2").getValue());
-    assertEquals(client.gets("test1", t).getCas(), vals.get().get("test1").getCas());
-    assertEquals(client.gets("test2", t).getCas(), vals.get().get("test2").getCas());
   }
 
   public void testAsyncGetsBulkWithTranscoderIterator() throws Exception {
@@ -820,7 +747,7 @@ public abstract class ProtocolBaseCase extends ClientBaseCase {
   public void testMultiReqAfterShutdown() throws Exception {
     client.shutdown();
     try {
-      Map<String, ?> m = client.getBulk("k1", "k2", "k3");
+      Map<String, ?> m = client.getBulk(Arrays.asList("k1", "k2", "k3"));
       fail("Expected IllegalStateException, got " + m);
     } catch (IllegalStateException e) {
       // OK

--- a/src/test/java/net/spy/memcached/TimeoutTest.java
+++ b/src/test/java/net/spy/memcached/TimeoutTest.java
@@ -2,6 +2,8 @@ package net.spy.memcached;
 
 import junit.framework.TestCase;
 
+import java.util.Arrays;
+
 public class TimeoutTest extends TestCase {
   private MemcachedClient client = null;
 
@@ -66,7 +68,7 @@ public class TimeoutTest extends TestCase {
   public void testGetBulkTimeout() {
     tryTimeout("getbulk", new Runnable() {
       public void run() {
-        client.getBulk("k", "k2");
+        client.getBulk(Arrays.asList("k", "k2"));
       }
     });
   }

--- a/src/test/manual/net/spy/memcached/bulkoperation/BulkDeleteTest.java
+++ b/src/test/manual/net/spy/memcached/bulkoperation/BulkDeleteTest.java
@@ -39,12 +39,6 @@ public class BulkDeleteTest extends BaseIntegrationTest {
     } catch (Exception e) {
       assertEquals("Key list is null.", e.getMessage());
     }
-    try {
-      String[] keys = null;
-      mc.asyncDeleteBulk(keys);
-    } catch (Exception e) {
-      assertEquals("Key list is null.", e.getMessage());
-    }
     // DELETE empty key
     try {
       List<String> keys = new ArrayList<String>();

--- a/src/test/manual/net/spy/memcached/frontcache/LocalCacheManagerTest.java
+++ b/src/test/manual/net/spy/memcached/frontcache/LocalCacheManagerTest.java
@@ -16,6 +16,8 @@
  */
 package net.spy.memcached.frontcache;
 
+import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Future;
 
@@ -34,11 +36,8 @@ public class LocalCacheManagerTest extends TestCase {
 
   private ArcusClient client;
 
-  // put keys
-  private final String[] keys = {
-      "key0", "key1", "key2", "key3", "key4",
-      "key5", "key6", "key7", "key8", "key9"
-  };
+  private final List<String> keys =
+      Arrays.asList("key0", "key1", "key2", "key3", "key4", "key5", "key6", "key7", "key8", "key9");
 
   @Override
   protected void setUp() throws Exception {
@@ -62,11 +61,13 @@ public class LocalCacheManagerTest extends TestCase {
       client.set(k, 2, k + "_value").get();
     }
 
-    Future<Object> f = client.asyncGet(keys[0]);
+    String key = keys.get(0);
+
+    Future<Object> f = client.asyncGet(key);
     Object result = f.get();
 
     Transcoder<Object> tc = null;
-    Object cached = client.getLocalCacheManager().get(keys[0], tc);
+    Object cached = client.getLocalCacheManager().get(key, tc);
 
     assertNotNull(result);
     assertNotNull(cached);
@@ -75,10 +76,10 @@ public class LocalCacheManagerTest extends TestCase {
     // after 3 seconds : remote expired, locally cached
     Thread.sleep(3000);
 
-    f = client.asyncGet(keys[0]);
+    f = client.asyncGet(key);
     result = f.get();
 
-    cached = client.getLocalCacheManager().get(keys[0], tc);
+    cached = client.getLocalCacheManager().get(key, tc);
 
     assertNotNull(result);
     assertNotNull(cached);
@@ -87,10 +88,10 @@ public class LocalCacheManagerTest extends TestCase {
     // after another 3 seconds : both remote and local expired
     Thread.sleep(3000);
 
-    f = client.asyncGet(keys[0]);
+    f = client.asyncGet(key);
     result = f.get();
 
-    cached = client.getLocalCacheManager().get(keys[0], tc);
+    cached = client.getLocalCacheManager().get(key, tc);
 
     assertNull(result);
     assertNull(cached);
@@ -118,7 +119,7 @@ public class LocalCacheManagerTest extends TestCase {
     // but we have locally cached results.
     result = client.getBulk(keys);
     assertNotNull(result);
-    assertTrue(keys.length == result.size());
+    assertEquals(keys.size(), result.size());
 
     // then after additional 3 seconds, locally cached results should be
     // expired.
@@ -132,7 +133,7 @@ public class LocalCacheManagerTest extends TestCase {
 
     result = client.getBulk(keys);
     assertNotNull(result);
-    assertTrue(0 == result.size());
+    assertEquals(0, result.size());
   }
 
   public void testAsyncGetBulk() throws Exception {
@@ -159,7 +160,7 @@ public class LocalCacheManagerTest extends TestCase {
     f = client.asyncGetBulk(keys);
     result = f.get();
     assertNotNull(result);
-    assertTrue(keys.length == result.size());
+    assertEquals(keys.size(), result.size());
 
     // then after additional 3 seconds, locally cached results should be
     // expired.
@@ -174,16 +175,16 @@ public class LocalCacheManagerTest extends TestCase {
     f = client.asyncGetBulk(keys);
     result = f.get();
     assertNotNull(result);
-    assertTrue(0 == result.size());
+    assertEquals(0, result.size());
   }
 
   public void testBulkPartial() throws Exception {
-    String keySet1[] = new String[keys.length / 2];
-    String keySet2[] = new String[keys.length / 2];
+    String[] keySet1 = new String[keys.size() / 2];
+    String[] keySet2 = new String[keys.size() / 2];
 
-    for (int i = 0; i < keys.length / 2; i++) {
-      keySet1[i] = keys[i * 2];
-      keySet2[i] = keys[i * 2 + 1];
+    for (int i = 0; i < keys.size() / 2; i++) {
+      keySet1[i] = keys.get(i * 2);
+      keySet2[i] = keys.get(i * 2 + 1);
     }
 
     // Set 1
@@ -216,7 +217,7 @@ public class LocalCacheManagerTest extends TestCase {
     f = client.asyncGetBulk(keys);
     result = f.get();
     assertNotNull(result);
-    assertTrue(keys.length == result.size());
+    assertEquals(keys.size(), result.size());
 
     // then after additional 3 seconds, locally cached Set 1 should be
     // expired.
@@ -231,7 +232,7 @@ public class LocalCacheManagerTest extends TestCase {
     f = client.asyncGetBulk(keys);
     result = f.get();
     assertNotNull(result);
-    assertTrue(keySet2.length == result.size());
+    assertEquals(keySet2.length, result.size());
   }
 
 }

--- a/src/test/manual/net/spy/memcached/test/MultiNodeFailureTest.java
+++ b/src/test/manual/net/spy/memcached/test/MultiNodeFailureTest.java
@@ -3,6 +3,8 @@ package net.spy.memcached.test;
 import net.spy.memcached.AddrUtil;
 import net.spy.memcached.MemcachedClient;
 
+import java.util.Arrays;
+
 /**
  * This is an attempt to reproduce a problem where a server fails during a
  * series of gets.
@@ -18,7 +20,7 @@ public final class MultiNodeFailureTest {
     while (true) {
       for (int i = 0; i < 1000; i++) {
         try {
-          c.getBulk("blah1", "blah2", "blah3", "blah4", "blah5");
+          c.getBulk(Arrays.asList("blah1", "blah2", "blah3", "blah4", "blah5"));
         } catch (Exception e) {
           e.printStackTrace();
         }


### PR DESCRIPTION
## 연관 이슈
- https://github.com/jam2in/arcus-works/issues/517

## 작업 내용
- 가변 인자를 사용하는 API를 Deprecate 시킵니다.
- 이에 필요없는 테스트 코드를 제거하고, 테스트 코드에서 Deprecated된 메서드를 사용하지 않도록 변경하였습니다.
