### PR TITLE
INTERNAL: use custom classloader in transcoder when deserializing

### DIFF
--- a/docs/user_guide/02-arcus-java-client.md
+++ b/docs/user_guide/02-arcus-java-client.md
@@ -533,6 +533,11 @@ ArcusClient client = new ArcusClient(SERVICE_CODE, factory);
   trans.setCompressionThreshold(4096);
   setTranscoder(trans);
   ```
+  직접 ClassLoader 객체를 지정해 사용할 수 있다. Spring Devtools와 같이 클래스로더를 별도로 두는
+  라이브러리를 사용할 때 캐시에서 조회하여 역직렬화 할 때 사용하는 클래스 로더와 프로세스에서 사용되고 있는 클래스 로더를 일치시키기 위해 사용한다.
+  ```java
+  SerializingTranscoder tc = new SerializingTranscoder(CachedData.MAX_SIZE, this.getClass().getClassLoader());
+  ```
 
 - setShouldOptimize(boolean o)
 

--- a/src/main/java/net/spy/memcached/transcoders/CollectionTranscoder.java
+++ b/src/main/java/net/spy/memcached/transcoders/CollectionTranscoder.java
@@ -48,6 +48,10 @@ public class CollectionTranscoder extends SerializingTranscoder implements
     super(max);
   }
 
+  public CollectionTranscoder(int max, ClassLoader cl) {
+    super(max, cl);
+  }
+
   public static int examineFlags(ElementValueType type) {
     int flags = 0;
     if (type == ElementValueType.STRING) {

--- a/src/main/java/net/spy/memcached/transcoders/SerializingTranscoder.java
+++ b/src/main/java/net/spy/memcached/transcoders/SerializingTranscoder.java
@@ -49,14 +49,21 @@ public class SerializingTranscoder extends BaseSerializingTranscoder
    * Get a serializing transcoder with the default max data size.
    */
   public SerializingTranscoder() {
-    this(CachedData.MAX_SIZE);
+    this(CachedData.MAX_SIZE, null);
   }
 
   /**
    * Get a serializing transcoder that specifies the max data size.
    */
   public SerializingTranscoder(int max) {
-    super(max);
+    super(max, null);
+  }
+
+  /**
+   * Get a serializing transcoder that specifies the max data size and classloader.
+   */
+  public SerializingTranscoder(int max, ClassLoader cl) {
+    super(max, cl);
   }
 
   @Override

--- a/src/test/java/net/spy/memcached/transcoders/BaseSerializingTranscoderTest.java
+++ b/src/test/java/net/spy/memcached/transcoders/BaseSerializingTranscoderTest.java
@@ -1,10 +1,16 @@
 package net.spy.memcached.transcoders;
 
+import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
+import java.io.Serializable;
 import java.io.UnsupportedEncodingException;
 
 import junit.framework.TestCase;
 
 import net.spy.memcached.CachedData;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertThrows;
 
 /**
  * Base tests of the base serializing transcoder stuff.
@@ -103,6 +109,67 @@ public class BaseSerializingTranscoderTest extends TestCase {
     } catch (RuntimeException e) {
       assertSame(UnsupportedEncodingException.class,
               e.getCause().getClass());
+    }
+  }
+
+  public void testDifferentClassLoaderMakeDifferentValue() throws Exception {
+    // load CustomEntry class with custom class loader.
+    CustomClassLoader customClassLoader = new CustomClassLoader();
+    customClassLoader.findClass("net.spy.memcached.transcoders." +
+            "BaseSerializingTranscoderTest$CustomEntry");
+    CustomEntry customEntry = new CustomEntry(1L, "one");
+
+    // serialize and deserialize with default class loader.
+    SerializingTranscoder tcWithDefaultClassLoader = new SerializingTranscoder(CachedData.MAX_SIZE);
+    byte[] bytes1 = tcWithDefaultClassLoader.serialize(customEntry);
+    Object deserialized1 = tcWithDefaultClassLoader.deserialize(bytes1);
+
+    // serialize and deserialize with custom class loader.
+    SerializingTranscoder tcWithCustomClassLoader
+            = new SerializingTranscoder(CachedData.MAX_SIZE, customClassLoader);
+    byte[] bytes2 = tcWithCustomClassLoader.serialize(customEntry);
+    Object deserialized2 = tcWithCustomClassLoader.deserialize(bytes2);
+
+    assertArrayEquals(bytes1, bytes2);
+    assertThrows(ClassCastException.class, () -> deserialized1.getClass().cast(deserialized2));
+    assertThrows(ClassCastException.class, () -> deserialized2.getClass().cast(deserialized1));
+    assertEquals(deserialized1.getClass().getName(), deserialized2.getClass().getName());
+    assertEquals(deserialized1.getClass(), CustomEntry.class);
+    assertEquals(deserialized1.getClass().getClassLoader(), this.getClass().getClassLoader());
+    assertEquals(deserialized2.getClass().getClassLoader(), customClassLoader);
+    assertNotSame(this.getClass().getClassLoader(), customClassLoader);
+  }
+
+  public static class CustomClassLoader extends ClassLoader {
+    @Override
+    protected Class<?> findClass(String name) throws ClassNotFoundException {
+      String resourceName = name.replace('.', '/') + ".class";
+
+      try (InputStream input = getClass().getClassLoader().getResourceAsStream(resourceName)) {
+        if (input == null) {
+          throw new ClassNotFoundException("Could not find resource: " + resourceName);
+        }
+        ByteArrayOutputStream byteStream = new ByteArrayOutputStream();
+        int nextValue;
+        while ((nextValue = input.read()) != -1) {
+          byteStream.write(nextValue);
+        }
+        byte[] classData = byteStream.toByteArray();
+        return defineClass(name, classData, 0, classData.length);
+      } catch (Exception e) {
+        throw new ClassNotFoundException("Could not load class " + name, e);
+      }
+    }
+  }
+
+  public static class CustomEntry implements Serializable {
+    private static final long serialVersionUID = 1000101L;
+    private final Long key;
+    private final String value;
+
+    public CustomEntry(Long key, String value) {
+      this.key = key;
+      this.value = value;
     }
   }
 


### PR DESCRIPTION
### 🔗 Related Issue

<!-- Please link related issue. ex) https://github.com/naver/arcus-java-client/issues/{issue_number} -->
- https://github.com/jam2in/arcus-works/issues/604

### ⌨️ What I did

<!-- Please describe this PR and what you've been working on. -->
- ClassLoaderObjectInputStream 내부 클래스를 추가하여 사용자가 Transcoder 생성 시 클래스로더를 입력할 경우 이를 사용하고, 만약 입력하지 않았다면 기본 클래스로더를 사용하도록 변경합니다.