### PR TITLE
INTERNA: Change callback method for mutate operation.

### DIFF
--- a/src/main/java/net/spy/memcached/OperationFactory.java
+++ b/src/main/java/net/spy/memcached/OperationFactory.java
@@ -182,7 +182,7 @@ public interface OperationFactory {
    * @return the new mutator operation
    */
   MutatorOperation mutate(Mutator m, String key, int by,
-                          long def, int exp, OperationCallback cb);
+                          long def, int exp, MutatorOperation.Callback cb);
 
   /**
    * Get a new StatsOperation.

--- a/src/main/java/net/spy/memcached/ops/BaseOperationFactory.java
+++ b/src/main/java/net/spy/memcached/ops/BaseOperationFactory.java
@@ -71,7 +71,7 @@ public abstract class BaseOperationFactory implements OperationFactory {
       MutatorOperation mo = (MutatorOperation) op;
       rv.add(mutate(mo.getType(), first(op.getKeys()),
               mo.getBy(), mo.getDefault(), mo.getExpiration(),
-              op.getCallback()));
+              (MutatorOperation.Callback) op.getCallback()));
     } else if (op instanceof StoreOperation) {
       StoreOperation so = (StoreOperation) op;
       rv.add(store(so.getStoreType(), first(op.getKeys()), so.getFlags(),

--- a/src/main/java/net/spy/memcached/ops/MutatorOperation.java
+++ b/src/main/java/net/spy/memcached/ops/MutatorOperation.java
@@ -24,4 +24,13 @@ public interface MutatorOperation extends KeyedOperation {
    * Get the expiration to set in case of a new entry.
    */
   int getExpiration();
+
+  interface Callback extends OperationCallback {
+    /**
+     * Callback for mutate operation.
+     *
+     * @param result the value that was mutated.
+     */
+    void gotMutatedValue(Long result);
+  }
 }

--- a/src/main/java/net/spy/memcached/protocol/ascii/AsciiOperationFactory.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/AsciiOperationFactory.java
@@ -119,7 +119,7 @@ public class AsciiOperationFactory extends BaseOperationFactory {
   }
 
   public MutatorOperation mutate(Mutator m, String key, int by,
-                                 long def, int exp, OperationCallback cb) {
+                                 long def, int exp, MutatorOperation.Callback cb) {
     return new MutatorOperationImpl(m, key, by, def, exp, cb);
   }
 

--- a/src/main/java/net/spy/memcached/protocol/binary/BinaryOperationFactory.java
+++ b/src/main/java/net/spy/memcached/protocol/binary/BinaryOperationFactory.java
@@ -124,7 +124,7 @@ public class BinaryOperationFactory extends BaseOperationFactory {
   }
 
   public MutatorOperation mutate(Mutator m, String key, int by,
-                                 long def, int exp, OperationCallback cb) {
+                                 long def, int exp, MutatorOperation.Callback cb) {
     return new MutatorOperationImpl(m, key, by, def, exp, cb);
   }
 

