### PR TITLE
INTERNAL: Remove unused boolean field dead in ArcusClient.

### DIFF
--- a/src/main/java/net/spy/memcached/ArcusClient.java
+++ b/src/main/java/net/spy/memcached/ArcusClient.java
@@ -190,7 +190,6 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
   private static final Logger arcusLogger = LoggerFactory.getLogger(ArcusClient.class);
   private static final String ARCUS_CLOUD_ADDR = "127.0.0.1:2181";
   private static final String DEFAULT_ARCUS_CLIENT_NAME = "ArcusClient";
-  private boolean dead;
 
   private final Transcoder<Object> collectionTranscoder;
 
@@ -366,7 +365,6 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
     if (cacheManager != null) {
       cacheManager.shutdown();
     }
-    dead = true;
     return result;
   }
 


### PR DESCRIPTION
## 이슈
https://github.com/jam2in/arcus-works/issues/572

## 변경 사항
ArcusClient 내의 private으로 설정된 dead 필드의 경우
shutdown() 호출되면 true로 변경된다.

하지만 ArcusClient 클래스 내에서는 어떠한 로직에서 사용되지 않고,
getter가 없어 다른 클래스에서의 접근도 불가하다.

또한 테스트 코드에서 리플렉션을 통해 사용되지도 않는다.
그래서 사용되지 않는 필드을 제거한다.