### PR TITLE
FEAT: Change ArcusClient mbean name more readable.

### DIFF
--- a/src/main/java/net/spy/memcached/ArcusClient.java
+++ b/src/main/java/net/spy/memcached/ArcusClient.java
@@ -330,7 +330,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
     }
     collectionTranscoder = new CollectionTranscoder();
     smgetKeyChunkSize = cf.getDefaultMaxSMGetKeyChunkSize();
-    registerMbean();
+    registerMbean(name);
   }
 
   /**
@@ -380,7 +380,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
   /**
    * Register mbean for Arcus client statistics.
    */
-  private void registerMbean() {
+  private void registerMbean(String name) {
     if ("false".equals(System.getProperty("arcus.mbean", "false").toLowerCase())) {
       getLogger().info("Arcus client statistics MBean is NOT registered.");
       return;
@@ -390,9 +390,9 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
       StatisticsHandler mbean = new StatisticsHandler(this);
       ArcusMBeanServer.getInstance().registMBean(
               mbean,
-              mbean.getClass().getPackage().getName() + ":type="
-                      + mbean.getClass().getSimpleName() + "-"
-                      + mbean.hashCode());
+              mbean.getClass().getPackage().getName()
+                      + ":type=" + mbean.getClass().getSimpleName()
+                      + ",name=" + name);
 
       getLogger().info("Arcus client statistics MBean is registered.");
     } catch (Exception e) {


### PR DESCRIPTION
## Related Issue

https://github.com/jam2in/arcus-works/issues/490

## 변경 내용
기존에 아래와 같은 포맷으로 수집되던 메트릭입니다.
```
net_spy_memcached_StatisticsHandler_747327855_reconnectCount_127.0.0.1:11212_ 0.0
```

이를 아래와 같이 변경하는 PR입니다.
```
net_spy_memcached_StatisticsHandler_reconnectCount_127.0.0.1:11212{name="ArcusClient-1(1-1) for test"}_ 0.0
```

일반화 시키면 아래와 같이 구성됩니다.
```
net_spy_memcached_StatisticsHandler_<수집메트릭>_<hostPort정보>{name=<ArcusClient 생성시 사용되는 name>}_ <값>
```

이슈의 코멘트도 참고부탁드립니다.
https://github.com/jam2in/arcus-works/issues/490#issuecomment-2164178885
