### PR TITLE
INTERNAL: return partial result if error or cancel occurred in getSome method of BulkGetFuture

### DIFF
--- a/src/main/java/net/spy/memcached/internal/BulkFuture.java
+++ b/src/main/java/net/spy/memcached/internal/BulkFuture.java
@@ -1,6 +1,5 @@
 package net.spy.memcached.internal;
 
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
@@ -29,17 +28,16 @@ public interface BulkFuture<V> extends Future<V> {
   /**
    * Wait for the operation to complete and return results.
    *
-   * If operation could not complete within specified
-   * timeout, partial result is returned. Otherwise, the
-   * behavior is identical to {@link #get(long, TimeUnit)}
+   * If operation could not complete within specified timeout, error, cancellation occurred,
+   * partial result is returned.
+   * Otherwise, the behavior is identical to {@link #get(long, TimeUnit)}
    *
    * @param timeout the maximum time to wait
    * @param unit    the time unit of the timeout argument
    * @return the computed result
    * @throws InterruptedException if the current thread was interrupted while waiting
-   * @throws ExecutionException   if the computation threw an exception
    */
-  V getSome(long timeout, TimeUnit unit) throws InterruptedException, ExecutionException;
+  V getSome(long timeout, TimeUnit unit) throws InterruptedException;
 
 
   int getOpCount();

--- a/src/main/java/net/spy/memcached/plugin/FrontCacheBulkGetFuture.java
+++ b/src/main/java/net/spy/memcached/plugin/FrontCacheBulkGetFuture.java
@@ -50,8 +50,7 @@ public class FrontCacheBulkGetFuture<T> extends BulkGetFuture<T> {
   }
 
   @Override
-  public Map<String, T> getSome(long duration, TimeUnit unit)
-          throws InterruptedException, ExecutionException {
+  public Map<String, T> getSome(long duration, TimeUnit unit) throws InterruptedException {
     if (result != null) {
       return result;
     }


### PR DESCRIPTION
### 🔗 Related Issue

<!-- Please link related issue. ex) https://github.com/naver/arcus-java-client/issues/{issue_number} -->
- 

### ⌨️ What I did

<!-- Please describe this PR and what you've been working on. -->
- getSome()에서 Error, Cancel이 발생하더라도 조회가 완료된 결과를 리턴하도록 변경했습니다.
- InterruptException이 발생한 경우에는 그대로 반환합니다.