### PR TITLE
INTERNAL: add factory methods without ConnectionFactoryBuilder for ArcusClient/ArcusClientPool

### DIFF
--- a/src/main/java/net/spy/memcached/ArcusClient.java
+++ b/src/main/java/net/spy/memcached/ArcusClient.java
@@ -189,7 +189,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
   private static String VERSION = null;
   private static final Object VERSION_LOCK = new Object();
   private static final Logger arcusLogger = LoggerFactory.getLogger(ArcusClient.class);
-  private static final String ARCUS_CLOUD_ADDR = "127.0.0.1:2181";
+  private static final String ARCUS_ADMIN_ADDR = "127.0.0.1:2181";
   private static final String DEFAULT_ARCUS_CLIENT_NAME = "ArcusClient";
 
   private final Transcoder<Object> collectionTranscoder;
@@ -217,6 +217,17 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
   /**
    * @param hostPorts   arcus admin addresses
    * @param serviceCode service code
+   * @return a single ArcusClient
+   */
+  public static ArcusClient createArcusClient(String hostPorts, String serviceCode) {
+
+    return ArcusClient.createArcusClient(hostPorts, serviceCode, new ConnectionFactoryBuilder(), 1, 10000).getClient();
+
+  }
+
+  /**
+   * @param hostPorts   arcus admin addresses
+   * @param serviceCode service code
    * @param cfb         ConnectionFactoryBuilder
    * @return a single ArcusClient
    */
@@ -235,7 +246,19 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
   public static ArcusClient createArcusClient(String serviceCode,
                                               ConnectionFactoryBuilder cfb) {
 
-    return ArcusClient.createArcusClient(ARCUS_CLOUD_ADDR, serviceCode, cfb, 1, 10000).getClient();
+    return ArcusClient.createArcusClient(ARCUS_ADMIN_ADDR, serviceCode, cfb, 1, 10000).getClient();
+
+  }
+
+  /**
+   * @param hostPorts   arcus admin addresses
+   * @param serviceCode service code
+   * @param poolSize    Arcus client pool size
+   * @return multiple ArcusClient
+   */
+  public static ArcusClientPool createArcusClientPool(String hostPorts, String serviceCode, int poolSize) {
+
+    return ArcusClient.createArcusClient(hostPorts, serviceCode, new ConnectionFactoryBuilder(), poolSize, 0);
 
   }
 
@@ -262,7 +285,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
   public static ArcusClientPool createArcusClientPool(String serviceCode,
                                                       ConnectionFactoryBuilder cfb, int poolSize) {
 
-    return ArcusClient.createArcusClient(ARCUS_CLOUD_ADDR, serviceCode, cfb, poolSize, 0);
+    return ArcusClient.createArcusClient(ARCUS_ADMIN_ADDR, serviceCode, cfb, poolSize, 0);
 
   }
 

--- a/src/test/manual/net/spy/memcached/ArcusClientConnectTest.java
+++ b/src/test/manual/net/spy/memcached/ArcusClientConnectTest.java
@@ -40,9 +40,8 @@ public class ArcusClientConnectTest extends TestCase {
 
   @Test
   public void testOpenAndWait() {
-    ConnectionFactoryBuilder cfb = new ConnectionFactoryBuilder();
     ArcusClient client = ArcusClient.createArcusClient(BaseIntegrationTest.ZK_HOST,
-            BaseIntegrationTest.ZK_SERVICE_ID, cfb);
+            BaseIntegrationTest.ZK_SERVICE_ID);
     client.shutdown();
   }
 }

--- a/src/test/manual/net/spy/memcached/ArcusClientNotExistsServiceCodeTest.java
+++ b/src/test/manual/net/spy/memcached/ArcusClientNotExistsServiceCodeTest.java
@@ -30,10 +30,8 @@ public class ArcusClientNotExistsServiceCodeTest extends TestCase {
       return;
     }
 
-    ConnectionFactoryBuilder cfb = new ConnectionFactoryBuilder();
     try {
-      ArcusClient.createArcusClient(BaseIntegrationTest.ZK_HOST,
-              "NOT_EXISTS_SVC_CODE", cfb);
+      ArcusClient.createArcusClient(BaseIntegrationTest.ZK_HOST, "NOT_EXISTS_SVC_CODE");
     } catch (NotExistsServiceCodeException e) {
       return;
     }

