### PR TITLE
INTERNAL: add node information into OperationException

### DIFF
--- a/src/main/java/net/spy/memcached/ops/OperationException.java
+++ b/src/main/java/net/spy/memcached/ops/OperationException.java
@@ -12,14 +12,6 @@ public final class OperationException extends IOException {
   private final OperationErrorType type;
 
   /**
-   * General exception (no message).
-   */
-  public OperationException() {
-    super();
-    type = OperationErrorType.GENERAL;
-  }
-
-  /**
    * Exception with a message.
    *
    * @param eType the type of error that occurred
@@ -39,12 +31,6 @@ public final class OperationException extends IOException {
 
   @Override
   public String toString() {
-    String rv = null;
-    if (type == OperationErrorType.GENERAL) {
-      rv = "OperationException: " + type;
-    } else {
-      rv = "OperationException: " + type + ": " + getMessage();
-    }
-    return rv;
+    return "OperationException: " + type + ": " + getMessage();
   }
 }

--- a/src/main/java/net/spy/memcached/protocol/BaseOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/BaseOperationImpl.java
@@ -243,10 +243,8 @@ public abstract class BaseOperationImpl extends SpyObject {
     getLogger().error("Error:  %s by %s", line, this);
     switch (eType) {
       case GENERAL:
-        exception = new OperationException();
-        break;
       case SERVER:
-        exception = new OperationException(eType, line);
+        exception = new OperationException(eType, line + " @ " + handlingNode.getNodeName());
         break;
       case CLIENT:
         if (line.contains("bad command line format")) {
@@ -257,7 +255,7 @@ public abstract class BaseOperationImpl extends SpyObject {
           String[] cmdLines = new String(bytes).split("\r\n");
           getLogger().error("Bad command: %s", cmdLines[0]);
         }
-        exception = new OperationException(eType, line);
+        exception = new OperationException(eType, line + " @ " + handlingNode.getNodeName());
         break;
       default:
         assert false;

--- a/src/test/java/net/spy/memcached/protocol/ascii/OperationExceptionTest.java
+++ b/src/test/java/net/spy/memcached/protocol/ascii/OperationExceptionTest.java
@@ -1,49 +1,46 @@
 package net.spy.memcached.protocol.ascii;
 
+import net.spy.memcached.collection.BaseIntegrationTest;
 import net.spy.memcached.ops.OperationErrorType;
 import net.spy.memcached.ops.OperationException;
 
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Test operation exception constructors and accessors and stuff.
  */
-public class OperationExceptionTest {
+class OperationExceptionTest extends BaseIntegrationTest {
 
   @Test
-  public void testEmpty() {
-    OperationException oe = new OperationException();
-    assertSame(OperationErrorType.GENERAL, oe.getType());
-    assertEquals("OperationException: GENERAL", String.valueOf(oe));
-  }
-
-  @Test
-  public void testServer() {
-    OperationException oe = new OperationException(
-            OperationErrorType.SERVER, "SERVER_ERROR figures");
+  void testServer() {
+    OperationException oe = new OperationException(OperationErrorType.SERVER,
+            "SERVER_ERROR figures" + " @ "
+                    + mc.getMemcachedConnection().getPrimaryNode("test").getNodeName());
     assertSame(OperationErrorType.SERVER, oe.getType());
-    assertEquals("OperationException: SERVER: SERVER_ERROR figures",
-            String.valueOf(oe));
+    assertTrue(String.valueOf(oe).startsWith("OperationException: SERVER:" +
+            " SERVER_ERROR figures @ ArcusClient-"));
   }
 
   @Test
-  public void testClient() {
-    OperationException oe = new OperationException(
-            OperationErrorType.CLIENT, "CLIENT_ERROR nope");
+  void testClient() {
+    OperationException oe = new OperationException(OperationErrorType.CLIENT,
+            "CLIENT_ERROR nope" + " @ "
+                    + mc.getMemcachedConnection().getPrimaryNode("test").getNodeName());
     assertSame(OperationErrorType.CLIENT, oe.getType());
-    assertEquals("OperationException: CLIENT: CLIENT_ERROR nope",
-            String.valueOf(oe));
+    assertTrue(String.valueOf(oe).startsWith("OperationException: CLIENT:" +
+            " CLIENT_ERROR nope @ ArcusClient-"));
   }
 
   @Test
-  public void testGeneral() {
-    // General type doesn't have additional info
-    OperationException oe = new OperationException(
-            OperationErrorType.GENERAL, "GENERAL wtf");
+  void testGeneral() {
+    OperationException oe = new OperationException(OperationErrorType.GENERAL,
+            "ERROR no matching command" + " @ "
+                    + mc.getMemcachedConnection().getPrimaryNode("test").getNodeName());
     assertSame(OperationErrorType.GENERAL, oe.getType());
-    assertEquals("OperationException: GENERAL", String.valueOf(oe));
+    assertTrue(String.valueOf(oe).startsWith("OperationException: GENERAL:" +
+            " ERROR no matching command @ ArcusClient-"));
   }
 }

--- a/src/test/manual/net/spy/memcached/collection/btree/BopMutateTest.java
+++ b/src/test/manual/net/spy/memcached/collection/btree/BopMutateTest.java
@@ -31,7 +31,7 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class BopMutateTest extends BaseIntegrationTest {
+class BopMutateTest extends BaseIntegrationTest {
 
   private String key = "BopMutate";
 
@@ -45,7 +45,7 @@ public class BopMutateTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testBopIncrDecr_Basic() throws Exception {
+  void testBopIncrDecr_Basic() throws Exception {
     // Create a list and add it 9 items
     addToBTree(key, items9);
 
@@ -68,7 +68,7 @@ public class BopMutateTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testBopIncrDecr_InitialValue() throws Exception {
+  void testBopIncrDecr_InitialValue() throws Exception {
     // Create a list and add it 9 items
     addToBTree(key, items9);
 
@@ -106,7 +106,7 @@ public class BopMutateTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testBopIncrDecr_Minus() throws Exception {
+  void testBopIncrDecr_Minus() throws Exception {
     // Create a list and add it 9 items
     addToBTree(key, items9);
 
@@ -116,7 +116,7 @@ public class BopMutateTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testBopIncrDecr_NoKeyError() throws Exception {
+  void testBopIncrDecr_NoKeyError() throws Exception {
     // Create a list and add it 9 items
     addToBTree(key, items9);
 
@@ -135,7 +135,7 @@ public class BopMutateTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testBopIncrDecr_StringError() throws Exception {
+  void testBopIncrDecr_StringError() throws Exception {
     // Create a list and add it 9 items
     addToBTree(key, items9);
 
@@ -147,9 +147,8 @@ public class BopMutateTest extends BaseIntegrationTest {
               .getResponse();
       System.out.println(response3.toString());
     } catch (Exception e) {
-      assertEquals(
-          "OperationException: CLIENT: "
-              + "CLIENT_ERROR cannot increment or decrement non-numeric value", e.getMessage());
+      assertTrue(e.getMessage().startsWith("OperationException: CLIENT:" +
+              " CLIENT_ERROR cannot increment or decrement non-numeric value @ ArcusClient-"));
     }
   }
 }


### PR DESCRIPTION
### 🔗 Related Issue

<!-- Please link related issue. ex) https://github.com/naver/arcus-java-client/issues/{issue_number} -->
- 

### ⌨️ What I did

<!-- Please describe this PR and what you've been working on. -->
- OperationException에 Operation을 담당하던 노드의 정보를 담도록 수정합니다.