### PR TITLE
INTERNAL: Change timeout value to parent property.

### DIFF
--- a/src/main/java/net/spy/memcached/plugin/FrontCacheGetFuture.java
+++ b/src/main/java/net/spy/memcached/plugin/FrontCacheGetFuture.java
@@ -46,6 +46,13 @@ public class FrontCacheGetFuture<T> extends GetFuture<T> {
   }
 
   @Override
+  public T get() throws InterruptedException, ExecutionException {
+    T t = parent.get();
+    localCacheManager.put(key, t);
+    return t;
+  }
+
+  @Override
   public T get(long timeout, TimeUnit unit) throws InterruptedException,
           ExecutionException, TimeoutException {
     T t = parent.get(timeout, unit);


### PR DESCRIPTION
## 변경 사항
Default 값으로 사용되던 FrontCacheGetFuture의 timeout을
parent의 timeout 값으로 변경합니다.