### PR TITLE
REFACTOR: Reformat OperationStatus initialization in OperationImpl

### DIFF
--- a/src/main/java/net/spy/memcached/protocol/ascii/BTreeGetBulkOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/BTreeGetBulkOperationImpl.java
@@ -174,8 +174,7 @@ public class BTreeGetBulkOperationImpl extends OperationImpl implements
     assert readOffset <= data.length : "readOffset is " + readOffset
             + " data.length is " + data.length;
 
-    getLogger()
-            .debug("readOffset: %d, length: %d", readOffset, data.length);
+    getLogger().debug("readOffset: %d, length: %d", readOffset, data.length);
 
     if (lookingFor == '\0') {
       int toRead = data.length - readOffset;
@@ -190,8 +189,7 @@ public class BTreeGetBulkOperationImpl extends OperationImpl implements
 
     if (lookingFor == '\0' && readOffset == data.length) {
       BTreeGetBulkOperation.Callback cb = (BTreeGetBulkOperation.Callback) getCallback();
-      cb.gotElement(
-          key, flags, getBulk.getSubkey(), getBulk.getEFlag(), data);
+      cb.gotElement(key, flags, getBulk.getSubkey(), getBulk.getEFlag(), data);
       lookingFor = '\r';
     }
 

--- a/src/main/java/net/spy/memcached/protocol/ascii/CollectionCountOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/CollectionCountOperationImpl.java
@@ -76,6 +76,8 @@ public class CollectionCountOperationImpl extends OperationImpl implements
       return;
     }
     /* ENABLE_MIGRATION end */
+
+    OperationStatus status;
     if (line.startsWith("COUNT=")) {
       // COUNT=<count>\r\n
       getLogger().debug("Got line %s", line);
@@ -84,17 +86,15 @@ public class CollectionCountOperationImpl extends OperationImpl implements
       assert "COUNT".equals(stuff[0]);
       count = Integer.parseInt(stuff[1]);
 
-      getCallback().receivedStatus(
-              new CollectionOperationStatus(new OperationStatus(true,
-                      String.valueOf(count))));
-      transitionState(OperationState.COMPLETE);
+      status = new CollectionOperationStatus(new OperationStatus(true,
+              String.valueOf(count)));
     } else {
-      OperationStatus status = matchStatus(
-          line, NOT_FOUND, TYPE_MISMATCH, BKEY_MISMATCH, UNREADABLE);
+      status = matchStatus(line, NOT_FOUND, TYPE_MISMATCH, BKEY_MISMATCH, UNREADABLE);
       getLogger().debug(status);
-      getCallback().receivedStatus(status);
-      transitionState(OperationState.COMPLETE);
     }
+
+    getCallback().receivedStatus(status);
+    transitionState(OperationState.COMPLETE);
   }
 
   public void initialize() {

--- a/src/main/java/net/spy/memcached/protocol/ascii/CollectionExistOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/CollectionExistOperationImpl.java
@@ -83,9 +83,9 @@ public class CollectionExistOperationImpl extends OperationImpl
       return;
     }
     /* ENABLE_MIGRATION end */
-    getCallback().receivedStatus(
-            matchStatus(line, EXIST, NOT_EXIST, NOT_FOUND, NOT_FOUND,
-                    TYPE_MISMATCH, UNREADABLE));
+    OperationStatus status = matchStatus(line, EXIST, NOT_EXIST,
+            NOT_FOUND, TYPE_MISMATCH, UNREADABLE);
+    getCallback().receivedStatus(status);
     transitionState(OperationState.COMPLETE);
   }
 

--- a/src/main/java/net/spy/memcached/protocol/ascii/CollectionInsertOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/CollectionInsertOperationImpl.java
@@ -113,10 +113,10 @@ public class CollectionInsertOperationImpl extends OperationImpl
     }
     /* ENABLE_MIGRATION end */
 
-    getCallback().receivedStatus(
-            matchStatus(line, STORED, REPLACED, CREATED_STORED, NOT_FOUND,
-                    ELEMENT_EXISTS, OVERFLOWED, OUT_OF_RANGE,
-                    TYPE_MISMATCH, BKEY_MISMATCH));
+    OperationStatus status = matchStatus(line, STORED, REPLACED, CREATED_STORED,
+            NOT_FOUND, ELEMENT_EXISTS, OVERFLOWED, OUT_OF_RANGE,
+            TYPE_MISMATCH, BKEY_MISMATCH);
+    getCallback().receivedStatus(status);
     transitionState(OperationState.COMPLETE);
   }
 

--- a/src/main/java/net/spy/memcached/protocol/ascii/CollectionMutateOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/CollectionMutateOperationImpl.java
@@ -93,19 +93,21 @@ public class CollectionMutateOperationImpl extends OperationImpl implements
       return;
     }
     /* ENABLE_MIGRATION end */
-    try {
-      // <result value>\r\n
-      Long.valueOf(line);
-      getCallback().receivedStatus(new OperationStatus(true, line));
-    } catch (NumberFormatException e) {
-      OperationStatus status = matchStatus(line, NOT_FOUND, NOT_FOUND_ELEMENT,
+
+    // <result value>\r\n
+    boolean allDigit = line.chars().allMatch(Character::isDigit);
+    OperationStatus status;
+    if (allDigit) {
+      status = new OperationStatus(true, line);
+    } else {
+      status = matchStatus(line, NOT_FOUND, NOT_FOUND_ELEMENT,
               UNREADABLE, OVERFLOWED, OUT_OF_RANGE,
               TYPE_MISMATCH, BKEY_MISMATCH);
 
       getLogger().debug(status);
-      getCallback().receivedStatus(status);
     }
 
+    getCallback().receivedStatus(status);
     transitionState(OperationState.COMPLETE);
   }
 

--- a/src/main/java/net/spy/memcached/protocol/ascii/CollectionUpdateOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/CollectionUpdateOperationImpl.java
@@ -102,10 +102,10 @@ public class CollectionUpdateOperationImpl extends OperationImpl implements
       return;
     }
     /* ENABLE_MIGRATION end */
