### PR TITLE
CLEANUP: Remove redundant and inconsistent line in OperationImpl

### DIFF
--- a/src/main/java/net/spy/memcached/protocol/ascii/BTreeFindPositionOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/BTreeFindPositionOperationImpl.java
@@ -73,8 +73,6 @@ public class BTreeFindPositionOperationImpl extends OperationImpl implements
   public void handleLine(String line) {
     getLogger().debug("Got line %s", line);
 
-    Integer position = null;
-
     /* ENABLE_MIGRATION if */
     if (hasNotMyKey(line)) {
       addRedirectSingleKeyOperation(line, key);
@@ -88,17 +86,12 @@ public class BTreeFindPositionOperationImpl extends OperationImpl implements
       assert stuff.length == 2;
       assert "POSITION".equals(stuff[0]);
 
-      // FIXME exception-based conversion.
-      try {
-        // POSITION=<position>\r\n
-        position = Integer.parseInt(stuff[1]);
-        BTreeFindPositionOperation.Callback cb =
-            (BTreeFindPositionOperation.Callback) getCallback();
-        cb.gotData(position);
-        getCallback().receivedStatus(POSITION);
-      } catch (Exception e) {
-        // expected : <error_string>
-      }
+      // POSITION=<position>\r\n
+      int position = Integer.parseInt(stuff[1]);
+      BTreeFindPositionOperation.Callback cb =
+              (BTreeFindPositionOperation.Callback) getCallback();
+      cb.gotData(position);
+      getCallback().receivedStatus(POSITION);
     } else {
       OperationStatus status = matchStatus(line, NOT_FOUND, UNREADABLE,
               BKEY_MISMATCH, TYPE_MISMATCH, NOT_FOUND_ELEMENT);

--- a/src/main/java/net/spy/memcached/protocol/ascii/BTreeGetByPositionOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/BTreeGetByPositionOperationImpl.java
@@ -125,7 +125,6 @@ public class BTreeGetByPositionOperationImpl extends OperationImpl implements
       getLogger().debug(status);
       getCallback().receivedStatus(status);
       transitionState(OperationState.COMPLETE);
-      return;
     }
   }
 

--- a/src/main/java/net/spy/memcached/protocol/ascii/BTreeInsertAndGetOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/BTreeInsertAndGetOperationImpl.java
@@ -151,7 +151,7 @@ public class BTreeInsertAndGetOperationImpl extends OperationImpl implements
         setReadType(OperationReadType.DATA);
       }
     } else {
-      OperationStatus status = null;
+      OperationStatus status;
       if (get.isUpdateIfExist()) {
         status = matchStatus(line, UPSERT_AND_GET_STATUS_ON_LINE);
       } else {
@@ -160,7 +160,6 @@ public class BTreeInsertAndGetOperationImpl extends OperationImpl implements
       getLogger().debug(status);
       getCallback().receivedStatus(status);
       transitionState(OperationState.COMPLETE);
-      return;
     }
   }
 

--- a/src/main/java/net/spy/memcached/protocol/ascii/BTreeSortMergeGetOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/BTreeSortMergeGetOperationImpl.java
@@ -145,7 +145,6 @@ public class BTreeSortMergeGetOperationImpl extends OperationImpl implements
       getLogger().debug(status);
       getCallback().receivedStatus(status);
       transitionState(OperationState.COMPLETE);
-      return;
     }
   }
 
@@ -283,7 +282,7 @@ public class BTreeSortMergeGetOperationImpl extends OperationImpl implements
     }
   }
 
-  private final void readMissedKeys(ByteBuffer bb) {
+  private void readMissedKeys(ByteBuffer bb) {
     int count = 0;
     if (lookingFor == '\0' && data == null) {
       while (bb.remaining() > 0) {
@@ -358,11 +357,10 @@ public class BTreeSortMergeGetOperationImpl extends OperationImpl implements
           byteBuffer.write(b);
         }
       }
-      return;
     }
   }
 
-  private final void readTrimmedKeys(ByteBuffer bb) {
+  private void readTrimmedKeys(ByteBuffer bb) {
     int count = 0;
     if (lookingFor == '\0' && data == null) {
       while (bb.remaining() > 0) {
@@ -418,7 +416,6 @@ public class BTreeSortMergeGetOperationImpl extends OperationImpl implements
           byteBuffer.write(b);
         }
       }
-      return;
     }
   }
 

