### PR TITLE
INTERNAL: make waitForQueues method into private

### DIFF
--- a/src/main/java/net/spy/memcached/ArcusClientPool.java
+++ b/src/main/java/net/spy/memcached/ArcusClientPool.java
@@ -462,11 +462,6 @@ public class ArcusClientPool implements MemcachedClientIF, ArcusClientIF {
   }
 
   @Override
-  public boolean waitForQueues(long timeout, TimeUnit unit) {
-    return this.getClient().waitForQueues(timeout, unit);
-  }
-
-  @Override
   public boolean addObserver(ConnectionObserver obs) {
     return this.getClient().addObserver(obs);
   }

--- a/src/main/java/net/spy/memcached/MemcachedClient.java
+++ b/src/main/java/net/spy/memcached/MemcachedClient.java
@@ -2122,7 +2122,7 @@ public class MemcachedClient extends SpyThread
    * @throws IllegalStateException in the rare circumstance where queue
    *                               is too full to accept any more requests
    */
-  public boolean waitForQueues(long timeout, TimeUnit unit) {
+  private boolean waitForQueues(long timeout, TimeUnit unit) {
     Collection<MemcachedNode> nodes = getAllNodes();
     final CountDownLatch latch = new CountDownLatch(nodes.size());
 

--- a/src/main/java/net/spy/memcached/MemcachedClientIF.java
+++ b/src/main/java/net/spy/memcached/MemcachedClientIF.java
@@ -182,8 +182,6 @@ public interface MemcachedClientIF {
 
   boolean shutdown(long timeout, TimeUnit unit);
 
-  boolean waitForQueues(long timeout, TimeUnit unit);
-
   boolean addObserver(ConnectionObserver obs);
 
   boolean removeObserver(ConnectionObserver obs);

--- a/src/test/manual/net/spy/memcached/test/MemcachedThreadBench.java
+++ b/src/test/manual/net/spy/memcached/test/MemcachedThreadBench.java
@@ -16,9 +16,6 @@
  */
 package net.spy.memcached.test;
 
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicInteger;
-
 import junit.framework.TestCase;
 
 import net.spy.memcached.AddrUtil;
@@ -135,8 +132,6 @@ public class MemcachedThreadBench extends TestCase {
   }
 
   private static class SetterThread extends Thread {
-    private static final AtomicInteger total = new AtomicInteger(0);
-    private static final int MAX_QUEUE = 10000;
     private final MemcachedClient mc;
     private final WorkerStat stat;
 
@@ -157,24 +152,14 @@ public class MemcachedThreadBench extends TestCase {
       long begin = System.currentTimeMillis();
       for (int i = stat.start; i < stat.start + stat.runs; i++) {
         try {
-          mc.set("" + i + keyBase, 3600, object).get();
+          mc.set(i + keyBase, 3600, object).get();
         } catch (Exception e) {
           fail(e.getMessage());
-        }
-        if (total.incrementAndGet() >= MAX_QUEUE) {
-          flush();
         }
       }
       long end = System.currentTimeMillis();
 
       stat.setterTime = end - begin;
-    }
-
-    private synchronized void flush() {
-      if (total.intValue() >= MAX_QUEUE) {
-        mc.waitForQueues(5, TimeUnit.SECONDS);
-        total.set(0);
-      }
     }
   }
 

--- a/src/test/manual/net/spy/memcached/test/ObserverToy.java
+++ b/src/test/manual/net/spy/memcached/test/ObserverToy.java
@@ -19,7 +19,7 @@ public final class ObserverToy {
   private ObserverToy() {
   }
 
-  public static void main(String args[]) throws Exception {
+  public static void main(String[] args) throws Exception {
     final ConnectionObserver obs = new ConnectionObserver() {
       public void connectionEstablished(SocketAddress sa,
                                         int reconnectCount) {
@@ -33,7 +33,7 @@ public final class ObserverToy {
 
     };
 
-    MemcachedClient c = new MemcachedClient(new DefaultConnectionFactory() {
+    MemcachedClient client = new MemcachedClient(new DefaultConnectionFactory() {
 
       @Override
       public Collection<ConnectionObserver> getInitialObservers() {
@@ -48,8 +48,12 @@ public final class ObserverToy {
     }, AddrUtil.getAddresses("localhost:11212"));
 
     while (true) {
-      c.waitForQueues(1, TimeUnit.SECONDS);
-      Thread.sleep(1000);
+      try {
+        client.asyncGet("ObserverToy").get(1, TimeUnit.SECONDS);
+        Thread.sleep(1000);
+      } catch (Exception e) {
+        e.printStackTrace();
+      }
     }
   }
 


### PR DESCRIPTION
### 🔗 Related Issue

<!-- Please link related issue. ex) https://github.com/naver/arcus-java-client/issues/{issue_number} -->
- https://github.com/jam2in/arcus-works/issues/585
### ⌨️ What I did

<!-- Please describe this PR and what you've been working on. -->
- waitForQueues 메서드를 private으로 변경합니다.
- MemcachedThreadBench 에서 사용되던 waitForQueues는 MemcachedClient#set 의 결과를 받은 후 다시 요청을 보내므로 필요 없어 제거합니다.
- ObserverToy에서 사용되던 waitForQueues는 asyncGet으로 대체합니다.