### PR TITLE
CLEANUP: rename units to unit

### DIFF
--- a/src/main/java/net/spy/memcached/OperationTimeoutException.java
+++ b/src/main/java/net/spy/memcached/OperationTimeoutException.java
@@ -45,16 +45,16 @@ public class OperationTimeoutException extends RuntimeException {
   }
 
   public OperationTimeoutException(long duration,
-                                   TimeUnit units,
+                                   TimeUnit unit,
                                    Operation op) {
     super(TimedOutMessageFactory
-            .createTimedoutMessage(duration, units, Collections.singleton(op)));
+            .createTimedoutMessage(duration, unit, Collections.singleton(op)));
   }
 
   public OperationTimeoutException(long duration,
-                                   TimeUnit units,
+                                   TimeUnit unit,
                                    Collection<Operation> ops) {
     super(TimedOutMessageFactory
-            .createTimedoutMessage(duration, units, ops));
+            .createTimedoutMessage(duration, unit, ops));
   }
 }

--- a/src/main/java/net/spy/memcached/TimedOutMessageFactory.java
+++ b/src/main/java/net/spy/memcached/TimedOutMessageFactory.java
@@ -13,7 +13,7 @@ public final class TimedOutMessageFactory {
   }
 
   public static String createTimedoutMessage(long duration,
-                                             TimeUnit units,
+                                             TimeUnit unit,
                                              Collection<Operation> ops) {
     StringBuilder rv = new StringBuilder();
     Operation firstOp = ops.iterator().next();
@@ -25,7 +25,7 @@ public final class TimedOutMessageFactory {
     }
     rv.append(firstOp.getAPIType())
       .append(" operation timed out (>").append(duration)
-      .append(" ").append(units).append(")");
+      .append(" ").append(unit).append(")");
     return createMessage(rv.toString(), ops);
   }
 

--- a/src/main/java/net/spy/memcached/internal/BroadcastFuture.java
+++ b/src/main/java/net/spy/memcached/internal/BroadcastFuture.java
@@ -52,9 +52,9 @@ public class BroadcastFuture<T> extends OperationFuture<T> {
   }
 
   @Override
