### PR TITLE
INTERNAL: Close Ehcache CacheManager when shutdown FrontCacheMemcachedClient.

### DIFF
--- a/src/main/java/net/spy/memcached/plugin/FrontCacheMemcachedClient.java
+++ b/src/main/java/net/spy/memcached/plugin/FrontCacheMemcachedClient.java
@@ -188,4 +188,20 @@ public class FrontCacheMemcachedClient extends MemcachedClient {
   public LocalCacheManager getLocalCacheManager() {
     return localCacheManager;
   }
+
+  @Override
+  public boolean shutdown(long timeout, TimeUnit unit) {
+    if (localCacheManager != null) {
+      localCacheManager.close();
+    }
+    return super.shutdown(timeout, unit);
+  }
+
+  @Override
+  public void shutdown() {
+    if (localCacheManager != null) {
+      localCacheManager.close();
+    }
+    super.shutdown();
+  }
 }

--- a/src/main/java/net/spy/memcached/plugin/LocalCacheManager.java
+++ b/src/main/java/net/spy/memcached/plugin/LocalCacheManager.java
@@ -35,11 +35,12 @@ import org.ehcache.config.builders.ResourcePoolsBuilder;
 public class LocalCacheManager {
 
   private final Logger logger = LoggerFactory.getLogger(getClass());
+  private final CacheManager cacheManager;
   private final Cache<String, Object> cache;
 
   public LocalCacheManager(String name, int max, int exptime) {
-    CacheManager cacheManager = CacheManagerBuilder.newCacheManagerBuilder()
-            .build(true);
+    this.cacheManager = CacheManagerBuilder.newCacheManagerBuilder().build(true);
+
     CacheConfiguration<String, Object> config =
             CacheConfigurationBuilder.newCacheConfigurationBuilder(String.class, Object.class,
                             ResourcePoolsBuilder.heap(max))
@@ -91,6 +92,10 @@ public class LocalCacheManager {
     } catch (Exception e) {
       logger.info("failed to remove the locally cached item : %s", e.getMessage());
     }
+  }
+
+  public void close() {
+    cacheManager.close();
   }
 
   @Override


### PR DESCRIPTION
### 🔗 Related Issue

<!-- Please link related issue. ex) https://github.com/naver/arcus-java-client/issues/{issue_number} -->
- 

### ⌨️ What I did

<!-- Please describe this PR and what you've been working on. -->
- FrontCacheMemcachedClient를 더 이상 사용하지 않게 된 경우, Ehcache3의 CacheManager 객체에 할당된 리소스를 즉시 해제합니다.