### PR TITLE
INTERNAL: use groupingKeys in asyncGet(s)Bulk

### DIFF
--- a/src/main/java/net/spy/memcached/ArcusClient.java
+++ b/src/main/java/net/spy/memcached/ArcusClient.java
@@ -1987,38 +1987,6 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
   }
 
   /**
-   * Turn the list of keys into groups of keys.
-   * All keys in a group belong to the same memcached server.
-   *
-   * @param keyList   list of keys
-   * @param maxKeyCountPerGroup max size of the key group (number of keys)
-   * @return list of grouped (memcached node + keys) in the group
-   */
-  private Collection<Entry<MemcachedNode, List<String>>> groupingKeys(List<String> keyList, int maxKeyCountPerGroup) {
-    List<Entry<MemcachedNode, List<String>>> resultList = new ArrayList<>();
-    Map<MemcachedNode, List<String>> nodeMap = new HashMap<>();
-    MemcachedConnection conn = getMemcachedConnection();
-
-    for (String key : keyList) {
-      MemcachedNode qa = conn.findNodeByKey(key);
-      List<String> keyGroup = nodeMap.get(qa);
-
-      if (keyGroup == null) {
-        keyGroup = new ArrayList<>();
-        nodeMap.put(qa, keyGroup);
-      } else if (keyGroup.size() >= maxKeyCountPerGroup) {
-        resultList.add(new AbstractMap.SimpleEntry<>(qa, keyGroup));
-        keyGroup = new ArrayList<>();
-        nodeMap.put(qa, keyGroup);
-      }
-      keyGroup.add(key);
-    }
-    // Add the Entry instance which is not full(smaller than groupSize) to the result.
-    resultList.addAll(nodeMap.entrySet());
-    return resultList;
-  }
-
-  /**
    * Generic smget operation for b+tree items. Public smget methods call this method.
    *
    * @param smGetList smget parameters (keys, eflags, and so on)

--- a/src/test/java/net/spy/memcached/ProtocolBaseCase.java
+++ b/src/test/java/net/spy/memcached/ProtocolBaseCase.java
@@ -237,7 +237,7 @@ public abstract class ProtocolBaseCase extends ClientBaseCase {
     }
   }
 
-  public void testInvalidKeyBulk() throws Exception {
+  public void testInvalidKeyBulk() {
     try {
       Object val = client.getBulk(Collections.singletonList("Key key2"));
       fail("Expected IllegalArgumentException, got " + val);


### PR DESCRIPTION
### 🔗 Related Issue

<!-- Please link related issue. ex) https://github.com/naver/arcus-java-client/issues/{issue_number} -->
- https://github.com/naver/arcus-java-client/pull/800#discussion_r1734170061

### ⌨️ What I did

<!-- Please describe this PR and what you've been working on. -->
> addKeyToMap() 메소드를 호출하지 않고,
> 호출 쪽에서 해당 로직을 직접 가지는 것이 좋을 것 같은 데,
> 확인하고 동의한다면 PR 보내 주세요.

- asyncGetBulk, asyncGetsBulk에서 노드에 따라 키를 분배할 때 groupingKeys 메서드를 사용하도록 변경합니다.
- 이를 통해 일관적인 내부 동작을 가질 수 있습니다.
- addKeyToMap, getWholeChunkSize 메서드는 제거하였습니다.