### PR TITLE
INTERNAL: Remove unused TimeoutException constructors.

### DIFF
--- a/src/main/java/net/spy/memcached/OperationTimeoutException.java
+++ b/src/main/java/net/spy/memcached/OperationTimeoutException.java
@@ -16,12 +16,6 @@
  */
 package net.spy.memcached;
 
-import java.util.Collection;
-import java.util.Collections;
-import java.util.concurrent.TimeUnit;
-
-import net.spy.memcached.ops.Operation;
-
 /**
  * Thrown by {@link MemcachedClient} when any internal operations timeout.
  *
@@ -42,19 +36,5 @@ public class OperationTimeoutException extends RuntimeException {
 
   public OperationTimeoutException(String message, Throwable cause) {
     super(message, cause);
-  }
-
-  public OperationTimeoutException(long duration,
-                                   TimeUnit unit,
-                                   Operation op) {
-    super(TimedOutMessageFactory
-            .createTimedoutMessage(duration, unit, Collections.singleton(op)));
-  }
-
-  public OperationTimeoutException(long duration,
-                                   TimeUnit unit,
-                                   Collection<Operation> ops) {
-    super(TimedOutMessageFactory
-            .createTimedoutMessage(duration, unit, ops));
   }
 }

--- a/src/main/java/net/spy/memcached/TimedOutMessageFactory.java
+++ b/src/main/java/net/spy/memcached/TimedOutMessageFactory.java
@@ -23,28 +23,12 @@ public final class TimedOutMessageFactory {
     if (firstOp.isPipeOperation()) {
       rv.append("pipe ");
     }
-    rv.append(firstOp.getAPIType())
-      .append(" operation timed out (>").append(duration)
-      .append(" ").append(unit).append(")");
-    return createMessage(rv.toString(), ops);
-  }
 
-  /**
-   * check bulk operation or not
-   * @param op operation
-   * @param ops number of operation (used in StoreOperationImpl, DeleteOperationImpl)
-   */
-  private static boolean isBulkOperation(Operation op, Collection<Operation> ops) {
-    if (op instanceof StoreOperation || op instanceof DeleteOperation) {
-      return ops.size() > 1;
-    }
-    return op.isBulkOperation();
-  }
+    rv.append(firstOp.getAPIType());
+    rv.append(" operation timed out (>").append(duration);
+    rv.append(" ").append(unit).append(") - ");
 
-  public static String createMessage(String message,
-                                     Collection<Operation> ops) {
-    StringBuilder rv = new StringBuilder(message);
-    rv.append(" - failing node");
+    rv.append("failing node");
     rv.append(ops.size() == 1 ? ": " : "s: ");
     boolean first = true;
     for (Operation op : ops) {
@@ -66,6 +50,18 @@ public final class TimedOutMessageFactory {
       }
     }
     return rv.toString();
+  }
+
+  /**
+   * check bulk operation or not
+   * @param op operation
+   * @param ops number of operation (used in StoreOperationImpl, DeleteOperationImpl)
+   */
+  private static boolean isBulkOperation(Operation op, Collection<Operation> ops) {
+    if (op instanceof StoreOperation || op instanceof DeleteOperation) {
+      return ops.size() > 1;
+    }
+    return op.isBulkOperation();
   }
 
 }

--- a/src/main/java/net/spy/memcached/internal/CheckedOperationTimeoutException.java
+++ b/src/main/java/net/spy/memcached/internal/CheckedOperationTimeoutException.java
@@ -32,23 +32,6 @@ public class CheckedOperationTimeoutException extends TimeoutException {
   private static final long serialVersionUID = 5187393339735774489L;
   private final Collection<Operation> operations;
 
-  /**
-   * Construct a CheckedOperationTimeoutException with the given message
-   * and operation.
-   *
-   * @param message the message
-   * @param op      the operation that timed out
-   */
-  public CheckedOperationTimeoutException(String message, Operation op) {
-    this(message, Collections.singleton(op));
-  }
-
-  public CheckedOperationTimeoutException(String message,
-                                          Collection<Operation> ops) {
-    super(TimedOutMessageFactory.createMessage(message, ops));
-    operations = ops;
-  }
-
   public CheckedOperationTimeoutException(long duration,
                                           TimeUnit unit,
                                           Operation op) {


### PR DESCRIPTION
### 🔗 Related Issue

<!-- Please link related issue. ex) https://github.com/naver/arcus-java-client/issues/{issue_number} -->
- https://github.com/jam2in/arcus-works/issues/586

### ⌨️ What I did

<!-- Please describe this PR and what you've been working on. -->
- OperationTimeout, CheckedOperationTimeout 클래스의 생성자 중 사용하지 않는 생성자를 제거합니다.
- 생성자를 제거하면서 필요한 변경도 함께 반영합니다.