### PR TITLE
INTERNAL: Fix transient field

### DIFF
--- a/src/main/java/net/spy/memcached/internal/BroadcastFuture.java
+++ b/src/main/java/net/spy/memcached/internal/BroadcastFuture.java
@@ -2,7 +2,6 @@ package net.spy.memcached.internal;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.HashSet;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
@@ -57,7 +56,7 @@ public class BroadcastFuture<T> extends OperationFuture<T> {
     long beforeAwait = System.currentTimeMillis();
     if (!latch.await(duration, unit)) {
       // whenever timeout occurs, continuous timeout counter will increase by 1.
-      Collection<Operation> timedOutOps = new HashSet<>();
+      Collection<Operation> timedOutOps = new ArrayList<>();
       for (Operation op : ops) {
         if (op.getState() != OperationState.COMPLETE) {
           MemcachedConnection.opTimedOut(op);

--- a/src/main/java/net/spy/memcached/internal/BulkGetFuture.java
+++ b/src/main/java/net/spy/memcached/internal/BulkGetFuture.java
@@ -19,7 +19,6 @@ package net.spy.memcached.internal;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
@@ -137,7 +136,7 @@ public class BulkGetFuture<T> implements BulkFuture<Map<String, T>> {
 
     long beforeAwait = System.currentTimeMillis();
     if (!latch.await(to, unit)) {
-      Collection<Operation> timedOutOps = new HashSet<>();
+      Collection<Operation> timedOutOps = new ArrayList<>();
       for (Operation op : ops) {
         if (op.getState() != OperationState.COMPLETE) {
           timedOutOps.add(op);

--- a/src/main/java/net/spy/memcached/internal/BulkOperationFuture.java
+++ b/src/main/java/net/spy/memcached/internal/BulkOperationFuture.java
@@ -3,7 +3,6 @@ package net.spy.memcached.internal;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
@@ -72,7 +71,7 @@ public class BulkOperationFuture<T> implements Future<Map<String, T>> {
 
     long beforeAwait = System.currentTimeMillis();
     if (!latch.await(duration, unit)) {
-      Collection<Operation> timedOutOps = new HashSet<>();
+      Collection<Operation> timedOutOps = new ArrayList<>();
       for (Operation op : ops) {
         if (op.getState() != OperationState.COMPLETE) {
           timedOutOps.add(op);

--- a/src/main/java/net/spy/memcached/internal/CheckedOperationTimeoutException.java
+++ b/src/main/java/net/spy/memcached/internal/CheckedOperationTimeoutException.java
@@ -16,6 +16,7 @@
  */
 package net.spy.memcached.internal;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.concurrent.TimeUnit;
@@ -30,13 +31,13 @@ import net.spy.memcached.ops.Operation;
 public class CheckedOperationTimeoutException extends TimeoutException {
 
   private static final long serialVersionUID = 5187393339735774489L;
-  private final Collection<Operation> operations;
+  private final ArrayList<Operation> operations;
 
   public CheckedOperationTimeoutException(long duration,
                                           TimeUnit unit,
                                           long elapsed,
                                           Operation op) {
-    this(duration, unit, elapsed, Collections.singleton(op));
+    this(duration, unit, elapsed, new ArrayList<>(Collections.singleton(op)));
   }
 
   public CheckedOperationTimeoutException(long duration,
@@ -44,7 +45,7 @@ public class CheckedOperationTimeoutException extends TimeoutException {
                                           long elapsed,
                                           Collection<Operation> ops) {
     super(ExceptionMessageFactory.createTimedOutMessage(duration, unit, elapsed, ops));
-    operations = ops;
+    operations =  new ArrayList<>(ops);
   }
 
   /**

--- a/src/main/java/net/spy/memcached/internal/CollectionGetBulkFuture.java
+++ b/src/main/java/net/spy/memcached/internal/CollectionGetBulkFuture.java
@@ -16,8 +16,8 @@
  */
 package net.spy.memcached.internal;
 
+import java.util.ArrayList;
 import java.util.Collection;
-import java.util.HashSet;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
@@ -63,7 +63,7 @@ public class CollectionGetBulkFuture<T> implements Future<T> {
 
     long beforeAwait = System.currentTimeMillis();
     if (!latch.await(duration, unit)) {
-      Collection<Operation> timedOutOps = new HashSet<>();
+      Collection<Operation> timedOutOps = new ArrayList<>();
       for (Operation op : ops) {
         if (op.getState() != OperationState.COMPLETE) {
           timedOutOps.add(op);

--- a/src/main/java/net/spy/memcached/internal/PipedCollectionFuture.java
+++ b/src/main/java/net/spy/memcached/internal/PipedCollectionFuture.java
@@ -2,7 +2,6 @@ package net.spy.memcached.internal;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.HashSet;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CountDownLatch;
@@ -64,7 +63,7 @@ public class PipedCollectionFuture<K, V>
 
     long beforeAwait = System.currentTimeMillis();
     if (!latch.await(duration, unit)) {
-      Collection<Operation> timedOutOps = new HashSet<>();
+      Collection<Operation> timedOutOps = new ArrayList<>();
       for (Operation op : ops) {
         if (op.getState() != OperationState.COMPLETE) {
           timedOutOps.add(op);

--- a/src/main/java/net/spy/memcached/internal/SMGetFuture.java
+++ b/src/main/java/net/spy/memcached/internal/SMGetFuture.java
@@ -16,8 +16,8 @@
  */
 package net.spy.memcached.internal;
 
+import java.util.ArrayList;
 import java.util.Collection;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
@@ -59,7 +59,7 @@ public final class SMGetFuture<T extends List<?>> implements Future<T> {
 
     long beforeAwait = System.currentTimeMillis();
     if (!latch.await(duration, unit)) {
-      Collection<Operation> timedOutOps = new HashSet<>();
+      Collection<Operation> timedOutOps = new ArrayList<>();
       for (Operation op : ops) {
         if (op.getState() != OperationState.COMPLETE) {
           timedOutOps.add(op);

--- a/src/test/manual/net/spy/memcached/emptycollection/VariousTypeTest.java
+++ b/src/test/manual/net/spy/memcached/emptycollection/VariousTypeTest.java
@@ -347,7 +347,7 @@ public class VariousTypeTest extends BaseIntegrationTest {
     private static final long serialVersionUID = 8942558579188233740L;
 
     private final int i;
-    private final List<String> list;
+    private final ArrayList<String> list;
 
     public UserDefinedClass() {
       this.i = 100;


### PR DESCRIPTION
### 🔗 Related Issue

<!-- Please link related issue. ex) https://github.com/naver/arcus-java-client/issues/{issue_number} -->
- https://github.com/jam2in/arcus-works/issues/568

### ⌨️ What I did

<!-- Please describe this PR and what you've been working on. -->
- jdk 21 lint 경고를 해결하였습니다. 

## Warning
### non-transient instance field of a serializable class declared with a non-serializable type

위는 직렬화 가능 여부가 명확하지 않아 발생하는 경고 입니다.

`CheckedOperationTimeoutException` 에서는 해당 필드를 직렬화가 가능한 명확한 타입인 ArrayList 로 변경하였습니다. 이에 명확한 타입에 맞추고 사용자가 입력한 순서대로 메세지를 생성하기위해 다른 클래스의 타입 또한 ArrayList 로 통일 하였습니다. 
https://github.com/naver/arcus-java-client/pull/807#issuecomment-2362586772

`VariousTypeTest` 에서는 직렬화 가능한 명확한 타입인 ArrayList 를 활용하였습니다.

