### PR TITLE
CLEANUP: Fix typo, `timedout` to `timedOut`.

### DIFF
--- a/src/main/java/net/spy/memcached/MemcachedConnection.java
+++ b/src/main/java/net/spy/memcached/MemcachedConnection.java
@@ -1534,7 +1534,7 @@ public final class MemcachedConnection extends SpyObject {
    * @param ops
    */
   public static void opsTimedOut(Collection<Operation> ops) {
-    Collection<String> timedoutNodes = new HashSet<>();
+    Collection<String> timedOutNodes = new HashSet<>();
     for (Operation op : ops) {
       try {
         MemcachedNode node = op.getHandlingNode();
@@ -1543,8 +1543,8 @@ public final class MemcachedConnection extends SpyObject {
         }
         // set timeout only once for the same node.
         String key = node.getSocketAddress().toString();
-        if (!timedoutNodes.contains(key)) {
-          timedoutNodes.add(key);
+        if (!timedOutNodes.contains(key)) {
+          timedOutNodes.add(key);
           node.setContinuousTimeout(true);
         }
       } catch (Exception e) {

--- a/src/main/java/net/spy/memcached/TimedOutMessageFactory.java
+++ b/src/main/java/net/spy/memcached/TimedOutMessageFactory.java
@@ -12,7 +12,7 @@ public final class TimedOutMessageFactory {
   private TimedOutMessageFactory() {
   }
 
-  public static String createTimedoutMessage(long duration,
+  public static String createTimedOutMessage(long duration,
                                              TimeUnit unit,
                                              Collection<Operation> ops) {
     StringBuilder rv = new StringBuilder();

--- a/src/main/java/net/spy/memcached/internal/BroadcastFuture.java
+++ b/src/main/java/net/spy/memcached/internal/BroadcastFuture.java
@@ -56,17 +56,17 @@ public class BroadcastFuture<T> extends OperationFuture<T> {
           throws InterruptedException, TimeoutException, ExecutionException {
     if (!latch.await(duration, unit)) {
       // whenever timeout occurs, continuous timeout counter will increase by 1.
-      Collection<Operation> timedoutOps = new HashSet<>();
+      Collection<Operation> timedOutOps = new HashSet<>();
       for (Operation op : ops) {
         if (op.getState() != OperationState.COMPLETE) {
           MemcachedConnection.opTimedOut(op);
-          timedoutOps.add(op);
+          timedOutOps.add(op);
         } else {
           MemcachedConnection.opSucceeded(op);
         }
       }
-      if (!timedoutOps.isEmpty()) {
-        throw new CheckedOperationTimeoutException(duration, unit, timedoutOps);
+      if (!timedOutOps.isEmpty()) {
+        throw new CheckedOperationTimeoutException(duration, unit, timedOutOps);
       }
     } else {
       // continuous timeout counter will be reset

--- a/src/main/java/net/spy/memcached/internal/BulkGetFuture.java
+++ b/src/main/java/net/spy/memcached/internal/BulkGetFuture.java
@@ -135,19 +135,19 @@ public class BulkGetFuture<T> implements BulkFuture<Map<String, T>> {
            throws InterruptedException, ExecutionException, TimeoutException {
 
     if (!latch.await(to, unit)) {
-      Collection<Operation> timedoutOps = new HashSet<>();
+      Collection<Operation> timedOutOps = new HashSet<>();
       for (Operation op : ops) {
         if (op.getState() != OperationState.COMPLETE) {
-          timedoutOps.add(op);
+          timedOutOps.add(op);
         } else {
           MemcachedConnection.opSucceeded(op);
         }
       }
-      if (!timedoutOps.isEmpty()) {
-        MemcachedConnection.opsTimedOut(timedoutOps);
+      if (!timedOutOps.isEmpty()) {
+        MemcachedConnection.opsTimedOut(timedOutOps);
         isTimeout.set(true);
 
-        TimeoutException e = new CheckedOperationTimeoutException(to, unit, timedoutOps);
+        TimeoutException e = new CheckedOperationTimeoutException(to, unit, timedOutOps);
         if (throwOnTimeout) {
           throw e;
         }

--- a/src/main/java/net/spy/memcached/internal/BulkOperationFuture.java
+++ b/src/main/java/net/spy/memcached/internal/BulkOperationFuture.java
@@ -70,17 +70,17 @@ public class BulkOperationFuture<T> implements Future<Map<String, T>> {
                             TimeUnit unit) throws InterruptedException,
           TimeoutException, ExecutionException {
     if (!latch.await(duration, unit)) {
-      Collection<Operation> timedoutOps = new HashSet<>();
+      Collection<Operation> timedOutOps = new HashSet<>();
       for (Operation op : ops) {
         if (op.getState() != OperationState.COMPLETE) {
-          timedoutOps.add(op);
+          timedOutOps.add(op);
         } else {
           MemcachedConnection.opSucceeded(op);
         }
       }
-      if (!timedoutOps.isEmpty()) {
-        MemcachedConnection.opsTimedOut(timedoutOps);
-        throw new CheckedOperationTimeoutException(duration, unit, timedoutOps);
+      if (!timedOutOps.isEmpty()) {
+        MemcachedConnection.opsTimedOut(timedOutOps);
+        throw new CheckedOperationTimeoutException(duration, unit, timedOutOps);
       }
     } else {
       // continuous timeout counter will be reset

--- a/src/main/java/net/spy/memcached/internal/CheckedOperationTimeoutException.java
+++ b/src/main/java/net/spy/memcached/internal/CheckedOperationTimeoutException.java
@@ -41,7 +41,7 @@ public class CheckedOperationTimeoutException extends TimeoutException {
   public CheckedOperationTimeoutException(long duration,
                                           TimeUnit unit,
                                           Collection<Operation> ops) {
-    super(TimedOutMessageFactory.createTimedoutMessage(duration, unit, ops));
+    super(TimedOutMessageFactory.createTimedOutMessage(duration, unit, ops));
     operations = ops;
   }
 

--- a/src/main/java/net/spy/memcached/internal/CollectionGetBulkFuture.java
+++ b/src/main/java/net/spy/memcached/internal/CollectionGetBulkFuture.java
@@ -61,17 +61,17 @@ public class CollectionGetBulkFuture<T> implements Future<T> {
   public T get(long duration, TimeUnit unit)
       throws InterruptedException, TimeoutException, ExecutionException {
     if (!latch.await(duration, unit)) {
-      Collection<Operation> timedoutOps = new HashSet<>();
+      Collection<Operation> timedDutOps = new HashSet<>();
       for (Operation op : ops) {
         if (op.getState() != OperationState.COMPLETE) {
-          timedoutOps.add(op);
+          timedDutOps.add(op);
         } else {
           MemcachedConnection.opSucceeded(op);
         }
       }
-      if (!timedoutOps.isEmpty()) {
-        MemcachedConnection.opsTimedOut(timedoutOps);
-        throw new CheckedOperationTimeoutException(duration, unit, timedoutOps);
+      if (!timedDutOps.isEmpty()) {
+        MemcachedConnection.opsTimedOut(timedDutOps);
+        throw new CheckedOperationTimeoutException(duration, unit, timedDutOps);
       }
     } else {
       // continuous timeout counter will be reset

--- a/src/main/java/net/spy/memcached/internal/PipedCollectionFuture.java
+++ b/src/main/java/net/spy/memcached/internal/PipedCollectionFuture.java
@@ -63,18 +63,18 @@ public class PipedCollectionFuture<K, V>
           throws InterruptedException, TimeoutException, ExecutionException {
 
     if (!latch.await(duration, unit)) {
-      Collection<Operation> timedoutOps = new HashSet<>();
+      Collection<Operation> timedOutOps = new HashSet<>();
       for (Operation op : ops) {
         if (op.getState() != OperationState.COMPLETE) {
-          timedoutOps.add(op);
+          timedOutOps.add(op);
         } else {
           MemcachedConnection.opSucceeded(op);
         }
       }
-      if (!timedoutOps.isEmpty()) {
+      if (!timedOutOps.isEmpty()) {
         // set timeout only once for piped ops requested to single node.
-        MemcachedConnection.opTimedOut(timedoutOps.iterator().next());
-        throw new CheckedOperationTimeoutException(duration, unit, timedoutOps);
+        MemcachedConnection.opTimedOut(timedOutOps.iterator().next());
+        throw new CheckedOperationTimeoutException(duration, unit, timedOutOps);
       }
     } else {
       // continuous timeout counter will be reset only once in pipe

--- a/src/main/java/net/spy/memcached/internal/SMGetFuture.java
+++ b/src/main/java/net/spy/memcached/internal/SMGetFuture.java
@@ -58,17 +58,17 @@ public final class SMGetFuture<T extends List<?>> implements Future<T> {
           throws InterruptedException, TimeoutException, ExecutionException {
 
     if (!latch.await(duration, unit)) {
-      Collection<Operation> timedoutOps = new HashSet<>();
+      Collection<Operation> timedOutOps = new HashSet<>();
       for (Operation op : ops) {
         if (op.getState() != OperationState.COMPLETE) {
-          timedoutOps.add(op);
+          timedOutOps.add(op);
         } else {
           MemcachedConnection.opSucceeded(op);
         }
       }
-      if (!timedoutOps.isEmpty()) {
-        MemcachedConnection.opsTimedOut(timedoutOps);
-        throw new CheckedOperationTimeoutException(duration, unit, timedoutOps);
+      if (!timedOutOps.isEmpty()) {
+        MemcachedConnection.opsTimedOut(timedOutOps);
+        throw new CheckedOperationTimeoutException(duration, unit, timedOutOps);
       }
     } else {
       // continuous timeout counter will be reset

--- a/src/test/java/net/spy/memcached/ArcusTimeoutMessageTest.java
+++ b/src/test/java/net/spy/memcached/ArcusTimeoutMessageTest.java
@@ -664,10 +664,10 @@ public class ArcusTimeoutMessageTest extends TestCase {
     try {
       mc.getVersions();
     } catch (Exception e) {
-      String exceptionMessage = getTimedoutHeadMessage(e.getMessage());
-      String timedoutMessages = getTimedoutHeadMessage(createTimedoutMessage(op));
+      String exceptionMessage = getTimedOutHeadMessage(e.getMessage());
+      String timedOutMessages = getTimedOutHeadMessage(createTimedOutMessage(op));
 
-      assertEquals(exceptionMessage, timedoutMessages);
+      assertEquals(exceptionMessage, timedOutMessages);
     }
   }
 
@@ -690,10 +690,10 @@ public class ArcusTimeoutMessageTest extends TestCase {
     try {
       mc.getStats();
     } catch (Exception e) {
-      String exceptionMessage = getTimedoutHeadMessage(e.getMessage());
-      String timedoutMessages = getTimedoutHeadMessage(createTimedoutMessage(op));
+      String exceptionMessage = getTimedOutHeadMessage(e.getMessage());
+      String timedOutMessages = getTimedOutHeadMessage(createTimedOutMessage(op));
 
-      assertEquals(exceptionMessage, timedoutMessages);
+      assertEquals(exceptionMessage, timedOutMessages);
     }
   }
 
@@ -705,10 +705,10 @@ public class ArcusTimeoutMessageTest extends TestCase {
     try {
       f.get(1L, TimeUnit.MILLISECONDS);
     } catch (Exception e) {
-      String exceptionMessage = getTimedoutHeadMessage(e.getMessage());
-      String timedoutMessages = getTimedoutHeadMessage(createTimedoutMessage(op));
+      String exceptionMessage = getTimedOutHeadMessage(e.getMessage());
+      String timedOutMessages = getTimedOutHeadMessage(createTimedOutMessage(op));
 
-      assertEquals(exceptionMessage, timedoutMessages);
+      assertEquals(exceptionMessage, timedOutMessages);
     }
     f.cancel(true);
   }
@@ -725,12 +725,12 @@ public class ArcusTimeoutMessageTest extends TestCase {
     };
   }
 
-  private String createTimedoutMessage(Operation op) {
+  private String createTimedOutMessage(Operation op) {
     return TimedOutMessageFactory
-            .createTimedoutMessage(1, TimeUnit.MILLISECONDS, Collections.singletonList(op));
+            .createTimedOutMessage(1, TimeUnit.MILLISECONDS, Collections.singletonList(op));
   }
 
-  private String getTimedoutHeadMessage(String message) {
+  private String getTimedOutHeadMessage(String message) {
     return message.split("-")[0];
   }
 }


### PR DESCRIPTION
### 🔗 Related Issue

<!-- Please link related issue. ex) https://github.com/naver/arcus-java-client/issues/{issue_number} -->
- 

### ⌨️ What I did

<!-- Please describe this PR and what you've been working on. -->
- 오타를 수정합니다.
- https://en.dict.naver.com/#/entry/enko/0e7f7abc1e2b476ebccaeec2bc7ea920