### PR TITLE
INTERNAL: deprecate static factory method of ArcusClient without zk address

### DIFF
--- a/src/main/java/net/spy/memcached/ArcusClient.java
+++ b/src/main/java/net/spy/memcached/ArcusClient.java
@@ -242,7 +242,10 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
    * @param serviceCode service code
    * @param cfb         ConnectionFactoryBuilder
    * @return a single ArcusClient
+   * @deprecated because service code must be along with admin addresses.
+   * Use {@link #createArcusClient(String, String, ConnectionFactoryBuilder)} instead.
    */
+  @Deprecated
   public static ArcusClient createArcusClient(String serviceCode,
                                               ConnectionFactoryBuilder cfb) {
 
@@ -281,7 +284,10 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
    * @param poolSize    Arcus client pool size
    * @param cfb         ConnectionFactoryBuilder
    * @return multiple ArcusClient
+   * @deprecated because service code must be along with admin addresses.
+   * Use {@link #createArcusClientPool(String, String, ConnectionFactoryBuilder, int)} instead.
    */
+  @Deprecated
   public static ArcusClientPool createArcusClientPool(String serviceCode,
                                                       ConnectionFactoryBuilder cfb, int poolSize) {
 

--- a/src/test/java/net/spy/memcached/ClientBaseCase.java
+++ b/src/test/java/net/spy/memcached/ClientBaseCase.java
@@ -36,10 +36,10 @@ import net.spy.memcached.transcoders.Transcoder;
 
 public abstract class ClientBaseCase extends TestCase {
 
-  public static final String ZK_HOST = System.getProperty("ZK_HOST",
+  public static final String ZK_ADDRESS = System.getProperty("ZK_ADDRESS",
           "127.0.0.1:2181");
 
-  public static final String ZK_SERVICE_ID = System.getProperty("ZK_SERVICE_ID",
+  public static final String SERVICE_CODE = System.getProperty("SERVICE_CODE",
           "test");
 
   public static final String ARCUS_HOST = System
@@ -67,8 +67,8 @@ public abstract class ClientBaseCase extends TestCase {
     System.out.println("USE_ZK=" + USE_ZK);
     System.out.println("SHUTDOWN_AFTER_EACH_TEST=" + USE_ZK);
     if (USE_ZK) {
-      System.out.println("ZK_HOST=" + ZK_HOST + ", ZK_SERVICE_ID="
-              + ZK_SERVICE_ID);
+      System.out.println("ZK_ADDRESS=" + ZK_ADDRESS + ", SERVICE_CODE="
+              + SERVICE_CODE);
     } else {
       System.out.println("ARCUS_HOST=" + ARCUS_HOST);
     }
@@ -303,7 +303,7 @@ public abstract class ClientBaseCase extends TestCase {
   }
 
   protected void openFromZK(ConnectionFactoryBuilder cfb) {
-    client = ArcusClient.createArcusClient(ZK_HOST, ZK_SERVICE_ID, cfb);
+    client = ArcusClient.createArcusClient(ZK_ADDRESS, SERVICE_CODE, cfb);
   }
 
   protected void openDirect(ConnectionFactory cf) throws Exception {

--- a/src/test/manual/net/spy/memcached/ArcusClientConnectTest.java
+++ b/src/test/manual/net/spy/memcached/ArcusClientConnectTest.java
@@ -40,8 +40,8 @@ public class ArcusClientConnectTest extends TestCase {
 
   @Test
   public void testOpenAndWait() {
-    ArcusClient client = ArcusClient.createArcusClient(BaseIntegrationTest.ZK_HOST,
-            BaseIntegrationTest.ZK_SERVICE_ID);
+    ArcusClient client = ArcusClient.createArcusClient(BaseIntegrationTest.ZK_ADDRESS,
+            BaseIntegrationTest.SERVICE_CODE);
     client.shutdown();
   }
 }

--- a/src/test/manual/net/spy/memcached/ArcusClientFrontCacheTest.java
+++ b/src/test/manual/net/spy/memcached/ArcusClientFrontCacheTest.java
@@ -45,8 +45,8 @@ public class ArcusClientFrontCacheTest extends TestCase {
     cfb.setFrontCacheExpireTime(10);
     cfb.setMaxFrontCacheElements(10);
 
-    ArcusClient.createArcusClient(BaseIntegrationTest.ZK_HOST,
-            BaseIntegrationTest.ZK_SERVICE_ID, cfb);
+    ArcusClient.createArcusClient(BaseIntegrationTest.ZK_ADDRESS,
+            BaseIntegrationTest.SERVICE_CODE, cfb);
   }
 
   @Test
@@ -55,8 +55,8 @@ public class ArcusClientFrontCacheTest extends TestCase {
     cfb.setFrontCacheExpireTime(10);
     cfb.setMaxFrontCacheElements(10);
 
-    ArcusClient.createArcusClientPool(BaseIntegrationTest.ZK_HOST,
-            BaseIntegrationTest.ZK_SERVICE_ID, cfb, 4);
+    ArcusClient.createArcusClientPool(BaseIntegrationTest.ZK_ADDRESS,
+            BaseIntegrationTest.SERVICE_CODE, cfb, 4);
   }
 
   @Test
@@ -65,8 +65,8 @@ public class ArcusClientFrontCacheTest extends TestCase {
     cfb.setFrontCacheExpireTime(10);
     cfb.setMaxFrontCacheElements(10);
 
-    ArcusClient client = ArcusClient.createArcusClient(BaseIntegrationTest.ZK_HOST,
-            BaseIntegrationTest.ZK_SERVICE_ID, cfb);
+    ArcusClient client = ArcusClient.createArcusClient(BaseIntegrationTest.ZK_ADDRESS,
+            BaseIntegrationTest.SERVICE_CODE, cfb);
 
     try {
       Assert.assertTrue(client.set("test:key", 100, "value").get());

--- a/src/test/manual/net/spy/memcached/ArcusClientNotExistsServiceCodeTest.java
+++ b/src/test/manual/net/spy/memcached/ArcusClientNotExistsServiceCodeTest.java
@@ -31,7 +31,7 @@ public class ArcusClientNotExistsServiceCodeTest extends TestCase {
     }
 
     try {
-      ArcusClient.createArcusClient(BaseIntegrationTest.ZK_HOST, "NOT_EXISTS_SVC_CODE");
+      ArcusClient.createArcusClient(BaseIntegrationTest.ZK_ADDRESS, "NOT_EXISTS_SVC_CODE");
     } catch (NotExistsServiceCodeException e) {
       return;
     }

--- a/src/test/manual/net/spy/memcached/ArcusClientPoolCreateTest.java
+++ b/src/test/manual/net/spy/memcached/ArcusClientPoolCreateTest.java
@@ -16,7 +16,6 @@ import static org.junit.Assume.assumeTrue;
 
 public class ArcusClientPoolCreateTest {
 
-  private static final String SERVICE_CODE = "test";
   private static final int POOL_SIZE = 3;
   private static final int CACHE_NODE_SIZE = 3;
 
@@ -29,8 +28,8 @@ public class ArcusClientPoolCreateTest {
   @Test
   public void testCreateClientPool() throws NoSuchFieldException, IllegalAccessException {
     //Create first ArcusClientPool instance.
-    ArcusClientPool clientPool = ArcusClient.createArcusClientPool(SERVICE_CODE,
-            new ConnectionFactoryBuilder(), POOL_SIZE);
+    ArcusClientPool clientPool = ArcusClient.createArcusClientPool(BaseIntegrationTest.ZK_ADDRESS,
+            BaseIntegrationTest.SERVICE_CODE, POOL_SIZE);
 
     ArcusClient[] allClients = clientPool.getAllClients();
 
@@ -51,8 +50,8 @@ public class ArcusClientPoolCreateTest {
     int firstPoolId = getPoolId();
 
     //Create second ArcusClientPool instance.
-    clientPool = ArcusClient.createArcusClientPool(SERVICE_CODE,
-            new ConnectionFactoryBuilder(), POOL_SIZE);
+    clientPool = ArcusClient.createArcusClientPool(BaseIntegrationTest.ZK_ADDRESS,
+            BaseIntegrationTest.SERVICE_CODE, new ConnectionFactoryBuilder(), POOL_SIZE);
 
     allClients = clientPool.getAllClients();
 

--- a/src/test/manual/net/spy/memcached/ArcusClientPoolReconnectTest.java
+++ b/src/test/manual/net/spy/memcached/ArcusClientPoolReconnectTest.java
@@ -26,8 +26,8 @@ import org.junit.Ignore;
 public class ArcusClientPoolReconnectTest extends TestCase {
 
   public void testOpenAndWait() {
-    ArcusClientPool client = ArcusClient.createArcusClientPool(BaseIntegrationTest.ZK_HOST,
-            BaseIntegrationTest.ZK_SERVICE_ID, 2);
+    ArcusClientPool client = ArcusClient.createArcusClientPool(BaseIntegrationTest.ZK_ADDRESS,
+            BaseIntegrationTest.SERVICE_CODE, 2);
 
     try {
       Thread.sleep(120000L);

--- a/src/test/manual/net/spy/memcached/ArcusClientPoolShutdownTest.java
+++ b/src/test/manual/net/spy/memcached/ArcusClientPoolShutdownTest.java
@@ -34,16 +34,16 @@ public class ArcusClientPoolShutdownTest extends TestCase {
       return;
     }
 
-    ArcusClientPool client = ArcusClient.createArcusClientPool(BaseIntegrationTest.ZK_HOST,
-            BaseIntegrationTest.ZK_SERVICE_ID, 2);
+    ArcusClientPool client = ArcusClient.createArcusClientPool(BaseIntegrationTest.ZK_ADDRESS,
+            BaseIntegrationTest.SERVICE_CODE, 2);
 
     // This threads must be stopped after client is shutdown.
     List<String> threadNames = new ArrayList<>();
     threadNames.add("main-EventThread");
-    threadNames.add("main-SendThread(" + BaseIntegrationTest.ZK_HOST + ")");
+    threadNames.add("main-SendThread(" + BaseIntegrationTest.ZK_ADDRESS + ")");
     threadNames
-            .add("Cache Manager IO for " + BaseIntegrationTest.ZK_SERVICE_ID +
-                    "@" + BaseIntegrationTest.ZK_HOST);
+            .add("Cache Manager IO for " + BaseIntegrationTest.SERVICE_CODE +
+                    "@" + BaseIntegrationTest.ZK_ADDRESS);
 
     // Check exists threads
     List<String> currentThreads = new ArrayList<>();

--- a/src/test/manual/net/spy/memcached/ArcusClientReconnectTest.java
+++ b/src/test/manual/net/spy/memcached/ArcusClientReconnectTest.java
@@ -30,8 +30,8 @@ public class ArcusClientReconnectTest extends TestCase {
       return;
     }
 
-    ArcusClient client = ArcusClient.createArcusClient(BaseIntegrationTest.ZK_HOST,
-            BaseIntegrationTest.ZK_SERVICE_ID);
+    ArcusClient client = ArcusClient.createArcusClient(BaseIntegrationTest.ZK_ADDRESS,
+            BaseIntegrationTest.SERVICE_CODE);
 
     try {
       Thread.sleep(120000L);

--- a/src/test/manual/net/spy/memcached/ArcusClientShutdownTest.java
+++ b/src/test/manual/net/spy/memcached/ArcusClientShutdownTest.java
@@ -34,16 +34,16 @@ public class ArcusClientShutdownTest extends TestCase {
       return;
     }
 
-    ArcusClient client = ArcusClient.createArcusClient(BaseIntegrationTest.ZK_HOST,
-            BaseIntegrationTest.ZK_SERVICE_ID);
+    ArcusClient client = ArcusClient.createArcusClient(BaseIntegrationTest.ZK_ADDRESS,
+            BaseIntegrationTest.SERVICE_CODE);
 
     // This threads must be stopped after client is shutdown.
     List<String> threadNames = new ArrayList<>();
     threadNames.add("main-EventThread");
-    threadNames.add("main-SendThread(" + BaseIntegrationTest.ZK_HOST + ")");
+    threadNames.add("main-SendThread(" + BaseIntegrationTest.ZK_ADDRESS + ")");
     threadNames
-            .add("Cache Manager IO for " + BaseIntegrationTest.ZK_SERVICE_ID +
-                    "@" + BaseIntegrationTest.ZK_HOST);
+            .add("Cache Manager IO for " + BaseIntegrationTest.SERVICE_CODE +
+                    "@" + BaseIntegrationTest.ZK_ADDRESS);
 
     // Check exists threads
     List<String> currentThreads = new ArrayList<>();

--- a/src/test/manual/net/spy/memcached/collection/BaseIntegrationTest.java
+++ b/src/test/manual/net/spy/memcached/collection/BaseIntegrationTest.java
@@ -34,10 +34,10 @@ import org.junit.Ignore;
 @Ignore
 public class BaseIntegrationTest extends TestCase {
 
-  public static final String ZK_HOST = System.getProperty("ZK_HOST",
+  public static final String ZK_ADDRESS = System.getProperty("ZK_ADDRESS",
           "127.0.0.1:2181");
 
-  public static final String ZK_SERVICE_ID = System.getProperty("ZK_SERVICE_ID",
+  public static final String SERVICE_CODE = System.getProperty("SERVICE_CODE",
           "test");
 
   public static final String ARCUS_HOST = System.getProperty("ARCUS_HOST",
@@ -59,8 +59,8 @@ public class BaseIntegrationTest extends TestCase {
     System.out.println("\tSHUTDOWN_AFTER_EACH_TEST = " + USE_ZK);
 
     if (USE_ZK) {
-      System.out.println("\tZK_HOST = " + ZK_HOST);
-      System.out.println("\tZK_SERVICE_ID = " + ZK_SERVICE_ID);
+      System.out.println("\tZK_ADDRESS = " + ZK_ADDRESS);
+      System.out.println("\tSERVICE_CODE = " + SERVICE_CODE);
     } else {
       System.out.println("\tARCUS_HOST = " + ARCUS_HOST);
     }
@@ -94,7 +94,7 @@ public class BaseIntegrationTest extends TestCase {
   }
 
   protected void openFromZK() {
-    mc = ArcusClient.createArcusClient(ZK_HOST, ZK_SERVICE_ID);
+    mc = ArcusClient.createArcusClient(ZK_ADDRESS, SERVICE_CODE);
   }
 
   protected void openDirect() throws Exception {


### PR DESCRIPTION
- https://github.com/jam2in/arcus-works/issues/569
- zk hostports를 입력받지 않는 정적 팩토리 메서드를 deprecate 시킵니다.
- BaseIntegrationTest 의 정적 필드를 사용하려다보니 네이밍이 조금 안익숙해서 ZK_HOST -> ZK_ADDRESS, ZK_SERVICE_ID -> ZK_SERVICE_CODE로 변경하였습니다.