--- a/src/test/java/net/spy/memcached/OperationFactoryTestBase.java
+++ b/src/test/java/net/spy/memcached/OperationFactoryTestBase.java
@@ -32,6 +32,7 @@ public abstract class OperationFactoryTestBase extends MockObjectTestCase {
   public final static String TEST_KEY = "someKey";
   protected OperationFactory ofact = null;
   protected OperationCallback genericCallback;
+  protected MutatorOperation.Callback genericMutationCallback;
   private byte[] testData;
 
   @Override
@@ -45,6 +46,21 @@ public abstract class OperationFactoryTestBase extends MockObjectTestCase {
 
       public void receivedStatus(OperationStatus status) {
         fail("Unexpected status:  " + status);
+      }
+    };
+    genericMutationCallback = new MutatorOperation.Callback() {
+      @Override
+      public void gotMutatedValue(Long result) {
+      }
+
+      @Override
+      public void receivedStatus(OperationStatus status) {
+        fail("Unexpected status:  " + status);
+      }
+
+      @Override
+      public void complete() {
+        fail("Unexpected invocation");
       }
     };
 
@@ -83,7 +99,7 @@ public abstract class OperationFactoryTestBase extends MockObjectTestCase {
     long def = 28775;
     int by = 7735;
     MutatorOperation op = ofact.mutate(Mutator.incr, TEST_KEY, by, def,
-            exp, genericCallback);
+            exp, genericMutationCallback);
 
     MutatorOperation op2 = cloneOne(MutatorOperation.class, op);
     assertKey(op2);
@@ -91,7 +107,7 @@ public abstract class OperationFactoryTestBase extends MockObjectTestCase {
     assertEquals(def, op2.getDefault());
     assertEquals(by, op2.getBy());
     assertSame(Mutator.incr, op2.getType());
-    assertCallback(op2);
+    assertMutationCallback(op2);
   }
 
   public void testMutatorOperationDecrCloning() {
@@ -99,7 +115,7 @@ public abstract class OperationFactoryTestBase extends MockObjectTestCase {
     long def = 28775;
     int by = 7735;
     MutatorOperation op = ofact.mutate(Mutator.decr, TEST_KEY, by, def,
-            exp, genericCallback);
+            exp, genericMutationCallback);
 
     MutatorOperation op2 = cloneOne(MutatorOperation.class, op);
     assertKey(op2);
@@ -107,7 +123,7 @@ public abstract class OperationFactoryTestBase extends MockObjectTestCase {
     assertEquals(def, op2.getDefault());
     assertEquals(by, op2.getBy());
     assertSame(Mutator.decr, op2.getType());
-    assertCallback(op2);
+    assertMutationCallback(op2);
   }
 
   public void testStoreOperationAddCloning() {
@@ -285,6 +301,10 @@ public abstract class OperationFactoryTestBase extends MockObjectTestCase {
 
   protected void assertCallback(Operation op) {
     assertSame(genericCallback, op.getCallback());
+  }
+
+  protected void assertMutationCallback(Operation op) {
+    assertSame(genericMutationCallback, op.getCallback());
   }
 
   private void assertBytes(byte[] bytes) {

--- a/src/test/java/net/spy/memcached/protocol/ascii/OperationFactoryTest.java
+++ b/src/test/java/net/spy/memcached/protocol/ascii/OperationFactoryTest.java
@@ -18,7 +18,7 @@ public class OperationFactoryTest extends OperationFactoryTestBase {
     long def = 28775;
     int by = 7735;
     MutatorOperation op = ofact.mutate(Mutator.incr, TEST_KEY, by, def,
-            exp, genericCallback);
+            exp, genericMutationCallback);
 
     MutatorOperation op2 = cloneOne(MutatorOperation.class, op);
     assertKey(op2);
@@ -26,7 +26,7 @@ public class OperationFactoryTest extends OperationFactoryTestBase {
     assertEquals(-1, op2.getDefault());
     assertEquals(by, op2.getBy());
     assertSame(Mutator.incr, op2.getType());
-    assertCallback(op2);
+    assertMutationCallback(op2);
   }
 
   @Override
@@ -35,7 +35,7 @@ public class OperationFactoryTest extends OperationFactoryTestBase {
     long def = 28775;
     int by = 7735;
     MutatorOperation op = ofact.mutate(Mutator.decr, TEST_KEY, by, def,
-            exp, genericCallback);
+            exp, genericMutationCallback);
 
     MutatorOperation op2 = cloneOne(MutatorOperation.class, op);
     assertKey(op2);
@@ -43,7 +43,7 @@ public class OperationFactoryTest extends OperationFactoryTestBase {
     assertEquals(-1, op2.getDefault());
     assertEquals(by, op2.getBy());
     assertSame(Mutator.decr, op2.getType());
-    assertCallback(op2);
+    assertMutationCallback(op2);
   }
 
 }

--- a/src/test/manual/net/spy/memcached/MultibyteKeyTest.java
+++ b/src/test/manual/net/spy/memcached/MultibyteKeyTest.java
@@ -68,6 +68,7 @@ import net.spy.memcached.ops.ConcatenationType;
 import net.spy.memcached.ops.GetAttrOperation;
 import net.spy.memcached.ops.GetsOperation;
 import net.spy.memcached.ops.Mutator;
+import net.spy.memcached.ops.MutatorOperation;
 import net.spy.memcached.ops.OperationCallback;
 import net.spy.memcached.ops.OperationStatus;
 import net.spy.memcached.ops.StoreType;
@@ -273,7 +274,22 @@ public class MultibyteKeyTest {
   @Test
   public void MutatorOperationImplTest() {
     try {
-      opFact.mutate(Mutator.incr, MULTIBYTE_KEY, 1, 1L, 0, genericCallback).initialize();
+      opFact.mutate(Mutator.incr, MULTIBYTE_KEY, 1, 1L, 0, new MutatorOperation.Callback() {
+        @Override
+        public void gotMutatedValue(Long result) {
+
+        }
+
+        @Override
+        public void receivedStatus(OperationStatus status) {
+
+        }
+
+        @Override
+        public void complete() {
+
+        }
+      }).initialize();
     } catch (java.nio.BufferOverflowException e) {
       Assert.fail();
     }


### PR DESCRIPTION
## 변경 내용

mutate의 연산 결과를 receivedStatus가 아닌
gotMutatedValue 콜백 메서드를 추가해 이를 통해
받아오도록 변경하였습니다.

## 관련 이슈
https://github.com/jam2in/arcus-works/issues/584#issuecomment-2216229651

