### PR TITLE
INTERNAL: make piped insert operations process synchronously

### DIFF
--- a/src/main/java/net/spy/memcached/collection/CollectionResponse.java
+++ b/src/main/java/net/spy/memcached/collection/CollectionResponse.java
@@ -44,6 +44,7 @@ public enum CollectionResponse {
 
   UNDEFINED,
   CANCELED,
+  STOPPED,
 
   INTERRUPT_EXCEPTION,
   EXECUTION_EXCEPTION,

--- a/src/main/java/net/spy/memcached/protocol/ascii/CollectionPipedInsertOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/CollectionPipedInsertOperationImpl.java
@@ -29,7 +29,7 @@ import net.spy.memcached.ops.OperationType;
 /**
  * Operation to store collection data in a memcached server.
  */
-public final class CollectionPipedInsertOperationImpl extends PipeOperationImpl
+public final class CollectionPipedInsertOperationImpl extends SingleKeyPipeOperationImpl
         implements CollectionPipedInsertOperation {
 
   public CollectionPipedInsertOperationImpl(String key,

--- a/src/main/java/net/spy/memcached/protocol/ascii/PipeOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/PipeOperationImpl.java
@@ -62,13 +62,13 @@ abstract class PipeOperationImpl extends OperationImpl {
 
   protected boolean successAll = true;
 
-  private final CollectionPipe collectionPipe;
-  private final PipedOperationCallback cb;
-  private final List<String> keys;
+  protected final CollectionPipe collectionPipe;
+  protected final PipedOperationCallback cb;
+  protected final List<String> keys;
   private final boolean isIdempotent;
 
-  private int index = 0;
-  private boolean readUntilLastLine = false;
+  protected int index = 0;
+  protected boolean readUntilLastLine = false;
 
   protected PipeOperationImpl(List<String> keys, CollectionPipe collectionPipe,
                               OperationCallback cb) {

--- a/src/main/java/net/spy/memcached/protocol/ascii/SingleKeyPipeOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/SingleKeyPipeOperationImpl.java
@@ -1,0 +1,99 @@
+package net.spy.memcached.protocol.ascii;
+
+import java.util.List;
+
+import net.spy.memcached.collection.CollectionPipe;
+import net.spy.memcached.ops.OperationCallback;
+import net.spy.memcached.ops.OperationState;
+import net.spy.memcached.ops.OperationStatus;
+
+public abstract class SingleKeyPipeOperationImpl extends PipeOperationImpl {
+
+  protected SingleKeyPipeOperationImpl(List<String> keys,
+                                       CollectionPipe collectionPipe,
+                                       OperationCallback cb) {
+    super(keys, collectionPipe, cb);
+  }
+
+  @Override
+  public void handleLine(String line) {
+    assert getState() == OperationState.READING
+            : "Read ``" + line + "'' when in " + getState() + " state";
+
+    /* ENABLE_REPLICATION if */
+    if (isWriteOperation() && hasSwitchedOver(line)) {
+      collectionPipe.setNextOpIndex(index);
+      prepareSwitchover(line);
+      return;
+    }
+    /* ENABLE_REPLICATION end */
+
+    /* ENABLE_MIGRATION if */
+    if (hasNotMyKey(line)) {
+      // Only one NOT_MY_KEY is provided in response of
+      // single key piped operation when redirection.
+      addRedirectSingleKeyOperation(line, keys.get(0));
+      if (collectionPipe.isNotPiped()) {
+        transitionState(OperationState.REDIRECT);
+      } else {
+        collectionPipe.setNextOpIndex(index);
+      }
+      return;
+    }
+    /* ENABLE_MIGRATION end */
+
+    if (collectionPipe.isNotPiped()) {
+      OperationStatus status = checkStatus(line);
+      if (!status.isSuccess()) {
+        successAll = false;
+      }
+      cb.gotStatus(index, status);
+
+      cb.receivedStatus((successAll) ? END : FAILED_END);
+      transitionState(OperationState.COMPLETE);
+      return;
+    }
+
+    /*
+      RESPONSE <count>\r\n
+      <status of the 1st pipelined command>\r\n
+      [ ... ]
+      <status of the last pipelined command>\r\n
+      END|PIPE_ERROR <error_string>\r\n
+    */
+    if (line.startsWith("END") || line.startsWith("PIPE_ERROR ")) {
+      /* ENABLE_MIGRATION if */
+      if (needRedirect()) {
+        transitionState(OperationState.REDIRECT);
+        return;
+      }
+      /* ENABLE_MIGRATION end */
+      cb.receivedStatus((index == collectionPipe.getItemCount() && successAll) ? END : FAILED_END);
+      transitionState(OperationState.COMPLETE);
+    } else if (line.startsWith("RESPONSE ")) {
+      getLogger().debug("Got line %s", line);
+
+      // TODO server should be fixed
+      line = line.replace("   ", " ");
+      line = line.replace("  ", " ");
+
+      String[] stuff = line.split(" ");
+      assert "RESPONSE".equals(stuff[0]);
+      readUntilLastLine = true;
+    } else {
+      OperationStatus status = checkStatus(line);
+      if (!status.isSuccess()) {
+        successAll = false;
+      }
+      cb.gotStatus(index, status);
+
+      index++;
+    }
+  }
+
+  @Override
+  protected OperationStatus checkStatus(String line) {
+    return null;
+  }
+
+}

--- a/src/test/manual/net/spy/memcached/bulkoperation/BopInsertBulkMultipleTest.java
+++ b/src/test/manual/net/spy/memcached/bulkoperation/BopInsertBulkMultipleTest.java
@@ -23,6 +23,7 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
+import net.spy.memcached.ArcusClient;
 import net.spy.memcached.collection.BaseIntegrationTest;
 import net.spy.memcached.collection.CollectionAttributes;
 import net.spy.memcached.collection.Element;
@@ -122,7 +123,7 @@ class BopInsertBulkMultipleTest extends BaseIntegrationTest {
 
       Map<Integer, CollectionOperationStatus> map = future.get(2000L,
               TimeUnit.MILLISECONDS);
-      assertEquals(bkeySize, map.size());
+      assertEquals(ArcusClient.MAX_PIPED_ITEM_COUNT + 1, map.size());
 
     } catch (Exception e) {
       e.printStackTrace();

--- a/src/test/manual/net/spy/memcached/bulkoperation/LopInsertBulkMultipleValueTest.java
+++ b/src/test/manual/net/spy/memcached/bulkoperation/LopInsertBulkMultipleValueTest.java
@@ -23,8 +23,10 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
+import net.spy.memcached.ArcusClient;
 import net.spy.memcached.collection.BaseIntegrationTest;
 import net.spy.memcached.collection.CollectionAttributes;
+import net.spy.memcached.collection.CollectionResponse;
 import net.spy.memcached.ops.CollectionOperationStatus;
 
 import org.junit.jupiter.api.AfterEach;
@@ -111,9 +113,7 @@ class LopInsertBulkMultipleValueTest extends BaseIntegrationTest {
   void testErrorCount() {
     int valueCount = 1200;
     Object[] valueList = new Object[valueCount];
-    for (int i = 0; i < valueList.length; i++) {
-      valueList[i] = "MyValue";
-    }
+    Arrays.fill(valueList, "MyValue");
 
     try {
       // SET
@@ -123,8 +123,11 @@ class LopInsertBulkMultipleValueTest extends BaseIntegrationTest {
 
       Map<Integer, CollectionOperationStatus> map = future.get(1000L,
               TimeUnit.MILLISECONDS);
-      assertEquals(valueCount, map.size());
-
+      assertEquals(ArcusClient.MAX_PIPED_ITEM_COUNT + 1, map.size());
+      assertEquals(map.get(ArcusClient.MAX_PIPED_ITEM_COUNT - 1).getResponse(),
+              CollectionResponse.NOT_FOUND);
+      assertEquals(map.get(ArcusClient.MAX_PIPED_ITEM_COUNT).getResponse(),
+              CollectionResponse.STOPPED);
     } catch (Exception e) {
       e.printStackTrace();
       fail();

--- a/src/test/manual/net/spy/memcached/bulkoperation/MopInsertBulkMultipleTest.java
+++ b/src/test/manual/net/spy/memcached/bulkoperation/MopInsertBulkMultipleTest.java
@@ -23,6 +23,7 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
+import net.spy.memcached.ArcusClient;
 import net.spy.memcached.collection.BaseIntegrationTest;
 import net.spy.memcached.collection.CollectionAttributes;
 import net.spy.memcached.ops.CollectionOperationStatus;
@@ -116,7 +117,7 @@ class MopInsertBulkMultipleTest extends BaseIntegrationTest {
 
       Map<Integer, CollectionOperationStatus> map = future.get(2000L,
               TimeUnit.MILLISECONDS);
-      assertEquals(elementSize, map.size());
+      assertEquals(ArcusClient.MAX_PIPED_ITEM_COUNT + 1, map.size());
 
     } catch (Exception e) {
       e.printStackTrace();

--- a/src/test/manual/net/spy/memcached/bulkoperation/PipeInsertTest.java
+++ b/src/test/manual/net/spy/memcached/bulkoperation/PipeInsertTest.java
@@ -22,6 +22,7 @@ import java.util.Map;
 import java.util.TreeMap;
 import java.util.concurrent.TimeUnit;
 
+import net.spy.memcached.ArcusClient;
 import net.spy.memcached.collection.BaseIntegrationTest;
 import net.spy.memcached.collection.CollectionAttributes;
 import net.spy.memcached.collection.Element;
@@ -253,7 +254,7 @@ class PipeInsertTest extends BaseIntegrationTest {
       Map<Integer, CollectionOperationStatus> map = future.get(5000L,
               TimeUnit.MILLISECONDS);
 
-      assertEquals(1000, map.size());
+      assertEquals(ArcusClient.MAX_PIPED_ITEM_COUNT + 1, map.size());
 
       Map<String, Object> rmap = mc.asyncMopGet(KEY, false, false)
               .get();

--- a/src/test/manual/net/spy/memcached/bulkoperation/SopInsertBulkMultipleValueTest.java
+++ b/src/test/manual/net/spy/memcached/bulkoperation/SopInsertBulkMultipleValueTest.java
@@ -122,7 +122,7 @@ class SopInsertBulkMultipleValueTest extends BaseIntegrationTest {
 
       Map<Integer, CollectionOperationStatus> map = future.get(2000L,
               TimeUnit.MILLISECONDS);
-      assertEquals(valueCount, map.size());
+      assertEquals(ArcusClient.MAX_PIPED_ITEM_COUNT + 1, map.size());
     } catch (Exception e) {
       e.printStackTrace();
       fail();


### PR DESCRIPTION
### 🔗 Related Issue

<!-- Please link related issue. ex) https://github.com/naver/arcus-java-client/issues/{issue_number} -->
- https://github.com/jam2in/arcus-works/issues/540

### ⌨️ What I did

<!-- Please describe this PR and what you've been working on. -->
- `lop/sop/mop/bop piped insert`에 한해 적용하는 PR입니다.
#### 동작 과정
- 500개 아이템 단위로 Operation 객체를 나누어 비동기로 일제히 요청을 보내던 것을 동기 방식으로 하나씩 보내어 Arcus 서버에 과도한 부하가 들어가는 것을 방지하고, 실패 시 다음 Operation을 수행하지 않도록 합니다.
- 이전 operation이 성공해야만 다음 operation이 writeQueue와 Future의 operation list에 추가됩니다.
- 만약 CLIENT_ERROR, SERVER_ERROR 실패가 발생하면 그 즉시 latch.countdown을 호출해 남은 operation을 수행하지 않습니다.
- OVERFLOWED, OUT_OF_RANGE 같은 실패가 발생하면 이후 operation의 첫 command가 NOT_EXECUTED 상태임을 future의 failedResult에 추가합니다.
- NOT_EXECUTED 이후의 모든 연산은 실행되지 않은 것입니다. (CANCELED가 아닌 NOT_EXECUTED를 사용하는 이유는 진짜 cancel 상황과의 혼용을 막고자 하기 위함입니다.)

- 본 PR 이전에 pipe 관련 클래스 구조 변경이 있었고, 이에 맞추어 SingleKeyPipedOperationImpl 클래스를 추가합니다.
  - PipedOperationImpl 자체를 수정할 경우 bulk insert까지 영향이 가기 때문에, single key 전용 operation 클래스를 추가한 후 handleLine 메서드를 수정했습니다.
  - 이 클래스를 CollectionPipedInsertOperationImpl 가 상속받도록 합니다. (추후 CollectionPipedUpdateOperationImpl 등 클래스들도 상속받을 예정입니다.)
  - PipedOperationImpl 클래스는 파이프를 사용하는 모든 Operation에 대한 로직을 관리하고, single key나 multi key에 대한 처리를 이 클래스와 같은 별도 클래스에 두어 분리된 형태로 관리할 수 있습니다.