-  public T get(long duration, TimeUnit units)
+  public T get(long duration, TimeUnit unit)
           throws InterruptedException, TimeoutException, ExecutionException {
-    if (!latch.await(duration, units)) {
+    if (!latch.await(duration, unit)) {
       // whenever timeout occurs, continuous timeout counter will increase by 1.
       Collection<Operation> timedoutOps = new HashSet<>();
       for (Operation op : ops) {
@@ -66,7 +66,7 @@ public class BroadcastFuture<T> extends OperationFuture<T> {
         }
       }
       if (!timedoutOps.isEmpty()) {
-        throw new CheckedOperationTimeoutException(duration, units, timedoutOps);
+        throw new CheckedOperationTimeoutException(duration, unit, timedoutOps);
       }
     } else {
       // continuous timeout counter will be reset

--- a/src/main/java/net/spy/memcached/internal/BulkGetFuture.java
+++ b/src/main/java/net/spy/memcached/internal/BulkGetFuture.java
@@ -84,14 +84,14 @@ public class BulkGetFuture<T> implements BulkFuture<Map<String, T>> {
   }
 
   @Override
-  public Map<String, T> getSome(long duration, TimeUnit units)
+  public Map<String, T> getSome(long duration, TimeUnit unit)
           throws InterruptedException, ExecutionException {
     Collection<Operation> timedoutOps = new HashSet<>();
-    Map<String, T> ret = internalGet(duration, units, timedoutOps);
+    Map<String, T> ret = internalGet(duration, unit, timedoutOps);
     if (!timedoutOps.isEmpty()) {
       isTimeout.set(true);
       LoggerFactory.getLogger(getClass()).warn(
-              new CheckedOperationTimeoutException(duration, units, timedoutOps).getMessage());
+              new CheckedOperationTimeoutException(duration, unit, timedoutOps).getMessage());
     }
     return ret;
 
@@ -104,13 +104,13 @@ public class BulkGetFuture<T> implements BulkFuture<Map<String, T>> {
    * @see java.util.concurrent.Future#get(long, java.util.concurrent.TimeUnit)
    */
   @Override
-  public Map<String, T> get(long duration, TimeUnit units)
+  public Map<String, T> get(long duration, TimeUnit unit)
           throws InterruptedException, ExecutionException, TimeoutException {
     Collection<Operation> timedoutOps = new HashSet<>();
-    Map<String, T> ret = internalGet(duration, units, timedoutOps);
+    Map<String, T> ret = internalGet(duration, unit, timedoutOps);
     if (!timedoutOps.isEmpty()) {
       isTimeout.set(true);
-      throw new CheckedOperationTimeoutException(duration, units, timedoutOps);
+      throw new CheckedOperationTimeoutException(duration, unit, timedoutOps);
     }
     return ret;
   }

--- a/src/main/java/net/spy/memcached/internal/BulkOperationFuture.java
+++ b/src/main/java/net/spy/memcached/internal/BulkOperationFuture.java
@@ -67,9 +67,9 @@ public class BulkOperationFuture<T> implements Future<Map<String, T>> {
 
   @Override
   public Map<String, T> get(long duration,
-                            TimeUnit units) throws InterruptedException,
+                            TimeUnit unit) throws InterruptedException,
           TimeoutException, ExecutionException {
-    if (!latch.await(duration, units)) {
+    if (!latch.await(duration, unit)) {
       Collection<Operation> timedoutOps = new HashSet<>();
       for (Operation op : ops) {
         if (op.getState() != OperationState.COMPLETE) {
@@ -80,7 +80,7 @@ public class BulkOperationFuture<T> implements Future<Map<String, T>> {
       }
       if (!timedoutOps.isEmpty()) {
         MemcachedConnection.opsTimedOut(timedoutOps);
-        throw new CheckedOperationTimeoutException(duration, units, timedoutOps);
+        throw new CheckedOperationTimeoutException(duration, unit, timedoutOps);
       }
     } else {
       // continuous timeout counter will be reset

--- a/src/main/java/net/spy/memcached/internal/CheckedOperationTimeoutException.java
+++ b/src/main/java/net/spy/memcached/internal/CheckedOperationTimeoutException.java
@@ -50,15 +50,15 @@ public class CheckedOperationTimeoutException extends TimeoutException {
   }
 
   public CheckedOperationTimeoutException(long duration,
-                                          TimeUnit units,
+                                          TimeUnit unit,
                                           Operation op) {
-    this(duration, units, Collections.singleton(op));
+    this(duration, unit, Collections.singleton(op));
   }
 
   public CheckedOperationTimeoutException(long duration,
-                                          TimeUnit units,
+                                          TimeUnit unit,
                                           Collection<Operation> ops) {
-    super(TimedOutMessageFactory.createTimedoutMessage(duration, units, ops));
+    super(TimedOutMessageFactory.createTimedoutMessage(duration, unit, ops));
     operations = ops;
   }
 

--- a/src/main/java/net/spy/memcached/internal/CollectionGetBulkFuture.java
+++ b/src/main/java/net/spy/memcached/internal/CollectionGetBulkFuture.java
@@ -58,9 +58,9 @@ public class CollectionGetBulkFuture<T> implements Future<T> {
   }
 
   @Override
-  public T get(long duration, TimeUnit units)
+  public T get(long duration, TimeUnit unit)
       throws InterruptedException, TimeoutException, ExecutionException {
-    if (!latch.await(duration, units)) {
+    if (!latch.await(duration, unit)) {
       Collection<Operation> timedoutOps = new HashSet<>();
       for (Operation op : ops) {
         if (op.getState() != OperationState.COMPLETE) {
@@ -71,7 +71,7 @@ public class CollectionGetBulkFuture<T> implements Future<T> {
       }
       if (!timedoutOps.isEmpty()) {
         MemcachedConnection.opsTimedOut(timedoutOps);
-        throw new CheckedOperationTimeoutException(duration, units, timedoutOps);
+        throw new CheckedOperationTimeoutException(duration, unit, timedoutOps);
       }
     } else {
       // continuous timeout counter will be reset

--- a/src/main/java/net/spy/memcached/internal/CollectionGetFuture.java
+++ b/src/main/java/net/spy/memcached/internal/CollectionGetFuture.java
@@ -16,9 +16,9 @@ public class CollectionGetFuture<T> extends CollectionFuture<T> {
   }
 
   @Override
-  public T get(long duration, TimeUnit units)
+  public T get(long duration, TimeUnit unit)
           throws InterruptedException, TimeoutException, ExecutionException {
-    super.get(duration, units); // for waiting latch.
+    super.get(duration, unit); // for waiting latch.
     return result == null ? null : result.getDecodedValue();
   }
 

--- a/src/main/java/net/spy/memcached/internal/GetFuture.java
+++ b/src/main/java/net/spy/memcached/internal/GetFuture.java
@@ -23,9 +23,9 @@ public class GetFuture<T> extends OperationFuture<T> {
   }
 
   @Override
-  public T get(long duration, TimeUnit units)
+  public T get(long duration, TimeUnit unit)
           throws InterruptedException, TimeoutException, ExecutionException {
-    super.get(duration, units); // for waiting latch.
+    super.get(duration, unit); // for waiting latch.
     return result == null ? null : result.getDecodedValue();
   }
 

--- a/src/main/java/net/spy/memcached/internal/OperationFuture.java
+++ b/src/main/java/net/spy/memcached/internal/OperationFuture.java
@@ -71,12 +71,12 @@ public class OperationFuture<T> extends SpyObject implements Future<T> {
     }
   }
 
-  public T get(long duration, TimeUnit units)
+  public T get(long duration, TimeUnit unit)
           throws InterruptedException, TimeoutException, ExecutionException {
-    if (!latch.await(duration, units)) {
+    if (!latch.await(duration, unit)) {
       // whenever timeout occurs, continuous timeout counter will increase by 1.
       MemcachedConnection.opTimedOut(op);
-      throw new CheckedOperationTimeoutException(duration, units, op);
+      throw new CheckedOperationTimeoutException(duration, unit, op);
     } else {
       // continuous timeout counter will be reset
       MemcachedConnection.opSucceeded(op);

--- a/src/main/java/net/spy/memcached/internal/PipedCollectionFuture.java
+++ b/src/main/java/net/spy/memcached/internal/PipedCollectionFuture.java
@@ -59,10 +59,10 @@ public class PipedCollectionFuture<K, V>
   }
 
   @Override
-  public Map<K, V> get(long duration, TimeUnit units)
+  public Map<K, V> get(long duration, TimeUnit unit)
           throws InterruptedException, TimeoutException, ExecutionException {
 
-    if (!latch.await(duration, units)) {
+    if (!latch.await(duration, unit)) {
       Collection<Operation> timedoutOps = new HashSet<>();
       for (Operation op : ops) {
         if (op.getState() != OperationState.COMPLETE) {
@@ -74,7 +74,7 @@ public class PipedCollectionFuture<K, V>
       if (!timedoutOps.isEmpty()) {
         // set timeout only once for piped ops requested to single node.
         MemcachedConnection.opTimedOut(timedoutOps.iterator().next());
-        throw new CheckedOperationTimeoutException(duration, units, timedoutOps);
+        throw new CheckedOperationTimeoutException(duration, unit, timedoutOps);
       }
     } else {
       // continuous timeout counter will be reset only once in pipe

--- a/src/main/java/net/spy/memcached/internal/SMGetFuture.java
+++ b/src/main/java/net/spy/memcached/internal/SMGetFuture.java
@@ -54,10 +54,10 @@ public final class SMGetFuture<T extends List<?>> implements Future<T> {
 
   @Override
   @SuppressWarnings("unchecked")
-  public T get(long duration, TimeUnit units)
+  public T get(long duration, TimeUnit unit)
           throws InterruptedException, TimeoutException, ExecutionException {
 
-    if (!latch.await(duration, units)) {
+    if (!latch.await(duration, unit)) {
       Collection<Operation> timedoutOps = new HashSet<>();
       for (Operation op : ops) {
         if (op.getState() != OperationState.COMPLETE) {
@@ -68,7 +68,7 @@ public final class SMGetFuture<T extends List<?>> implements Future<T> {
       }
       if (!timedoutOps.isEmpty()) {
         MemcachedConnection.opsTimedOut(timedoutOps);
-        throw new CheckedOperationTimeoutException(duration, units, timedoutOps);
+        throw new CheckedOperationTimeoutException(duration, unit, timedoutOps);
       }
     } else {
       // continuous timeout counter will be reset

--- a/src/main/java/net/spy/memcached/plugin/FrontCacheBulkGetFuture.java
+++ b/src/main/java/net/spy/memcached/plugin/FrontCacheBulkGetFuture.java
@@ -35,11 +35,11 @@ public class FrontCacheBulkGetFuture<T> extends BulkGetFuture<T> {
   }
 
   @Override
-  public Map<String, T> get(long duration, TimeUnit units)
+  public Map<String, T> get(long duration, TimeUnit unit)
           throws InterruptedException, ExecutionException, TimeoutException {
     if (result == null) {
       try {
-        result = super.get(duration, units);
+        result = super.get(duration, unit);
       } catch (TimeoutException e) {
         throw new OperationTimeoutException(e);
       }
@@ -50,12 +50,12 @@ public class FrontCacheBulkGetFuture<T> extends BulkGetFuture<T> {
   }
 
   @Override
-  public Map<String, T> getSome(long duration, TimeUnit units)
+  public Map<String, T> getSome(long duration, TimeUnit unit)
           throws InterruptedException, ExecutionException {
     if (result != null) {
       return result;
     }
-    Map<String, T> getSomeResult = super.getSome(duration, units);
+    Map<String, T> getSomeResult = super.getSome(duration, unit);
     if (getSomeResult.size() == getOpCount()) {
       result = getSomeResult;
     }


### PR DESCRIPTION
- 하나의 TimeUnit 타입을 인자로 받는 경우 units 대신 unit 이라는 변수명을 사용하도록 합니다.