### PR TITLE
TEST: Add ArcusClient naming test to CI.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,6 @@ jobs:
           cd ~/arcus && docker compose up -d 
 
       - name: Test ARCUS Client Without ZK
-        run: mvn clean verify -DUSE_ZK=false -Dtest=ObserverTest
+        run: mvn clean verify -DUSE_ZK=false -Dtest=ObserverTest,ArcusClientCreateTest
       - name: Test ARCUS Client With ZK
         run: mvn clean verify -DUSE_ZK=true

--- a/src/main/java/net/spy/memcached/ArcusClient.java
+++ b/src/main/java/net/spy/memcached/ArcusClient.java
@@ -333,7 +333,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
    */
   public ArcusClient(ConnectionFactory cf, List<InetSocketAddress> addrs)
           throws IOException {
-    this(cf, DEFAULT_ARCUS_CLIENT_NAME + CLIENT_ID.getAndIncrement(), addrs);
+    this(cf, DEFAULT_ARCUS_CLIENT_NAME + "-" + CLIENT_ID.getAndIncrement(), addrs);
   }
 
   /**

--- a/src/test/manual/net/spy/memcached/ArcusClientCreateTest.java
+++ b/src/test/manual/net/spy/memcached/ArcusClientCreateTest.java
@@ -5,6 +5,8 @@ import java.net.InetSocketAddress;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import net.spy.memcached.collection.BaseIntegrationTest;
 
@@ -46,14 +48,15 @@ public class ArcusClientCreateTest {
 
   @Test
   public void testCreateClientWithDefaultName() throws IOException {
-    int clientId = 1;
     ArcusClient arcusClient = new ArcusClient(new DefaultConnectionFactory(), addrs);
 
     Collection<MemcachedNode> nodes = arcusClient.getAllNodes();
-    MemcachedNode node = nodes.iterator().next();
-
     Assert.assertEquals(nodes.size(), 1);
-    Assert.assertEquals(node.getNodeName(), "ArcusClient" + "-" + clientId + " " + hostName);
+
+    MemcachedNode node = nodes.iterator().next();
+    Pattern compile = Pattern.compile("ArcusClient-\\d+ " + hostName);
+    Matcher matcher = compile.matcher(node.getNodeName());
+    Assert.assertTrue(matcher.matches());
   }
 
   @Test(expected = NullPointerException.class)


### PR DESCRIPTION
https://github.com/naver/arcus-java-client/pull/738

- 위 PR에서 반영되지 않았던 CI 테스트 설정을 수정했습니다.
- 테스트 코드 통과를 위해 ArcusClient의 기본 네이밍 방식에 있던 버그를 수정했습니다.
- ArcusClient 객체가 여러번 생성되었어도 테스트 코드가 통과하도록 정확한 CLIENT_ID 값이 아닌 정규식을 사용하도록 했습니다.