### PR TITLE
FIX: Concurrency problem in locator allNodes.

### DIFF
--- a/src/main/java/net/spy/memcached/ArcusKetamaNodeLocator.java
+++ b/src/main/java/net/spy/memcached/ArcusKetamaNodeLocator.java
@@ -41,7 +41,7 @@ import net.spy.memcached.util.ArcusKetamaNodeLocatorConfiguration;
 public class ArcusKetamaNodeLocator extends SpyObject implements NodeLocator {
 
   private final TreeMap<Long, SortedSet<MemcachedNode>> ketamaNodes;
-  private final Collection<MemcachedNode> allNodes;
+  private Collection<MemcachedNode> allNodes;
 
   /* ENABLE_MIGRATION if */
   private TreeMap<Long, SortedSet<MemcachedNode>> ketamaAlterNodes;
@@ -206,15 +206,16 @@ public class ArcusKetamaNodeLocator extends SpyObject implements NodeLocator {
                      Collection<MemcachedNode> toDelete) {
     lock.lock();
     try {
+      ArrayList<MemcachedNode> newAllNodes = new ArrayList<>(allNodes);
       // Add memcached nodes.
       for (MemcachedNode node : toAttach) {
-        allNodes.add(node);
+        newAllNodes.add(node);
         insertHash(node);
       }
 
       // Remove memcached nodes.
       for (MemcachedNode node : toDelete) {
-        allNodes.remove(node);
+        newAllNodes.remove(node);
         removeHash(node);
         try {
           node.closeChannel();
@@ -223,6 +224,7 @@ public class ArcusKetamaNodeLocator extends SpyObject implements NodeLocator {
                   "Failed to closeChannel the node : " + node);
         }
       }
+      allNodes = newAllNodes;
     } finally {
       /* ENABLE_MIGRATION if */
       if (migrationInProgress && alterNodes.isEmpty()) {

--- a/src/main/java/net/spy/memcached/ArcusReplKetamaNodeLocator.java
+++ b/src/main/java/net/spy/memcached/ArcusReplKetamaNodeLocator.java
@@ -42,7 +42,7 @@ public class ArcusReplKetamaNodeLocator extends SpyObject implements NodeLocator
 
   private final TreeMap<Long, SortedSet<MemcachedReplicaGroup>> ketamaGroups;
   private final HashMap<String, MemcachedReplicaGroup> allGroups;
-  private final Collection<MemcachedNode> allNodes;
+  private Collection<MemcachedNode> allNodes;
 
   /* ENABLE_MIGRATION if */
   private TreeMap<Long, SortedSet<MemcachedReplicaGroup>> ketamaAlterGroups;
@@ -251,9 +251,10 @@ public class ArcusReplKetamaNodeLocator extends SpyObject implements NodeLocator
      */
     lock.lock();
     try {
+      ArrayList<MemcachedNode> newAllNodes = new ArrayList<>(allNodes);
       // Remove memcached nodes.
       for (MemcachedNode node : toDelete) {
-        allNodes.remove(node);
+        newAllNodes.remove(node);
         removeNodeFromGroup(node);
         try {
           node.closeChannel();
@@ -269,7 +270,7 @@ public class ArcusReplKetamaNodeLocator extends SpyObject implements NodeLocator
 
       // Add memcached nodes.
       for (MemcachedNode node : toAttach) {
-        allNodes.add(node);
+        newAllNodes.add(node);
         insertNodeIntoGroup(node);
       }
 
@@ -280,6 +281,7 @@ public class ArcusReplKetamaNodeLocator extends SpyObject implements NodeLocator
         removeHash(group);
       }
       toDeleteGroups.clear();
+      allNodes = newAllNodes;
     } finally {
       /* ENABLE_MIGRATION if */
       if (migrationInProgress && alterNodes.isEmpty()) {


### PR DESCRIPTION
## 이슈
https://github.com/jam2in/arcus-works/issues/490#issuecomment-2199206597
위 코멘트 말고도 Braodcast 연산 시에 getAll()을 호출하는데
read는 worker-thread 로 write는 IO 스레드에 의해서
ConcurrentModificationException이 발생할 수도 있습니다.

왜냐하면 기존 구현은 리턴되는 Collections.unmodifiableCollection이
allNodes 참조와 연결되어있기 때문입니다.

반환 값에 새로운 참조를 넣어서 기존 allNodes 참조와의 
연결을 끊어주면 동시성 문제가 발생하지 않습니다.

다른 대안으로는 `new CopyOnWriteArrayList<>(allNodes);`와 같은 타입을 리턴할 수도 있습니다.
다만 alterNodes와의 구현 통일성 때문에 현재 구현을 채택했습니다.

참고로 alterNodes는 위와 같이 서로 다른 스레드가 
각각 동시에 read/write 하는 로직이 존재하지 않습니다.