### PR TITLE
INTERNAL: add mop upsert API

### DIFF
--- a/src/main/java/net/spy/memcached/ArcusClient.java
+++ b/src/main/java/net/spy/memcached/ArcusClient.java
@@ -101,6 +101,7 @@ import net.spy.memcached.collection.MapDelete;
 import net.spy.memcached.collection.MapGet;
 import net.spy.memcached.collection.MapInsert;
 import net.spy.memcached.collection.MapUpdate;
+import net.spy.memcached.collection.MapUpsert;
 import net.spy.memcached.collection.SMGetElement;
 import net.spy.memcached.collection.SMGetMode;
 import net.spy.memcached.collection.SetCreate;
@@ -2235,6 +2236,25 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
     BTreeUpsert<T> bTreeUpsert = new BTreeUpsert<>(value, elementFlag, null, attributesForCreate);
 
     return asyncCollectionInsert(key, String.valueOf(bkey), bTreeUpsert, tc);
+  }
+
+  @Override
+  public CollectionFuture<Boolean> asyncMopUpsert(String key, String mkey, Object value,
+                                                  CollectionAttributes attributesForCreate) {
+    validateMKey(mkey);
+    MapUpsert<Object> mapUpsert = new MapUpsert<>(value, attributesForCreate);
+
+    return asyncCollectionInsert(key, mkey, mapUpsert, collectionTranscoder);
+  }
+
+  @Override
+  public <T> CollectionFuture<Boolean> asyncMopUpsert(String key, String mkey, T value,
+                                                      CollectionAttributes attributesForCreate,
+                                                      Transcoder<T> tc) {
+    validateMKey(mkey);
+    MapUpsert<T> mapUpsert = new MapUpsert<>(value, attributesForCreate);
+
+    return asyncCollectionInsert(key, mkey, mapUpsert, tc);
   }
 
   @Override

