### PR TITLE
INTERNAL: Upgrade ehcache version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
         <zookeeper.version>3.5.9</zookeeper.version>
         <log4j.version>2.23.1</log4j.version>
         <slf4j.version>2.0.12</slf4j.version>
-        <ehcache.version>2.6.0</ehcache.version>
+        <ehcache.version>3.10.8</ehcache.version>
         <junit.version>5.10.2</junit.version>
         <jmock.version>2.13.1</jmock.version>
     </properties>
@@ -79,10 +79,16 @@
             <version>${slf4j.version}</version>
         </dependency>
         <dependency>
-            <groupId>net.sf.ehcache</groupId>
-            <artifactId>ehcache-core</artifactId>
+            <groupId>org.ehcache</groupId>
+            <artifactId>ehcache</artifactId>
             <version>${ehcache.version}</version>
             <exclusions>
+                <!--> org.glassfish.jaxb is blocked in maven 3.8.1 as it comes from http (not https) repository.
+                Also, it is not required in java 8 so we excluded it. See https://github.com/ehcache/ehcache3/issues/2881. </-->
+                <exclusion>
+                    <groupId>org.glassfish.jaxb</groupId>
+                    <artifactId>jaxb-runtime</artifactId>
+                </exclusion>
                 <exclusion>
                     <groupId>org.slf4j</groupId>
                     <artifactId>slf4j-api</artifactId>

