### PR TITLE
REFACTOR: Remove unused arg and constructor in localCacheManager.

### DIFF
--- a/src/main/java/net/spy/memcached/plugin/FrontCacheMemcachedClient.java
+++ b/src/main/java/net/spy/memcached/plugin/FrontCacheMemcachedClient.java
@@ -90,7 +90,7 @@ public class FrontCacheMemcachedClient extends MemcachedClient {
       return super.asyncGet(key, tc);
     }
 
-    final T t = localCacheManager.get(key, tc);
+    final T t = localCacheManager.get(key);
     if (t != null) {
       return new GetFuture<T>(null, 0) {
         @Override
@@ -159,7 +159,7 @@ public class FrontCacheMemcachedClient extends MemcachedClient {
     while (keyIter.hasNext() && tc_iter.hasNext()) {
       String key = keyIter.next();
       Transcoder<T> tc = tc_iter.next();
-      T value = localCacheManager.get(key, tc);
+      T value = localCacheManager.get(key);
       if (value != null) {
         frontCacheHit.put(key, value);
         continue;

--- a/src/main/java/net/spy/memcached/plugin/LocalCacheManager.java
+++ b/src/main/java/net/spy/memcached/plugin/LocalCacheManager.java
@@ -26,7 +26,6 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 import net.spy.memcached.compat.log.Logger;
 import net.spy.memcached.compat.log.LoggerFactory;
-import net.spy.memcached.transcoders.Transcoder;
 
 import net.sf.ehcache.Cache;
 import net.sf.ehcache.CacheManager;
@@ -44,10 +43,6 @@ public class LocalCacheManager {
 
   protected Cache cache;
   protected String name;
-
-  public LocalCacheManager() {
-    this("DEFAULT_ARCUS_LOCAL_CACHE");
-  }
 
   public LocalCacheManager(String name) {
     this.name = name;
@@ -77,7 +72,7 @@ public class LocalCacheManager {
     }
   }
 
-  public <T> T get(String key, Transcoder<T> tc) {
+  public <T> T get(String key) {
     if (cache == null) {
       return null;
     }
@@ -97,10 +92,10 @@ public class LocalCacheManager {
     return null;
   }
 
-  public <T> Future<T> asyncGet(final String key, final Transcoder<T> tc) {
+  public <T> Future<T> asyncGet(final String key) {
     Task<T> task = new Task<T>(new Callable<T>() {
       public T call() throws Exception {
-        return get(key, tc);
+        return get(key);
       }
     });
     return task;

--- a/src/test/manual/net/spy/memcached/frontcache/LocalCacheManagerTest.java
+++ b/src/test/manual/net/spy/memcached/frontcache/LocalCacheManagerTest.java
@@ -27,7 +27,6 @@ import net.spy.memcached.ArcusClient;
 import net.spy.memcached.ConnectionFactoryBuilder;
 import net.spy.memcached.internal.BulkFuture;
 import net.spy.memcached.plugin.LocalCacheManager;
-import net.spy.memcached.transcoders.Transcoder;
 
 public class LocalCacheManagerTest extends TestCase {
 
@@ -63,8 +62,7 @@ public class LocalCacheManagerTest extends TestCase {
     Future<Object> f = client.asyncGet(key);
     Object result = f.get();
 
-    Transcoder<Object> tc = null;
-    Object cached = client.getLocalCacheManager().get(key, tc);
+    Object cached = client.getLocalCacheManager().get(key);
 
     assertNotNull(result);
     assertNotNull(cached);
@@ -76,7 +74,7 @@ public class LocalCacheManagerTest extends TestCase {
     f = client.asyncGet(key);
     result = f.get();
 
-    cached = client.getLocalCacheManager().get(key, tc);
+    cached = client.getLocalCacheManager().get(key);
 
     assertNotNull(result);
     assertNotNull(cached);
@@ -88,7 +86,7 @@ public class LocalCacheManagerTest extends TestCase {
     f = client.asyncGet(key);
     result = f.get();
 
-    cached = client.getLocalCacheManager().get(key, tc);
+    cached = client.getLocalCacheManager().get(key);
 
     assertNull(result);
     assertNull(cached);
@@ -105,8 +103,7 @@ public class LocalCacheManagerTest extends TestCase {
     // expecting that the keys are locally cached.
     LocalCacheManager lcm = client.getLocalCacheManager();
     for (String k : keys) {
-      Transcoder<Object> tc = null;
-      Object got = lcm.get(k, tc);
+      Object got = lcm.get(k);
       assertNotNull(got);
     }
 
@@ -123,8 +120,7 @@ public class LocalCacheManagerTest extends TestCase {
     Thread.sleep(3000);
 
     for (String k : keys) {
-      Transcoder<Object> tc = null;
-      Object got = lcm.get(k, tc);
+      Object got = lcm.get(k);
       assertNull(got);
     }
 
@@ -145,8 +141,7 @@ public class LocalCacheManagerTest extends TestCase {
     // expecting that the keys are locally cached.
     LocalCacheManager lcm = client.getLocalCacheManager();
     for (String k : keys) {
-      Transcoder<Object> tc = null;
-      Object got = lcm.get(k, tc);
+      Object got = lcm.get(k);
       assertNotNull(got);
     }
 
@@ -164,8 +159,7 @@ public class LocalCacheManagerTest extends TestCase {
     Thread.sleep(3000);
 
     for (String k : keys) {
-      Transcoder<Object> tc = null;
-      Object got = lcm.get(k, tc);
+      Object got = lcm.get(k);
       assertNull(got);
     }
 
@@ -196,8 +190,7 @@ public class LocalCacheManagerTest extends TestCase {
     // expecting that the keys are locally cached.
     LocalCacheManager lcm = client.getLocalCacheManager();
     for (String k : keySet1) {
-      Transcoder<Object> tc = null;
-      Object got = lcm.get(k, tc);
+      Object got = lcm.get(k);
       assertNotNull(got);
     }
 
@@ -221,8 +214,7 @@ public class LocalCacheManagerTest extends TestCase {
     Thread.sleep(3000);
 
     for (String k : keySet1) {
-      Transcoder<Object> tc = null;
-      Object got = lcm.get(k, tc);
+      Object got = lcm.get(k);
       assertNull(got);
     }
 


### PR DESCRIPTION
### 관련 이슈
https://github.com/jam2in/arcus-works/issues/398

### 변경 내용
사용되지 않는 생성자와 get() 메서드의 tracscoder 인자를 삭제시켰습니다.