### PR TITLE
INTERNAL: Upgrade the JDK and dependencies, except for those whose interfaces have changed.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,13 +14,19 @@ concurrency:
 
 jobs:
   test:
-    runs-on: ubuntu-20.04
+    name: JDK ${{ matrix.jdk }}, ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        jdk: [ 8, 11, 17 ]
+        os: [ ubuntu-20.04 ]
+      fail-fast: true
     steps:
-      - uses: actions/checkout@v3
-      - name: Set up JDK 11
-        uses: actions/setup-java@v2
+      - uses: actions/checkout@v4
+      - name: Set up JDK ${{ matrix.jdk }}
+        uses: actions/setup-java@v4
         with:
-          java-version: '11'
+          java-version: ${{ matrix.jdk }}
           distribution: 'temurin'
           cache: 'maven'
       - name: Update apt-get
@@ -33,9 +39,7 @@ jobs:
           # build server
           cd ~/arcus && docker compose up -d 
 
-      - name: Build ARCUS Client
-        run: mvn install -DskipTests
       - name: Test ARCUS Client Without ZK
-        run: mvn test -DUSE_ZK=false -Dtest=ObserverTest
+        run: mvn clean verify -DUSE_ZK=false -Dtest=ObserverTest
       - name: Test ARCUS Client With ZK
-        run: mvn test -DUSE_ZK=true
+        run: mvn clean verify -DUSE_ZK=true

--- a/pom.xml
+++ b/pom.xml
@@ -10,6 +10,13 @@
     <url>https://github.com/naver/arcus-java-client</url>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <java.version>8</java.version>
+        <zookeeper.version>3.5.9</zookeeper.version>
+        <log4j.version>2.23.1</log4j.version>
+        <slf4j.version>2.0.12</slf4j.version>
+        <ehcache.version>2.6.0</ehcache.version>
+        <junit.version>4.13.1</junit.version>
+        <jmock.version>1.2.0</jmock.version>
     </properties>
     <licenses>
         <license>
@@ -45,19 +52,19 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
-            <version>2.17.1</version>
+            <version>${log4j.version}</version>
             <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-api</artifactId>
-            <version>2.17.1</version>
+            <version>${log4j.version}</version>
             <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-slf4j-impl</artifactId>
-            <version>2.17.1</version>
+            <version>${log4j.version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.slf4j</groupId>
@@ -69,12 +76,12 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>1.7.24</version>
+            <version>${slf4j.version}</version>
         </dependency>
         <dependency>
             <groupId>net.sf.ehcache</groupId>
             <artifactId>ehcache-core</artifactId>
-            <version>2.6.0</version>
+            <version>${ehcache.version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.slf4j</groupId>
@@ -85,7 +92,7 @@
         <dependency>
             <groupId>org.apache.zookeeper</groupId>
             <artifactId>zookeeper</artifactId>
-            <version>3.5.9</version>
+            <version>${zookeeper.version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>log4j</groupId>
@@ -99,6 +106,10 @@
                     <groupId>org.slf4j</groupId>
                     <artifactId>slf4j-log4j12</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-reload4j</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
 
@@ -106,13 +117,13 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.13.1</version>
+            <version>${junit.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>jmock</groupId>
             <artifactId>jmock</artifactId>
-            <version>1.2.0</version>
+            <version>${jmock.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -124,16 +135,16 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.1</version>
                 <configuration>
-                    <source>1.6</source>
-                    <target>1.6</target>
+                    <source>${java.version}</source>
+                    <target>${java.version}</target>
+                    <encoding>UTF-8</encoding>
                     <debug>true</debug>
                     <optimize>true</optimize>
-                    <encoding>utf-8</encoding>
                     <showDeprecation>true</showDeprecation>
                     <showWarnings>true</showWarnings>
                     <compilerArgs>
                         <arg>-Xlint:all</arg>
-                        <arg>-Xlint:-options</arg> <!-- For warning about old java version 6. -->
+                        <arg>-Xlint:-options</arg> <!-- For warning about old java version 8. -->
                         <arg>-Xlint:-processing</arg> <!-- For meaningless warning about annotations -->
                         <arg>-Xlint:-classfile</arg> <!-- For provided spotbugs in ZK Client -->
                         <arg>-Werror</arg>
@@ -143,6 +154,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>
+                <version>3.6.1</version>
                 <executions>
                     <execution>
                         <id>copy-dependencies</id>


### PR DESCRIPTION
https://github.com/jam2in/arcus-works/issues/523

# pom.xml 변경 사항

위 이슈와 오프라인에서 논의한 대로, JDK 8로 업그레이드 하면서 업데이트 가능한 라이브러리 버전도 업데이트 합니다.
단, 라이브러리의 인터페이스가 변경되지 않는 선에서만 업데이트를 합니다.

메이븐 플러그인을 제외한 모든 버전은 변수로 관리하도록 변경했고, `maven-dependency-plugin`의 버전을 명시하지 않았을 때 컴파일이 잘 되지 않는 현상이 있어 버전을 명시했습니다.

# ci.yml 변경 사항

https://github.com/qos-ch/slf4j/blob/v_2.0.12/.github/workflows/main.yml

다른 오픈 소스 프로젝트를 봤을 때 여러 JDK 버전에서 CI를 수행하고 있음을 확인했습니다.

JDK 8로 업그레이드 한 이후로는 최소 JDK 8에서는 호환이 되어야 할 것으로 보아 LTS 버전인 8, 11, 17에서 테스트 코드를 수행하도록 했습니다.
11은 빼도 될 것 같지만 기존에 사용하던 버전이 11이라서 우선 남겼습니다.

OS도 여러 OS를 선택할 수 있지만 기존에 사용하던 우분투 20.04만 사용합니다.