### PR TITLE
FEATURE: Add DefaultArcusConnectionFactory class.

### DIFF
--- a/src/main/java/net/spy/memcached/ConnectionFactoryBuilder.java
+++ b/src/main/java/net/spy/memcached/ConnectionFactoryBuilder.java
@@ -35,6 +35,28 @@ import net.spy.memcached.protocol.ascii.AsciiOperationFactory;
 import net.spy.memcached.protocol.binary.BinaryOperationFactory;
 import net.spy.memcached.transcoders.Transcoder;
 
+import static net.spy.memcached.DefaultArcusConnectionFactory.DEFAULT_DELIMITER;
+import static net.spy.memcached.DefaultArcusConnectionFactory.DEFAULT_DNS_CACHE_TTL_CHECK;
+import static net.spy.memcached.DefaultArcusConnectionFactory.DEFAULT_FAILURE_MODE;
+import static net.spy.memcached.DefaultArcusConnectionFactory.DEFAULT_FRONTCACHE_EXPIRETIME;
+import static net.spy.memcached.DefaultArcusConnectionFactory.DEFAULT_FRONT_CACHE_COPY_ON_READ;
+import static net.spy.memcached.DefaultArcusConnectionFactory.DEFAULT_FRONT_CACHE_COPY_ON_WRITE;
+import static net.spy.memcached.DefaultArcusConnectionFactory.DEFAULT_FRONT_CACHE_NAME_PREFIX;
+import static net.spy.memcached.DefaultArcusConnectionFactory.DEFAULT_HASH;
+import static net.spy.memcached.DefaultArcusConnectionFactory.DEFAULT_IS_DAEMON;
+import static net.spy.memcached.DefaultArcusConnectionFactory.DEFAULT_KEEP_ALIVE;
+import static net.spy.memcached.DefaultArcusConnectionFactory.DEFAULT_MAX_FRONTCACHE_ELEMENTS;
+import static net.spy.memcached.DefaultArcusConnectionFactory.DEFAULT_MAX_RECONNECT_DELAY;
+import static net.spy.memcached.DefaultArcusConnectionFactory.DEFAULT_MAX_SMGET_KEY_CHUNK_SIZE;
+import static net.spy.memcached.DefaultArcusConnectionFactory.DEFAULT_MAX_TIMEOUTDURATION_THRESHOLD;
+import static net.spy.memcached.DefaultArcusConnectionFactory.DEFAULT_MAX_TIMEOUTEXCEPTION_THRESHOLD;
+import static net.spy.memcached.DefaultArcusConnectionFactory.DEFAULT_MAX_TIMEOUTRATIO_THRESHOLD;
+import static net.spy.memcached.DefaultArcusConnectionFactory.DEFAULT_OPERATION_TIMEOUT;
+import static net.spy.memcached.DefaultArcusConnectionFactory.DEFAULT_OP_QUEUE_MAX_BLOCK_TIME;
+import static net.spy.memcached.DefaultArcusConnectionFactory.DEFAULT_READ_BUFFER_SIZE;
+import static net.spy.memcached.DefaultArcusConnectionFactory.DEFAULT_SHOULD_OPTIMIZE;
+import static net.spy.memcached.DefaultArcusConnectionFactory.DEFAULT_USE_NAGLE_ALGORITHM;
+
 /**
  * Builder for more easily configuring a ConnectionFactory.
  */
