### PR TITLE
INTERNAL: Remove public ArcusClient constructor.

### DIFF
--- a/src/main/java/net/spy/memcached/CacheManager.java
+++ b/src/main/java/net/spy/memcached/CacheManager.java
@@ -70,7 +70,7 @@ public class CacheManager extends SpyThread implements Watcher,
   private static final int ZK_SESSION_TIMEOUT = 15000;
 
   private static final long ZK_CONNECT_TIMEOUT = ZK_SESSION_TIMEOUT;
-  private static final AtomicInteger POOL_ID = new AtomicInteger(1);
+  static final AtomicInteger POOL_ID = new AtomicInteger(1);
 
   private final String zkConnectString;
 

--- a/src/test/java/net/spy/memcached/ArcusTimeoutTest.java
+++ b/src/test/java/net/spy/memcached/ArcusTimeoutTest.java
@@ -53,17 +53,10 @@ class ArcusTimeoutTest {
   }
 
   private void initClient() throws IOException {
-    mc = new ArcusClient(new DefaultConnectionFactory() {
-      @Override
-      public long getOperationTimeout() {
-        return 1;
-      }
-
-      @Override
-      public FailureMode getFailureMode() {
-        return FailureMode.Retry;
-      }
-    }, AddrUtil.getAddresses("0.0.0.0:23456"));
+    mc = ArcusClient.createArcusClient(AddrUtil.getAddresses("0.0.0.0:23456"),
+            new ConnectionFactoryBuilder()
+            .setOpTimeout(1)
+            .setFailureMode(FailureMode.Retry));
   }
 
   @AfterEach

--- a/src/test/java/net/spy/memcached/ClientBaseCase.java
+++ b/src/test/java/net/spy/memcached/ClientBaseCase.java
@@ -301,7 +301,10 @@ abstract class ClientBaseCase {
     if (USE_ZK) {
       openFromZK(new CFB(cf));
     } else {
-      openDirect(cf);
+      openDirect(new ConnectionFactoryBuilder()
+              .setOpTimeout(cf.getOperationTimeout())
+              .setFailureMode(cf.getFailureMode())
+              .setInitialObservers(cf.getInitialObservers()));
     }
   }
 
@@ -309,8 +312,8 @@ abstract class ClientBaseCase {
     client = ArcusClient.createArcusClient(ZK_ADDRESS, SERVICE_CODE, cfb);
   }
 
-  protected void openDirect(ConnectionFactory cf) throws Exception {
-    client = new ArcusClient(cf, AddrUtil.getAddresses(ARCUS_HOST));
+  protected void openDirect(ConnectionFactoryBuilder cfb) throws Exception {
+    client = ArcusClient.createArcusClient(AddrUtil.getAddresses(ARCUS_HOST), cfb);
   }
 
   @BeforeEach

--- a/src/test/manual/net/spy/memcached/ArcusClientCreateTest.java
+++ b/src/test/manual/net/spy/memcached/ArcusClientCreateTest.java
@@ -15,7 +15,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
@@ -38,19 +37,8 @@ class ArcusClientCreateTest {
   }
 
   @Test
-  void testCreateClientWithCustomName() throws IOException {
-    ArcusClient arcusClient = new ArcusClient(new DefaultConnectionFactory(), clientName, addrs);
-
-    Collection<MemcachedNode> nodes = arcusClient.getAllNodes();
-    MemcachedNode node = nodes.iterator().next();
-
-    assertEquals(nodes.size(), 1);
-    assertEquals(node.getNodeName(), clientName + " " + hostName);
-  }
-
-  @Test
   void testCreateClientWithDefaultName() throws IOException {
-    ArcusClient arcusClient = new ArcusClient(new DefaultConnectionFactory(), addrs);
+    ArcusClient arcusClient = ArcusClient.createArcusClient(addrs, new ConnectionFactoryBuilder());
 
     Collection<MemcachedNode> nodes = arcusClient.getAllNodes();
     assertEquals(nodes.size(), 1);
@@ -59,12 +47,5 @@ class ArcusClientCreateTest {
     Pattern compile = Pattern.compile("ArcusClient-\\d+ " + hostName);
     Matcher matcher = compile.matcher(node.getNodeName());
     assertTrue(matcher.matches());
-  }
-
-  @Test
-  void testCreateClientNullName() throws IOException {
-    assertThrows(NullPointerException.class, () -> {
-      new ArcusClient(new DefaultConnectionFactory(), null, addrs);
-    });
   }
 }

--- a/src/test/manual/net/spy/memcached/collection/BaseIntegrationTest.java
+++ b/src/test/manual/net/spy/memcached/collection/BaseIntegrationTest.java
@@ -120,7 +120,7 @@ public class BaseIntegrationTest {
     };
     cfb.setInitialObservers(Collections.singleton(obs));
 
-    mc = new ArcusClient(cfb.build(), AddrUtil.getAddresses(ARCUS_HOST));
+    mc = ArcusClient.createArcusClient(AddrUtil.getAddresses(ARCUS_HOST), cfb);
     latch.await();
   }
 


### PR DESCRIPTION
### 이슈
https://github.com/jam2in/arcus-works/issues/572

### 구현
~~public으로 설정된 ArcusClient 생성자를 
외부 사용자가 접근 할 수 없게 protected로 변경했습니다.
추후 ArcusClient가 상속 구조를 가질 수도 있을 것 같아 private으로 설정하지 않았습니다.~~

블라블라..

이와 더불어 기존에 memcached 주소로 연결할 수 있는 기능은
createArcusClient or createArcusClientPool 이라는 스태틱 메서드로 제공합니다. (pool도 제공)