### PR TITLE
INTERNAL: Change addOp logic in mutate api.

### DIFF
--- a/src/main/java/net/spy/memcached/MemcachedClient.java
+++ b/src/main/java/net/spy/memcached/MemcachedClient.java
@@ -1788,17 +1788,17 @@ public class MemcachedClient extends SpyThread
     final CountDownLatch latch = new CountDownLatch(1);
     final OperationFuture<Long> rv = new OperationFuture<>(
             latch, operationTimeout);
-    Operation op = addOp(key, opFact.mutate(m, key, by, def, exp,
-        new OperationCallback() {
-          public void receivedStatus(OperationStatus s) {
-            rv.set(Long.parseLong(s.isSuccess() ? s.getMessage() : "-1"), s);
-          }
+    Operation op = opFact.mutate(m, key, by, def, exp, new OperationCallback() {
+      public void receivedStatus(OperationStatus s) {
+        rv.set(Long.parseLong(s.isSuccess() ? s.getMessage() : "-1"), s);
+      }
 
-          public void complete() {
-            latch.countDown();
-          }
-        }));
+      public void complete() {
+        latch.countDown();
+      }
+    });
     rv.setOperation(op);
+    addOp(key, op);
     return rv;
   }
 


### PR DESCRIPTION
기존 api들의 구현과 동일하게
Operation 생성하고 나서 addOp() 하는 형태로 변경하였습니다.

다른 api들을 살펴본 결과 이러한 형태는 mutate 연산만 가지고 있습니다.

