### PR TITLE
REFACTOR: Remove duplicated lines for checking ending byte

### DIFF
--- a/src/main/java/net/spy/memcached/protocol/ascii/BTreeFindPositionWithGetOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/BTreeFindPositionWithGetOperationImpl.java
@@ -208,23 +208,7 @@ public class BTreeFindPositionWithGetOperationImpl extends OperationImpl impleme
     }
 
     if (lookingFor != '\0' && bb.hasRemaining()) {
-      do {
-        byte tmp = bb.get();
-        assert tmp == lookingFor : "Expecting " + lookingFor + ", got "
-                + (char) tmp;
-
-        switch (lookingFor) {
-          case '\r':
-            lookingFor = '\n';
-            break;
-          case '\n':
-            lookingFor = '\0';
-            break;
-          default:
-            assert false : "Looking for unexpected char: "
-                    + (char) lookingFor;
-        }
-      } while (lookingFor != '\0' && bb.hasRemaining());
+      lookingFor = findLineEndingByte(bb, lookingFor);
 
       if (lookingFor == '\0') {
         data = null;

--- a/src/main/java/net/spy/memcached/protocol/ascii/BTreeGetBulkOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/BTreeGetBulkOperationImpl.java
@@ -196,23 +196,7 @@ public class BTreeGetBulkOperationImpl extends OperationImpl implements
     }
 
     if (lookingFor != '\0' && bb.hasRemaining()) {
-      do {
-        byte tmp = bb.get();
-        assert tmp == lookingFor : "Expecting " + lookingFor + ", got "
-                + (char) tmp;
-
-        switch (lookingFor) {
-          case '\r':
-            lookingFor = '\n';
-            break;
-          case '\n':
-            lookingFor = '\0';
-            break;
-          default:
-            assert false : "Looking for unexpected char: "
-                    + (char) lookingFor;
-        }
-      } while (lookingFor != '\0' && bb.hasRemaining());
+      lookingFor = findLineEndingByte(bb, lookingFor);
 
       if (lookingFor == '\0') {
         data = null;

--- a/src/main/java/net/spy/memcached/protocol/ascii/BTreeGetByPositionOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/BTreeGetByPositionOperationImpl.java
@@ -210,23 +210,7 @@ public class BTreeGetByPositionOperationImpl extends OperationImpl implements
     }
 
     if (lookingFor != '\0' && bb.hasRemaining()) {
-      do {
-        byte tmp = bb.get();
-        assert tmp == lookingFor : "Expecting " + lookingFor + ", got "
-                + (char) tmp;
-
-        switch (lookingFor) {
-          case '\r':
-            lookingFor = '\n';
-            break;
-          case '\n':
-            lookingFor = '\0';
-            break;
-          default:
-            assert false : "Looking for unexpected char: "
-                    + (char) lookingFor;
-        }
-      } while (lookingFor != '\0' && bb.hasRemaining());
+      lookingFor = findLineEndingByte(bb, lookingFor);
 
       if (lookingFor == '\0') {
         data = null;

--- a/src/main/java/net/spy/memcached/protocol/ascii/BTreeInsertAndGetOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/BTreeInsertAndGetOperationImpl.java
@@ -236,23 +236,7 @@ public class BTreeInsertAndGetOperationImpl extends OperationImpl implements
     }
 
     if (lookingFor != '\0' && bb.hasRemaining()) {
-      do {
-        byte tmp = bb.get();
-        assert tmp == lookingFor : "Expecting " + lookingFor + ", got "
-                + (char) tmp;
-
-        switch (lookingFor) {
-          case '\r':
-            lookingFor = '\n';
-            break;
-          case '\n':
-            lookingFor = '\0';
-            break;
-          default:
-            assert false : "Looking for unexpected char: "
-                    + (char) lookingFor;
-        }
-      } while (lookingFor != '\0' && bb.hasRemaining());
+      lookingFor = findLineEndingByte(bb, lookingFor);
 
       if (lookingFor == '\0') {
         data = null;

--- a/src/main/java/net/spy/memcached/protocol/ascii/BTreeSortMergeGetOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/BTreeSortMergeGetOperationImpl.java
@@ -257,23 +257,7 @@ public class BTreeSortMergeGetOperationImpl extends OperationImpl implements
     }
 
     if (lookingFor != '\0' && bb.hasRemaining()) {
-      do {
-        byte tmp = bb.get();
-        assert tmp == lookingFor : "Expecting " + lookingFor + ", got "
-                + (char) tmp;
-
-        switch (lookingFor) {
-          case '\r':
-            lookingFor = '\n';
-            break;
-          case '\n':
-            lookingFor = '\0';
-            break;
-          default:
-            assert false : "Looking for unexpected char: "
-                    + (char) lookingFor;
-        }
-      } while (lookingFor != '\0' && bb.hasRemaining());
+      lookingFor = findLineEndingByte(bb, lookingFor);
 
       if (lookingFor == '\0') {
         data = null;

--- a/src/main/java/net/spy/memcached/protocol/ascii/BTreeSortMergeGetOperationOldImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/BTreeSortMergeGetOperationOldImpl.java
@@ -219,23 +219,7 @@ public class BTreeSortMergeGetOperationOldImpl extends OperationImpl implements
     }
 
     if (lookingFor != '\0' && bb.hasRemaining()) {
-      do {
-        byte tmp = bb.get();
-        assert tmp == lookingFor : "Expecting " + lookingFor + ", got "
-                + (char) tmp;
-
-        switch (lookingFor) {
-          case '\r':
-            lookingFor = '\n';
-            break;
-          case '\n':
-            lookingFor = '\0';
-            break;
-          default:
-            assert false : "Looking for unexpected char: "
-                    + (char) lookingFor;
-        }
-      } while (lookingFor != '\0' && bb.hasRemaining());
+      lookingFor = findLineEndingByte(bb, lookingFor);
 
       if (lookingFor == '\0') {
         data = null;

--- a/src/main/java/net/spy/memcached/protocol/ascii/BaseGetOpImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/BaseGetOpImpl.java
@@ -110,7 +110,7 @@ abstract class BaseGetOpImpl extends OperationImpl {
   }
 
   @Override
-  public final void handleRead(ByteBuffer b) {
+  public final void handleRead(ByteBuffer bb) {
     assert currentKey != null;
     assert data != null;
     // This will be the case, because we'll clear them when it's not.
@@ -121,10 +121,10 @@ abstract class BaseGetOpImpl extends OperationImpl {
     // If we're not looking for termination, we're still looking for data
     if (lookingFor == '\0') {
       int toRead = data.length - readOffset;
-      int available = b.remaining();
+      int available = bb.remaining();
       toRead = Math.min(toRead, available);
       getLogger().debug("Reading %d bytes", toRead);
-      b.get(data, readOffset, toRead);
+      bb.get(data, readOffset, toRead);
       readOffset += toRead;
     }
     // Transition us into a ``looking for \r\n'' kind of state if we've
@@ -143,22 +143,9 @@ abstract class BaseGetOpImpl extends OperationImpl {
       lookingFor = '\r';
     }
     // If we're looking for an ending byte, let's go find it.
-    if (lookingFor != '\0' && b.hasRemaining()) {
-      do {
-        byte tmp = b.get();
-        assert tmp == lookingFor : "Expecting " + lookingFor + ", got "
-                + (char) tmp;
-        switch (lookingFor) {
-          case '\r':
-            lookingFor = '\n';
-            break;
-          case '\n':
-            lookingFor = '\0';
-            break;
-          default:
-            assert false : "Looking for unexpected char: " + (char) lookingFor;
-        }
-      } while (lookingFor != '\0' && b.hasRemaining());
+    if (lookingFor != '\0' && bb.hasRemaining()) {
+      lookingFor = findLineEndingByte(bb, lookingFor);
+
       // Completed the read, reset stuff.
       if (lookingFor == '\0') {
         currentKey = null;

--- a/src/main/java/net/spy/memcached/protocol/ascii/CollectionGetOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/CollectionGetOperationImpl.java
@@ -232,23 +232,7 @@ public class CollectionGetOperationImpl extends OperationImpl
     }
 
     if (lookingFor != '\0' && bb.hasRemaining()) {
-      do {
-        byte tmp = bb.get();
-        assert tmp == lookingFor : "Expecting " + lookingFor + ", got "
-                + (char) tmp;
-
-        switch (lookingFor) {
-          case '\r':
-            lookingFor = '\n';
-            break;
-          case '\n':
-            lookingFor = '\0';
-            break;
-          default:
-            assert false : "Looking for unexpected char: "
-                    + (char) lookingFor;
-        }
-      } while (lookingFor != '\0' && bb.hasRemaining());
+      lookingFor = findLineEndingByte(bb, lookingFor);
 
       if (lookingFor == '\0') {
         data = null;

--- a/src/main/java/net/spy/memcached/protocol/ascii/OperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/OperationImpl.java
@@ -104,6 +104,23 @@ abstract class OperationImpl extends BaseOperationImpl implements Operation {
     bb.put(CRLF);
   }
 
+  protected final byte findLineEndingByte(ByteBuffer buffer, byte initial) {
+    byte current = initial;
+    while (buffer.hasRemaining()) {
+      byte b = buffer.get();
+      assert b == current : "Expecting " + current + ", got " + (char) b;
+
+      if (current == '\r') {
+        current = '\n';
+      } else if (current == '\n') {
+        return '\0';
+      } else {
+        assert false : "Looking for unexpected char: " + (char) current;
+      }
+    }
+    return current;
+  }
+
   private String getLineFromBuffer(ByteBuffer data) throws UnsupportedEncodingException {
     boolean lineFound = false;
     while (data.remaining() > 0) {


### PR DESCRIPTION
## 이슈 연결

- https://github.com/jam2in/arcus-works/issues/159

## 작업 사항

- OperationImpl 클래스들에서 `ByteBuffer`에서 `\0`을 확인하는 코드가 반복됩니다.
  - 반복되는 코드를 `OperationImpl` 클래스의 protected final 메소드로 분리했습니다.
- `BaseGetOperationImpl`에서 `ByteBuffer`를 `b`라는 변수명을 사용하고 있습니다. 하지만 다른 클래스들에서는 `bb`로 사용중입니다.
  - 변수명을 `bb`로 수정했습니다.