### PR TITLE
INTERNAL: Change CacheManager class to interface named ServerManager.

### DIFF
--- a/docs/user_guide/02-arcus-java-client.md
+++ b/docs/user_guide/02-arcus-java-client.md
@@ -171,7 +171,7 @@ ArcusClientPool pool = ArcusClient.createArcusClientPool(ARCUS_ADMIN, SERVICE_CO
 ARCUS client 객체를 정상적으로 생성하면, 아래의 로그와 같이 cache cloud와 정상 연결됨을 볼 수 있다.
 
 ```
-WARN net.spy.memcached.CacheManager: All arcus connections are established.
+WARN net.spy.memcached.ElasticCacheManager: All arcus connections are established.
 ```
 
 ARCUS cache cloud로 정상 연결되지 않으면, 다음과 같은 로그가 보인다.
@@ -179,7 +179,7 @@ ARCUS cache cloud로 정상 연결되지 않으면, 다음과 같은 로그가 �
 접속 실패한 cache server에 대해서는 ARCUS client가 1초에 한 번씩 자동으로 재연결을 시도한다.
 
 ```
-WARN net.spy.memcached.CacheManager: Some arcus connections are not established.
+WARN net.spy.memcached.ElasticCacheManager: Some arcus connections are not established.
 ```
 
 ### ARCUS Client 소멸

--- a/docs/user_guide/10-log-message.md
+++ b/docs/user_guide/10-log-message.md
@@ -8,7 +8,7 @@ Java client에서 남기는 로그들과 그것들이 의미하는 바는 아래
 ARCUS client가 정상적으로 초기화 되면 다음과 같은 로그를 남긴다.
 
 ```java
-INFO net.spy.memcached.CacheManager: CacheManager started. ([mailto:dev@dev.arcuscloud.nhncorp.com:17288 dev@dev.arcuscloud.nhncorp.com:17288])
+INFO net.spy.memcached.ElasticCacheManager: CacheManager started. ([mailto:dev@dev.arcuscloud.nhncorp.com:17288 dev@dev.arcuscloud.nhncorp.com:17288])
 
 WARN net.spy.memcached.CacheMonitor: Cache list has been changed : From=null, To=[127.0.0.1:11211-hostname, xxx.xxx.xxx.xxx:xxxx-hostname] : [serviceCode=dev]
 
@@ -20,7 +20,7 @@ INFO net.spy.memcached.MemcachedConnection: Connection state changed for sun.nio
 
 INFO net.spy.memcached.MemcachedConnection: Connection state changed for sun.nio.ch.SelectionKeyImpl@2e5bbd6
 
-2011-09-21 10:44:54.055 WARN net.spy.memcached.CacheManager: All arcus connections are established.
+2011-09-21 10:44:54.055 WARN net.spy.memcached.ElasticCacheManager: All arcus connections are established.
 ```
 
 #### ARCUS admin address가 잘못 되었을 때
@@ -28,9 +28,9 @@ INFO net.spy.memcached.MemcachedConnection: Connection state changed for sun.nio
 ARCUS admin address를 잘못 지정했거나 server가 응답이 없을 때 아래와 같은 로그를 남긴다.
 
 ```java
-FATAL net.spy.memcached.CacheManager: Unexpected exception. contact to arcus administrator
+FATAL net.spy.memcached.ElasticCacheManager: Unexpected exception. contact to arcus administrator
 
-INFO net.spy.memcached.CacheManager: Close ZooKeeper client.
+INFO net.spy.memcached.ElasticCacheManager: Close ZooKeeper client.
 ```
 
 #### ARCUS admin과 연결이 단절 되었을 때
@@ -54,9 +54,9 @@ WARN net.spy.memcached.CacheMonitor: Session expired. Trying to reconnect to the
 ```java
 INFO net.spy.memcached.CacheMonitor: Shutting down the CacheMonitor : [serviceCode=dev]
 
-WARN net.spy.memcached.CacheManager: Unexpected disconnection from Arcus admin. Trying to reconnect to Arcus admin.
+WARN net.spy.memcached.ElasticCacheManager: Unexpected disconnection from Arcus admin. Trying to reconnect to Arcus admin.
 
-INFO net.spy.memcached.CacheManager: Close ZooKeeper client.
+INFO net.spy.memcached.ElasticCacheManager: Close ZooKeeper client.
 ```
 
 Reconnect에 성공하면 아래와 같은 로그가 남는다.

--- a/src/main/java/net/spy/memcached/ArcusClient.java
+++ b/src/main/java/net/spy/memcached/ArcusClient.java
@@ -208,10 +208,10 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
 
   private static final int MAX_DNS_CACHE_TTL = 300;
 
-  private CacheManager cacheManager;
+  private ServerManager serverManager;
 
-  public void setCacheManager(CacheManager cacheManager) {
-    this.cacheManager = cacheManager;
+  public void setServerManager(ServerManager serverManager) {
+    this.serverManager = serverManager;
   }
 
   /**
@@ -314,8 +314,8 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
       throw new IllegalArgumentException("Service code is empty.");
     }
 
-    CacheManager exe = new CacheManager(hostPorts, serviceCode, cfb, poolSize, waitTimeForConnect);
-    return new ArcusClientPool(poolSize, exe.getAC());
+    ServerManager manager = new ElasticCacheManager(hostPorts, serviceCode, cfb, poolSize, waitTimeForConnect);
+    return new ArcusClientPool(poolSize, manager.getClients());
   }
 
   /**
@@ -426,8 +426,8 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
   public boolean shutdown(long timeout, TimeUnit unit) {
     final boolean result = super.shutdown(timeout, unit);
     // Connect to Arcus server directly, cache manager may be null.
-    if (cacheManager != null) {
-      cacheManager.shutdown();
+    if (serverManager != null) {
+      serverManager.shutdown();
     }
     return result;
   }

--- a/src/main/java/net/spy/memcached/MemcachedConnection.java
+++ b/src/main/java/net/spy/memcached/MemcachedConnection.java
@@ -304,7 +304,7 @@ public final class MemcachedConnection extends SpyObject {
     }
     /* ENABLE_REPLICATION end */
 
-    // Deal with the memcached server group that's been added by CacheManager.
+    // Deal with the memcached server group that's been added by ServerManager.
     handleCacheNodesChange();
 
     if (!reconnectQueue.isEmpty()) {
@@ -680,7 +680,7 @@ public final class MemcachedConnection extends SpyObject {
     addOperation(node, op);
   }
 
-  // Handle the memcached server group that's been added by CacheManager.
+  // Handle the memcached server group that's been added by ServerManager.
   void handleCacheNodesChange() throws IOException {
     /* ENABLE_MIGRATION if */
     /*

--- a/src/main/java/net/spy/memcached/ServerManager.java
+++ b/src/main/java/net/spy/memcached/ServerManager.java
@@ -1,0 +1,7 @@
+package net.spy.memcached;
+
+public interface ServerManager {
+  ArcusClient[] getClients();
+
+  void shutdown();
+}

--- a/src/test/manual/net/spy/memcached/ArcusClientPoolCreateTest.java
+++ b/src/test/manual/net/spy/memcached/ArcusClientPoolCreateTest.java
@@ -75,7 +75,7 @@ public class ArcusClientPoolCreateTest {
   }
 
   private int getPoolId() throws NoSuchFieldException, IllegalAccessException {
-    Class<CacheManager> clazz = CacheManager.class;
+    Class<ElasticCacheManager> clazz = ElasticCacheManager.class;
     Field poolId = clazz.getDeclaredField("POOL_ID");
     poolId.setAccessible(true);
     AtomicInteger atomicInteger = (AtomicInteger) poolId.get(null);


### PR DESCRIPTION
### 🔗 Related Issue

<!-- Please link related issue. ex) https://github.com/naver/arcus-java-client/issues/{issue_number} -->
- 

### ⌨️ What I did

<!-- Please describe this PR and what you've been working on. -->
- CacheManager 클래스를 인터페이스로 변경하면서 이름을 ServerManager로 바꿉니다.
- 기존 CacheManager의 구현을 ElasticCacheManager 클래스로 이관힙니다.