### PR TITLE
INTERNAL: Resolved the jdk lint "this-escape" warning in the final class manner.

### DIFF
--- a/src/main/java/net/spy/memcached/ArcusKetamaNodeLocator.java
+++ b/src/main/java/net/spy/memcached/ArcusKetamaNodeLocator.java
@@ -38,7 +38,7 @@ import java.util.concurrent.locks.ReentrantLock;
 import net.spy.memcached.compat.SpyObject;
 import net.spy.memcached.util.ArcusKetamaNodeLocatorConfiguration;
 
-public class ArcusKetamaNodeLocator extends SpyObject implements NodeLocator {
+public final class ArcusKetamaNodeLocator extends SpyObject implements NodeLocator {
 
   private final TreeMap<Long, SortedSet<MemcachedNode>> ketamaNodes;
   private final Collection<MemcachedNode> allNodes;

--- a/src/main/java/net/spy/memcached/ArcusReplKetamaNodeLocator.java
+++ b/src/main/java/net/spy/memcached/ArcusReplKetamaNodeLocator.java
@@ -38,7 +38,7 @@ import java.util.concurrent.locks.ReentrantLock;
 import net.spy.memcached.compat.SpyObject;
 import net.spy.memcached.util.ArcusReplKetamaNodeLocatorConfiguration;
 
-public class ArcusReplKetamaNodeLocator extends SpyObject implements NodeLocator {
+public final class ArcusReplKetamaNodeLocator extends SpyObject implements NodeLocator {
 
   private final TreeMap<Long, SortedSet<MemcachedReplicaGroup>> ketamaGroups;
   private final HashMap<String, MemcachedReplicaGroup> allGroups;

--- a/src/main/java/net/spy/memcached/ConnectionFactoryBuilder.java
+++ b/src/main/java/net/spy/memcached/ConnectionFactoryBuilder.java
@@ -78,7 +78,7 @@ public class ConnectionFactoryBuilder {
 
   private int maxFrontCacheElements = DefaultConnectionFactory.DEFAULT_MAX_FRONTCACHE_ELEMENTS;
   private int frontCacheExpireTime = DefaultConnectionFactory.DEFAULT_FRONTCACHE_EXPIRETIME;
-  private String frontCacheName = "ArcusFrontCache_" + this.hashCode();
+  private String frontCacheName;
 
   private int maxSMGetChunkSize = DefaultConnectionFactory.DEFAULT_MAX_SMGET_KEY_CHUNK_SIZE;
   private byte delimiter = DefaultConnectionFactory.DEFAULT_DELIMITER;
@@ -609,6 +609,9 @@ public class ConnectionFactoryBuilder {
 
       @Override
       public String getFrontCacheName() {
+        if (frontCacheName == null) {
+          frontCacheName = "ArcusFrontCache_" + this.hashCode();
+        }
         return frontCacheName;
       }
 

--- a/src/main/java/net/spy/memcached/protocol/ascii/BTreeFindPositionOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/BTreeFindPositionOperationImpl.java
@@ -33,7 +33,7 @@ import net.spy.memcached.ops.OperationState;
 import net.spy.memcached.ops.OperationStatus;
 import net.spy.memcached.ops.OperationType;
 
-public class BTreeFindPositionOperationImpl extends OperationImpl implements
+public final class BTreeFindPositionOperationImpl extends OperationImpl implements
         BTreeFindPositionOperation {
 
   private static final OperationStatus GET_CANCELED = new CollectionOperationStatus(

--- a/src/main/java/net/spy/memcached/protocol/ascii/BTreeFindPositionWithGetOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/BTreeFindPositionWithGetOperationImpl.java
@@ -35,7 +35,7 @@ import net.spy.memcached.ops.OperationState;
 import net.spy.memcached.ops.OperationStatus;
 import net.spy.memcached.ops.OperationType;
 
-public class BTreeFindPositionWithGetOperationImpl extends OperationImpl implements
+public final class BTreeFindPositionWithGetOperationImpl extends OperationImpl implements
         BTreeFindPositionWithGetOperation {
 
   private final ByteArrayOutputStream byteBuffer = new ByteArrayOutputStream();

--- a/src/main/java/net/spy/memcached/protocol/ascii/BTreeGetBulkOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/BTreeGetBulkOperationImpl.java
@@ -36,7 +36,7 @@ import net.spy.memcached.ops.OperationType;
 /**
  * Operation to retrieve b+tree data with multiple keys
  */
-public class BTreeGetBulkOperationImpl extends OperationImpl implements
+public final class BTreeGetBulkOperationImpl extends OperationImpl implements
         BTreeGetBulkOperation {
 
   private final ByteArrayOutputStream byteBuffer = new ByteArrayOutputStream();

--- a/src/main/java/net/spy/memcached/protocol/ascii/BTreeGetByPositionOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/BTreeGetByPositionOperationImpl.java
@@ -36,7 +36,7 @@ import net.spy.memcached.ops.OperationState;
 import net.spy.memcached.ops.OperationStatus;
 import net.spy.memcached.ops.OperationType;
 
-public class BTreeGetByPositionOperationImpl extends OperationImpl implements
+public final class BTreeGetByPositionOperationImpl extends OperationImpl implements
         BTreeGetByPositionOperation {
 
   private final ByteArrayOutputStream byteBuffer = new ByteArrayOutputStream();

--- a/src/main/java/net/spy/memcached/protocol/ascii/BTreeInsertAndGetOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/BTreeInsertAndGetOperationImpl.java
@@ -36,7 +36,7 @@ import net.spy.memcached.ops.OperationState;
 import net.spy.memcached.ops.OperationStatus;
 import net.spy.memcached.ops.OperationType;
 
-public class BTreeInsertAndGetOperationImpl extends OperationImpl implements
+public final class BTreeInsertAndGetOperationImpl extends OperationImpl implements
         BTreeInsertAndGetOperation {
 
   private static final int OVERHEAD = 32;

--- a/src/main/java/net/spy/memcached/protocol/ascii/BTreeSortMergeGetOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/BTreeSortMergeGetOperationImpl.java
@@ -39,7 +39,7 @@ import net.spy.memcached.util.BTreeUtil;
 /**
  * Operation to retrieve b+tree data with multiple keys
  */
-public class BTreeSortMergeGetOperationImpl extends OperationImpl implements
+public final class BTreeSortMergeGetOperationImpl extends OperationImpl implements
         BTreeSortMergeGetOperation {
 
   private final ByteArrayOutputStream byteBuffer = new ByteArrayOutputStream();

--- a/src/main/java/net/spy/memcached/protocol/ascii/BTreeSortMergeGetOperationOldImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/BTreeSortMergeGetOperationOldImpl.java
@@ -36,7 +36,7 @@ import net.spy.memcached.ops.OperationType;
 /**
  * Operation to retrieve b+tree data with multiple keys
  */
-public class BTreeSortMergeGetOperationOldImpl extends OperationImpl implements
+public final class BTreeSortMergeGetOperationOldImpl extends OperationImpl implements
         BTreeSortMergeGetOperationOld {
 
   private final ByteArrayOutputStream byteBuffer = new ByteArrayOutputStream();

--- a/src/main/java/net/spy/memcached/protocol/ascii/CollectionBulkInsertOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/CollectionBulkInsertOperationImpl.java
@@ -33,7 +33,7 @@ import net.spy.memcached.ops.OperationType;
 /**
  * Operation to store collection data in a memcached server.
  */
-public class CollectionBulkInsertOperationImpl extends OperationImpl
+public final class CollectionBulkInsertOperationImpl extends OperationImpl
         implements CollectionBulkInsertOperation {
 
   private static final OperationStatus STORE_CANCELED = new CollectionOperationStatus(

--- a/src/main/java/net/spy/memcached/protocol/ascii/CollectionCountOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/CollectionCountOperationImpl.java
@@ -37,7 +37,7 @@ import net.spy.memcached.ops.OperationType;
 /**
  * Operation to get exists item count from collection in a memcached server.
  */
-public class CollectionCountOperationImpl extends OperationImpl implements
+public final class CollectionCountOperationImpl extends OperationImpl implements
         CollectionCountOperation {
 
   private static final OperationStatus GET_CANCELED = new CollectionOperationStatus(

--- a/src/main/java/net/spy/memcached/protocol/ascii/CollectionCreateOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/CollectionCreateOperationImpl.java
@@ -40,7 +40,7 @@ import net.spy.memcached.ops.OperationType;
 /**
  * Operation to create empty collection in a memcached server.
  */
-public class CollectionCreateOperationImpl extends OperationImpl
+public final class CollectionCreateOperationImpl extends OperationImpl
         implements CollectionCreateOperation {
 
   private static final int OVERHEAD = 32;

--- a/src/main/java/net/spy/memcached/protocol/ascii/CollectionDeleteOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/CollectionDeleteOperationImpl.java
@@ -40,7 +40,7 @@ import net.spy.memcached.ops.OperationType;
 /**
  * Operation to delete collection data in a memcached server.
  */
-public class CollectionDeleteOperationImpl extends OperationImpl
+public final class CollectionDeleteOperationImpl extends OperationImpl
         implements CollectionDeleteOperation {
 
   private static final OperationStatus DELETE_CANCELED = new CollectionOperationStatus(

--- a/src/main/java/net/spy/memcached/protocol/ascii/CollectionExistOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/CollectionExistOperationImpl.java
@@ -37,7 +37,7 @@ import net.spy.memcached.ops.OperationType;
 /**
  * Operation to check membership of an item in collection in a memcached server.
  */
-public class CollectionExistOperationImpl extends OperationImpl
+public final class CollectionExistOperationImpl extends OperationImpl
         implements CollectionExistOperation {
 
   private static final int OVERHEAD = 32;

--- a/src/main/java/net/spy/memcached/protocol/ascii/CollectionGetOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/CollectionGetOperationImpl.java
@@ -43,7 +43,7 @@ import net.spy.memcached.ops.OperationType;
 /**
  * Operation to retrieve collection data in a memcached server.
  */
-public class CollectionGetOperationImpl extends OperationImpl
+public final class CollectionGetOperationImpl extends OperationImpl
         implements CollectionGetOperation {
 
   private final ByteArrayOutputStream byteBuffer = new ByteArrayOutputStream();

--- a/src/main/java/net/spy/memcached/protocol/ascii/CollectionInsertOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/CollectionInsertOperationImpl.java
@@ -42,7 +42,7 @@ import net.spy.memcached.ops.OperationType;
 /**
  * Operation to store collection data in a memcached server.
  */
-public class CollectionInsertOperationImpl extends OperationImpl
+public final class CollectionInsertOperationImpl extends OperationImpl
         implements CollectionInsertOperation {
 
   private static final int OVERHEAD = 32;

--- a/src/main/java/net/spy/memcached/protocol/ascii/CollectionMutateOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/CollectionMutateOperationImpl.java
@@ -38,7 +38,7 @@ import net.spy.memcached.ops.OperationType;
 /**
  * Operation to incr/decr item value from collection in a memcached server.
  */
-public class CollectionMutateOperationImpl extends OperationImpl implements
+public final class CollectionMutateOperationImpl extends OperationImpl implements
         CollectionMutateOperation {
 
   private static final OperationStatus GET_CANCELED = new CollectionOperationStatus(

--- a/src/main/java/net/spy/memcached/protocol/ascii/CollectionPipedExistOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/CollectionPipedExistOperationImpl.java
@@ -31,7 +31,7 @@ import net.spy.memcached.ops.OperationState;
 import net.spy.memcached.ops.OperationStatus;
 import net.spy.memcached.ops.OperationType;
 
-public class CollectionPipedExistOperationImpl extends OperationImpl implements
+public final class CollectionPipedExistOperationImpl extends OperationImpl implements
         CollectionPipedExistOperation {
 
   private static final OperationStatus EXIST_CANCELED = new CollectionOperationStatus(

--- a/src/main/java/net/spy/memcached/protocol/ascii/CollectionPipedInsertOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/CollectionPipedInsertOperationImpl.java
@@ -34,7 +34,7 @@ import net.spy.memcached.ops.OperationType;
 /**
  * Operation to store collection data in a memcached server.
  */
-public class CollectionPipedInsertOperationImpl extends OperationImpl
+public final class CollectionPipedInsertOperationImpl extends OperationImpl
         implements CollectionPipedInsertOperation {
 
   private static final OperationStatus STORE_CANCELED = new CollectionOperationStatus(

--- a/src/main/java/net/spy/memcached/protocol/ascii/CollectionPipedUpdateOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/CollectionPipedUpdateOperationImpl.java
@@ -36,7 +36,7 @@ import net.spy.memcached.ops.OperationType;
 /**
  * Operation to update collection data in a memcached server.
  */
-public class CollectionPipedUpdateOperationImpl extends OperationImpl implements
+public final class CollectionPipedUpdateOperationImpl extends OperationImpl implements
         CollectionPipedUpdateOperation {
 
   private static final OperationStatus STORE_CANCELED = new CollectionOperationStatus(

--- a/src/main/java/net/spy/memcached/protocol/ascii/CollectionUpdateOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/CollectionUpdateOperationImpl.java
@@ -39,7 +39,7 @@ import net.spy.memcached.ops.OperationType;
 /**
  * Operation to update collection data in a memcached server.
  */
-public class CollectionUpdateOperationImpl extends OperationImpl implements
+public final class CollectionUpdateOperationImpl extends OperationImpl implements
         CollectionUpdateOperation {
 
   private static final int OVERHEAD = 32;

--- a/src/main/java/net/spy/memcached/protocol/ascii/ConcatenationOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/ConcatenationOperationImpl.java
@@ -25,7 +25,7 @@ import net.spy.memcached.ops.OperationCallback;
 /**
  * Operation for ascii concatenations.
  */
-public class ConcatenationOperationImpl extends BaseStoreOperationImpl
+public final class ConcatenationOperationImpl extends BaseStoreOperationImpl
         implements ConcatenationOperation {
 
   private final ConcatenationType concatType;

--- a/src/main/java/net/spy/memcached/protocol/ascii/MGetOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/MGetOperationImpl.java
@@ -9,7 +9,7 @@ import net.spy.memcached.ops.GetOperation;
 /**
  * Operation for retrieving data.
  */
-public class MGetOperationImpl extends BaseGetOpImpl implements GetOperation {
+public final class MGetOperationImpl extends BaseGetOpImpl implements GetOperation {
 
   private static final String CMD = "mget";
 

--- a/src/main/java/net/spy/memcached/protocol/ascii/MGetsOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/MGetsOperationImpl.java
@@ -9,7 +9,7 @@ import net.spy.memcached.ops.GetsOperation;
 /**
  * Operation for retrieving data.
  */
-public class MGetsOperationImpl extends BaseGetOpImpl implements GetsOperation {
+public final class MGetsOperationImpl extends BaseGetOpImpl implements GetsOperation {
 
   private static final String CMD = "mgets";
 

--- a/src/main/java/net/spy/memcached/protocol/binary/OptimizedSetImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/binary/OptimizedSetImpl.java
@@ -34,7 +34,7 @@ import net.spy.memcached.ops.OperationState;
 import net.spy.memcached.ops.OperationStatus;
 import net.spy.memcached.ops.StoreType;
 
-public class OptimizedSetImpl extends OperationImpl implements Operation {
+public final class OptimizedSetImpl extends OperationImpl implements Operation {
 
   private static final OperationCallback NOOP_CALLBACK = new NoopCallback();
 


### PR DESCRIPTION
### 🔗 Related Issue

<!-- Please link related issue. ex) https://github.com/naver/arcus-java-client/issues/{issue_number} -->
- https://github.com/jam2in/arcus-works/issues/568

### ⌨️ What I did

<!-- Please describe this PR and what you've been working on. -->
- jdk 21 lint 의 `possible 'this' escape before subclass is fully initialized` 를 일부 해결하였습니다.

### possible 'this' escape before subclass is fully initialized

위는 아직 final 클래스가 아닌 클래스에 대하여 초기화가 끝나지 않았을때, 다른 클래스에서 해당 클래스를 참조하는 경우에 발생합니다.

따라서 경고를 해결하기 위해서는

1. final class 로 선언
2. 생성자가 끝난 후 다른 함수에서 경고가 발생하는 (this 를 외부로 넘기는) 메서드를 호출합니다.
3. 외부 클래스에 this 를 넘기지 않아도 되는 경우 생성자에서 해당 역할을 합니다.

해당 pr 에서는 2, 3번에 해당하는 방법으로 해결할 수 있는 코드를 수정하였습니다.

### 경고가 발생한 코드

1. `ConnectionFactoryBuilder` 의 `frontCacheName` 은 필드 초기화 부분에서 this.hashCode() 를 호출하여 해당 경고가 발생하였습니다. 

2. `ConnectionFactoryBuilder` 를 제외한 자식 클래스의 생성자는 부모 클래스의 필드를 초기화 할때 부모 클래스의 메서드를 호출하여 초기화를 시키고 있습니다. 이에 생성자 안에서 외부 클래스로 this 를 넘기게 되어 경고가 발생하였습니다.

### 수정한 코드

1. `frontCacheName` 은 `get` 을 통해 호출되어 `get` 메서드에 초기화 부분을 넣어 수정하였습니다.

2. 부모 클래스의 해당 필드의 접근자를 protected 로 변경하여 해당 필드를 자식 클래스의 생성자에서 초기화 하도록 하였습니다.

