### PR TITLE
TEST: Wait for 1 second when store value in testSyncGetTimeouts().

### DIFF
--- a/src/test/java/net/spy/memcached/ProtocolBaseCase.java
+++ b/src/test/java/net/spy/memcached/ProtocolBaseCase.java
@@ -653,7 +653,7 @@ public abstract class ProtocolBaseCase extends ClientBaseCase {
       }
     });
 
-    assertTrue(client.set(key, 0, value).get());
+    assertTrue(client.set(key, 0, value).get(1, TimeUnit.SECONDS));
     try {
       for (int i = 0; i < 1000000; i++) {
         client.get(key);


### PR DESCRIPTION
### 🔗 Related Issue

<!-- Please link related issue. ex) https://github.com/naver/arcus-java-client/issues/{issue_number} -->
- testSyncGetTimeouts() 메소드에서는 타임아웃을 의도적으로 일으키기 위해 기본 Timeout이 1 밀리초인 MemcachedClient를 사용한다.
- 데이터를 저장하기 위해 set 연산을 수행할 때는 타임아웃을 의도하지 않았음에도 1 밀리초만 기다린다.

### ⌨️ What I did

<!-- Please describe this PR and what you've been working on. -->
- 타임아웃을 의도하지 않는 set 연산 수행 시에는 1초를 기다립니다.