### PR TITLE
INTERNAL: Add actual elapsed duration to timeout exception message.

### DIFF
--- a/src/main/java/net/spy/memcached/TimedOutMessageFactory.java
+++ b/src/main/java/net/spy/memcached/TimedOutMessageFactory.java
@@ -14,7 +14,9 @@ public final class TimedOutMessageFactory {
 
   public static String createTimedOutMessage(long duration,
                                              TimeUnit unit,
+                                             long elapsed,
                                              Collection<Operation> ops) {
+
     StringBuilder rv = new StringBuilder();
     Operation firstOp = ops.iterator().next();
     if (isBulkOperation(firstOp, ops)) {
@@ -25,7 +27,9 @@ public final class TimedOutMessageFactory {
     }
 
     rv.append(firstOp.getAPIType());
-    rv.append(" operation timed out (>").append(duration);
+    rv.append(" operation timed out (");
+    rv.append(unit.convert(elapsed, TimeUnit.MILLISECONDS));
+    rv.append(" >= ").append(duration);
     rv.append(" ").append(unit).append(") - ");
 
     rv.append("failing node");

--- a/src/main/java/net/spy/memcached/internal/BroadcastFuture.java
+++ b/src/main/java/net/spy/memcached/internal/BroadcastFuture.java
@@ -54,6 +54,8 @@ public class BroadcastFuture<T> extends OperationFuture<T> {
   @Override
   public T get(long duration, TimeUnit unit)
           throws InterruptedException, TimeoutException, ExecutionException {
+
+    long beforeAwait = System.currentTimeMillis();
     if (!latch.await(duration, unit)) {
       // whenever timeout occurs, continuous timeout counter will increase by 1.
       Collection<Operation> timedOutOps = new HashSet<>();
@@ -66,7 +68,8 @@ public class BroadcastFuture<T> extends OperationFuture<T> {
         }
       }
       if (!timedOutOps.isEmpty()) {
-        throw new CheckedOperationTimeoutException(duration, unit, timedOutOps);
+        long elapsed = System.currentTimeMillis() - beforeAwait;
+        throw new CheckedOperationTimeoutException(duration, unit, elapsed, timedOutOps);
       }
     } else {
       // continuous timeout counter will be reset

--- a/src/main/java/net/spy/memcached/internal/BulkGetFuture.java
+++ b/src/main/java/net/spy/memcached/internal/BulkGetFuture.java
@@ -134,6 +134,7 @@ public class BulkGetFuture<T> implements BulkFuture<Map<String, T>> {
   private Map<String, T> internalGet(long to, TimeUnit unit, boolean throwOnTimeout)
            throws InterruptedException, ExecutionException, TimeoutException {
 
+    long beforeAwait = System.currentTimeMillis();
     if (!latch.await(to, unit)) {
       Collection<Operation> timedOutOps = new HashSet<>();
       for (Operation op : ops) {
@@ -147,7 +148,8 @@ public class BulkGetFuture<T> implements BulkFuture<Map<String, T>> {
         MemcachedConnection.opsTimedOut(timedOutOps);
         isTimeout.set(true);
 
-        TimeoutException e = new CheckedOperationTimeoutException(to, unit, timedOutOps);
+        long elapsed = System.currentTimeMillis() - beforeAwait;
+        TimeoutException e = new CheckedOperationTimeoutException(to, unit, elapsed, timedOutOps);
         if (throwOnTimeout) {
           throw e;
         }

--- a/src/main/java/net/spy/memcached/internal/CheckedOperationTimeoutException.java
+++ b/src/main/java/net/spy/memcached/internal/CheckedOperationTimeoutException.java
@@ -34,14 +34,16 @@ public class CheckedOperationTimeoutException extends TimeoutException {
 
   public CheckedOperationTimeoutException(long duration,
                                           TimeUnit unit,
+                                          long elapsed,
                                           Operation op) {
-    this(duration, unit, Collections.singleton(op));
+    this(duration, unit, elapsed, Collections.singleton(op));
   }
 
   public CheckedOperationTimeoutException(long duration,
                                           TimeUnit unit,
+                                          long elapsed,
                                           Collection<Operation> ops) {
-    super(TimedOutMessageFactory.createTimedOutMessage(duration, unit, ops));
+    super(TimedOutMessageFactory.createTimedOutMessage(duration, unit, elapsed, ops));
     operations = ops;
   }
 

--- a/src/main/java/net/spy/memcached/internal/OperationFuture.java
+++ b/src/main/java/net/spy/memcached/internal/OperationFuture.java
@@ -73,10 +73,14 @@ public class OperationFuture<T> extends SpyObject implements Future<T> {
 
   public T get(long duration, TimeUnit unit)
           throws InterruptedException, TimeoutException, ExecutionException {
+
+    long beforeAwait = System.currentTimeMillis();
     if (!latch.await(duration, unit)) {
       // whenever timeout occurs, continuous timeout counter will increase by 1.
       MemcachedConnection.opTimedOut(op);
-      throw new CheckedOperationTimeoutException(duration, unit, op);
+
+      long elapsed = System.currentTimeMillis() - beforeAwait;
+      throw new CheckedOperationTimeoutException(duration, unit, elapsed, op);
     } else {
       // continuous timeout counter will be reset
       MemcachedConnection.opSucceeded(op);

--- a/src/test/java/net/spy/memcached/ArcusTimeoutMessageTest.java
+++ b/src/test/java/net/spy/memcached/ArcusTimeoutMessageTest.java
@@ -20,6 +20,7 @@ import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -29,6 +30,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.regex.Pattern;
 
 import junit.framework.TestCase;
 
@@ -726,11 +728,18 @@ public class ArcusTimeoutMessageTest extends TestCase {
   }
 
   private String createTimedOutMessage(Operation op) {
-    return TimedOutMessageFactory
-            .createTimedOutMessage(1, TimeUnit.MILLISECONDS, Collections.singletonList(op));
+    Collection<Operation> ops = Collections.singleton(op);
+    return TimedOutMessageFactory.createTimedOutMessage(1, TimeUnit.MILLISECONDS, 0, ops);
   }
 
   private String getTimedOutHeadMessage(String message) {
-    return message.split("-")[0];
+    String[] tokens = message.split("-")[0].split(" >= ");
+    String token = tokens[0];
+
+    token = token.substring(0, token.lastIndexOf('('));
+    String result = (token + "(>= " + tokens[1]).trim();
+
+    assertTrue(Pattern.matches("[A-Z]+ operation timed out \\(>= [0-9]+ [A-Z]+\\)", result));
+    return result;
   }
 }

--- a/src/test/java/net/spy/memcached/internal/CheckedOperationTimeoutExceptionTest.java
+++ b/src/test/java/net/spy/memcached/internal/CheckedOperationTimeoutExceptionTest.java
@@ -34,30 +34,31 @@ public class CheckedOperationTimeoutExceptionTest extends TestCase {
 
   private final long duration = 1;
   private final TimeUnit unit = TimeUnit.MILLISECONDS;
+  private final long elapsed = 5;
 
   public void testSingleOperation() {
     Operation op = buildOp(11211);
-    Exception e = new CheckedOperationTimeoutException(duration, unit, op);
+    Exception e = new CheckedOperationTimeoutException(duration, unit, elapsed, op);
 
     String expected = CheckedOperationTimeoutException.class.getName() +
-            ": UNDEFINED operation timed out (>1 MILLISECONDS)" +
+            ": UNDEFINED operation timed out (5 >= 1 MILLISECONDS)" +
             " - failing node: localhost:11211 [WRITE_QUEUED] [MOCK_STATE]";
     assertEquals(expected, e.toString());
   }
 
   public void testNullNode() {
     Operation op = new TestOperation();
-    Exception e = new CheckedOperationTimeoutException(duration, unit, op);
+    Exception e = new CheckedOperationTimeoutException(duration, unit, elapsed, op);
 
     String expected = CheckedOperationTimeoutException.class.getName() +
-            ": UNDEFINED operation timed out (>1 MILLISECONDS)" +
+            ": UNDEFINED operation timed out (5 >= 1 MILLISECONDS)" +
             " - failing node: <unknown> [WRITE_QUEUED]";
     assertEquals(expected, e.toString());
   }
 
   public void testNullOperation() {
     try {
-      Exception e = new CheckedOperationTimeoutException(duration, unit, (Operation) null);
+      Exception e = new CheckedOperationTimeoutException(duration, unit, elapsed, (Operation) null);
       fail("NullPointerException is NOT thrown... " + e.getMessage());
     } catch (Exception e) {
       e.printStackTrace();
@@ -69,10 +70,10 @@ public class CheckedOperationTimeoutExceptionTest extends TestCase {
     Collection<Operation> ops = new ArrayList<>();
     ops.add(buildOp(11211));
     ops.add(buildOp(64212));
-    Exception e = new CheckedOperationTimeoutException(duration, unit, ops);
+    Exception e = new CheckedOperationTimeoutException(duration, unit, elapsed, ops);
 
     String expected = CheckedOperationTimeoutException.class.getName() +
-            ": UNDEFINED operation timed out (>1 MILLISECONDS)" +
+            ": UNDEFINED operation timed out (5 >= 1 MILLISECONDS)" +
             " - failing nodes: localhost:11211 [WRITE_QUEUED] [MOCK_STATE]," +
             " localhost:64212 [WRITE_QUEUED] [MOCK_STATE]";
     assertEquals(expected, e.toString());


### PR DESCRIPTION
### 🔗 Related Issue

<!-- Please link related issue. ex) https://github.com/naver/arcus-java-client/issues/{issue_number} -->
- https://github.com/jam2in/arcus-works/issues/573

### ⌨️ What I did

<!-- Please describe this PR and what you've been working on. -->
- CountDownLatch.await() 수행 전의 시점을 기록한 뒤, Timeout 메세지를 생성할 때 현재 시점과의 차이를 계산합니다.
- CountDownLatch.await() 수행 직후의 시점을 기록하지 않은 이유는 다음과 같습니다.
  - CPU가 충분할 경우 : CountDownLatch.await() 수행 직후의 시점과 Timeout 메세지를 생성할 때의 시점에 큰 차이가 없음
  - CPU가 부족할 경우 : Timeout 메세지를 생성할 때의 시점을 선택해야 CPU 부족 상태를 더욱 확실하게 인지 가능