### PR TITLE
TEST: Fix `java.net.spy.memcached.protocol.ascii.BaseOpTest` to ensure it tests correctly.

### DIFF
--- a/src/test/java/net/spy/memcached/protocol/ascii/BaseOpTest.java
+++ b/src/test/java/net/spy/memcached/protocol/ascii/BaseOpTest.java
@@ -27,44 +27,33 @@ import java.util.List;
 
 import net.spy.memcached.compat.BaseMockCase;
 
+import static org.junit.Assert.assertThrows;
+
 /**
  * Test the basic operation buffer handling stuff.
  */
 public class BaseOpTest extends BaseMockCase {
 
   public void testAssertions() {
-    try {
+    assertThrows(AssertionError.class, () -> {
       assert false;
-      fail("Assertions are not enabled.");
-    } catch (AssertionError e) {
-      // OK
-    }
+    });
   }
 
-  public void testDataReadType() throws Exception {
+  public void testDataReadType() {
     SimpleOp op = new SimpleOp(OperationReadType.DATA);
     assertSame(OperationReadType.DATA, op.getReadType());
     // Make sure lines aren't handled
-    try {
-      op.handleLine("x");
-      fail("Handled a line in data mode");
-    } catch (AssertionError e) {
-      // ok
-    }
+    assertThrows(AssertionError.class, () -> op.handleLine("x"));
     op.setBytesToRead(2);
     op.handleRead(ByteBuffer.wrap("hi".getBytes()));
   }
 
-  public void testLineReadType() throws Exception {
+  public void testLineReadType() {
     SimpleOp op = new SimpleOp(OperationReadType.LINE);
     assertSame(OperationReadType.LINE, op.getReadType());
     // Make sure lines aren't handled
-    try {
-      op.handleRead(ByteBuffer.allocate(3));
-      fail("Handled data in line mode");
-    } catch (AssertionError e) {
-      // ok
-    }
+    assertThrows(AssertionError.class, () -> op.handleRead(ByteBuffer.allocate(3)));
     op.handleLine("x");
   }
 


### PR DESCRIPTION
### 🔗 Related Issue

<!-- Please link related issue. ex) https://github.com/naver/arcus-java-client/issues/{issue_number} -->
- AssertionError는 `assert`문에 의한 실패도 잡고 fail() 메소드에 의한 실패도 잡는데, 잡아놓은 실패가 무엇인지 확인하지 않고 있다.

### ⌨️ What I did

<!-- Please describe this PR and what you've been working on. -->
- fail() 메소드에 진입하지 않았음을 검증합니다.