### PR TITLE
INTERNAL: Divide  method for constructor

### DIFF
--- a/src/main/java/net/spy/memcached/protocol/TCPMemcachedNodeImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/TCPMemcachedNodeImpl.java
@@ -150,7 +150,7 @@ public abstract class TCPMemcachedNodeImpl extends SpyObject
     this.opQueueMaxBlockTime = opQueueMaxBlockTime;
     shouldAuth = waitForAuth;
     isAsciiProtocol = asciiProtocol;
-    setupForAuth("init authentication");
+    authLatch = new CountDownLatch(shouldAuth ? 1 : 0);
   }
 
   public final void copyInputQueue() {


### PR DESCRIPTION
### 🔗 Related Issue

<!-- Please link related issue. ex) https://github.com/naver/arcus-java-client/issues/{issue_number} -->
- https://github.com/jam2in/arcus-works/issues/568
- https://github.com/naver/arcus-java-client/pull/810#discussion_r1774846955

### ⌨️ What I did

<!-- Please describe this PR and what you've been working on. -->
기존의 `setupForAuth()` 메서드는 `authLatch` 초기화 외에 `TCPMemcachedNodeImpl` 인스턴스의 버퍼와 큐등 필드들을 **초기화** 시키는 역할을 합니다. 
하지만, 생성자에서는 이미 초기화 된 형태이므로 `authLatch` 외의 필드를 초기화 하는 것은 불필요하여 **제거**하였습니다.

제거함에 따라 기존의 `getLogger().warn()` 호출로 발생하던 `this-escape` 경고 또한 피할 수 있습니다.

기존 코드의 `setupForAuth()` 에서는 `inputQ`, `readQ`, `writeQ` 와 버퍼들을 빈 상태로 초기화 하는 역할을 수행하는데, 생성자에서 호출하는 경우 이미 빈 상태이기 때문에 `authLatch` 만을 초기화 하여도 충분합니다.