--- a/src/main/java/net/spy/memcached/ArcusClientIF.java
+++ b/src/main/java/net/spy/memcached/ArcusClientIF.java
@@ -1473,6 +1473,45 @@ public interface ArcusClientIF {
                                                Transcoder<T> tc);
 
   /**
+   * Insert or Update an element.
+   * <p>
+   * If element does not exist in the map, insert the element.
+   * If element exists in the map, the value of element will be updated.
+   * If map does not exist and attributesForCreate argument is not null,
+   * new map will be created by attributes and the element will be inserted.
+   *
+   * @param key                 key of a map
+   * @param mkey                key of a map element
+   * @param value               value of a map element
+   * @param attributesForCreate create a map with attributes, if given key is not exists.
+   * @return a future indicating success, false if there was no key and
+   * attributesForCreate argument is null.
+   */
+  CollectionFuture<Boolean> asyncMopUpsert(String key, String mkey, Object value,
+                                           CollectionAttributes attributesForCreate);
+
+  /**
+   * Insert or Update an element.
+   * <p>
+   * If element does not exist in the map, insert the element.
+   * If element exists in the map, the value of element will be updated.
+   * If map does not exist and attributesForCreate argument is not null,
+   * new map will be created by attributes and the element will be inserted.
+   *
+   * @param <T>                 the expected class of the value
+   * @param key                 key of a map
+   * @param mkey                key of a map element
+   * @param value               value of a map element
+   * @param attributesForCreate create a map with attributes, if given key is not exists.
+   * @param tc                  transcoder to encode value
+   * @return a future indicating success, false if there was no key and
+   * attributesForCreate argument is null.
+   */
+  <T> CollectionFuture<Boolean> asyncMopUpsert(String key, String mkey, T value,
+                                               CollectionAttributes attributesForCreate,
+                                               Transcoder<T> tc);
+
+  /**
    * Update an element from the b+tree
    *
    * @param key         key of a b+tree

--- a/src/main/java/net/spy/memcached/ArcusClientPool.java
+++ b/src/main/java/net/spy/memcached/ArcusClientPool.java
@@ -1149,6 +1149,19 @@ public class ArcusClientPool implements MemcachedClientIF, ArcusClientIF {
   }
 
   @Override
+  public CollectionFuture<Boolean> asyncMopUpsert(String key, String mkey, Object value,
+                                                  CollectionAttributes attributesForCreate) {
+    return this.getClient().asyncMopUpsert(key, mkey, value, attributesForCreate);
+  }
+
+  @Override
+  public <T> CollectionFuture<Boolean> asyncMopUpsert(String key, String mkey, T value,
+                                                      CollectionAttributes attributesForCreate,
+                                                      Transcoder<T> tc) {
+    return this.getClient().asyncMopUpsert(key, mkey, value, attributesForCreate, tc);
+  }
+
+  @Override
   public CollectionFuture<Boolean> asyncBopInsert(String key, byte[] bkey,
                                                   byte[] eFlag, Object value,
                                                   CollectionAttributes attributesForCreate) {

--- a/src/main/java/net/spy/memcached/collection/MapUpsert.java
+++ b/src/main/java/net/spy/memcached/collection/MapUpsert.java
@@ -1,0 +1,16 @@
+package net.spy.memcached.collection;
+
+public class MapUpsert<T> extends CollectionInsert<T> {
+
+  private static final String command = "mop upsert";
+
+  public MapUpsert(T value, CollectionAttributes attr) {
+    super(CollectionType.map, value, null, null, attr);
+  }
+
+  @Override
+  public String getCommand() {
+    return command;
+  }
+
+}

--- a/src/main/java/net/spy/memcached/ops/APIType.java
+++ b/src/main/java/net/spy/memcached/ops/APIType.java
@@ -43,6 +43,7 @@ public enum APIType {
   // Map API Type
   MOP_CREATE(OperationType.WRITE),
   MOP_INSERT(OperationType.WRITE),
+  MOP_UPSERT(OperationType.WRITE),
   MOP_UPDATE(OperationType.WRITE),
   MOP_DELETE(OperationType.WRITE),
   MOP_GET(OperationType.RW),

--- a/src/main/java/net/spy/memcached/protocol/ascii/CollectionInsertOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/CollectionInsertOperationImpl.java
@@ -29,6 +29,7 @@ import net.spy.memcached.collection.CollectionInsert;
 import net.spy.memcached.collection.CollectionResponse;
 import net.spy.memcached.collection.ListInsert;
 import net.spy.memcached.collection.MapInsert;
+import net.spy.memcached.collection.MapUpsert;
 import net.spy.memcached.collection.SetInsert;
 import net.spy.memcached.ops.APIType;
 import net.spy.memcached.ops.CollectionInsertOperation;
@@ -87,6 +88,8 @@ public class CollectionInsertOperationImpl extends OperationImpl
       setAPIType(APIType.SOP_INSERT);
     } else if (this.collectionInsert instanceof MapInsert) {
       setAPIType(APIType.MOP_INSERT);
+    } else if (this.collectionInsert instanceof MapUpsert) {
+      setAPIType(APIType.MOP_UPSERT);
     } else if (this.collectionInsert instanceof BTreeInsert) {
       setAPIType(APIType.BOP_INSERT);
     } else if (this.collectionInsert instanceof BTreeUpsert) {

--- a/src/test/manual/net/spy/memcached/collection/map/MopUpsertTest.java
+++ b/src/test/manual/net/spy/memcached/collection/map/MopUpsertTest.java
@@ -1,0 +1,74 @@
+package net.spy.memcached.collection.map;
+
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import net.spy.memcached.collection.BaseIntegrationTest;
+import net.spy.memcached.collection.CollectionAttributes;
+import net.spy.memcached.collection.CollectionResponse;
+import net.spy.memcached.internal.CollectionFuture;
+import net.spy.memcached.ops.CollectionOperationStatus;
+
+import org.junit.Assert;
+
+public class MopUpsertTest extends BaseIntegrationTest {
+
+  private final String KEY = this.getClass().getSimpleName();
+  private final String MKEY = "upsertTestMkey";
+
+  private final String VALUE = "VALUE";
+  private final String NEW_VALUE = "NEWVALUE";
+
+  private final CollectionAttributes collectionAttributes = new CollectionAttributes();
+
+  @Override
+  protected void setUp() throws Exception {
+    super.setUp();
+    mc.delete(KEY).get();
+    Assert.assertNull(mc.asyncGetAttr(KEY).get());
+  }
+
+  @Override
+  protected void tearDown() throws Exception {
+    mc.delete(KEY).get();
+    super.tearDown();
+  }
+
+  public void testUpsertIfKeyExists() {
+    try {
+      // given
+      Assert.assertTrue(mc.asyncMopInsert(KEY, MKEY, VALUE, collectionAttributes).get());
+
+      // when
+      CollectionFuture<Boolean> future =
+              mc.asyncMopUpsert(KEY, MKEY, NEW_VALUE, collectionAttributes);
+      Boolean result = future.get();
+      CollectionOperationStatus operationStatus = future.getOperationStatus();
+
+      // then
+      assertTrue(result);
+      assertEquals(CollectionResponse.REPLACED, operationStatus.getResponse());
+      Map<String, Object> map = mc.asyncMopGet(KEY, false, false)
+              .get(1000, TimeUnit.MILLISECONDS);
+      assertEquals(NEW_VALUE, map.get(MKEY));
+    } catch (Exception e) {
+      Assert.fail(e.getMessage());
+    }
+  }
+
+  public void testUpsertIfKeyDoesNotExist() {
+    try {
+      // given & when
+      CollectionFuture<Boolean> future =
+              mc.asyncMopUpsert(KEY, MKEY, "VALUE", collectionAttributes);
+      Boolean result = future.get();
+      CollectionOperationStatus operationStatus = future.getOperationStatus();
+
+      // then
+      Assert.assertTrue("Upsert failed", result);
+      assertEquals(CollectionResponse.CREATED_STORED, operationStatus.getResponse());
+    } catch (Exception e) {
+      Assert.fail(e.getMessage());
+    }
+  }
+}


### PR DESCRIPTION
- https://github.com/jam2in/arcus-works/issues/579
- mop upsert API를 추가합니다. develop 버전 memcached 가 릴리즈되고 난 후에 CI가 통과할 수 있습니다.