-    getCallback().receivedStatus(
-            matchStatus(line, UPDATED, NOT_FOUND, NOT_FOUND_ELEMENT,
-                    NOTHING_TO_UPDATE, TYPE_MISMATCH, BKEY_MISMATCH,
-                    EFLAG_MISMATCH, SERVER_ERROR));
+    OperationStatus status = matchStatus(line, UPDATED, NOT_FOUND, NOT_FOUND_ELEMENT,
+            NOTHING_TO_UPDATE, TYPE_MISMATCH, BKEY_MISMATCH,
+            EFLAG_MISMATCH, SERVER_ERROR);
+    getCallback().receivedStatus(status);
     transitionState(OperationState.COMPLETE);
   }
 

--- a/src/main/java/net/spy/memcached/protocol/ascii/GetAttrOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/GetAttrOperationImpl.java
@@ -86,8 +86,7 @@ class GetAttrOperationImpl extends OperationImpl implements GetAttrOperation {
 
       cb.gotAttribute(key, stuff[1]);
     } else {
-      OperationStatus status = matchStatus(line, END, NOT_FOUND,
-              ATTR_ERROR_NOT_FOUND);
+      OperationStatus status = matchStatus(line, END, NOT_FOUND, ATTR_ERROR_NOT_FOUND);
       getLogger().debug(status);
       getCallback().receivedStatus(status);
       transitionState(OperationState.COMPLETE);

--- a/src/main/java/net/spy/memcached/protocol/ascii/MutatorOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/MutatorOperationImpl.java
@@ -85,14 +85,16 @@ final class MutatorOperationImpl extends OperationImpl
     }
     /* ENABLE_MIGRATION end */
 
-    OperationStatus status = null;
-    try {
-      Long.valueOf(line);
-      getCallback().receivedStatus(new OperationStatus(true, line, StatusCode.SUCCESS));
-    } catch (NumberFormatException e) {
+    // <result value>\r\n
+    boolean allDigit = line.chars().allMatch(Character::isDigit);
+    OperationStatus status;
+    if (allDigit) {
+      status = new OperationStatus(true, line, StatusCode.SUCCESS);
+    } else {
       status = matchStatus(line, NOT_FOUND, TYPE_MISMATCH);
-      getCallback().receivedStatus(status);
     }
+
+    getCallback().receivedStatus(status);
     transitionState(OperationState.COMPLETE);
   }
 

--- a/src/main/java/net/spy/memcached/protocol/ascii/SetAttrOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/SetAttrOperationImpl.java
@@ -84,9 +84,9 @@ class SetAttrOperationImpl extends OperationImpl
       return;
     }
     /* ENABLE_MIGRATION end */
-    getCallback().receivedStatus(
-            matchStatus(line, OK, NOT_FOUND, ATTR_ERROR_NOT_FOUND,
-                    ATTR_ERROR_BAD_VALUE));
+    OperationStatus status = matchStatus(line, OK, NOT_FOUND,
+            ATTR_ERROR_NOT_FOUND, ATTR_ERROR_BAD_VALUE);
+    getCallback().receivedStatus(status);
     transitionState(OperationState.COMPLETE);
   }
 

--- a/src/main/java/net/spy/memcached/protocol/ascii/VersionOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/VersionOperationImpl.java
@@ -46,14 +46,14 @@ final class VersionOperationImpl extends OperationImpl
 
   @Override
   public void handleLine(String line) {
-    OperationStatus cause;
+    OperationStatus status;
     if (line.startsWith("VERSION ")) {
-      cause = new OperationStatus(
-              true, line.substring("VERSION ".length()), StatusCode.SUCCESS);
+      status = new OperationStatus(true, line.substring("VERSION ".length()), StatusCode.SUCCESS);
     } else {
-      cause = new OperationStatus(false, line, StatusCode.fromAsciiLine(line));
+      status = new OperationStatus(false, line, StatusCode.fromAsciiLine(line));
     }
-    getCallback().receivedStatus(cause);
+
+    getCallback().receivedStatus(status);
     transitionState(OperationState.COMPLETE);
   }
 


### PR DESCRIPTION
### 🔗 Related Issue
<!-- Please link related issue. ex) https://github.com/naver/arcus-java-client/issues/{issue_number} -->
- https://github.com/jam2in/arcus-works/issues/159

### ⌨️ What I did
- if-else 문 마지막에서 `transitionState(OperationState.COMPLETE);`를 한번만 호출하도록 수정합니다.
    - `CollectionCountOperationImpl`
- `CollectionExistOperationImpl` 클래스의 `handleLine()` 메서드에서,
   `matchStatus()` 메서드를 호출할 때 `NOT_FOUND` 인자가 두 번 사용되는 부분을 한 번만 사용하도록 수정합니다.
- `matchStatus()` 메서드를 호출할 때, 인자가 많아 여러 줄로 작성된 경우 `OperationStatus` 객체를 생성하도록 합니다.
    #### AS-IS
    ```java
    getCallback().receivedStatus(
            matchStatus(line, EXIST, NOT_EXIST, NOT_FOUND, NOT_FOUND,
                    TYPE_MISMATCH, UNREADABLE));
    ```
    
    #### TO-BE
    ```java
    OperationStatus status = matchStatus(line, EXIST, NOT_EXIST,
            NOT_FOUND, TYPE_MISMATCH, UNREADABLE);
    getCallback().receivedStatus(status);
    ```