### PR TITLE
INTERNAL: return CompositeException from get method in BulkGetFuture

### DIFF
--- a/src/main/java/net/spy/memcached/ExceptionMessageFactory.java
+++ b/src/main/java/net/spy/memcached/ExceptionMessageFactory.java
@@ -1,15 +1,16 @@
 package net.spy.memcached;
 
 import java.util.Collection;
+import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 import net.spy.memcached.ops.DeleteOperation;
 import net.spy.memcached.ops.Operation;
 import net.spy.memcached.ops.StoreOperation;
 
-public final class TimedOutMessageFactory {
+public final class ExceptionMessageFactory {
 
-  private TimedOutMessageFactory() {
+  private ExceptionMessageFactory() {
   }
 
   public static String createTimedOutMessage(long duration,
@@ -68,4 +69,21 @@ public final class TimedOutMessageFactory {
     return op.isBulkOperation();
   }
 
+  public static String createCompositeMessage(List<Exception> exceptions) {
+    StringBuilder rv = new StringBuilder();
+    rv.append("Multiple exceptions (");
+    rv.append(exceptions.size());
+    rv.append(") reported: ");
+    boolean first = true;
+    for (Exception e : exceptions) {
+      if (first) {
+        first = false;
+      } else {
+        rv.append(", ");
+      }
+      rv.append(e.getMessage());
+    }
+    return rv.toString();
+
+  }
 }

--- a/src/main/java/net/spy/memcached/internal/BulkGetFuture.java
+++ b/src/main/java/net/spy/memcached/internal/BulkGetFuture.java
@@ -16,9 +16,11 @@
  */
 package net.spy.memcached.internal;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
@@ -159,13 +161,18 @@ public class BulkGetFuture<T> implements BulkFuture<Map<String, T>> {
     }
 
     if (throwException) {
+      List<Exception> exceptions = new ArrayList<>();
       for (Operation op : ops) {
         if (op.isCancelled()) {
-          throw new ExecutionException(new RuntimeException(op.getCancelCause()));
+          exceptions.add(new RuntimeException(op.getCancelCause()));
         }
         if (op.hasErrored()) {
-          throw new ExecutionException(op.getException());
+          exceptions.add(op.getException());
         }
+      }
+
+      if (!exceptions.isEmpty()) {
+        throw new CompositeException(exceptions);
       }
     }
 

--- a/src/main/java/net/spy/memcached/internal/CheckedOperationTimeoutException.java
+++ b/src/main/java/net/spy/memcached/internal/CheckedOperationTimeoutException.java
@@ -21,7 +21,7 @@ import java.util.Collections;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
-import net.spy.memcached.TimedOutMessageFactory;
+import net.spy.memcached.ExceptionMessageFactory;
 import net.spy.memcached.ops.Operation;
 
 /**
@@ -43,7 +43,7 @@ public class CheckedOperationTimeoutException extends TimeoutException {
                                           TimeUnit unit,
                                           long elapsed,
                                           Collection<Operation> ops) {
-    super(TimedOutMessageFactory.createTimedOutMessage(duration, unit, elapsed, ops));
+    super(ExceptionMessageFactory.createTimedOutMessage(duration, unit, elapsed, ops));
     operations = ops;
   }
 

--- a/src/main/java/net/spy/memcached/internal/CompositeException.java
+++ b/src/main/java/net/spy/memcached/internal/CompositeException.java
@@ -1,0 +1,22 @@
+package net.spy.memcached.internal;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+
+import net.spy.memcached.ExceptionMessageFactory;
+
+public class CompositeException extends ExecutionException {
+
+  private static final long serialVersionUID = -599478797582490012L;
+  private final ArrayList<Exception> exceptions = new ArrayList<>();
+
+  CompositeException(List<Exception> exceptions) {
+    super(ExceptionMessageFactory.createCompositeMessage(exceptions));
+    this.exceptions.addAll(exceptions);
+  }
+
+  public List<Exception> getExceptions() {
+    return exceptions;
+  }
+}

--- a/src/test/java/net/spy/memcached/CancellationBaseCase.java
+++ b/src/test/java/net/spy/memcached/CancellationBaseCase.java
@@ -8,6 +8,8 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
+import net.spy.memcached.internal.CompositeException;
+
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -56,8 +58,13 @@ public abstract class CancellationBaseCase {
       Object o = f.get();
       fail("Expected cancellation, got " + o);
     } catch (ExecutionException e) {
-      assertTrue(e.getCause() instanceof RuntimeException);
-      assertTrue(e.getCause().getMessage().contains("Cancelled"));
+      if (e instanceof CompositeException) {
+        assertTrue(((CompositeException) e).getExceptions()
+                .get(0).getMessage().contains("Cancelled"));
+      } else {
+        assertTrue(e.getCause() instanceof RuntimeException);
+        assertTrue(e.getCause().getMessage().contains("Cancelled"));
+      }
     }
   }
 


### PR DESCRIPTION
### 🔗 Related Issue

<!-- Please link related issue. ex) https://github.com/naver/arcus-java-client/issues/{issue_number} -->
- https://github.com/naver/arcus-java-client/issues/27

### ⌨️ What I did

<!-- Please describe this PR and what you've been working on. -->
- get()에서 다수 캐시 노드에서 발생한 예외들을 CompositeException으로 묶어 사용자가 list를 통해 모든 예외 사항을 조회할 수 있도록 변경했습니다.
- +) 참고로 FrontCacheBulkGetFuture의 get()에서는 기존에 모든 예외를 던지고 있고, getSome()에서는 에러가 발생해도 일부 결과를 가져와 로컬 캐시에 넣고, 로컬 캐시 결과와 병합하므로 기존대로 동작해도 문제가 없습니다.