--- a/src/test/manual/net/spy/memcached/ArcusClientPoolReconnectTest.java
+++ b/src/test/manual/net/spy/memcached/ArcusClientPoolReconnectTest.java
@@ -26,9 +26,8 @@ import org.junit.Ignore;
 public class ArcusClientPoolReconnectTest extends TestCase {
 
   public void testOpenAndWait() {
-    ConnectionFactoryBuilder cfb = new ConnectionFactoryBuilder();
     ArcusClientPool client = ArcusClient.createArcusClientPool(BaseIntegrationTest.ZK_HOST,
-            BaseIntegrationTest.ZK_SERVICE_ID, cfb, 2);
+            BaseIntegrationTest.ZK_SERVICE_ID, 2);
 
     try {
       Thread.sleep(120000L);

--- a/src/test/manual/net/spy/memcached/ArcusClientPoolShutdownTest.java
+++ b/src/test/manual/net/spy/memcached/ArcusClientPoolShutdownTest.java
@@ -34,9 +34,8 @@ public class ArcusClientPoolShutdownTest extends TestCase {
       return;
     }
 
-    ConnectionFactoryBuilder cfb = new ConnectionFactoryBuilder();
     ArcusClientPool client = ArcusClient.createArcusClientPool(BaseIntegrationTest.ZK_HOST,
-            BaseIntegrationTest.ZK_SERVICE_ID, cfb, 2);
+            BaseIntegrationTest.ZK_SERVICE_ID, 2);
 
     // This threads must be stopped after client is shutdown.
     List<String> threadNames = new ArrayList<>();

--- a/src/test/manual/net/spy/memcached/ArcusClientReconnectTest.java
+++ b/src/test/manual/net/spy/memcached/ArcusClientReconnectTest.java
@@ -30,9 +30,8 @@ public class ArcusClientReconnectTest extends TestCase {
       return;
     }
 
-    ConnectionFactoryBuilder cfb = new ConnectionFactoryBuilder();
     ArcusClient client = ArcusClient.createArcusClient(BaseIntegrationTest.ZK_HOST,
-            BaseIntegrationTest.ZK_SERVICE_ID, cfb);
+            BaseIntegrationTest.ZK_SERVICE_ID);
 
     try {
       Thread.sleep(120000L);

--- a/src/test/manual/net/spy/memcached/ArcusClientShutdownTest.java
+++ b/src/test/manual/net/spy/memcached/ArcusClientShutdownTest.java
@@ -34,9 +34,8 @@ public class ArcusClientShutdownTest extends TestCase {
       return;
     }
 
-    ConnectionFactoryBuilder cfb = new ConnectionFactoryBuilder();
     ArcusClient client = ArcusClient.createArcusClient(BaseIntegrationTest.ZK_HOST,
-            BaseIntegrationTest.ZK_SERVICE_ID, cfb);
+            BaseIntegrationTest.ZK_SERVICE_ID);
 
     // This threads must be stopped after client is shutdown.
     List<String> threadNames = new ArrayList<>();

--- a/src/test/manual/net/spy/memcached/collection/BaseIntegrationTest.java
+++ b/src/test/manual/net/spy/memcached/collection/BaseIntegrationTest.java
@@ -94,8 +94,7 @@ public class BaseIntegrationTest extends TestCase {
   }
 
   protected void openFromZK() {
-    ConnectionFactoryBuilder cfb = new ConnectionFactoryBuilder();
-    mc = ArcusClient.createArcusClient(ZK_HOST, ZK_SERVICE_ID, cfb);
+    mc = ArcusClient.createArcusClient(ZK_HOST, ZK_SERVICE_ID);
   }
 
   protected void openDirect() throws Exception {


### PR DESCRIPTION
- https://github.com/jam2in/arcus-works/issues/569 논의 중 ConnectionFactoryBuilder 생략한 팩토리 메서드 제공의 필요성을 찾게 되어 추가합니다.
- ARCUS_CLOUD_ADDR -> ARCUS_ADMIN_ADDR 로 용어를 변경했는데, 위 이슈로 인해 추후 제거될 예정이라면 그대로 두겠습니다.
- 기존 테스트 코드에서 ConnectionFactoryBuilder를 수정하지 않고 그대로 사용하는 경우 새로 생성한 팩토리 메서드를 사용하도록 했습니다.