### PR TITLE
FIX: FrontCacheGetFuture default timeout value.

### DIFF
--- a/src/main/java/net/spy/memcached/plugin/FrontCacheGetFuture.java
+++ b/src/main/java/net/spy/memcached/plugin/FrontCacheGetFuture.java
@@ -24,6 +24,8 @@ import java.util.concurrent.TimeoutException;
 import net.spy.memcached.internal.GetFuture;
 import net.spy.memcached.ops.OperationStatus;
 
+import static net.spy.memcached.DefaultConnectionFactory.DEFAULT_OPERATION_TIMEOUT;
+
 /**
  * Future returned for GET operations.
  *
@@ -37,7 +39,7 @@ public class FrontCacheGetFuture<T> extends GetFuture<T> {
   private final String key;
 
   public FrontCacheGetFuture(LocalCacheManager localCacheManager, String key, GetFuture<T> parent) {
-    super(new CountDownLatch(0), 1);
+    super(new CountDownLatch(0), DEFAULT_OPERATION_TIMEOUT);
     this.parent = parent;
     this.localCacheManager = localCacheManager;
     this.key = key;

--- a/src/test/manual/net/spy/memcached/frontcache/LocalCacheManagerTest.java
+++ b/src/test/manual/net/spy/memcached/frontcache/LocalCacheManagerTest.java
@@ -29,9 +29,6 @@ import net.spy.memcached.internal.BulkFuture;
 import net.spy.memcached.plugin.LocalCacheManager;
 import net.spy.memcached.transcoders.Transcoder;
 
-import org.junit.Ignore;
-
-@Ignore
 public class LocalCacheManagerTest extends TestCase {
 
   private ArcusClient client;


### PR DESCRIPTION
## 구현내용

기존 생성자처럼 `super(new CountDownLatch(0), 1);`을 통해
GetFuture를 초기화 할 경우 다음과 같은 문제가 발생한다.
Future.get()을 호출하면 `Future.get(1L, Mills)`로 동작하게 되고
TimeoutException이 발생하게 된다.

```java
    //LocalCache를 활성화 한 뒤 호출
    Future<Object> f = client.asyncGet(key);
    Object result = f.get(); // TimeoutException 발생
```

1L을 DefaultTimeout 값으로 변경합니다.

기존에  LocalCacheManagerTest가 Ignore 처리되어서
테스트 코드 상에서 확인되지 않았습니다.

참고로 기존에 붙은 `@Ingore`는 java client의 
첫 커밋부터 유지되었기에 그 의도를 파악하기 어렵습니다.