--- a/src/main/java/net/spy/memcached/protocol/ascii/BaseGetOpImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/BaseGetOpImpl.java
@@ -67,6 +67,12 @@ abstract class BaseGetOpImpl extends OperationImpl {
 
   @Override
   public final void handleLine(String line) {
+    /*
+      VALUE <key> <flags> <bytes> [<cas unique>]\r\n
+      <data block>\r\n
+      ...
+      END\r\n
+    */
     if (line.equals("END")) {
       getLogger().debug("Get complete!");
       /* ENABLE_MIGRATION if */
@@ -188,9 +194,9 @@ abstract class BaseGetOpImpl extends OperationImpl {
       int numKeys = keys.size();
       commandBuilder.append(cmd);
       commandBuilder.append(' ');
-      commandBuilder.append(String.valueOf(lenKeys));
+      commandBuilder.append(lenKeys);
       commandBuilder.append(' ');
-      commandBuilder.append(String.valueOf(numKeys));
+      commandBuilder.append(numKeys);
       commandBuilder.append(RN_STRING);
       commandBuilder.append(keysString);
       commandBuilder.append(RN_STRING);

--- a/src/main/java/net/spy/memcached/protocol/ascii/CollectionCountOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/CollectionCountOperationImpl.java
@@ -94,7 +94,6 @@ public class CollectionCountOperationImpl extends OperationImpl implements
       getLogger().debug(status);
       getCallback().receivedStatus(status);
       transitionState(OperationState.COMPLETE);
-      return;
     }
   }
 

--- a/src/main/java/net/spy/memcached/protocol/ascii/CollectionGetOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/CollectionGetOperationImpl.java
@@ -145,7 +145,6 @@ public class CollectionGetOperationImpl extends OperationImpl
       getLogger().debug(status);
       getCallback().receivedStatus(status);
       transitionState(OperationState.COMPLETE);
-      return;
     }
   }
 

--- a/src/main/java/net/spy/memcached/protocol/ascii/CollectionMutateOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/CollectionMutateOperationImpl.java
@@ -80,8 +80,6 @@ public class CollectionMutateOperationImpl extends OperationImpl implements
 
   public void handleLine(String line) {
 
-    OperationStatus status = null;
-
     /* ENABLE_REPLICATION if */
     if (hasSwitchedOver(line)) {
       receivedMoveOperations(line);
@@ -100,8 +98,9 @@ public class CollectionMutateOperationImpl extends OperationImpl implements
       Long.valueOf(line);
       getCallback().receivedStatus(new OperationStatus(true, line));
     } catch (NumberFormatException e) {
-      status = matchStatus(line, NOT_FOUND, NOT_FOUND_ELEMENT, TYPE_MISMATCH, BKEY_MISMATCH,
-              UNREADABLE, OVERFLOWED, OUT_OF_RANGE);
+      OperationStatus status = matchStatus(line, NOT_FOUND, NOT_FOUND_ELEMENT,
+              UNREADABLE, OVERFLOWED, OUT_OF_RANGE,
+              TYPE_MISMATCH, BKEY_MISMATCH);
 
       getLogger().debug(status);
       getCallback().receivedStatus(status);

--- a/src/main/java/net/spy/memcached/protocol/ascii/GetAttrOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/GetAttrOperationImpl.java
@@ -69,6 +69,13 @@ class GetAttrOperationImpl extends OperationImpl implements GetAttrOperation {
       return;
     }
     /* ENABLE_MIGRATION end */
+
+    /*
+      ATTR <name>=<value>\r\n
+      ATTR <name>=<value>\r\n
+      ...
+      END\r\n
+    */
     if (line.startsWith("ATTR ")) {
       getLogger().debug("Got line %s", line);
 


### PR DESCRIPTION
## 이슈 연결

- https://github.com/jam2in/arcus-works/issues/159

## 작업 사항

- 다른 handleRead 함수와는 다르게 불필요한 null 변수 선언하는 부분이 있었습니다.
    - 나중에 선언후 바로 대입하는 것으로 변경했습니다.
- `BTreeFindPositionOperationImpl`에서 position을 확인하기 위해 `parseInt`를 try-catch 문으로 감싸고 있습니다.
    - 서버의 응답값이 `position=string\r\n`과 같은 형태로 반환되는 경우를 처리하는 부분입니다.
    - 그런데 catch 문안에서 아무 동작을 하지 않아서 불필요합니다. 그리고 try catch의 유무와 상관없이 테스트 로직이 정상적으로 수행됩니다.
    - 일반적인 에러(`NOT_FOUND`)의 경우, if-else로 분기하기 때문에 try 문과 상관없이 정상적으로 처리됩니다.
    - 이와 유사한 `BTreeFindPositionWithGetOperationImpl` 클래스에서는 position을 `parseInt`할때 try 문을 사용하지 않습니다.