--- a/src/main/java/net/spy/memcached/ConnectionFactoryBuilder.java
+++ b/src/main/java/net/spy/memcached/ConnectionFactoryBuilder.java
@@ -79,9 +79,6 @@ public class ConnectionFactoryBuilder {
   private int maxFrontCacheElements = DefaultConnectionFactory.DEFAULT_MAX_FRONTCACHE_ELEMENTS;
   private int frontCacheExpireTime = DefaultConnectionFactory.DEFAULT_FRONTCACHE_EXPIRETIME;
   private String frontCacheName = "ArcusFrontCache_" + this.hashCode();
-  private boolean frontCacheCopyOnRead = DefaultConnectionFactory.DEFAULT_FRONT_CACHE_COPY_ON_READ;
-  private boolean frontCacheCopyOnWrite =
-      DefaultConnectionFactory.DEFAULT_FRONT_CACHE_COPY_ON_WRITE;
 
   private int maxSMGetChunkSize = DefaultConnectionFactory.DEFAULT_MAX_SMGET_KEY_CHUNK_SIZE;
   private byte delimiter = DefaultConnectionFactory.DEFAULT_DELIMITER;
@@ -367,16 +364,16 @@ public class ConnectionFactoryBuilder {
   /**
    * Set front cache copyOnRead property
    */
+  @Deprecated
   public ConnectionFactoryBuilder setFrontCacheCopyOnRead(boolean copyOnRead) {
-    frontCacheCopyOnRead = copyOnRead;
     return this;
   }
 
   /**
    * Set front cache copyOnWrite property
    */
+  @Deprecated
   public ConnectionFactoryBuilder setFrontCacheCopyOnWrite(boolean copyOnWrite) {
-    frontCacheCopyOnWrite = copyOnWrite;
     return this;
   }
 
@@ -636,13 +633,17 @@ public class ConnectionFactoryBuilder {
       }
 
       @Override
+      @SuppressWarnings("deprecation")
+      @Deprecated
       public boolean getFrontCacheCopyOnRead() {
-        return frontCacheCopyOnRead;
+        return DefaultConnectionFactory.DEFAULT_FRONT_CACHE_COPY_ON_READ;
       }
 
       @Override
+      @SuppressWarnings("deprecation")
+      @Deprecated
       public boolean getFrontCacheCopyOnWrite() {
-        return frontCacheCopyOnWrite;
+        return DefaultConnectionFactory.DEFAULT_FRONT_CACHE_COPY_ON_WRITE;
       }
 
       @Override

--- a/src/main/java/net/spy/memcached/DefaultConnectionFactory.java
+++ b/src/main/java/net/spy/memcached/DefaultConnectionFactory.java
@@ -134,13 +134,17 @@ public class DefaultConnectionFactory extends SpyObject
       "ArcusFrontCache" + new Object().hashCode();
 
   /**
+   * copyOnRead is no longer used
    * Default copyOnRead : false
    */
+  @Deprecated
   public static final boolean DEFAULT_FRONT_CACHE_COPY_ON_READ = false;
 
   /**
+   * copyOnWrite is no longer used
    * Default copyOnWrite : false
    */
+  @Deprecated
   public static final boolean DEFAULT_FRONT_CACHE_COPY_ON_WRITE = false;
 
   /**
@@ -347,11 +351,13 @@ public class DefaultConnectionFactory extends SpyObject
   }
 
   @Override
+  @Deprecated
   public boolean getFrontCacheCopyOnRead() {
     return DEFAULT_FRONT_CACHE_COPY_ON_READ;
   }
 
   @Override
+  @Deprecated
   public boolean getFrontCacheCopyOnWrite() {
     return DEFAULT_FRONT_CACHE_COPY_ON_WRITE;
   }

--- a/src/main/java/net/spy/memcached/plugin/FrontCacheMemcachedClient.java
+++ b/src/main/java/net/spy/memcached/plugin/FrontCacheMemcachedClient.java
@@ -66,13 +66,8 @@ public class FrontCacheMemcachedClient extends MemcachedClient {
       String cacheName = cf.getFrontCacheName();
       int maxElements = cf.getMaxFrontCacheElements();
       int timeToLiveSeconds = cf.getFrontCacheExpireTime();
-      boolean copyOnRead = cf.getFrontCacheCopyOnRead();
-      boolean copyOnWrite = cf.getFrontCacheCopyOnWrite();
-      // TODO add an additional option
-      // int timeToIdleSeconds = timeToLiveSeconds;
 
-      localCacheManager = new LocalCacheManager(cacheName, maxElements,
-              timeToLiveSeconds, copyOnRead, copyOnWrite);
+      localCacheManager = new LocalCacheManager(cacheName, maxElements, timeToLiveSeconds);
     }
   }
 


### PR DESCRIPTION
### 🔗 Related Issue

<!-- Please link related issue. ex) https://github.com/naver/arcus-java-client/issues/{issue_number} -->
- https://github.com/jam2in/arcus-works/issues/600

### ⌨️ What I did

<!-- Please describe this PR and what you've been working on. -->
- ehcache version 3 로 업그레이드
  - cacheManger 변경
  ehcache2 에서는 cacheManger 를 싱글톤으로 관리하며 전체 어플리케이션에서 하나의 cacheManger 만을 사용합니다. 하지만, ehcache3 의 경우에는 여러 cacheManger 를 둘 수 있습니다. 따라서 이번 버전업 에서는 코드 자체에 싱글톤 패턴을 적용시켜 기존과 동일하게 cacheManger 를 어플리케이션에서 하나만 가지도록 하였습니다.

  - Element 객체의 삭제
  ehcahce2 의 Element 객체가 ehcache3 에서는 삭제되었습니다. 삭제된 후에 Cache 에 직접 저장하는 형태로 바뀌어 이를 수정하였습니다.

  - CacheConfiguration 변경
  기존 설정이 사라지거나 기본 디폴트 설정으로 변경되었습니다.
`.copyOnRead(copyOnRead), .copyOnWrite(copyOnWrite)` : 이 설정은 사라지고 원래 false 로 설정을 하였는데 이것이 기본동작이 되었습니다.
`diskExpiryThreadIntervalSeconds` : 해당 설정은 사라졌습니다.
`LRU policy` : 해당 설정은 디폴트 값입니다.
이 외 설정은 인터페이스가 바뀌어 그에 따라 수정하였습니다.

- 기존의 ehcahe2 에서는 cacheManger가 하나로 이를 싱글톤으로 관리하였는데 이를 생성자 마다 하나씩 가지도록 변경했습니다.

- TTL 만을 설정하도록 변경했습니다.
