### PR TITLE
CLEANUP: use bkey instead of subkey when it only related to btree

### DIFF
--- a/src/main/java/net/spy/memcached/ArcusClient.java
+++ b/src/main/java/net/spy/memcached/ArcusClient.java
@@ -2105,16 +2105,16 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
         }
 
         @Override
-        public void gotData(String key, int flags, Object subkey, byte[] eflag, byte[] data) {
+        public void gotData(String key, int flags, Object bkey, byte[] eflag, byte[] data) {
           if (stopCollect.get()) {
             return;
           }
 
-          if (subkey instanceof Long) {
-            eachResult.add(new SMGetElement<>(key, (Long) subkey, eflag,
+          if (bkey instanceof Long) {
+            eachResult.add(new SMGetElement<>(key, (Long) bkey, eflag,
                     tc.decode(new CachedData(flags, data, tc.getMaxSize()))));
-          } else if (subkey instanceof byte[]) {
-            eachResult.add(new SMGetElement<>(key, (byte[]) subkey, eflag,
+          } else if (bkey instanceof byte[]) {
+            eachResult.add(new SMGetElement<>(key, (byte[]) bkey, eflag,
                     tc.decode(new CachedData(flags, data, tc.getMaxSize()))));
           }
         }
@@ -2170,16 +2170,16 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
         }
 
         @Override
-        public void gotData(String key, int flags, Object subkey, byte[] eflag, byte[] data) {
+        public void gotData(String key, int flags, Object bkey, byte[] eflag, byte[] data) {
           if (stopCollect.get()) {
             return;
           }
 
-          if (subkey instanceof Long) {
-            eachResult.add(new SMGetElement<>(key, (Long) subkey, eflag,
+          if (bkey instanceof Long) {
+            eachResult.add(new SMGetElement<>(key, (Long) bkey, eflag,
                     tc.decode(new CachedData(flags, data, tc.getMaxSize()))));
           } else {
-            eachResult.add(new SMGetElement<>(key, (byte[]) subkey, eflag,
+            eachResult.add(new SMGetElement<>(key, (byte[]) bkey, eflag,
                     tc.decode(new CachedData(flags, data, tc.getMaxSize()))));
           }
         }
@@ -2194,15 +2194,15 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
         }
 
         @Override
-        public void gotTrimmedKey(String key, Object subkey) {
+        public void gotTrimmedKey(String key, Object bkey) {
           if (stopCollect.get()) {
             return;
           }
 
-          if (subkey instanceof Long) {
-            result.addTrimmedKey(key, new BKeyObject((Long) subkey));
+          if (bkey instanceof Long) {
+            result.addTrimmedKey(key, new BKeyObject((Long) bkey));
           } else {
-            result.addTrimmedKey(key, new BKeyObject((byte[]) subkey));
+            result.addTrimmedKey(key, new BKeyObject((byte[]) bkey));
           }
         }
       });

--- a/src/main/java/net/spy/memcached/ArcusClientPool.java
+++ b/src/main/java/net/spy/memcached/ArcusClientPool.java
@@ -1428,47 +1428,47 @@ public class ArcusClientPool implements MemcachedClientIF, ArcusClientIF {
   }
 
   @Override
-  public CollectionFuture<Long> asyncBopIncr(String key, long subkey, int by) {
-    return this.getClient().asyncBopIncr(key, subkey, by);
+  public CollectionFuture<Long> asyncBopIncr(String key, long bkey, int by) {
+    return this.getClient().asyncBopIncr(key, bkey, by);
   }
 
   @Override
-  public CollectionFuture<Long> asyncBopIncr(String key, byte[] subkey, int by) {
-    return this.getClient().asyncBopIncr(key, subkey, by);
+  public CollectionFuture<Long> asyncBopIncr(String key, byte[] bkey, int by) {
+    return this.getClient().asyncBopIncr(key, bkey, by);
   }
 
   @Override
-  public CollectionFuture<Long> asyncBopIncr(String key, long subkey,
+  public CollectionFuture<Long> asyncBopIncr(String key, long bkey,
                                              int by, long initial, byte[] eFlag) {
-    return this.getClient().asyncBopIncr(key, subkey, by, initial, eFlag);
+    return this.getClient().asyncBopIncr(key, bkey, by, initial, eFlag);
   }
 
   @Override
-  public CollectionFuture<Long> asyncBopIncr(String key, byte[] subkey,
+  public CollectionFuture<Long> asyncBopIncr(String key, byte[] bkey,
                                              int by, long initial, byte[] eFlag) {
-    return this.getClient().asyncBopIncr(key, subkey, by, initial, eFlag);
+    return this.getClient().asyncBopIncr(key, bkey, by, initial, eFlag);
   }
 
   @Override
-  public CollectionFuture<Long> asyncBopDecr(String key, long subkey, int by) {
-    return this.getClient().asyncBopDecr(key, subkey, by);
+  public CollectionFuture<Long> asyncBopDecr(String key, long bkey, int by) {
+    return this.getClient().asyncBopDecr(key, bkey, by);
   }
 
   @Override
-  public CollectionFuture<Long> asyncBopDecr(String key, byte[] subkey, int by) {
-    return this.getClient().asyncBopDecr(key, subkey, by);
+  public CollectionFuture<Long> asyncBopDecr(String key, byte[] bkey, int by) {
+    return this.getClient().asyncBopDecr(key, bkey, by);
   }
 
   @Override
-  public CollectionFuture<Long> asyncBopDecr(String key, long subkey,
+  public CollectionFuture<Long> asyncBopDecr(String key, long bkey,
                                              int by, long initial, byte[] eFlag) {
-    return this.getClient().asyncBopDecr(key, subkey, by, initial, eFlag);
+    return this.getClient().asyncBopDecr(key, bkey, by, initial, eFlag);
   }
 
   @Override
-  public CollectionFuture<Long> asyncBopDecr(String key, byte[] subkey,
+  public CollectionFuture<Long> asyncBopDecr(String key, byte[] bkey,
                                              int by, long initial, byte[] eFlag) {
-    return this.getClient().asyncBopDecr(key, subkey, by, initial, eFlag);
+    return this.getClient().asyncBopDecr(key, bkey, by, initial, eFlag);
   }
 
   @Override

--- a/src/main/java/net/spy/memcached/collection/BTreeGetBulk.java
+++ b/src/main/java/net/spy/memcached/collection/BTreeGetBulk.java
@@ -38,7 +38,7 @@ public interface BTreeGetBulk<T> {
 
   boolean headerReady(int spaceCount);
 
-  Object getSubkey();
+  Object getBkey();
 
   int getDataLength();
 

--- a/src/main/java/net/spy/memcached/collection/BTreeGetBulkImpl.java
+++ b/src/main/java/net/spy/memcached/collection/BTreeGetBulkImpl.java
@@ -38,7 +38,7 @@ public abstract class BTreeGetBulkImpl<T> implements BTreeGetBulk<T> {
   protected final int offset;
   protected final int count;
 
-  protected Object subkey;
+  protected Object bkey;
   private int dataLength;
   private byte[] eflag = null;
 
@@ -118,12 +118,12 @@ public abstract class BTreeGetBulkImpl<T> implements BTreeGetBulk<T> {
   public void decodeItemHeader(String[] splited) {
     if (splited.length == 3) {
       // ELEMENT <bkey> <bytes>
-      this.subkey = decodeSubkey(splited[1]);
+      this.bkey = decodeBkey(splited[1]);
       this.dataLength = Integer.parseInt(splited[2]);
       this.eflag = null;
     } else if (splited.length == 4) {
       // ELEMENT <bkey> <eflag> <bytes>
-      this.subkey = decodeSubkey(splited[1]);
+      this.bkey = decodeBkey(splited[1]);
       this.eflag = BTreeUtil.hexStringToByteArrays(splited[2].substring(2));
       this.dataLength = Integer.parseInt(splited[3]);
     }
@@ -145,5 +145,5 @@ public abstract class BTreeGetBulkImpl<T> implements BTreeGetBulk<T> {
     return eflag;
   }
 
-  protected abstract Object decodeSubkey(String subkey);
+  protected abstract Object decodeBkey(String bkey);
 }

--- a/src/main/java/net/spy/memcached/collection/BTreeGetBulkWithByteTypeBkey.java
+++ b/src/main/java/net/spy/memcached/collection/BTreeGetBulkWithByteTypeBkey.java
@@ -38,12 +38,12 @@ public class BTreeGetBulkWithByteTypeBkey<T> extends BTreeGetBulkImpl<T> {
     super(node, keyList, range, eFlagFilter, offset, count);
   }
 
-  public byte[] getSubkey() {
-    return (byte[]) subkey;
+  public byte[] getBkey() {
+    return (byte[]) bkey;
   }
 
-  protected Object decodeSubkey(String subkey) {
-    return BTreeUtil.hexStringToByteArrays(subkey.substring(2));
+  protected Object decodeBkey(String bkey) {
+    return BTreeUtil.hexStringToByteArrays(bkey.substring(2));
   }
 
   @Override

--- a/src/main/java/net/spy/memcached/collection/BTreeGetBulkWithLongTypeBkey.java
+++ b/src/main/java/net/spy/memcached/collection/BTreeGetBulkWithLongTypeBkey.java
@@ -36,12 +36,12 @@ public class BTreeGetBulkWithLongTypeBkey<T> extends BTreeGetBulkImpl<T> {
     super(node, keyList, range, eFlagFilter, offset, count);
   }
 
-  public Long getSubkey() {
-    return (Long) subkey;
+  public Long getBkey() {
+    return (Long) bkey;
   }
 
-  protected Object decodeSubkey(String subkey) {
-    return Long.parseLong(subkey);
+  protected Object decodeBkey(String bkey) {
+    return Long.parseLong(bkey);
   }
 
   @Override

--- a/src/main/java/net/spy/memcached/collection/BTreeSMGet.java
+++ b/src/main/java/net/spy/memcached/collection/BTreeSMGet.java
@@ -42,7 +42,7 @@ public interface BTreeSMGet<T> {
 
   int getFlags();
 
-  Object getSubkey();
+  Object getBkey();
 
   int getDataLength();
 

--- a/src/main/java/net/spy/memcached/collection/BTreeSMGetImpl.java
+++ b/src/main/java/net/spy/memcached/collection/BTreeSMGetImpl.java
@@ -41,7 +41,7 @@ public abstract class BTreeSMGetImpl<T> implements BTreeSMGet<T> {
 
   private String key;
   private int flags;
-  protected Object subkey;
+  protected Object bkey;
   private int dataLength;
   private byte[] eflag = null;
 
@@ -156,7 +156,7 @@ public abstract class BTreeSMGetImpl<T> implements BTreeSMGet<T> {
 
     this.key = splited[0];
     this.flags = Integer.parseInt(splited[1]);
-    this.subkey = decodeSubkey(splited[2]);
+    this.bkey = decodeBkey(splited[2]);
 
     if (splited.length == 4) {
       // <key> <flags> <bkey> <bytes>
@@ -169,5 +169,5 @@ public abstract class BTreeSMGetImpl<T> implements BTreeSMGet<T> {
     }
   }
 
-  protected abstract Object decodeSubkey(String subkey);
+  protected abstract Object decodeBkey(String bkey);
 }

--- a/src/main/java/net/spy/memcached/collection/BTreeSMGetWithByteTypeBkey.java
+++ b/src/main/java/net/spy/memcached/collection/BTreeSMGetWithByteTypeBkey.java
@@ -39,13 +39,13 @@ public class BTreeSMGetWithByteTypeBkey<T> extends BTreeSMGetImpl<T> {
   }
 
   @Override
-  public byte[] getSubkey() {
-    return (byte[]) subkey;
+  public byte[] getBkey() {
+    return (byte[]) bkey;
   }
 
   @Override
-  protected Object decodeSubkey(String subkey) {
-    return BTreeUtil.hexStringToByteArrays(subkey.substring(2));
+  protected Object decodeBkey(String bkey) {
+    return BTreeUtil.hexStringToByteArrays(bkey.substring(2));
   }
 
   @Override

--- a/src/main/java/net/spy/memcached/collection/BTreeSMGetWithByteTypeBkeyOld.java
+++ b/src/main/java/net/spy/memcached/collection/BTreeSMGetWithByteTypeBkeyOld.java
@@ -40,13 +40,13 @@ public class BTreeSMGetWithByteTypeBkeyOld<T> extends BTreeSMGetImpl<T> {
   }
 
   @Override
-  public byte[] getSubkey() {
-    return (byte[]) subkey;
+  public byte[] getBkey() {
+    return (byte[]) bkey;
   }
 
   @Override
-  protected Object decodeSubkey(String subkey) {
-    return BTreeUtil.hexStringToByteArrays(subkey.substring(2));
+  protected Object decodeBkey(String bkey) {
+    return BTreeUtil.hexStringToByteArrays(bkey.substring(2));
   }
 
   @Override

--- a/src/main/java/net/spy/memcached/collection/BTreeSMGetWithLongTypeBkey.java
+++ b/src/main/java/net/spy/memcached/collection/BTreeSMGetWithLongTypeBkey.java
@@ -37,13 +37,13 @@ public class BTreeSMGetWithLongTypeBkey<T> extends BTreeSMGetImpl<T> {
   }
 
   @Override
-  public Long getSubkey() {
-    return (Long) subkey;
+  public Long getBkey() {
+    return (Long) bkey;
   }
 
   @Override
-  protected Object decodeSubkey(String subkey) {
-    return Long.parseLong(subkey);
+  protected Object decodeBkey(String bkey) {
+    return Long.parseLong(bkey);
   }
 
   @Override

--- a/src/main/java/net/spy/memcached/collection/BTreeSMGetWithLongTypeBkeyOld.java
+++ b/src/main/java/net/spy/memcached/collection/BTreeSMGetWithLongTypeBkeyOld.java
@@ -38,13 +38,13 @@ public class BTreeSMGetWithLongTypeBkeyOld<T> extends BTreeSMGetImpl<T> {
   }
 
   @Override
-  public Long getSubkey() {
-    return (Long) subkey;
+  public Long getBkey() {
+    return (Long) bkey;
   }
 
   @Override
-  protected Object decodeSubkey(String subkey) {
-    return Long.parseLong(subkey);
+  protected Object decodeBkey(String bkey) {
+    return Long.parseLong(bkey);
   }
 
   @Override

--- a/src/main/java/net/spy/memcached/ops/BTreeGetBulkOperation.java
+++ b/src/main/java/net/spy/memcached/ops/BTreeGetBulkOperation.java
@@ -22,7 +22,7 @@ public interface BTreeGetBulkOperation extends KeyedOperation {
   BTreeGetBulk<?> getBulk();
 
   interface Callback extends OperationCallback {
-    void gotElement(String key, int flags, Object subkey, byte[] eflag, byte[] data);
+    void gotElement(String key, int flags, Object bkey, byte[] eflag, byte[] data);
 
     void gotKey(String key, int elementCount, OperationStatus status);
   }

--- a/src/main/java/net/spy/memcached/ops/BTreeSortMergeGetOperation.java
+++ b/src/main/java/net/spy/memcached/ops/BTreeSortMergeGetOperation.java
@@ -22,10 +22,10 @@ public interface BTreeSortMergeGetOperation extends KeyedOperation {
   BTreeSMGet<?> getSMGet();
 
   interface Callback extends OperationCallback {
-    void gotData(String key, int flags, Object subkey, byte[] eflag, byte[] data);
+    void gotData(String key, int flags, Object bkey, byte[] eflag, byte[] data);
 
     void gotMissedKey(String key, OperationStatus cause);
 
-    void gotTrimmedKey(String key, Object subkey);
+    void gotTrimmedKey(String key, Object bkey);
   }
 }

--- a/src/main/java/net/spy/memcached/ops/BTreeSortMergeGetOperationOld.java
+++ b/src/main/java/net/spy/memcached/ops/BTreeSortMergeGetOperationOld.java
@@ -18,7 +18,7 @@ package net.spy.memcached.ops;
 
 public interface BTreeSortMergeGetOperationOld extends KeyedOperation {
   interface Callback extends OperationCallback {
-    void gotData(String key, int flags, Object subkey, byte[] eflag, byte[] data);
+    void gotData(String key, int flags, Object bkey, byte[] eflag, byte[] data);
 
     void gotMissedKey(byte[] data);
   }

--- a/src/main/java/net/spy/memcached/ops/MultiBTreeGetBulkOperationCallback.java
+++ b/src/main/java/net/spy/memcached/ops/MultiBTreeGetBulkOperationCallback.java
@@ -25,8 +25,8 @@ public class MultiBTreeGetBulkOperationCallback extends MultiOperationCallback
   }
 
   @Override
-  public void gotElement(String key, int flags, Object subkey, byte[] eflag, byte[] data) {
-    ((BTreeGetBulkOperation.Callback) originalCallback).gotElement(key, flags, subkey, eflag, data);
+  public void gotElement(String key, int flags, Object bkey, byte[] eflag, byte[] data) {
+    ((BTreeGetBulkOperation.Callback) originalCallback).gotElement(key, flags, bkey, eflag, data);
   }
 
   @Override

--- a/src/main/java/net/spy/memcached/ops/MultiBTreeSortMergeGetOperationCallback.java
+++ b/src/main/java/net/spy/memcached/ops/MultiBTreeSortMergeGetOperationCallback.java
@@ -25,9 +25,9 @@ public class MultiBTreeSortMergeGetOperationCallback extends MultiOperationCallb
   }
 
   @Override
-  public void gotData(String key, int flags, Object subkey, byte[] eflag, byte[] data) {
+  public void gotData(String key, int flags, Object bkey, byte[] eflag, byte[] data) {
     ((BTreeSortMergeGetOperation.Callback) originalCallback).gotData(key, flags,
-        subkey, eflag, data);
+            bkey, eflag, data);
   }
 
   @Override
@@ -36,7 +36,7 @@ public class MultiBTreeSortMergeGetOperationCallback extends MultiOperationCallb
   }
 
   @Override
-  public void gotTrimmedKey(String key, Object subkey) {
-    ((BTreeSortMergeGetOperation.Callback) originalCallback).gotTrimmedKey(key, subkey);
+  public void gotTrimmedKey(String key, Object bkey) {
+    ((BTreeSortMergeGetOperation.Callback) originalCallback).gotTrimmedKey(key, bkey);
   }
 }

--- a/src/main/java/net/spy/memcached/protocol/ascii/BTreeGetBulkOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/BTreeGetBulkOperationImpl.java
@@ -189,7 +189,7 @@ public class BTreeGetBulkOperationImpl extends OperationImpl implements
 
     if (lookingFor == '\0' && readOffset == data.length) {
       BTreeGetBulkOperation.Callback cb = (BTreeGetBulkOperation.Callback) getCallback();
-      cb.gotElement(key, flags, getBulk.getSubkey(), getBulk.getEFlag(), data);
+      cb.gotElement(key, flags, getBulk.getBkey(), getBulk.getEFlag(), data);
       lookingFor = '\r';
     }
 

--- a/src/main/java/net/spy/memcached/protocol/ascii/BTreeSortMergeGetOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/BTreeSortMergeGetOperationImpl.java
@@ -252,7 +252,7 @@ public class BTreeSortMergeGetOperationImpl extends OperationImpl implements
 
     if (lookingFor == '\0' && readOffset == data.length && count < lineCount) {
       BTreeSortMergeGetOperation.Callback cb = (BTreeSortMergeGetOperation.Callback) getCallback();
-      cb.gotData(smGet.getKey(), smGet.getFlags(), smGet.getSubkey(), smGet.getEflag(), data);
+      cb.gotData(smGet.getKey(), smGet.getFlags(), smGet.getBkey(), smGet.getEflag(), data);
       lookingFor = '\r';
     }
 

--- a/src/main/java/net/spy/memcached/protocol/ascii/BTreeSortMergeGetOperationOldImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/BTreeSortMergeGetOperationOldImpl.java
@@ -214,7 +214,7 @@ public class BTreeSortMergeGetOperationOldImpl extends OperationImpl implements
     if (lookingFor == '\0' && readOffset == data.length) {
       BTreeSortMergeGetOperationOld.Callback cb =
           (BTreeSortMergeGetOperationOld.Callback) getCallback();
-      cb.gotData(smGet.getKey(), smGet.getFlags(), smGet.getSubkey(), smGet.getEflag(), data);
+      cb.gotData(smGet.getKey(), smGet.getFlags(), smGet.getBkey(), smGet.getEflag(), data);
       lookingFor = '\r';
     }
 

--- a/src/main/java/net/spy/memcached/protocol/binary/BinaryOperationFactory.java
+++ b/src/main/java/net/spy/memcached/protocol/binary/BinaryOperationFactory.java
@@ -196,14 +196,6 @@ public class BinaryOperationFactory extends BaseOperationFactory {
             "CollectionInsertOperation is not supported in binary protocol yet.");
   }
 
-  public CollectionInsertOperation collectionInsert(String key, byte[] subkey,
-                                                    CollectionInsert<?> collectionInsert,
-                                                    byte[] data,
-                                                    OperationCallback cb) {
-    throw new RuntimeException(
-            "CollectionInsertOperation is not supported in binary protocol yet.");
-  }
-
   public CollectionPipedInsertOperation collectionPipedInsert(String key,
                                                               CollectionPipedInsert<?> insert,
                                                               OperationCallback cb) {

--- a/src/test/manual/net/spy/memcached/MultibyteKeyTest.java
+++ b/src/test/manual/net/spy/memcached/MultibyteKeyTest.java
@@ -287,7 +287,7 @@ public class MultibyteKeyTest {
                       keyList, 0L, 100L, ElementFlagFilter.DO_NOT_FILTER, 0, SMGetMode.UNIQUE),
           new BTreeSortMergeGetOperation.Callback() {
             @Override
-            public void gotData(String key, int flags, Object subkey, byte[] eflag, byte[] data) {
+            public void gotData(String key, int flags, Object bkey, byte[] eflag, byte[] data) {
             }
 
             @Override
@@ -295,7 +295,7 @@ public class MultibyteKeyTest {
             }
 
             @Override
-            public void gotTrimmedKey(String key, Object subkey) {
+            public void gotTrimmedKey(String key, Object bkey) {
             }
 
             @Override
@@ -319,7 +319,7 @@ public class MultibyteKeyTest {
                       keyList, 0L, 100L, ElementFlagFilter.DO_NOT_FILTER, 0, 0),
           new BTreeSortMergeGetOperationOld.Callback() {
             @Override
-            public void gotData(String key, int flags, Object subkey, byte[] eflag, byte[] data) {
+            public void gotData(String key, int flags, Object bkey, byte[] eflag, byte[] data) {
             }
 
             @Override
@@ -425,7 +425,7 @@ public class MultibyteKeyTest {
           new BTreeGet(from, to, 0, 0, false, false, ElementFlagFilter.DO_NOT_FILTER),
           new CollectionGetOperation.Callback() {
             @Override
-            public void gotData(String subkey, int flags, byte[] data, byte[] eflag) {
+            public void gotData(String bkey, int flags, byte[] data, byte[] eflag) {
             }
 
             @Override
@@ -517,7 +517,7 @@ public class MultibyteKeyTest {
           ),
           new BTreeGetBulkOperation.Callback() {
             @Override
-            public void gotElement(String key, int flags, Object subkey,
+            public void gotElement(String key, int flags, Object bkey,
                                    byte[] eflag, byte[] data) {
             }
 


### PR DESCRIPTION
### 🔗 Related Issue
- https://github.com/naver/arcus-java-client/issues/521
### ⌨️ What I did
- btree에서만 사용되는 메서드/필드의 경우 subkey라는 용어 대신 bkey라는 용어를 사용하도록 합니다.
- btree외에 list, set, map에서 함께 사용되는 메서드/필드의 경우 변경하지 않았습니다.
- BinaryOperationFactory에서 사용되지 않는 collectionInsert 메서드를 제거했습니다.
- CollectionGet 추상 클래스의 경우 subkey 필드가 존재하고, 이를 ListGet, MapGet, BTreeGet, BTreeFindPositionWithGet 등 상속클래스에서 사용합니다. 여기서 BTreeGet, BTreeFindPositionWithGet 내부적으로 bkey라는 용어를 사용할 수 없습니다. 이러한 구조는 이슈를 생성해 다른 PR로 개선하도록 하겠습니다.