### PR TITLE
REFACTOR: Check spaceCount before String conversion in BTreeGetBulk.handleRead

### DIFF
--- a/src/main/java/net/spy/memcached/collection/BTreeGetBulk.java
+++ b/src/main/java/net/spy/memcached/collection/BTreeGetBulk.java
@@ -22,6 +22,8 @@ import net.spy.memcached.MemcachedNode;
 
 public interface BTreeGetBulk<T> {
 
+  int headerCount = 3;
+
   void setKeySeparator(String keySeparator);
 
   String getSpaceSeparatedKeys();
@@ -34,9 +36,7 @@ public interface BTreeGetBulk<T> {
 
   String getCommand();
 
-  boolean elementHeaderReady(int spaceCount);
-
-  boolean keyHeaderReady(int spaceCount);
+  boolean headerReady(int spaceCount);
 
   Object getSubkey();
 
@@ -44,7 +44,7 @@ public interface BTreeGetBulk<T> {
 
   byte[] getEFlag();
 
-  void decodeItemHeader(String itemHeader);
+  void decodeItemHeader(String[] splited);
 
   BTreeGetBulk<T> clone(MemcachedNode node, List<String> keyList);
 }

--- a/src/main/java/net/spy/memcached/collection/BTreeGetBulkImpl.java
+++ b/src/main/java/net/spy/memcached/collection/BTreeGetBulkImpl.java
@@ -115,9 +115,7 @@ public abstract class BTreeGetBulkImpl<T> implements BTreeGetBulk<T> {
     return str;
   }
 
-  public void decodeItemHeader(String itemHeader) {
-    String[] splited = itemHeader.split(" ");
-
+  public void decodeItemHeader(String[] splited) {
     if (splited.length == 3) {
       // ELEMENT <bkey> <bytes>
       this.subkey = decodeSubkey(splited[1]);
@@ -135,12 +133,8 @@ public abstract class BTreeGetBulkImpl<T> implements BTreeGetBulk<T> {
     return command;
   }
 
-  public boolean elementHeaderReady(int spaceCount) {
-    return spaceCount == 3 || spaceCount == 4;
-  }
-
-  public boolean keyHeaderReady(int spaceCount) {
-    return spaceCount == 3 || spaceCount == 5;
+  public boolean headerReady(int spaceCount) {
+    return spaceCount == BTreeGetBulk.headerCount;
   }
 
   public int getDataLength() {


### PR DESCRIPTION
### 이슈 연결

- https://github.com/jam2in/arcus-works/issues/160

### 작업 사항
 - 기존에 BTreeGetBulk에서 사용하지 않던 keyHeaderReady 함수를 삭제했습니다.
     - smget과 유사하게, header 개수를 의미하는 headerCount 변수를 BTreeGetBulk 인터페이스에 추가했습니다.
     - headerCount 변수를 headerReady 함수에서 사용하도록 했습니다.

 - 기존에는 space 문자를 만날 때마다 String 객체를 매번 생성합니다.
     - spaceCount가 btree 응답 형식 header 개수(3개)일 때만 byteBuffer에서 String 객체를 생성하도록 했습니다.

 - 기존에는 서버가 보낸 응답이 ELEMENT로 시작하는지 확인하기 위해서 space마다 String 객체를 만듭니다. 그렇지 않다면 byteBuffer.write를 합니다.
     - spaceCount == 3일때만 String을 만들고, 기존 구현과 같은 동작을 하기 위해서 약간의 수정을 했습니다.
     - ELEMENT로 시작하지 않는 String의 경우, byteBuffer.write를 실행한 다음, continue로 반복문의 다음 로직을 건너뛰었습니다.

 - 기존에는 String을 split하고 decodeItemHeader 함수에서 다시 한번 split합니다.
     - 이미 split된 값들을 위 함수에서 재사용하도록 함수 인자를 변경했습니다.