@@ -46,51 +68,43 @@ public class ConnectionFactoryBuilder {
 
   private Transcoder<Object> transcoder;
   private Transcoder<Object> collectionTranscoder;
-
-  private FailureMode failureMode = FailureMode.Cancel;
-
-  private Collection<ConnectionObserver> initialObservers
-          = Collections.emptyList();
-
   private OperationFactory opFact;
 
+  private Collection<ConnectionObserver> initialObservers = Collections.emptyList();
+  private FailureMode failureMode = DEFAULT_FAILURE_MODE;
+
   private Locator locator = Locator.ARCUSCONSISTENT;
-  private long opTimeout = -1;
-  private boolean isDaemon = true;
-  private boolean shouldOptimize = false;
-  private boolean useNagle = false;
-  private boolean keepAlive = false;
-  private boolean dnsCacheTtlCheck = true;
-  //private long maxReconnectDelay =
-  //DefaultConnectionFactory.DEFAULT_MAX_RECONNECT_DELAY;
-  private long maxReconnectDelay = 1;
+  private long opTimeout = DEFAULT_OPERATION_TIMEOUT;
+  private boolean isDaemon = DEFAULT_IS_DAEMON;
+  private boolean shouldOptimize = DEFAULT_SHOULD_OPTIMIZE;
+  private boolean useNagle = DEFAULT_USE_NAGLE_ALGORITHM;
+  private boolean keepAlive = DEFAULT_KEEP_ALIVE;
+  private boolean dnsCacheTtlCheck = DEFAULT_DNS_CACHE_TTL_CHECK;
+  private long maxReconnectDelay = DEFAULT_MAX_RECONNECT_DELAY;
 
-  private int readBufSize = -1;
-  private HashAlgorithm hashAlg = HashAlgorithm.KETAMA_HASH;
+  private int readBufSize = DEFAULT_READ_BUFFER_SIZE;
+  private HashAlgorithm hashAlg = DEFAULT_HASH;
   private AuthDescriptor authDescriptor = null;
-  private long opQueueMaxBlockTime = -1;
+  private long opQueueMaxBlockTime = DEFAULT_OP_QUEUE_MAX_BLOCK_TIME;
 
-  // private int timeoutExceptionThreshold =
-  //     DefaultConnectionFactory.DEFAULT_MAX_TIMEOUTEXCEPTION_THRESHOLD;
-  private int timeoutExceptionThreshold = 10;
-  private int timeoutRatioThreshold = DefaultConnectionFactory.DEFAULT_MAX_TIMEOUTRATIO_THRESHOLD;
-  private int timeoutDurationThreshold = 1000;
+  private int timeoutExceptionThreshold = DEFAULT_MAX_TIMEOUTEXCEPTION_THRESHOLD;
+  private int timeoutRatioThreshold = DEFAULT_MAX_TIMEOUTRATIO_THRESHOLD;
+  private int timeoutDurationThreshold = DEFAULT_MAX_TIMEOUTDURATION_THRESHOLD;
 
-  private int maxFrontCacheElements = DefaultConnectionFactory.DEFAULT_MAX_FRONTCACHE_ELEMENTS;
-  private int frontCacheExpireTime = DefaultConnectionFactory.DEFAULT_FRONTCACHE_EXPIRETIME;
-  private String frontCacheName = "ArcusFrontCache_" + this.hashCode();
-  private boolean frontCacheCopyOnRead = DefaultConnectionFactory.DEFAULT_FRONT_CACHE_COPY_ON_READ;
-  private boolean frontCacheCopyOnWrite =
-      DefaultConnectionFactory.DEFAULT_FRONT_CACHE_COPY_ON_WRITE;
+  private final String frontCacheName = DEFAULT_FRONT_CACHE_NAME_PREFIX + this.hashCode();
+  private int maxFrontCacheElements = DEFAULT_MAX_FRONTCACHE_ELEMENTS;
+  private int frontCacheExpireTime = DEFAULT_FRONTCACHE_EXPIRETIME;
+  private boolean frontCacheCopyOnRead = DEFAULT_FRONT_CACHE_COPY_ON_READ;
+  private boolean frontCacheCopyOnWrite = DEFAULT_FRONT_CACHE_COPY_ON_WRITE;
 
-  private int maxSMGetChunkSize = DefaultConnectionFactory.DEFAULT_MAX_SMGET_KEY_CHUNK_SIZE;
-  private byte delimiter = DefaultConnectionFactory.DEFAULT_DELIMITER;
+  private int maxSMGetChunkSize = DEFAULT_MAX_SMGET_KEY_CHUNK_SIZE;
+  private byte delimiter = DEFAULT_DELIMITER;
 
   /* ENABLE_REPLICATION if */
   private boolean arcusReplEnabled = false;
 
   private ReadPriority readPriority = ReadPriority.MASTER;
-  private Map<APIType, ReadPriority> apiReadPriorityList = new HashMap<>();
+  private final Map<APIType, ReadPriority> apiReadPriorityList = new HashMap<>();
   /* ENABLE_REPLICATION end */
 
   /* ENABLE_MIGRATION if */
@@ -459,7 +473,7 @@ public class ConnectionFactoryBuilder {
    * Get the ConnectionFactory set up with the provided parameters.
    */
   public ConnectionFactory build() {
-    return new DefaultConnectionFactory() {
+    return new DefaultArcusConnectionFactory(frontCacheName) {
 
       /* ENABLE_REPLICATION if */
       @Override

--- a/src/main/java/net/spy/memcached/DefaultArcusConnectionFactory.java
+++ b/src/main/java/net/spy/memcached/DefaultArcusConnectionFactory.java
@@ -1,0 +1,85 @@
+package net.spy.memcached;
+
+public class DefaultArcusConnectionFactory extends DefaultConnectionFactory
+        implements ConnectionFactory {
+
+  /**
+   * Default failureMode : FailureMode.Cancel
+   */
+  public static final FailureMode DEFAULT_FAILURE_MODE = FailureMode.Cancel;
+
+  /**
+   * Default isDaemon : true
+   */
+  public static final boolean DEFAULT_IS_DAEMON = true;
+
+  /**
+   * Maximum amount of time (in seconds) to wait between reconnect attempts.
+   */
+  public static final long DEFAULT_MAX_RECONNECT_DELAY = 1;
+
+  /**
+   * Default hashAlgorithm : HashAlgorithm.KETAMA_HASH
+   */
+  public static final HashAlgorithm DEFAULT_HASH = HashAlgorithm.KETAMA_HASH;
+
+  /**
+   * Maximum number + 2 of timeout exception for shutdown connection
+   */
+  public static final int DEFAULT_MAX_TIMEOUTEXCEPTION_THRESHOLD = 10;
+
+  /**
+   * Maximum timeout duration in milliseconds for shutdown connection
+   */
+  public static final int DEFAULT_MAX_TIMEOUTDURATION_THRESHOLD = 1000;
+
+  /**
+   * Default front cache name prefix : ArcusFrontCache_
+   */
+  public static final String DEFAULT_FRONT_CACHE_NAME_PREFIX = "ArcusFrontCache_";
+
+  private final String frontCacheName;
+
+  public DefaultArcusConnectionFactory() {
+    this.frontCacheName = DEFAULT_FRONT_CACHE_NAME_PREFIX + this.hashCode();
+  }
+
+  DefaultArcusConnectionFactory(String frontCacheName) {
+    this.frontCacheName = frontCacheName;
+  }
+
+  @Override
+  public FailureMode getFailureMode() {
+    return DEFAULT_FAILURE_MODE;
+  }
+
+  @Override
+  public boolean isDaemon() {
+    return DEFAULT_IS_DAEMON;
+  }
+
+  @Override
+  public long getMaxReconnectDelay() {
+    return DEFAULT_MAX_RECONNECT_DELAY;
+  }
+
+  @Override
+  public HashAlgorithm getHashAlg() {
+    return DEFAULT_HASH;
+  }
+
+  @Override
+  public int getTimeoutExceptionThreshold() {
+    return DEFAULT_MAX_TIMEOUTEXCEPTION_THRESHOLD;
+  }
+
+  @Override
+  public int getTimeoutDurationThreshold() {
+    return DEFAULT_MAX_TIMEOUTDURATION_THRESHOLD;
+  }
+
+  @Override
+  public String getFrontCacheName() {
+    return frontCacheName;
+  }
+}

--- a/src/main/java/net/spy/memcached/DefaultConnectionFactory.java
+++ b/src/main/java/net/spy/memcached/DefaultConnectionFactory.java
@@ -98,6 +98,31 @@ public class DefaultConnectionFactory extends SpyObject
   public static final long DEFAULT_OPERATION_TIMEOUT = 700L;
 
   /**
+   * Default isDaemon : false
+   */
+  public static final boolean DEFAULT_IS_DAEMON = false;
+
+  /**
+   * Default useNagleAlgorithm : false
+   */
+  public static final boolean DEFAULT_USE_NAGLE_ALGORITHM = false;
+
+  /**
+   * Default keepAlive : false
+   */
+  public static final boolean DEFAULT_KEEP_ALIVE = false;
+
+  /**
+   * Default shouldOptimize : false
+   */
+  public static final boolean DEFAULT_SHOULD_OPTIMIZE = false;
+
+  /**
+   * Default dnsCacheTtlCheck : true
+   */
+  public static final boolean DEFAULT_DNS_CACHE_TTL_CHECK = true;
+
+  /**
    * Maximum amount of time (in seconds) to wait between reconnect attempts.
    */
   public static final long DEFAULT_MAX_RECONNECT_DELAY = 30;
@@ -159,8 +184,7 @@ public class DefaultConnectionFactory extends SpyObject
 
   /* ENABLE_REPLICATION if */
   public static final ReadPriority DEFAULT_READ_PRIORITY = ReadPriority.MASTER;
-  private Map<APIType, ReadPriority> DEFAULT_API_READ_PRIORITY_LIST =
-          new HashMap<>();
+  private final Map<APIType, ReadPriority> DEFAULT_API_READ_PRIORITY_LIST = new HashMap<>();
   /* ENABLE_REPLICATION end */
 
   /**
@@ -281,7 +305,7 @@ public class DefaultConnectionFactory extends SpyObject
   }
 
   public boolean isDaemon() {
-    return false;
+    return DEFAULT_IS_DAEMON;
   }
 
   public Collection<ConnectionObserver> getInitialObservers() {
@@ -297,11 +321,11 @@ public class DefaultConnectionFactory extends SpyObject
   }
 
   public boolean useNagleAlgorithm() {
-    return false;
+    return DEFAULT_USE_NAGLE_ALGORITHM;
   }
-  @Override
+
   public boolean getKeepAlive() {
-    return false;
+    return DEFAULT_KEEP_ALIVE;
   }
 
   @Override
@@ -310,7 +334,7 @@ public class DefaultConnectionFactory extends SpyObject
   }
 
   public boolean shouldOptimize() {
-    return false;
+    return DEFAULT_SHOULD_OPTIMIZE;
   }
 
   public long getMaxReconnectDelay() {

--- a/src/test/manual/net/spy/memcached/DefaultArcusConnectionFactoryTest.java
+++ b/src/test/manual/net/spy/memcached/DefaultArcusConnectionFactoryTest.java
@@ -1,0 +1,129 @@
+package net.spy.memcached;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNull;
+
+public class DefaultArcusConnectionFactoryTest {
+
+  private final static Set<Class<?>> PRIMITIVE_TYPES = new HashSet<>();
+  private final static Set<String> OBJECT_METHODS = new HashSet<>();
+
+  static {
+    PRIMITIVE_TYPES.add(Boolean.class);
+    PRIMITIVE_TYPES.add(Byte.class);
+    PRIMITIVE_TYPES.add(Short.class);
+    PRIMITIVE_TYPES.add(Integer.class);
+    PRIMITIVE_TYPES.add(Long.class);
+    PRIMITIVE_TYPES.add(Float.class);
+    PRIMITIVE_TYPES.add(Double.class);
+    PRIMITIVE_TYPES.add(Character.class);
+    PRIMITIVE_TYPES.add(String.class);
+
+    for (Method method : Object.class.getMethods()) {
+      OBJECT_METHODS.add(method.getName());
+    }
+  }
+
+  @Test
+  public void testCompareToDefaultConnectionFactory()
+          throws InvocationTargetException, IllegalAccessException {
+
+    ConnectionFactory a = new DefaultConnectionFactory();
+    ConnectionFactory b = new DefaultArcusConnectionFactory();
+
+    Set<String> methodsReturnDifferent = new HashSet<>();
+    methodsReturnDifferent.add("getFailureMode");
+    methodsReturnDifferent.add("isDaemon");
+    methodsReturnDifferent.add("getMaxReconnectDelay");
+    methodsReturnDifferent.add("getHashAlg");
+    methodsReturnDifferent.add("getTimeoutExceptionThreshold");
+    methodsReturnDifferent.add("getTimeoutDurationThreshold");
+    methodsReturnDifferent.add("getFrontCacheName");
+
+    compareConnectionFactory(a, b, methodsReturnDifferent);
+  }
+
+  @Test
+  public void testCompareToConnectionFactoryBuilder()
+          throws InvocationTargetException, IllegalAccessException {
+
+    ConnectionFactory a = new ConnectionFactoryBuilder().build();
+    ConnectionFactory b = new DefaultArcusConnectionFactory(a.getFrontCacheName());
+
+    compareConnectionFactory(a, b, new HashSet<>());
+  }
+
+  private void compareConnectionFactory(ConnectionFactory a,
+                                        ConnectionFactory b,
+                                        Set<String> methodsReturnDifferent)
+          throws InvocationTargetException, IllegalAccessException {
+
+    Map<String, Method> aMethods = getMethodsToTest(a);
+    Map<String, Method> bMethods = getMethodsToTest(b);
+
+    assertFalse(aMethods.isEmpty());
+    assertFalse(bMethods.isEmpty());
+
+    for (Map.Entry<String, Method> aEntry : aMethods.entrySet()) {
+      String methodName = aEntry.getKey();
+      if (!bMethods.containsKey(methodName)) {
+        continue;
+      }
+
+      Object aField = aEntry.getValue().invoke(a);
+      Object bField = bMethods.get(methodName).invoke(b);
+
+      if (methodsReturnDifferent.contains(methodName)) {
+        assertNotEquals(aField, bField);
+        continue;
+      }
+
+      if (aField == null) {
+        assertNull(bField);
+        continue;
+      }
+
+      Class<?> aClass = aField.getClass();
+      if (PRIMITIVE_TYPES.contains(aClass)) {
+        assertEquals(aField, bField);
+      } else {
+        assertEquals(aClass, bField.getClass());
+      }
+    }
+  }
+
+  private Map<String, Method> getMethodsToTest(Object c) {
+    Map<String, Method> methods = new HashMap<>();
+    for (Method method : c.getClass().getMethods()) {
+      int modifiers = method.getModifiers();
+      if (!Modifier.isPublic(modifiers) || Modifier.isStatic(modifiers)) {
+        continue;
+      }
+      if (method.getParameterCount() > 0) {
+        continue;
+      }
+      if (method.getReturnType().equals(Void.TYPE)) {
+        continue;
+      }
+      if (OBJECT_METHODS.contains(method.getName())) {
+        continue;
+      }
+
+      methods.put(method.getName(), method);
+    }
+
+    return methods;
+  }
+}


### PR DESCRIPTION
# 🔗 Related Issue

<!-- Please link related issue. ex) https://github.com/naver/arcus-java-client/issues/{issue_number} -->
- https://github.com/jam2in/arcus-works/issues/570

# ⌨️ What I did

<!-- Please describe this PR and what you've been working on. -->
ArcusConnectionFactory 클래스를 추가합니다.
대부분의 구현이 DefaultConnectionFactory와 같아 DefaultConnectionFactory를 상속받도록 했습니다.

# static final 필드 추가

다음과 같은 기준으로 ConnectionFactoryBuilder 클래스의 필드 기본값을 ArcusConnectionFactory 클래스 내에 static final로 선언했습니다.
- DefaultConnectionFactory 클래스에 이미 static final로 선언되어 있지만 ConnectionFactoryBuilder 클래스의 필드 기본값과 다른 경우
  - `DEFAULT_FAILURE_MODE = FailureMode.Cancel`
  - `DEFAULT_IS_DAEMON = true`
  - `DEFAULT_MAX_RECONNECT_DELAY = 1`
  - `HashAlgorithm DEFAULT_HASH = HashAlgorithm.KETAMA_HASH`
  - `DEFAULT_MAX_TIMEOUTEXCEPTION_THRESHOLD = 10`
  - `DEFAULT_MAX_TIMEOUTDURATION_THRESHOLD = 1000`

## 기본값을 리터럴에서 static final 필드로 변경

ConnectionFactoryBuilder 클래스의 필드 기본값 중 리터럴로 하드코딩 되어 있는 경우 내부 동작이 달라지지 않는 선에서 static final 값을 참조하도록 했습니다.
만약 필드의 기본값으로 할당할 static final 필드가 없다면 새롭게 추가했습니다.
단, 아래와 같은 경우 기존대로 리터럴을 기본값으로 사용하도록 했습니다.
- ARCUS 캐시 클러스터가 기준임을 명확히 알 수 있는 경우
  - `private Locator locator = Locator.ARCUSCONSISTENT;`
  - Replication, Migration 관련 필드들
- 기본값이 명확하며, 서로 다른 세 가지 방식으로 ConnectionFactory 객체를 생성해도 기본값이 같은 경우
  - `private Collection<ConnectionObserver> initialObservers = Collections.emptyList();`
  - `private AuthDescriptor authDescriptor = null;`

# 테스트 코드

ArcusConnectionFactory와 다음의 두 가지를 비교하는 테스트 코드를 추가했습니다.
- DefaultConnectionFactory
- ConnectionFactoryBuilder

향후 기본값을 잘못 변경했을 때 테스트 코드를 통해 알아차릴 수 있도록 Reflection을 이용하여 서로 다른 결과를 반환해야 하는 메소드가 아니라면 동일한 값이 반환되는지 검증하기 때문에 테스트 코드가 엄격해 보일 수 있습니다.
단, 메소드가 Primitive Type도 아니고 String 타입도 아닌 값을 반환하는 경우 Object.eqauls() 메소드를 구현하지 않은 객체는 값을 비교할 수 없어 반환된 객체의 값이 아닌 타입이 동일한지 검증합니다.