### PR TITLE
FIX: Change BKeyObject constructor in BopGetResultImpl

### DIFF
--- a/src/main/java/net/spy/memcached/internal/result/BopGetResultImpl.java
+++ b/src/main/java/net/spy/memcached/internal/result/BopGetResultImpl.java
@@ -52,7 +52,7 @@ public class BopGetResultImpl<K, V> implements GetResult<Map<K, Element<V>>> {
         CachedData cachedData = entry.getValue();
         if (isByteBKey) {
           temp.put(bKey, BTreeUtil.makeBTreeElement(
-                  new BKeyObject((ByteArrayBKey) bKey), cachedData, transcoder));
+                  new BKeyObject(((ByteArrayBKey) bKey).getBytes()), cachedData, transcoder));
         } else {
           temp.put(bKey, BTreeUtil.makeBTreeElement(
                   new BKeyObject((Long) bKey), cachedData, transcoder));


### PR DESCRIPTION
BopGetResultImpl에서 사용하던 `BKeyObject(ByteArrayKey)`의 생성자가 
아래 PR이 머지되면서 사용할 수 없게 됩니다.
https://github.com/naver/arcus-java-client/pull/736

`BKeyObject(byte[])` 생성자를 사용하도록 수정합니다.