### PR TITLE
FEAT: Change the way ArcusClient is named.

### DIFF
--- a/src/main/java/net/spy/memcached/ArcusClient.java
+++ b/src/main/java/net/spy/memcached/ArcusClient.java
@@ -204,6 +204,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
   private static final int MAX_MKEY_LENGTH = 250;
 
   private static final int SHUTDOWN_TIMEOUT_MILLISECONDS = 2000;
+  private static final AtomicInteger CLIENT_ID = new AtomicInteger(1);
 
   private CacheManager cacheManager;
 
@@ -294,6 +295,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
 
   /**
    * Create an Arcus client for the given memcached server addresses.
+   * Only invoked by initArcusClient in CacheManger.
    *
    * @param cf    connection factory to configure connections for this client
    * @param name  client name
@@ -331,10 +333,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
    */
   public ArcusClient(ConnectionFactory cf, List<InetSocketAddress> addrs)
           throws IOException {
-    super(cf, DEFAULT_ARCUS_CLIENT_NAME, addrs);
-    collectionTranscoder = new CollectionTranscoder();
-    smgetKeyChunkSize = cf.getDefaultMaxSMGetKeyChunkSize();
-    registerMbean();
+    this(cf, DEFAULT_ARCUS_CLIENT_NAME + CLIENT_ID.getAndIncrement(), addrs);
   }
 
   /**

--- a/src/main/java/net/spy/memcached/CacheManager.java
+++ b/src/main/java/net/spy/memcached/CacheManager.java
@@ -29,6 +29,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import net.spy.memcached.ArcusClientException.InitializeClientException;
 import net.spy.memcached.compat.SpyThread;
@@ -69,6 +70,7 @@ public class CacheManager extends SpyThread implements Watcher,
   private static final int ZK_SESSION_TIMEOUT = 15000;
 
   private static final long ZK_CONNECT_TIMEOUT = ZK_SESSION_TIMEOUT;
+  private static final AtomicInteger POOL_ID = new AtomicInteger(1);
 
   private final String zkConnectString;
 
@@ -661,11 +663,13 @@ public class CacheManager extends SpyThread implements Watcher,
     };
     cfb.setInitialObservers(Collections.singleton(observer));
 
+    int poolId = CacheManager.POOL_ID.getAndIncrement();
     client = new ArcusClient[poolSize];
     int i = 0;
     try {
       for (; i < poolSize; i++) {
-        String clientName = "ArcusClient(" + (i + 1) + "-" + poolSize + ") for " + serviceCode;
+        String clientName = "ArcusClient" + "-" + poolId +
+                "(" + (i + 1) + "-" + poolSize + ") for " + serviceCode;
         client[i] = ArcusClient.getInstance(cfb.build(), clientName, socketList);
         client[i].setName("Memcached IO for " + serviceCode);
         client[i].setCacheManager(this);

--- a/src/test/manual/net/spy/memcached/ArcusClientCreateTest.java
+++ b/src/test/manual/net/spy/memcached/ArcusClientCreateTest.java
@@ -1,0 +1,63 @@
+package net.spy.memcached;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+import net.spy.memcached.collection.BaseIntegrationTest;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assume.assumeFalse;
+
+public class ArcusClientCreateTest {
+
+  private static final String clientName = "TEST";
+  private static final String hostName = "localhost/127.0.0.1:11211";
+  private static final List<InetSocketAddress> addrs = new ArrayList<>();
+
+  @Before
+  public void setUp() throws Exception {
+    // This test assumes we does not use ZK
+    assumeFalse(BaseIntegrationTest.USE_ZK);
+    addrs.add(new InetSocketAddress("localhost", 11211));
+  }
+
+  @After
+  public void release() {
+    addrs.clear();
+  }
+
+  @Test
+  public void testCreateClientWithCustomName() throws IOException {
+    ArcusClient arcusClient = new ArcusClient(new DefaultConnectionFactory(), clientName, addrs);
+
+    Collection<MemcachedNode> nodes = arcusClient.getAllNodes();
+    MemcachedNode node = nodes.iterator().next();
+
+    Assert.assertEquals(nodes.size(), 1);
+    Assert.assertEquals(node.getNodeName(), clientName + " " + hostName);
+  }
+
+  @Test
+  public void testCreateClientWithDefaultName() throws IOException {
+    int clientId = 1;
+    ArcusClient arcusClient = new ArcusClient(new DefaultConnectionFactory(), addrs);
+
+    Collection<MemcachedNode> nodes = arcusClient.getAllNodes();
+    MemcachedNode node = nodes.iterator().next();
+
+    Assert.assertEquals(nodes.size(), 1);
+    Assert.assertEquals(node.getNodeName(), "ArcusClient" + "-" + clientId + " " + hostName);
+  }
+
+  @Test(expected = NullPointerException.class)
+  public void testCreateClientNullName() throws IOException {
+    new ArcusClient(new DefaultConnectionFactory(), null, addrs);
+  }
+}

--- a/src/test/manual/net/spy/memcached/ArcusClientPoolCreateTest.java
+++ b/src/test/manual/net/spy/memcached/ArcusClientPoolCreateTest.java
@@ -1,0 +1,84 @@
+package net.spy.memcached;
+
+import java.lang.reflect.Field;
+import java.util.Collection;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import net.spy.memcached.collection.BaseIntegrationTest;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assume.assumeTrue;
+
+public class ArcusClientPoolCreateTest {
+
+  private static final String SERVICE_CODE = "test";
+  private static final int POOL_SIZE = 3;
+  private static final int CACHE_NODE_SIZE = 3;
+
+  @Before
+  public void setUp() throws Exception {
+    // This test assumes we use ZK
+    assumeTrue(BaseIntegrationTest.USE_ZK);
+  }
+
+  @Test
+  public void testCreateClientPool() throws NoSuchFieldException, IllegalAccessException {
+    //Create first ArcusClientPool instance.
+    ArcusClientPool clientPool = ArcusClient.createArcusClientPool(SERVICE_CODE,
+            new ConnectionFactoryBuilder(), POOL_SIZE);
+
+    ArcusClient[] allClients = clientPool.getAllClients();
+
+    Assert.assertEquals(allClients.length, POOL_SIZE);
+    for (int i = 0 ; i < POOL_SIZE ; i++) {
+      Assert.assertEquals(allClients[i].getMemcachedConnection().getLocator().getAll().size(),
+              CACHE_NODE_SIZE);
+      Collection<MemcachedNode> nodes =
+              allClients[i].getMemcachedConnection().getLocator().getAll();
+      for (MemcachedNode mc : nodes) {
+        Pattern compile =
+                Pattern.compile("ArcusClient-(\\d+)\\(" + (i + 1) + "-" + POOL_SIZE + "\\)");
+        Matcher matcher = compile.matcher(mc.getNodeName().split(" ")[0]);
+        Assert.assertTrue(matcher.matches());
+      }
+    }
+
+    int firstPoolId = getPoolId();
+
+    //Create second ArcusClientPool instance.
+    clientPool = ArcusClient.createArcusClientPool(SERVICE_CODE,
+            new ConnectionFactoryBuilder(), POOL_SIZE);
+
+    allClients = clientPool.getAllClients();
+
+    Assert.assertEquals(allClients.length, POOL_SIZE);
+    for (int i = 0 ; i < POOL_SIZE ; i++) {
+      Assert.assertEquals(allClients[i].getMemcachedConnection().getLocator().getAll().size(),
+              CACHE_NODE_SIZE);
+      Collection<MemcachedNode> nodes =
+              allClients[i].getMemcachedConnection().getLocator().getAll();
+      for (MemcachedNode mc : nodes) {
+        Pattern compile =
+                Pattern.compile("ArcusClient-(\\d+)\\(" + (i + 1) + "-" + POOL_SIZE + "\\)");
+        Matcher matcher = compile.matcher(mc.getNodeName().split(" ")[0]);
+        Assert.assertTrue(matcher.matches());
+      }
+    }
+
+    int secondPoolId = getPoolId();
+    Assert.assertTrue(secondPoolId > firstPoolId);
+  }
+
+  private int getPoolId() throws NoSuchFieldException, IllegalAccessException {
+    Class<CacheManager> clazz = CacheManager.class;
+    Field poolId = clazz.getDeclaredField("POOL_ID");
+    poolId.setAccessible(true);
+    AtomicInteger atomicInteger = (AtomicInteger) poolId.get(null);
+    return atomicInteger.get();
+  }
+}


### PR DESCRIPTION
### 관련 이슈
https://github.com/jam2in/arcus-works/issues/344,
https://github.com/jam2in/arcus-works/issues/490

## 변경 내용
### Index 구분
ArcusClientPool의 PoolIndex와 ArcusClient의 ClientIndex는 각각 서로 다른 counter로 관리합니다.

### ArcusClientPool 사용 시
`ArcusClient(1-4)` ->`ArcusClient-1(1-4)`와 같은 네이밍으로 변경
생성된 ArcusClientPool 중에서 첫번째 풀이고, 4개의 사이즈 중 1번째 클라이언트 인스턴스임을 의미


### ArcusClient만 사용 시 -> zk 없이 캐시 클러스터 or 싱글 캐시 사용 모두 포함
- 기존 : <사용자가 설정한 String 네임> 또는 "ArcusClient"로 표현됨
- 사용자가 name을 생성자의 인자로 줄 경우 : client-index가 적용되지 않도록 구현했습니다.
  - 호출되는 생성자 : `public ArcusClient(ConnectionFactory cf, String name, List<InetSocketAddress> addrs)`
- default 설정된 name(=ArcusClient) 사용 시
  - 호출되는 생성자 : `public ArcusClient(ConnectionFactory cf, List<InetSocketAddress> addrs)`
  - ArucsClient-2 -> "ArucsClient"는 디폴트 네임이고, ArcusClient객체만 사용하는 2번째 인스턴스라는 의미