### PR TITLE
INTERNAL: use Arraylist instead of ConcurrentLinkedQueue in future

### DIFF
--- a/src/main/java/net/spy/memcached/ArcusClient.java
+++ b/src/main/java/net/spy/memcached/ArcusClient.java
@@ -33,7 +33,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
-import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
@@ -2002,7 +2001,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
           final int count, final boolean reverse, final Transcoder<T> tc) {
 
     final CountDownLatch blatch = new CountDownLatch(smGetList.size());
-    final ConcurrentLinkedQueue<Operation> ops = new ConcurrentLinkedQueue<>();
+    final Collection<Operation> ops = new ArrayList<>(smGetList.size());
     final SMGetResultOldImpl<T> result = new SMGetResultOldImpl<>(offset, count, reverse, smGetList.size() > 1);
 
     // if processedSMGetCount is 0, then all smget is done.
@@ -2070,7 +2069,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
           final boolean reverse, final Transcoder<T> tc) {
 
     final CountDownLatch blatch = new CountDownLatch(smGetList.size());
-    final ConcurrentLinkedQueue<Operation> ops = new ConcurrentLinkedQueue<>();
+    final Collection<Operation> ops = new ArrayList<>(smGetList.size());
     final SMGetResultImpl<T> result = new SMGetResultImpl<>(count, unique, reverse);
 
     // if processedSMGetCount is 0, then all smget is done.
@@ -3434,7 +3433,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
           final boolean reverse, final Transcoder<T> tc) {
 
     final CountDownLatch latch = new CountDownLatch(getBulkList.size());
-    final ConcurrentLinkedQueue<Operation> ops = new ConcurrentLinkedQueue<>();
+    final Collection<Operation> ops = new ArrayList<>();
     final Map<String, List<BTreeElement<Long, CachedData>>> cachedDataMap =
             new HashMap<>();
     final Map<String, CollectionOperationStatus> opStatusMap =
@@ -3494,7 +3493,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
           final boolean reverse, final Transcoder<T> tc) {
 
     final CountDownLatch latch = new CountDownLatch(getBulkList.size());
-    final ConcurrentLinkedQueue<Operation> ops = new ConcurrentLinkedQueue<>();
+    final Collection<Operation> ops = new ArrayList<>(getBulkList.size());
     final Map<String, List<BTreeElement<ByteArrayBKey, CachedData>>> cachedDataMap =
             new HashMap<>();
     final Map<String, CollectionOperationStatus> opStatusMap =

--- a/src/main/java/net/spy/memcached/internal/BroadcastFuture.java
+++ b/src/main/java/net/spy/memcached/internal/BroadcastFuture.java
@@ -3,7 +3,6 @@ package net.spy.memcached.internal;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
-import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
@@ -14,7 +13,7 @@ import net.spy.memcached.ops.Operation;
 import net.spy.memcached.ops.OperationState;
 
 public class BroadcastFuture<T> extends OperationFuture<T> {
-  private final List<Operation> ops;
+  private final Collection<Operation> ops;
 
   public BroadcastFuture(long timeout , T result, int latchSize) {
     super(new CountDownLatch(latchSize), timeout);

--- a/src/main/java/net/spy/memcached/internal/BulkOperationFuture.java
+++ b/src/main/java/net/spy/memcached/internal/BulkOperationFuture.java
@@ -1,10 +1,10 @@
 package net.spy.memcached.internal;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
-import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
@@ -18,7 +18,7 @@ import net.spy.memcached.ops.OperationState;
 
 public class BulkOperationFuture<T> implements Future<Map<String, T>> {
   protected final Map<String, T> failedResult = new HashMap<>();
-  protected final ConcurrentLinkedQueue<Operation> ops = new ConcurrentLinkedQueue<>();
+  protected final Collection<Operation> ops = new ArrayList<>();
   protected final long timeout;
   protected final CountDownLatch latch;
 

--- a/src/main/java/net/spy/memcached/internal/PipedCollectionFuture.java
+++ b/src/main/java/net/spy/memcached/internal/PipedCollectionFuture.java
@@ -1,10 +1,10 @@
 package net.spy.memcached.internal;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
@@ -18,7 +18,7 @@ import net.spy.memcached.ops.OperationState;
 
 public class PipedCollectionFuture<K, V>
         extends CollectionFuture<Map<K, V>> {
-  private final ConcurrentLinkedQueue<Operation> ops = new ConcurrentLinkedQueue<>();
+  private final Collection<Operation> ops = new ArrayList<>();
   private final AtomicReference<CollectionOperationStatus> operationStatus
           = new AtomicReference<>(null);
 


### PR DESCRIPTION
### 🔗 Related Issue

<!-- Please link related issue. ex) https://github.com/naver/arcus-java-client/issues/{issue_number} -->
- https://github.com/jam2in/arcus-works/issues/408

### ⌨️ What I did

<!-- Please describe this PR and what you've been working on. -->
- future에서 Operation 목록들을 담기 위해 ConcurrentLinkedQueue으로 둘 필요가 없으므로 ArrayList로 변경합니다.
- 참고로 기존에 spymemcached에서 여러 Operation을 담는 BulkGetFuture에서 Arraylist를 사용하였습니다.