### PR TITLE
FIX: Set default value of shouldOptimize to false.

### DIFF
--- a/src/main/java/net/spy/memcached/DefaultConnectionFactory.java
+++ b/src/main/java/net/spy/memcached/DefaultConnectionFactory.java
@@ -304,7 +304,7 @@ public class DefaultConnectionFactory extends SpyObject
     return false;
   }
   public boolean shouldOptimize() {
-    return true;
+    return false;
   }
 
   public long getMaxReconnectDelay() {


### PR DESCRIPTION
### 🔗 Related Issue

<!-- Please link related issue. ex) https://github.com/naver/arcus-java-client/issues/{issue_number} -->
- https://github.com/jam2in/arcus-works/issues/570

### ⌨️ What I did

<!-- Please describe this PR and what you've been working on. -->
- shouldOptimize의 기본값을 항상 false로 고정합니다.