### PR TITLE
INTERNAL: Remove public modifier in test method

### DIFF
--- a/src/test/java/net/spy/memcached/AbstractNodeLocationCase.java
+++ b/src/test/java/net/spy/memcached/AbstractNodeLocationCase.java
@@ -11,7 +11,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
-public abstract class AbstractNodeLocationCase {
+abstract class AbstractNodeLocationCase {
 
   protected MemcachedNode[] nodes;
   protected NodeLocator locator;
@@ -39,21 +39,21 @@ public abstract class AbstractNodeLocationCase {
   }
 
   @Test
-  public final void testCloningGetPrimary() {
+  final void testCloningGetPrimary() {
     setupNodes(5);
     assertTrue(locator.getReadonlyCopy().getPrimary("hi")
             instanceof MemcachedNodeROImpl);
   }
 
   @Test
-  public final void testCloningGetAll() {
+  final void testCloningGetAll() {
     setupNodes(5);
     assertTrue(locator.getReadonlyCopy().getAll().iterator().next()
             instanceof MemcachedNodeROImpl);
   }
 
   @Test
-  public final void testCloningGetSequence() {
+  final void testCloningGetSequence() {
     setupNodes(5);
     assertTrue(locator.getReadonlyCopy().getSequence("hi").next()
             instanceof MemcachedNodeROImpl);

--- a/src/test/java/net/spy/memcached/AddrUtilTest.java
+++ b/src/test/java/net/spy/memcached/AddrUtilTest.java
@@ -29,10 +29,10 @@ import static org.junit.jupiter.api.Assertions.fail;
 /**
  * Test the AddrUtils stuff.
  */
-public class AddrUtilTest {
+class AddrUtilTest {
 
   @Test
-  public void testSingle() throws Exception {
+  void testSingle() throws Exception {
     List<InetSocketAddress> addrs =
             AddrUtil.getAddresses("www.google.com:80");
     assertEquals(1, addrs.size());
@@ -41,7 +41,7 @@ public class AddrUtilTest {
   }
 
   @Test
-  public void testTwo() throws Exception {
+  void testTwo() throws Exception {
     List<InetSocketAddress> addrs =
             AddrUtil.getAddresses("www.google.com:80 www.yahoo.com:81");
     assertEquals(2, addrs.size());
@@ -52,7 +52,7 @@ public class AddrUtilTest {
   }
 
   @Test
-  public void testThree() throws Exception {
+  void testThree() throws Exception {
     List<InetSocketAddress> addrs =
             AddrUtil.getAddresses(" ,  www.google.com:80 ,, ,, www.yahoo.com:81 , ,,");
     assertEquals(2, addrs.size());
@@ -63,7 +63,7 @@ public class AddrUtilTest {
   }
 
   @Test
-  public void testBrokenHost() throws Exception {
+  void testBrokenHost() throws Exception {
     String s = "www.google.com:80 www.yahoo.com:81:more";
     try {
       List<InetSocketAddress> addrs = AddrUtil.getAddresses(s);
@@ -75,7 +75,7 @@ public class AddrUtilTest {
   }
 
   @Test
-  public void testBrokenHost2() throws Exception {
+  void testBrokenHost2() throws Exception {
     String s = "www.google.com:80 www.yahoo.com";
     try {
       List<InetSocketAddress> addrs = AddrUtil.getAddresses(s);
@@ -87,7 +87,7 @@ public class AddrUtilTest {
   }
 
   @Test
-  public void testNullList() throws Exception {
+  void testNullList() throws Exception {
     String s = null;
     try {
       List<InetSocketAddress> addrs = AddrUtil.getAddresses(s);
@@ -98,7 +98,7 @@ public class AddrUtilTest {
   }
 
   @Test
-  public void testIPv6Host() throws Exception {
+  void testIPv6Host() throws Exception {
     List<InetSocketAddress> addrs =
             AddrUtil.getAddresses("::1:80");
     assertEquals(1, addrs.size());

--- a/src/test/java/net/spy/memcached/ArcusKetamaHashingTest.java
+++ b/src/test/java/net/spy/memcached/ArcusKetamaHashingTest.java
@@ -13,22 +13,22 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class ArcusKetamaHashingTest {
+class ArcusKetamaHashingTest {
 
   @Test
-  public void testSmallSet() {
+  void testSmallSet() {
     String[] stringNodes = generateAddresses(3);
     runThisManyNodes(stringNodes[0], stringNodes[1]);
   }
 
   @Test
-  public void testLargeSet() {
+  void testLargeSet() {
     String[] stringNodes = generateAddresses(100);
     runThisManyNodes(stringNodes[0], stringNodes[1]);
   }
 
   @Test
-  public void testHashCollision() {
+  void testHashCollision() {
     StringBuilder sb = new StringBuilder();
     int maxIdx = 103;
     for (int i = 0; i <= maxIdx; i++) {

--- a/src/test/java/net/spy/memcached/ArcusKetamaNodeLocatorTest.java
+++ b/src/test/java/net/spy/memcached/ArcusKetamaNodeLocatorTest.java
@@ -35,7 +35,7 @@ import static org.jmock.AbstractExpectations.returnValue;
 /**
  * Test Arcus ketama node location.
  */
-public class ArcusKetamaNodeLocatorTest extends AbstractNodeLocationCase {
+class ArcusKetamaNodeLocatorTest extends AbstractNodeLocationCase {
 
   @Override
   protected void setupNodes(int n) {
@@ -53,7 +53,7 @@ public class ArcusKetamaNodeLocatorTest extends AbstractNodeLocationCase {
   }
 
   @Test
-  public void testAll() throws Exception {
+  void testAll() throws Exception {
     setupNodes(4);
 
     Collection<MemcachedNode> all = locator.getAll();
@@ -64,7 +64,7 @@ public class ArcusKetamaNodeLocatorTest extends AbstractNodeLocationCase {
   }
 
   @Test
-  public void testAllClone() throws Exception {
+  void testAllClone() throws Exception {
     setupNodes(4);
 
     Collection<MemcachedNode> all = locator.getReadonlyCopy().getAll();
@@ -72,7 +72,7 @@ public class ArcusKetamaNodeLocatorTest extends AbstractNodeLocationCase {
   }
 
   @Test
-  public void testLookups() {
+  void testLookups() {
     setupNodes(4);
     assertSame(nodes[0], locator.getPrimary("dustin"));
     assertSame(nodes[2], locator.getPrimary("noelani"));
@@ -80,7 +80,7 @@ public class ArcusKetamaNodeLocatorTest extends AbstractNodeLocationCase {
   }
 
   @Test
-  public void testLookupsClone() {
+  void testLookupsClone() {
     setupNodes(4);
     assertSame(nodes[0].toString(),
             locator.getReadonlyCopy().getPrimary("dustin").toString());
@@ -91,7 +91,7 @@ public class ArcusKetamaNodeLocatorTest extends AbstractNodeLocationCase {
   }
 
   @Test
-  public void testContinuumWrapping() {
+  void testContinuumWrapping() {
     setupNodes(4);
 
     assertSame(nodes[3], locator.getPrimary("V5XS8C8N"));
@@ -100,7 +100,7 @@ public class ArcusKetamaNodeLocatorTest extends AbstractNodeLocationCase {
   }
 
   @Test
-  public void testClusterResizing() {
+  void testClusterResizing() {
     setupNodes(4);
     assertSame(nodes[0], locator.getPrimary("dustin"));
     assertSame(nodes[2], locator.getPrimary("noelani"));
@@ -113,13 +113,13 @@ public class ArcusKetamaNodeLocatorTest extends AbstractNodeLocationCase {
   }
 
   @Test
-  public void testSequence1() {
+  void testSequence1() {
     setupNodes(4);
     assertSequence("dustin", 0, 2, 1, 2);
   }
 
   @Test
-  public void testSequence2() {
+  void testSequence2() {
     setupNodes(4);
     assertSequence("noelani", 2, 1, 1, 3);
   }
@@ -129,7 +129,7 @@ public class ArcusKetamaNodeLocatorTest extends AbstractNodeLocationCase {
   }
 
   @Test
-  public void testLibKetamaCompat() {
+  void testLibKetamaCompat() {
     setupNodes(5);
     assertPosForKey("36", 2);
     assertPosForKey("10037", 3);
@@ -154,7 +154,7 @@ public class ArcusKetamaNodeLocatorTest extends AbstractNodeLocationCase {
   }
 
   @Test
-  public void testLibKetamaCompatTwo() {
+  void testLibKetamaCompatTwo() {
     String servers[] = {
       "10.0.1.1:11211",
       "10.0.1.2:11211",

--- a/src/test/java/net/spy/memcached/ArcusTimeoutTest.java
+++ b/src/test/java/net/spy/memcached/ArcusTimeoutTest.java
@@ -42,7 +42,7 @@ import org.junit.jupiter.api.BeforeEach;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-public class ArcusTimeoutTest {
+class ArcusTimeoutTest {
   private ArcusClient mc = null;
 
   private final String KEY = this.getClass().getSimpleName();
@@ -75,7 +75,7 @@ public class ArcusTimeoutTest {
   }
 
   @Test
-  public void testCollectionFutureTimeout() {
+  void testCollectionFutureTimeout() {
     CollectionFuture<Boolean> future;
 
     future = mc.asyncBopInsert(KEY, 0, null, "hello", new CollectionAttributes());
@@ -83,7 +83,7 @@ public class ArcusTimeoutTest {
   }
 
   @Test
-  public void testBulkSetTimeout() {
+  void testBulkSetTimeout() {
     int keySize = 100000;
 
     String[] keys = new String[keySize];
@@ -98,7 +98,7 @@ public class ArcusTimeoutTest {
   }
 
   @Test
-  public void testBulkSetTimeoutUsingSingleThread() {
+  void testBulkSetTimeoutUsingSingleThread() {
     int keySize = 100000;
 
     String[] keys = new String[keySize];
@@ -113,7 +113,7 @@ public class ArcusTimeoutTest {
   }
 
   @Test
-  public void testBulkDeleteTimeout() {
+  void testBulkDeleteTimeout() {
     int keySize = 100000;
 
     List<String> keys = new ArrayList<>(keySize);
@@ -126,7 +126,7 @@ public class ArcusTimeoutTest {
   }
 
   @Test
-  public void testBulkDeleteTimeoutUsingSingleThread() {
+  void testBulkDeleteTimeoutUsingSingleThread() {
     int keySize = 100000;
 
     List<String> keys = new ArrayList<>(keySize);
@@ -139,7 +139,7 @@ public class ArcusTimeoutTest {
   }
 
   @Test
-  public void testSopPipedInsertBulkTimeout() {
+  void testSopPipedInsertBulkTimeout() {
     String key = "testTimeout";
     int valueCount = mc.getMaxPipedItemCount();
     Object[] valueList = new Object[valueCount];
@@ -153,7 +153,7 @@ public class ArcusTimeoutTest {
   }
 
   @Test
-  public void testSopInsertBulkTimeout() {
+  void testSopInsertBulkTimeout() {
     String value = "MyValue";
     int keySize = 100000;
     String[] keys = new String[keySize];
@@ -167,7 +167,7 @@ public class ArcusTimeoutTest {
   }
 
   @Test
-  public void testLopPipedInsertBulkTimeout() {
+  void testLopPipedInsertBulkTimeout() {
     int valueCount = 500;
     Object[] valueList = new Object[valueCount];
     Arrays.fill(valueList, "MyValue");
@@ -179,7 +179,7 @@ public class ArcusTimeoutTest {
   }
 
   @Test
-  public void testLopInsertBulkTimeout() {
+  void testLopInsertBulkTimeout() {
     String value = "MyValue";
     int keySize = 250000;
 
@@ -194,7 +194,7 @@ public class ArcusTimeoutTest {
   }
 
   @Test
-  public void testBopPipedInsertBulkTimeout() {
+  void testBopPipedInsertBulkTimeout() {
     String key = "MyBopKey";
     String value = "MyValue";
 
@@ -210,7 +210,7 @@ public class ArcusTimeoutTest {
   }
 
   @Test
-  public void testBopInsertBulkTimeout() {
+  void testBopInsertBulkTimeout() {
     String value = "MyValue";
     long bkey = Long.MAX_VALUE;
 
@@ -227,7 +227,7 @@ public class ArcusTimeoutTest {
   }
 
   @Test
-  public void testOldSMGetTimeout() {
+  void testOldSMGetTimeout() {
     List<String> keyList = new ArrayList<>();
     for (int i = 0; i < 1000; i++) {
       keyList.add(KEY + i);
@@ -239,7 +239,7 @@ public class ArcusTimeoutTest {
   }
 
   @Test
-  public void testSMGetTimeout() {
+  void testSMGetTimeout() {
     List<String> keyList = new ArrayList<>();
     for (int i = 0; i < 1000; i++) {
       keyList.add(KEY + i);
@@ -253,7 +253,7 @@ public class ArcusTimeoutTest {
   }
 
   @Test
-  public void testByteArrayBKeyOldSMGetTimeout() {
+  void testByteArrayBKeyOldSMGetTimeout() {
     ArrayList<String> keyList;
     keyList = new ArrayList<>();
     for (int i = 0; i < 1000; i++) {
@@ -269,7 +269,7 @@ public class ArcusTimeoutTest {
   }
 
   @Test
-  public void testByteArrayBKeySMGetTimeout() {
+  void testByteArrayBKeySMGetTimeout() {
     List<String> keyList = new ArrayList<>();
     for (int i = 0; i < 1000; i++) {
       keyList.add(KEY + i);
@@ -286,13 +286,13 @@ public class ArcusTimeoutTest {
   }
 
   @Test
-  public void testFlushByPrefixTimeout() {
+  void testFlushByPrefixTimeout() {
     OperationFuture<Boolean> flushFuture = mc.flush("prefix");
     assertThrows(TimeoutException.class, () -> flushFuture.get(1L, TimeUnit.MILLISECONDS));
   }
 
   @Test
-  public void testMopInsertBulkMultipleTimeout() {
+  void testMopInsertBulkMultipleTimeout() {
     String key = "MyMopKey";
     String value = "MyValue";
 
@@ -309,7 +309,7 @@ public class ArcusTimeoutTest {
   }
 
   @Test
-  public void testMopInsertBulkTimeout() {
+  void testMopInsertBulkTimeout() {
     String mkey = "MyMopKey";
     String value = "MyValue";
     int keySize = 250000;

--- a/src/test/java/net/spy/memcached/ArrayModNodeLocatorTest.java
+++ b/src/test/java/net/spy/memcached/ArrayModNodeLocatorTest.java
@@ -12,7 +12,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 /**
  * Test the ArrayModNodeLocator.
  */
-public class ArrayModNodeLocatorTest extends AbstractNodeLocationCase {
+class ArrayModNodeLocatorTest extends AbstractNodeLocationCase {
 
   @Override
   protected void setupNodes(int n) {
@@ -22,7 +22,7 @@ public class ArrayModNodeLocatorTest extends AbstractNodeLocationCase {
   }
 
   @Test
-  public void testPrimary() throws Exception {
+  void testPrimary() throws Exception {
     setupNodes(4);
     assertSame(nodes[3], locator.getPrimary("dustin"));
     assertSame(nodes[0], locator.getPrimary("x"));
@@ -30,7 +30,7 @@ public class ArrayModNodeLocatorTest extends AbstractNodeLocationCase {
   }
 
   @Test
-  public void testPrimaryClone() throws Exception {
+  void testPrimaryClone() throws Exception {
     setupNodes(4);
     assertEquals(nodes[3].toString(),
             locator.getReadonlyCopy().getPrimary("dustin").toString());
@@ -41,7 +41,7 @@ public class ArrayModNodeLocatorTest extends AbstractNodeLocationCase {
   }
 
   @Test
-  public void testAll() throws Exception {
+  void testAll() throws Exception {
     setupNodes(4);
     Collection<MemcachedNode> all = locator.getAll();
     assertEquals(4, all.size());
@@ -52,32 +52,32 @@ public class ArrayModNodeLocatorTest extends AbstractNodeLocationCase {
   }
 
   @Test
-  public void testAllClone() throws Exception {
+  void testAllClone() throws Exception {
     setupNodes(4);
     Collection<MemcachedNode> all = locator.getReadonlyCopy().getAll();
     assertEquals(4, all.size());
   }
 
   @Test
-  public void testSeq1() {
+  void testSeq1() {
     setupNodes(4);
     assertSequence("dustin", 0, 1, 2);
   }
 
   @Test
-  public void testSeq2() {
+  void testSeq2() {
     setupNodes(4);
     assertSequence("noelani", 1, 2, 3);
   }
 
   @Test
-  public void testSeqOnlyOneServer() {
+  void testSeqOnlyOneServer() {
     setupNodes(1);
     assertSequence("noelani");
   }
 
   @Test
-  public void testSeqWithTwoNodes() {
+  void testSeqWithTwoNodes() {
     setupNodes(2);
     assertSequence("dustin", 0);
   }

--- a/src/test/java/net/spy/memcached/AsciiCancellationTest.java
+++ b/src/test/java/net/spy/memcached/AsciiCancellationTest.java
@@ -3,6 +3,6 @@ package net.spy.memcached;
 /**
  * Test cancellation in ascii protocol.
  */
-public class AsciiCancellationTest extends CancellationBaseCase {
+class AsciiCancellationTest extends CancellationBaseCase {
   // uses defaults
 }

--- a/src/test/java/net/spy/memcached/AsciiClientTest.java
+++ b/src/test/java/net/spy/memcached/AsciiClientTest.java
@@ -28,10 +28,10 @@ import org.junit.jupiter.api.Test;
 /**
  * This test assumes a client is running on localhost:11211.
  */
-public class AsciiClientTest extends ProtocolBaseCase {
+class AsciiClientTest extends ProtocolBaseCase {
 
   @Test
-  public void testBadOperation() throws Exception {
+  void testBadOperation() throws Exception {
     client.addOp("x", new ExtensibleOperationImpl(new OperationCallback() {
       public void complete() {
         System.err.println("Complete.");

--- a/src/test/java/net/spy/memcached/AsciiIPV6ClientTest.java
+++ b/src/test/java/net/spy/memcached/AsciiIPV6ClientTest.java
@@ -3,7 +3,7 @@ package net.spy.memcached;
 /**
  * Test the test protocol over IPv6.
  */
-public class AsciiIPV6ClientTest extends AsciiClientTest {
+class AsciiIPV6ClientTest extends AsciiClientTest {
 
   @Override
   protected void initClient(ConnectionFactory cf) throws Exception {

--- a/src/test/java/net/spy/memcached/BinaryCancellationTest.java
+++ b/src/test/java/net/spy/memcached/BinaryCancellationTest.java
@@ -3,7 +3,7 @@ package net.spy.memcached;
 /**
  * Test cancellation in the binary protocol.
  */
-public class BinaryCancellationTest extends CancellationBaseCase {
+class BinaryCancellationTest extends CancellationBaseCase {
 
   @Override
   protected void initClient() throws Exception {

--- a/src/test/java/net/spy/memcached/BinaryClientTest.java
+++ b/src/test/java/net/spy/memcached/BinaryClientTest.java
@@ -10,7 +10,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 /**
  * This test assumes a binary server is running on localhost:11211.
  */
-public class BinaryClientTest extends ProtocolBaseCase {
+class BinaryClientTest extends ProtocolBaseCase {
 
   @Override
   protected void initClient() throws Exception {
@@ -34,25 +34,25 @@ public class BinaryClientTest extends ProtocolBaseCase {
 
   @Test
   @Override
-  public void testGetStatsCacheDump() throws Exception {
+  void testGetStatsCacheDump() throws Exception {
     // XXX:  Cachedump isn't returning anything from the server in binprot
     assertTrue(true);
   }
 
   @Test
   @Override
-  public void testGetsBulk() throws Exception {
+  void testGetsBulk() throws Exception {
     assertTrue(true);
   }
 
   @Test
   @Override
-  public void testAsyncGetsBulkWithTranscoderIterator() throws Exception {
+  void testAsyncGetsBulkWithTranscoderIterator() throws Exception {
     assertTrue(true);
   }
 
   @Test
-  public void testCASAppendFail() throws Exception {
+  void testCASAppendFail() throws Exception {
     final String key = "append.key";
     assertTrue(client.set(key, 5, "test").get());
     CASValue<Object> casv = client.gets(key);
@@ -61,7 +61,7 @@ public class BinaryClientTest extends ProtocolBaseCase {
   }
 
   @Test
-  public void testCASAppendSuccess() throws Exception {
+  void testCASAppendSuccess() throws Exception {
     final String key = "append.key";
     assertTrue(client.set(key, 5, "test").get());
     CASValue<Object> casv = client.gets(key);
@@ -70,7 +70,7 @@ public class BinaryClientTest extends ProtocolBaseCase {
   }
 
   @Test
-  public void testCASPrependFail() throws Exception {
+  void testCASPrependFail() throws Exception {
     final String key = "append.key";
     assertTrue(client.set(key, 5, "test").get());
     CASValue<Object> casv = client.gets(key);
@@ -79,7 +79,7 @@ public class BinaryClientTest extends ProtocolBaseCase {
   }
 
   @Test
-  public void testCASPrependSuccess() throws Exception {
+  void testCASPrependSuccess() throws Exception {
     final String key = "append.key";
     assertTrue(client.set(key, 5, "test").get());
     CASValue<Object> casv = client.gets(key);

--- a/src/test/java/net/spy/memcached/BinaryIPV6ClientTest.java
+++ b/src/test/java/net/spy/memcached/BinaryIPV6ClientTest.java
@@ -3,7 +3,7 @@ package net.spy.memcached;
 /**
  * Binary IPv6 client test.
  */
-public class BinaryIPV6ClientTest extends BinaryClientTest {
+class BinaryIPV6ClientTest extends BinaryClientTest {
 
   @Override
   protected void initClient(ConnectionFactory cf) throws Exception {

--- a/src/test/java/net/spy/memcached/CASMutatorTest.java
+++ b/src/test/java/net/spy/memcached/CASMutatorTest.java
@@ -14,7 +14,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 /**
  * Test the CAS mutator.
  */
-public class CASMutatorTest extends ClientBaseCase {
+class CASMutatorTest extends ClientBaseCase {
 
   private CASMutation<Long> mutation;
   private CASMutator<Long> mutator;
@@ -28,20 +28,20 @@ public class CASMutatorTest extends ClientBaseCase {
   }
 
   @Test
-  public void testDefaultConstructor() {
+  void testDefaultConstructor() {
     // Just validate that this doesn't throw an exception.
     new CASMutator<>(client, new LongTranscoder());
   }
 
   @Test
-  public void testConcurrentCAS() throws Throwable {
+  void testConcurrentCAS() throws Throwable {
     int num = SyncThread.getDistinctResultCount(20,
         () -> mutator.cas("test.cas.concurrent", 0L, 0, mutation));
     assertEquals(20, num);
   }
 
   @Test
-  public void testIncorrectTypeInCAS() throws Throwable {
+  void testIncorrectTypeInCAS() throws Throwable {
     // Stick something for this CAS in the cache.
     assertTrue(client.set("x", 0, "not a long").get());
     try {
@@ -53,14 +53,14 @@ public class CASMutatorTest extends ClientBaseCase {
   }
 
   @Test
-  public void testCASUpdateWithNullInitial() throws Throwable {
+  void testCASUpdateWithNullInitial() throws Throwable {
     assertTrue(client.set("x", 0, 1L).get());
     Long rv = mutator.cas("x", (Long) null, 0, mutation);
     assertEquals(rv, (Long) 2L);
   }
 
   @Test
-  public void testCASUpdateWithNullInitialNoExistingVal() throws Throwable {
+  void testCASUpdateWithNullInitialNoExistingVal() throws Throwable {
     assertNull(client.get("x"));
     Long rv = mutator.cas("x", (Long) null, 0, mutation);
     assertNull(rv);
@@ -68,7 +68,7 @@ public class CASMutatorTest extends ClientBaseCase {
   }
 
   @Test
-  public void testCASValueToString() {
+  void testCASValueToString() {
     CASValue<String> c = new CASValue<>(717L, "hi");
     assertEquals("{CasValue 717/hi}", c.toString());
   }

--- a/src/test/java/net/spy/memcached/CacheMapTest.java
+++ b/src/test/java/net/spy/memcached/CacheMapTest.java
@@ -27,7 +27,7 @@ import static org.jmock.AbstractExpectations.returnValue;
 /**
  * Test the CacheMap.
  */
-public class CacheMapTest {
+class CacheMapTest {
 
   private final static int EXP = 8175;
   private Mockery context;
@@ -62,7 +62,7 @@ public class CacheMapTest {
   }
 
   @Test
-  public void testNoExpConstructor() throws Exception {
+  void testNoExpConstructor() throws Exception {
     context.checking(buildExpectations(e -> {
       e.oneOf(client).getTranscoder();
       e.will(returnValue(transcoder));
@@ -75,7 +75,7 @@ public class CacheMapTest {
   }
 
   @Test
-  public void testBaseConstructor() throws Exception {
+  void testBaseConstructor() throws Exception {
     BaseCacheMap<Integer> bcm = new BaseCacheMap<>(client,
             EXP, "base", new IntegerTranscoder());
     Field f = BaseCacheMap.class.getDeclaredField("exp");
@@ -84,7 +84,7 @@ public class CacheMapTest {
   }
 
   @Test
-  public void testClear() {
+  void testClear() {
     try {
       cacheMap.clear();
       fail("Expected unsupported operation exception");
@@ -94,56 +94,56 @@ public class CacheMapTest {
   }
 
   @Test
-  public void testGetPositive() {
+  void testGetPositive() {
     expectGetAndReturn("blaha", "something");
     assertEquals("something", cacheMap.get("a"));
   }
 
   @Test
-  public void testGetNegative() {
+  void testGetNegative() {
     expectGetAndReturn("blaha", null);
     assertNull(cacheMap.get("a"));
   }
 
   @Test
-  public void testGetNotString() {
+  void testGetNotString() {
     assertNull(cacheMap.get(new Object()));
   }
 
   @Test
-  public void testContainsPositive() {
+  void testContainsPositive() {
     expectGetAndReturn("blaha", new Object());
     assertTrue(cacheMap.containsKey("a"));
   }
 
   @Test
-  public void testContainsNegative() {
+  void testContainsNegative() {
     expectGetAndReturn("blaha", null);
     assertFalse(cacheMap.containsKey("a"));
   }
 
   @Test
-  public void testContainsValue() {
+  void testContainsValue() {
     assertFalse(cacheMap.containsValue("anything"));
   }
 
   @Test
-  public void testEntrySet() {
+  void testEntrySet() {
     assertEquals(0, cacheMap.entrySet().size());
   }
 
   @Test
-  public void testKeySet() {
+  void testKeySet() {
     assertEquals(0, cacheMap.keySet().size());
   }
 
   @Test
-  public void testtIsEmpty() {
+  void testtIsEmpty() {
     assertFalse(cacheMap.isEmpty());
   }
 
   @Test
-  public void testPutAll() {
+  void testPutAll() {
     context.checking(buildExpectations(e -> {
       e.oneOf(client).set("blaha", EXP, "vala");
       e.oneOf(client).set("blahb", EXP, "valb");
@@ -157,17 +157,17 @@ public class CacheMapTest {
   }
 
   @Test
-  public void testSize() {
+  void testSize() {
     assertEquals(0, cacheMap.size());
   }
 
   @Test
-  public void testValues() {
+  void testValues() {
     assertEquals(0, cacheMap.values().size());
   }
 
   @Test
-  public void testRemove() {
+  void testRemove() {
     expectGetAndReturn("blaha", "olda");
     context.checking(buildExpectations(e -> {
       e.oneOf(client).delete("blaha");
@@ -177,12 +177,12 @@ public class CacheMapTest {
   }
 
   @Test
-  public void testRemoveNotString() {
+  void testRemoveNotString() {
     assertNull(cacheMap.remove(new Object()));
   }
 
   @Test
-  public void testPut() {
+  void testPut() {
     expectGetAndReturn("blaha", "olda");
     context.checking(buildExpectations(e -> {
       e.oneOf(client).set("blaha", EXP, "newa");

--- a/src/test/java/net/spy/memcached/CacheMonitorTest.java
+++ b/src/test/java/net/spy/memcached/CacheMonitorTest.java
@@ -39,7 +39,7 @@ import static net.spy.memcached.ExpectationsUtil.buildExpectations;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class CacheMonitorTest {
+class CacheMonitorTest {
 
   private Watcher watcher;
   private CacheMonitorListener listener;
@@ -69,7 +69,7 @@ public class CacheMonitorTest {
   }
 
   @Test
-  public void testProcessResult() {
+  void testProcessResult() {
     // when
     children.add("0.0.0.0:11211");
     context.checking(buildExpectations(e -> {
@@ -85,7 +85,7 @@ public class CacheMonitorTest {
   }
 
   @Test
-  public void testProcessResult_emptyChildren() {
+  void testProcessResult_emptyChildren() {
     List<String> fakeChildren = new ArrayList<>();
     fakeChildren.add("0.0.0.0:23456");
 
@@ -103,7 +103,7 @@ public class CacheMonitorTest {
   }
 
   @Test
-  public void testProcessResult_otherEvents() {
+  void testProcessResult_otherEvents() {
     children.add("127.0.0.1:11211");
     context.checking(buildExpectations(e -> {
       e.never(listener).commandCacheListChange(children);
@@ -142,7 +142,7 @@ public class CacheMonitorTest {
   }
 
   @Test
-  public void testProcess_syncConnected() throws Exception {
+  void testProcess_syncConnected() throws Exception {
     // when
     WatchedEvent event = new WatchedEvent(
         EventType.None, KeeperState.SyncConnected, ARCUS_BASE_CACHE_LIST_ZPATH + "/dev");
@@ -155,7 +155,7 @@ public class CacheMonitorTest {
   }
 
   @Test
-  public void testProcess_disconnected() throws Exception {
+  void testProcess_disconnected() throws Exception {
     // when
     WatchedEvent event = new WatchedEvent(
         EventType.None, KeeperState.Disconnected, ARCUS_BASE_CACHE_LIST_ZPATH + "/dev");
@@ -168,7 +168,7 @@ public class CacheMonitorTest {
   }
 
   @Test
-  public void testProcess_expired() throws Exception {
+  void testProcess_expired() throws Exception {
     // when
     WatchedEvent event = new WatchedEvent(
         EventType.None, KeeperState.Expired, ARCUS_BASE_CACHE_LIST_ZPATH + "/dev");
@@ -184,7 +184,7 @@ public class CacheMonitorTest {
   }
 
   @Test
-  public void testProcess_nodeChildrenChanged() throws Exception {
+  void testProcess_nodeChildrenChanged() throws Exception {
     // when
     WatchedEvent event = new WatchedEvent(
         EventType.NodeChildrenChanged,

--- a/src/test/java/net/spy/memcached/CancelFailureModeTest.java
+++ b/src/test/java/net/spy/memcached/CancelFailureModeTest.java
@@ -10,7 +10,7 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
-public class CancelFailureModeTest {
+class CancelFailureModeTest {
   private String serverList = "127.0.0.1:11311";
   private MemcachedClient client = null;
 
@@ -32,7 +32,7 @@ public class CancelFailureModeTest {
   }
 
   @Test
-  public void testQueueingToDownServer() throws Exception {
+  void testQueueingToDownServer() throws Exception {
     Future<Boolean> f = client.add("someKey", 0, "some object");
     try {
       boolean b = f.get();

--- a/src/test/java/net/spy/memcached/CancellationBaseCase.java
+++ b/src/test/java/net/spy/memcached/CancellationBaseCase.java
@@ -21,7 +21,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 /**
  * Base class for cancellation tests.
  */
-public abstract class CancellationBaseCase {
+abstract class CancellationBaseCase {
   private static final String serverList = "127.0.0.1:64213";
   private MemcachedClient client = null;
 
@@ -69,13 +69,13 @@ public abstract class CancellationBaseCase {
   }
 
   @Test
-  public void testAvailableServers() throws Exception {
+  void testAvailableServers() throws Exception {
     tryTimeout(client.asyncGet("x"));
     assertEquals(Collections.emptyList(), client.getAvailableServers());
   }
 
   @Test
-  public void testUnavailableServers() throws Exception {
+  void testUnavailableServers() throws Exception {
     tryTimeout(client.asyncGet("x"));
     assertEquals(new ArrayList<>(
                     Collections.singleton("/127.0.0.1:64213")),
@@ -97,52 +97,52 @@ public abstract class CancellationBaseCase {
   }
 
   @Test
-  public void testAsyncGetCancellation() throws Exception {
+  void testAsyncGetCancellation() throws Exception {
     tryTestSequence(client.asyncGet("k"));
   }
 
   @Test
-  public void testAsyncGetsCancellation() throws Exception {
+  void testAsyncGetsCancellation() throws Exception {
     tryTestSequence(client.asyncGets("k"));
   }
 
   @Test
-  public void testAsyncGetBulkCancellationCollection() throws Exception {
+  void testAsyncGetBulkCancellationCollection() throws Exception {
     tryTestSequence(client.asyncGetBulk(Arrays.asList("k", "k2")));
   }
 
   @Test
-  public void testDeleteCancellation() throws Exception {
+  void testDeleteCancellation() throws Exception {
     tryTestSequence(client.delete("x"));
   }
 
   @Test
-  public void testflushCancellation() throws Exception {
+  void testflushCancellation() throws Exception {
     tryTestSequence(client.flush());
   }
 
   @Test
-  public void testDelayedflushCancellation() throws Exception {
+  void testDelayedflushCancellation() throws Exception {
     tryTestSequence(client.flush(3));
   }
 
   @Test
-  public void testReplaceCancellation() throws Exception {
+  void testReplaceCancellation() throws Exception {
     tryTestSequence(client.replace("x", 3, "y"));
   }
 
   @Test
-  public void testAddCancellation() throws Exception {
+  void testAddCancellation() throws Exception {
     tryTestSequence(client.add("x", 3, "y"));
   }
 
   @Test
-  public void testSetCancellation() throws Exception {
+  void testSetCancellation() throws Exception {
     tryTestSequence(client.set("x", 3, "y"));
   }
 
   @Test
-  public void testCASCancellation() throws Exception {
+  void testCASCancellation() throws Exception {
     tryTestSequence(client.asyncCAS("x", 3, "y"));
   }
 }

--- a/src/test/java/net/spy/memcached/ClientBaseCase.java
+++ b/src/test/java/net/spy/memcached/ClientBaseCase.java
@@ -37,7 +37,7 @@ import org.junit.jupiter.api.BeforeEach;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public abstract class ClientBaseCase {
+abstract class ClientBaseCase {
 
   public static final String ZK_ADDRESS = System.getProperty("ZK_ADDRESS",
           "127.0.0.1:2181");

--- a/src/test/java/net/spy/memcached/ConnectionFactoryBuilderTest.java
+++ b/src/test/java/net/spy/memcached/ConnectionFactoryBuilderTest.java
@@ -47,7 +47,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 /**
  * Test the connection factory builder.
  */
-public class ConnectionFactoryBuilderTest {
+class ConnectionFactoryBuilderTest {
 
   private ConnectionFactoryBuilder b;
 
@@ -57,7 +57,7 @@ public class ConnectionFactoryBuilderTest {
   }
 
   @Test
-  public void testDefaults() throws Exception {
+  void testDefaults() throws Exception {
     ConnectionFactory f = b.build();
     assertEquals(DefaultConnectionFactory.DEFAULT_OPERATION_TIMEOUT,
             f.getOperationTimeout());
@@ -107,7 +107,7 @@ public class ConnectionFactoryBuilderTest {
   }
 
   @Test
-  public void testModifications() throws Exception {
+  void testModifications() throws Exception {
     ConnectionObserver testObserver = new ConnectionObserver() {
       public void connectionLost(SocketAddress sa) {
         // none
@@ -176,14 +176,14 @@ public class ConnectionFactoryBuilderTest {
   }
 
   @Test
-  public void testProtocolSetterBinary() {
+  void testProtocolSetterBinary() {
     assertTrue(
             b.setProtocol(Protocol.BINARY).build().getOperationFactory()
                     instanceof BinaryOperationFactory);
   }
 
   @Test
-  public void testProtocolSetterText() {
+  void testProtocolSetterText() {
     assertTrue(
             b.setProtocol(Protocol.TEXT).build().getOperationFactory()
                     instanceof AsciiOperationFactory);

--- a/src/test/java/net/spy/memcached/ConnectionFactoryTest.java
+++ b/src/test/java/net/spy/memcached/ConnectionFactoryTest.java
@@ -7,28 +7,28 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 /**
  * Test connection factory variations.
  */
-public class ConnectionFactoryTest {
+class ConnectionFactoryTest {
 
   // These tests are a little lame.  They don't verify anything other than
   // that the code executes without failure.
   @Test
-  public void testBinaryEmptyCons() {
+  void testBinaryEmptyCons() {
     new BinaryConnectionFactory();
   }
 
   @Test
-  public void testBinaryTwoIntCons() {
+  void testBinaryTwoIntCons() {
     new BinaryConnectionFactory(5, 5);
   }
 
   @Test
-  public void testBinaryAnIntAnotherIntAndAHashAlgorithmCons() {
+  void testBinaryAnIntAnotherIntAndAHashAlgorithmCons() {
     new BinaryConnectionFactory(5, 5,
             HashAlgorithm.FNV1_64_HASH);
   }
 
   @Test
-  public void testQueueSizes() {
+  void testQueueSizes() {
     ConnectionFactory cf = new DefaultConnectionFactory(100, 1024);
     assertEquals(100, cf.createOperationQueue().remainingCapacity());
     assertEquals(Integer.MAX_VALUE,

--- a/src/test/java/net/spy/memcached/ConsistentHashingTest.java
+++ b/src/test/java/net/spy/memcached/ConsistentHashingTest.java
@@ -18,15 +18,15 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * Ignore it now and fix it later.
  */
 @Disabled
-public class ConsistentHashingTest {
+class ConsistentHashingTest {
 
   @Test
-  public void testSmallSet() {
+  void testSmallSet() {
     runThisManyNodes(3);
   }
 
   @Test
-  public void testLargeSet() {
+  void testLargeSet() {
     runThisManyNodes(100);
   }
 

--- a/src/test/java/net/spy/memcached/DoLotsOfSets.java
+++ b/src/test/java/net/spy/memcached/DoLotsOfSets.java
@@ -13,7 +13,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 /**
  * Small test program that does a bunch of sets in a tight loop.
  */
-public final class DoLotsOfSets {
+final class DoLotsOfSets {
 
   private DoLotsOfSets() {
   }

--- a/src/test/java/net/spy/memcached/HashAlgorithmTest.java
+++ b/src/test/java/net/spy/memcached/HashAlgorithmTest.java
@@ -11,7 +11,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 /**
  * Test the hash algorithms.
  */
-public class HashAlgorithmTest {
+class HashAlgorithmTest {
 
   private void assertHash(HashAlgorithm ha, String key, long exp) {
     assertTrue(exp >= 0L);
@@ -25,14 +25,14 @@ public class HashAlgorithmTest {
   }
 
   @Test
-  public void testNativeHash() {
+  void testNativeHash() {
     for (String k : new String[]{"Test1", "Test2", "Test3", "Test4"}) {
       assertNativeHash(k);
     }
   }
 
   @Test
-  public void testCrc32Hash() {
+  void testCrc32Hash() {
     Map<String, Long> exp = new HashMap<>();
     exp.put("Test1", 19315L);
     exp.put("Test2", 21114L);
@@ -46,7 +46,7 @@ public class HashAlgorithmTest {
   }
 
   @Test
-  public void testFnv1_64() {
+  void testFnv1_64() {
     HashMap<String, Long> exp = new HashMap<>();
     exp.put("", 0x84222325L);
     exp.put(" ", 0x8601b7ffL);
@@ -64,7 +64,7 @@ public class HashAlgorithmTest {
 
   // Thanks much to pierre@demartines.com for this unit test.
   @Test
-  public void testFnv1a_64() {
+  void testFnv1a_64() {
     HashMap<String, Long> exp = new HashMap<>();
     exp.put("", 0x84222325L);
     exp.put(" ", 0x8601817fL);
@@ -81,7 +81,7 @@ public class HashAlgorithmTest {
   }
 
   @Test
-  public void testFnv1_32() {
+  void testFnv1_32() {
     HashMap<String, Long> exp = new HashMap<>();
     exp.put("", 0x811c9dc5L);
     exp.put(" ", 0x050c5d3fL);
@@ -98,7 +98,7 @@ public class HashAlgorithmTest {
   }
 
   @Test
-  public void testFnv1a_32() {
+  void testFnv1a_32() {
     HashMap<String, Long> exp = new HashMap<>();
     exp.put("", 0x811c9dc5L);
     exp.put(" ", 0x250c8f7fL);
@@ -116,7 +116,7 @@ public class HashAlgorithmTest {
 
   // These values came from libketama's test prog.
   @Test
-  public void testKetamaHash() {
+  void testKetamaHash() {
     HashMap<String, Long> exp = new HashMap<>();
     exp.put("26", 3979113294L);
     exp.put("1404", 2065000984L);

--- a/src/test/java/net/spy/memcached/KetamaConnectionFactoryTest.java
+++ b/src/test/java/net/spy/memcached/KetamaConnectionFactoryTest.java
@@ -11,14 +11,14 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * A very basic test that the KetamaConnectionFactory returns both the correct
  * hash algorithm and the correct node locator.
  */
-public class KetamaConnectionFactoryTest {
+class KetamaConnectionFactoryTest {
 
   /*
    * This *is* kinda lame, but it tests the specific differences from the
    * DefaultConnectionFactory.
    */
   @Test
-  public void testCorrectTypes() {
+  void testCorrectTypes() {
     ConnectionFactory factory = new KetamaConnectionFactory();
 
     NodeLocator locator = factory.createLocator(new ArrayList<>());

--- a/src/test/java/net/spy/memcached/KetamaNodeLocatorTest.java
+++ b/src/test/java/net/spy/memcached/KetamaNodeLocatorTest.java
@@ -18,7 +18,7 @@ import static org.jmock.AbstractExpectations.returnValue;
 /**
  * Test ketama node location.
  */
-public class KetamaNodeLocatorTest extends AbstractNodeLocationCase {
+class KetamaNodeLocatorTest extends AbstractNodeLocationCase {
 
   protected void setupNodes(HashAlgorithm alg, int n) {
     super.setupNodes(n);
@@ -40,7 +40,7 @@ public class KetamaNodeLocatorTest extends AbstractNodeLocationCase {
   }
 
   @Test
-  public void testAll() throws Exception {
+  void testAll() throws Exception {
     setupNodes(4);
 
     Collection<MemcachedNode> all = locator.getAll();
@@ -51,7 +51,7 @@ public class KetamaNodeLocatorTest extends AbstractNodeLocationCase {
   }
 
   @Test
-  public void testAllClone() throws Exception {
+  void testAllClone() throws Exception {
     setupNodes(4);
 
     Collection<MemcachedNode> all = locator.getReadonlyCopy().getAll();
@@ -59,7 +59,7 @@ public class KetamaNodeLocatorTest extends AbstractNodeLocationCase {
   }
 
   @Test
-  public void testLookups() {
+  void testLookups() {
     setupNodes(4);
     assertSame(nodes[0], locator.getPrimary("dustin"));
     assertSame(nodes[2], locator.getPrimary("noelani"));
@@ -67,7 +67,7 @@ public class KetamaNodeLocatorTest extends AbstractNodeLocationCase {
   }
 
   @Test
-  public void testLookupsClone() {
+  void testLookupsClone() {
     setupNodes(4);
     assertSame(nodes[0].toString(),
             locator.getReadonlyCopy().getPrimary("dustin").toString());
@@ -78,7 +78,7 @@ public class KetamaNodeLocatorTest extends AbstractNodeLocationCase {
   }
 
   @Test
-  public void testContinuumWrapping() {
+  void testContinuumWrapping() {
     setupNodes(4);
 
     assertSame(nodes[3], locator.getPrimary("V5XS8C8N"));
@@ -87,7 +87,7 @@ public class KetamaNodeLocatorTest extends AbstractNodeLocationCase {
   }
 
   @Test
-  public void testClusterResizing() {
+  void testClusterResizing() {
     setupNodes(4);
     assertSame(nodes[0], locator.getPrimary("dustin"));
     assertSame(nodes[2], locator.getPrimary("noelani"));
@@ -100,13 +100,13 @@ public class KetamaNodeLocatorTest extends AbstractNodeLocationCase {
   }
 
   @Test
-  public void testSequence1() {
+  void testSequence1() {
     setupNodes(4);
     assertSequence("dustin", 0, 2, 1, 2);
   }
 
   @Test
-  public void testSequence2() {
+  void testSequence2() {
     setupNodes(4);
     assertSequence("noelani", 2, 1, 1, 3);
   }
@@ -116,7 +116,7 @@ public class KetamaNodeLocatorTest extends AbstractNodeLocationCase {
   }
 
   @Test
-  public void testLibKetamaCompat() {
+  void testLibKetamaCompat() {
     setupNodes(5);
     assertPosForKey("36", 2);
     assertPosForKey("10037", 3);
@@ -125,7 +125,7 @@ public class KetamaNodeLocatorTest extends AbstractNodeLocationCase {
   }
 
   @Test
-  public void testFNV1A_32() {
+  void testFNV1A_32() {
     HashAlgorithm alg = HashAlgorithm.FNV1A_32_HASH;
     setupNodes(alg, 5);
     assertSequence("noelani", 1, 2, 2, 2, 3);
@@ -152,7 +152,7 @@ public class KetamaNodeLocatorTest extends AbstractNodeLocationCase {
   }
 
   @Test
-  public void testLibKetamaCompatTwo() {
+  void testLibKetamaCompatTwo() {
     String servers[] = {
         "10.0.1.1:11211",
         "10.0.1.2:11211",

--- a/src/test/java/net/spy/memcached/LongClientTest.java
+++ b/src/test/java/net/spy/memcached/LongClientTest.java
@@ -16,10 +16,10 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 /**
  * Longer running test case.
  */
-public class LongClientTest extends ClientBaseCase {
+class LongClientTest extends ClientBaseCase {
 
   @Test
-  public void testParallelGet() throws Throwable {
+  void testParallelGet() throws Throwable {
     // Get a connection with the get optimization disabled.
     client.shutdown();
     initClient(new DefaultConnectionFactory() {

--- a/src/test/java/net/spy/memcached/MemcachedClientConstructorTest.java
+++ b/src/test/java/net/spy/memcached/MemcachedClientConstructorTest.java
@@ -18,7 +18,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 /**
  * Test the various memcached client constructors.
  */
-public class MemcachedClientConstructorTest {
+class MemcachedClientConstructorTest {
 
   private MemcachedClient client = null;
 
@@ -48,7 +48,7 @@ public class MemcachedClientConstructorTest {
   }
 
   @Test
-  public void testVarargConstructor() throws Exception {
+  void testVarargConstructor() throws Exception {
     if (!USE_ZK) {
       String tokens[] = ARCUS_HOST.split(":");
       String ip = tokens[0];
@@ -60,7 +60,7 @@ public class MemcachedClientConstructorTest {
   }
 
   @Test
-  public void testEmptyVarargConstructor() throws Exception {
+  void testEmptyVarargConstructor() throws Exception {
     try {
       client = new MemcachedClient();
       fail("Expected illegal arg exception, got " + client);
@@ -70,7 +70,7 @@ public class MemcachedClientConstructorTest {
   }
 
   @Test
-  public void testNulListConstructor() throws Exception {
+  void testNulListConstructor() throws Exception {
     try {
       List<InetSocketAddress> l = null;
       client = new MemcachedClient(l);
@@ -81,7 +81,7 @@ public class MemcachedClientConstructorTest {
   }
 
   @Test
-  public void testEmptyListConstructor() throws Exception {
+  void testEmptyListConstructor() throws Exception {
     try {
       client = new MemcachedClient(
               Collections.<InetSocketAddress>emptyList());
@@ -92,7 +92,7 @@ public class MemcachedClientConstructorTest {
   }
 
   @Test
-  public void testNullFactoryConstructor() throws Exception {
+  void testNullFactoryConstructor() throws Exception {
     try {
       client = new MemcachedClient(null,
               AddrUtil.getAddresses(ARCUS_HOST));
@@ -103,7 +103,7 @@ public class MemcachedClientConstructorTest {
   }
 
   @Test
-  public void testNegativeTimeout() throws Exception {
+  void testNegativeTimeout() throws Exception {
     try {
       client = new MemcachedClient(new DefaultConnectionFactory() {
         @Override
@@ -119,7 +119,7 @@ public class MemcachedClientConstructorTest {
   }
 
   @Test
-  public void testZeroTimeout() throws Exception {
+  void testZeroTimeout() throws Exception {
     try {
       client = new MemcachedClient(new DefaultConnectionFactory() {
         @Override
@@ -135,7 +135,7 @@ public class MemcachedClientConstructorTest {
   }
 
   @Test
-  public void testConnFactoryWithoutOpFactory() throws Exception {
+  void testConnFactoryWithoutOpFactory() throws Exception {
     try {
       client = new MemcachedClient(new DefaultConnectionFactory() {
         @Override
@@ -151,7 +151,7 @@ public class MemcachedClientConstructorTest {
   }
 
   @Test
-  public void testConnFactoryWithoutConns() throws Exception {
+  void testConnFactoryWithoutConns() throws Exception {
     try {
       client = new MemcachedClient(new DefaultConnectionFactory() {
         @Override
@@ -169,7 +169,7 @@ public class MemcachedClientConstructorTest {
   }
 
   @Test
-  public void testArraymodNodeLocatorAccessor() throws Exception {
+  void testArraymodNodeLocatorAccessor() throws Exception {
     client = new MemcachedClient(AddrUtil.getAddresses(ARCUS_HOST));
     assertTrue(client.getNodeLocator() instanceof ArrayModNodeLocator);
     assertTrue(client.getNodeLocator().getPrimary("x")
@@ -177,7 +177,7 @@ public class MemcachedClientConstructorTest {
   }
 
   @Test
-  public void testKetamaNodeLocatorAccessor() throws Exception {
+  void testKetamaNodeLocatorAccessor() throws Exception {
     client = new MemcachedClient(new KetamaConnectionFactory(),
             AddrUtil.getAddresses(ARCUS_HOST));
     assertTrue(client.getNodeLocator() instanceof KetamaNodeLocator);

--- a/src/test/java/net/spy/memcached/MemcachedConnectionTest.java
+++ b/src/test/java/net/spy/memcached/MemcachedConnectionTest.java
@@ -39,7 +39,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 /**
  * Test stuff that can be tested within a MemcachedConnection separately.
  */
-public class MemcachedConnectionTest {
+class MemcachedConnectionTest {
 
   private MemcachedConnection conn;
   private ArcusKetamaNodeLocator locator;
@@ -61,7 +61,7 @@ public class MemcachedConnectionTest {
   }
 
   @Test
-  public void testDebugBuffer() {
+  void testDebugBuffer() {
     String input = "this is a test _";
     ByteBuffer bb = ByteBuffer.wrap(input.getBytes());
     String s = MemcachedConnection.dbgBuffer(bb, input.length());
@@ -69,7 +69,7 @@ public class MemcachedConnectionTest {
   }
 
   @Test
-  public void testNodesChangeQueue() throws Exception {
+  void testNodesChangeQueue() throws Exception {
     // when
     conn.setCacheNodesChange(AddrUtil.getAddresses("0.0.0.0:11211"));
 
@@ -99,7 +99,7 @@ public class MemcachedConnectionTest {
   }
 
   @Test
-  public void testNodesChangeQueue_empty() throws Exception {
+  void testNodesChangeQueue_empty() throws Exception {
     // when
     // on servers in the queue
 
@@ -111,7 +111,7 @@ public class MemcachedConnectionTest {
   }
 
   @Test
-  public void testNodesChangeQueue_invalid_addr() {
+  void testNodesChangeQueue_invalid_addr() {
     try {
       // when : putting an invalid address
       conn.setCacheNodesChange(AddrUtil.getAddresses(""));
@@ -128,7 +128,7 @@ public class MemcachedConnectionTest {
   }
 
   @Test
-  public void testNodesChangeQueue_redundant() throws Exception {
+  void testNodesChangeQueue_redundant() throws Exception {
     // when
     conn.setCacheNodesChange(AddrUtil.getAddresses("0.0.0.0:11211,0.0.0.0:11211"));
 
@@ -140,7 +140,7 @@ public class MemcachedConnectionTest {
   }
 
   @Test
-  public void testNodesChangeQueue_twice() throws Exception {
+  void testNodesChangeQueue_twice() throws Exception {
     // when
     conn.setCacheNodesChange(AddrUtil.getAddresses("0.0.0.0:11211"));
     conn.setCacheNodesChange(AddrUtil.getAddresses("0.0.0.0:11211"));
@@ -153,12 +153,12 @@ public class MemcachedConnectionTest {
   }
 
   @Test
-  public void testAddOperations() throws Exception {
+  void testAddOperations() throws Exception {
   }
 
   @SuppressWarnings("unchecked")
   @Test
-  public void testReconnectQueue_delayReconnect() throws Exception {
+  void testReconnectQueue_delayReconnect() throws Exception {
     MemcachedConnection.ReconnectQueue reconnectQueue = new MemcachedConnection.ReconnectQueue(1);
 
     Field reconMapField =
@@ -233,7 +233,7 @@ public class MemcachedConnectionTest {
 
   @SuppressWarnings("unchecked")
   @Test
-  public void testReconnectQueue_immediateReconnect() throws Exception {
+  void testReconnectQueue_immediateReconnect() throws Exception {
     MemcachedConnection.ReconnectQueue reconnectQueue = new MemcachedConnection.ReconnectQueue(1);
 
     Field reconMapField =

--- a/src/test/java/net/spy/memcached/MemcachedNodeROImplTest.java
+++ b/src/test/java/net/spy/memcached/MemcachedNodeROImplTest.java
@@ -25,7 +25,7 @@ import static org.jmock.AbstractExpectations.returnValue;
 /**
  * Test readonliness of the MemcachedNodeROImpl
  */
-public class MemcachedNodeROImplTest {
+class MemcachedNodeROImplTest {
 
   private Mockery context;
 
@@ -40,7 +40,7 @@ public class MemcachedNodeROImplTest {
   }
 
   @Test
-  public void testReadOnliness() throws Exception {
+  void testReadOnliness() throws Exception {
     SocketAddress sa = new InetSocketAddress(11211);
     MemcachedNode m = context.mock(MemcachedNode.class, "node");
     MemcachedNodeROImpl node =

--- a/src/test/java/net/spy/memcached/ObserverTest.java
+++ b/src/test/java/net/spy/memcached/ObserverTest.java
@@ -19,7 +19,7 @@ import static org.junit.jupiter.api.Assumptions.assumeTrue;
 /**
  * Test observer hooks.
  */
-public class ObserverTest extends ClientBaseCase {
+class ObserverTest extends ClientBaseCase {
 
   @BeforeEach
   protected void setUp() throws Exception {
@@ -32,7 +32,7 @@ public class ObserverTest extends ClientBaseCase {
   }
 
   @Test
-  public void testConnectionObserver() throws Exception {
+  void testConnectionObserver() throws Exception {
     ConnectionObserver obs = new LoggingObserver();
     assertTrue(client.addObserver(obs), "Didn't add observer.");
     assertTrue(client.removeObserver(obs), "Didn't remove observer.");
@@ -40,7 +40,7 @@ public class ObserverTest extends ClientBaseCase {
   }
 
   @Test
-  public void testInitialObservers() throws Exception {
+  void testInitialObservers() throws Exception {
     assumeTrue(!USE_ZK);
     assertTrue(client.shutdown(5, TimeUnit.SECONDS),
             "Couldn't shut down within five seconds");

--- a/src/test/java/net/spy/memcached/OperationFactoryTestBase.java
+++ b/src/test/java/net/spy/memcached/OperationFactoryTestBase.java
@@ -77,7 +77,7 @@ public abstract class OperationFactoryTestBase {
   protected abstract OperationFactory getOperationFactory();
 
   @Test
-  public void testDeleteOperationCloning() {
+  void testDeleteOperationCloning() {
     DeleteOperation op = ofact.delete(TEST_KEY, genericCallback);
 
     DeleteOperation op2 = cloneOne(DeleteOperation.class, op);
@@ -86,7 +86,7 @@ public abstract class OperationFactoryTestBase {
   }
 
   @Test
-  public void testCASOperationCloning() {
+  void testCASOperationCloning() {
     CASOperation op = ofact.cas(StoreType.set,
             "someKey", 727582, 8174, 7175, testData, genericCallback);
 
@@ -134,7 +134,7 @@ public abstract class OperationFactoryTestBase {
   }
 
   @Test
-  public void testStoreOperationAddCloning() {
+  void testStoreOperationAddCloning() {
     int exp = 823862;
     int flags = 7735;
     StoreOperation op = ofact.store(StoreType.add, TEST_KEY,
@@ -149,7 +149,7 @@ public abstract class OperationFactoryTestBase {
   }
 
   @Test
-  public void testStoreOperationSetCloning() {
+  void testStoreOperationSetCloning() {
     int exp = 823862;
     int flags = 7735;
     StoreOperation op = ofact.store(StoreType.set, TEST_KEY,
@@ -164,7 +164,7 @@ public abstract class OperationFactoryTestBase {
   }
 
   @Test
-  public void testConcatenationOperationAppendCloning() {
+  void testConcatenationOperationAppendCloning() {
     long casId = 82757248;
     ConcatenationOperation op = ofact.cat(ConcatenationType.append, casId,
             TEST_KEY, testData, genericCallback);
@@ -177,7 +177,7 @@ public abstract class OperationFactoryTestBase {
   }
 
   @Test
-  public void testConcatenationOperationPrependCloning() {
+  void testConcatenationOperationPrependCloning() {
     long casId = 82757248;
     ConcatenationOperation op = ofact.cat(ConcatenationType.prepend, casId,
             TEST_KEY, testData, genericCallback);
@@ -190,7 +190,7 @@ public abstract class OperationFactoryTestBase {
   }
 
   @Test
-  public void testSingleGetOperationCloning() {
+  void testSingleGetOperationCloning() {
     GetOperation.Callback callback = context.mock(GetOperation.Callback.class);
     GetOperation op = ofact.get(TEST_KEY, callback);
 
@@ -200,7 +200,7 @@ public abstract class OperationFactoryTestBase {
   }
 
   @Test
-  public void testSingleGetsOperationCloning() {
+  void testSingleGetsOperationCloning() {
     GetsOperation.Callback callback = context.mock(GetsOperation.Callback.class);
     GetsOperation op = ofact.gets(TEST_KEY, callback);
 
@@ -211,7 +211,7 @@ public abstract class OperationFactoryTestBase {
 
   // These are harder cases as they fan out.
   @Test
-  public void testMultipleGetOperationCloning() {
+  void testMultipleGetOperationCloning() {
     Collection<String> keys = Arrays.asList("k1", "k2", "k3");
     GetOperation.Callback callback = context.mock(GetOperation.Callback.class);
     GetOperation op = ofact.get(keys, callback);
@@ -231,7 +231,7 @@ public abstract class OperationFactoryTestBase {
   }
 
   @Test
-  public void testMultipleGetOperationFanout() {
+  void testMultipleGetOperationFanout() {
     Collection<String> keys = Arrays.asList("k1", "k2", "k3");
     GetOperation.Callback callback = context.mock(GetOperation.Callback.class);
     OperationStatus st = new OperationStatus(true, "blah");

--- a/src/test/java/net/spy/memcached/ProtocolBaseCase.java
+++ b/src/test/java/net/spy/memcached/ProtocolBaseCase.java
@@ -51,10 +51,10 @@ import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
-public abstract class ProtocolBaseCase extends ClientBaseCase {
+abstract class ProtocolBaseCase extends ClientBaseCase {
 
   @Test
-  public void testAssertions() {
+  void testAssertions() {
     boolean caught = false;
     try {
       assert false;
@@ -65,7 +65,7 @@ public abstract class ProtocolBaseCase extends ClientBaseCase {
   }
 
   @Test
-  public void testGetStats() throws Exception {
+  void testGetStats() throws Exception {
     Map<SocketAddress, Map<String, String>> stats = client.getStats();
     System.out.println("Stats:  " + stats);
     assertEquals(client.getAllNodes().size(), stats.size());
@@ -74,7 +74,7 @@ public abstract class ProtocolBaseCase extends ClientBaseCase {
   }
 
   @Test
-  public void testGetStatsSlabs() throws Exception {
+  void testGetStatsSlabs() throws Exception {
     // There needs to at least have been one value set or there may be
     // no slabs to check.
     assertTrue(client.set("slabinitializer", 0, "hi").get());
@@ -86,7 +86,7 @@ public abstract class ProtocolBaseCase extends ClientBaseCase {
   }
 
   @Test
-  public void testGetStatsSizes() throws Exception {
+  void testGetStatsSizes() throws Exception {
     // Arcus does not support "stats sizes"
     if (true) {
       return;
@@ -102,7 +102,7 @@ public abstract class ProtocolBaseCase extends ClientBaseCase {
   }
 
   @Test
-  public void testGetStatsCacheDump() throws Exception {
+  void testGetStatsCacheDump() throws Exception {
     // There needs to at least have been one value set or there
     // won't be anything to dump
     assertTrue(client.set("dumpinitializer", 0, "hi").get());
@@ -115,7 +115,7 @@ public abstract class ProtocolBaseCase extends ClientBaseCase {
   }
 
   @Test
-  public void testDelayedFlush() throws Exception {
+  void testDelayedFlush() throws Exception {
     assertNull(client.get("test1"));
     assertTrue(client.set("test1", 5, "test1value").get());
     assertTrue(client.set("test2", 5, "test2value").get());
@@ -128,32 +128,32 @@ public abstract class ProtocolBaseCase extends ClientBaseCase {
   }
 
   @Test
-  public void testNoop() {
+  void testNoop() {
     // This runs through the startup/flush cycle
   }
 
   @Test
-  public void testDoubleShutdown() {
+  void testDoubleShutdown() {
     client.shutdown();
     client.shutdown();
   }
 
   @Test
-  public void testSimpleGet() throws Exception {
+  void testSimpleGet() throws Exception {
     assertNull(client.get("test1"));
     assertTrue(client.set("test1", 5, "test1value").get());
     assertEquals("test1value", client.get("test1"));
   }
 
   @Test
-  public void testSimpleCASGets() throws Exception {
+  void testSimpleCASGets() throws Exception {
     assertNull(client.gets("test1"));
     assertTrue(client.set("test1", 5, "test1value").get());
     assertEquals("test1value", client.gets("test1").getValue());
   }
 
   @Test
-  public void testCAS() throws Exception {
+  void testCAS() throws Exception {
     final String key = "castestkey";
     // First, make sure it doesn't work for a non-existing value.
     assertSame(CASResponse.NOT_FOUND,
@@ -187,7 +187,7 @@ public abstract class ProtocolBaseCase extends ClientBaseCase {
   }
 
   @Test
-  public void testReallyLongCASId() throws Exception {
+  void testReallyLongCASId() throws Exception {
     String key = "this-is-my-key";
     assertSame(CASResponse.NOT_FOUND,
             client.cas(key, 9223372036854775807L, "bad value"),
@@ -195,7 +195,7 @@ public abstract class ProtocolBaseCase extends ClientBaseCase {
   }
 
   @Test
-  public void testExtendedUTF8Key() throws Exception {
+  void testExtendedUTF8Key() throws Exception {
     String key = "\u2013\u00ba\u2013\u220f\u2014\u00c4";
     assertNull(client.get(key));
     assertTrue(client.set(key, 5, "test1value").get());
@@ -203,7 +203,7 @@ public abstract class ProtocolBaseCase extends ClientBaseCase {
   }
 
   @Test
-  public void testInvalidKey1() throws Exception {
+  void testInvalidKey1() throws Exception {
     try {
       client.get("key with spaces");
       fail("Expected IllegalArgumentException getting key with spaces");
@@ -213,7 +213,7 @@ public abstract class ProtocolBaseCase extends ClientBaseCase {
   }
 
   @Test
-  public void testInvalidKey2() throws Exception {
+  void testInvalidKey2() throws Exception {
     try {
       StringBuilder longKey = new StringBuilder();
       // MAX_KEY_LENGTH is 4000.
@@ -228,7 +228,7 @@ public abstract class ProtocolBaseCase extends ClientBaseCase {
   }
 
   @Test
-  public void testInvalidKey3() throws Exception {
+  void testInvalidKey3() throws Exception {
     try {
       Object val = client.get("Key\n");
       fail("Expected IllegalArgumentException, got " + val);
@@ -238,7 +238,7 @@ public abstract class ProtocolBaseCase extends ClientBaseCase {
   }
 
   @Test
-  public void testInvalidKey4() throws Exception {
+  void testInvalidKey4() throws Exception {
     try {
       Object val = client.get("Key\r");
       fail("Expected IllegalArgumentException, got " + val);
@@ -248,7 +248,7 @@ public abstract class ProtocolBaseCase extends ClientBaseCase {
   }
 
   @Test
-  public void testInvalidKey5() throws Exception {
+  void testInvalidKey5() throws Exception {
     try {
       Object val = client.get("Key\0");
       fail("Expected IllegalArgumentException, got " + val);
@@ -258,7 +258,7 @@ public abstract class ProtocolBaseCase extends ClientBaseCase {
   }
 
   @Test
-  public void testInvalidKeyBlank() throws Exception {
+  void testInvalidKeyBlank() throws Exception {
     try {
       Object val = client.get("");
       fail("Expected IllegalArgumentException, got " + val);
@@ -268,7 +268,7 @@ public abstract class ProtocolBaseCase extends ClientBaseCase {
   }
 
   @Test
-  public void testInvalidKeyBulk() throws Exception {
+  void testInvalidKeyBulk() throws Exception {
     try {
       Object val = client.getBulk(Collections.singletonList("Key key2"));
       fail("Expected IllegalArgumentException, got " + val);
@@ -278,7 +278,7 @@ public abstract class ProtocolBaseCase extends ClientBaseCase {
   }
 
   @Test
-  public void testParallelSetGet() throws Throwable {
+  void testParallelSetGet() throws Throwable {
     int cnt = SyncThread.getDistinctResultCount(10, () -> {
       int size = 10;
       List<String> keys = new ArrayList<>(size);
@@ -307,7 +307,7 @@ public abstract class ProtocolBaseCase extends ClientBaseCase {
   }
 
   @Test
-  public void testParallelSetMultiGet() throws Throwable {
+  void testParallelSetMultiGet() throws Throwable {
     int cnt = SyncThread.getDistinctResultCount(10, () -> {
       int size = 10;
       List<String> keys = new ArrayList<>(size);
@@ -336,7 +336,7 @@ public abstract class ProtocolBaseCase extends ClientBaseCase {
   }
 
   @Test
-  public void testParallelSetAutoMultiGet() throws Throwable {
+  void testParallelSetAutoMultiGet() throws Throwable {
     int cnt = SyncThread.getDistinctResultCount(10, () -> {
       assertTrue(client.set("testparallel", 60, "parallelvalue").get());
       for (int i = 0; i < 10; i++) {
@@ -348,7 +348,7 @@ public abstract class ProtocolBaseCase extends ClientBaseCase {
   }
 
   @Test
-  public void testAdd() throws Exception {
+  void testAdd() throws Exception {
     assertNull(client.get("test1"));
     assertTrue(client.set("test1", 5, "test1value").get());
     assertEquals("test1value", client.get("test1"));
@@ -358,7 +358,7 @@ public abstract class ProtocolBaseCase extends ClientBaseCase {
   }
 
   @Test
-  public void testAddWithTranscoder() throws Exception {
+  void testAddWithTranscoder() throws Exception {
     Transcoder<String> t = new TestTranscoder();
     assertNull(client.get("test1", t));
     assertTrue(client.set("test1", 5, "test1value", t).get());
@@ -369,7 +369,7 @@ public abstract class ProtocolBaseCase extends ClientBaseCase {
   }
 
   @Test
-  public void testAddNotSerializable() throws Exception {
+  void testAddNotSerializable() throws Exception {
     try {
       client.add("t1", 5, new Object());
       fail("expected illegal argument exception");
@@ -379,7 +379,7 @@ public abstract class ProtocolBaseCase extends ClientBaseCase {
   }
 
   @Test
-  public void testSetNotSerializable() throws Exception {
+  void testSetNotSerializable() throws Exception {
     try {
       client.set("t1", 5, new Object());
       fail("expected illegal argument exception");
@@ -389,7 +389,7 @@ public abstract class ProtocolBaseCase extends ClientBaseCase {
   }
 
   @Test
-  public void testReplaceNotSerializable() throws Exception {
+  void testReplaceNotSerializable() throws Exception {
     try {
       client.replace("t1", 5, new Object());
       fail("expected illegal argument exception");
@@ -399,14 +399,14 @@ public abstract class ProtocolBaseCase extends ClientBaseCase {
   }
 
   @Test
-  public void testUpdate() throws Exception {
+  void testUpdate() throws Exception {
     assertNull(client.get("test1"));
     assertFalse(client.replace("test1", 5, "test1value").get());
     assertNull(client.get("test1"));
   }
 
   @Test
-  public void testUpdateWithTranscoder() throws Exception {
+  void testUpdateWithTranscoder() throws Exception {
     Transcoder<String> t = new TestTranscoder();
     assertNull(client.get("test1", t));
     assertFalse(client.replace("test1", 5, "test1value", t).get());
@@ -415,7 +415,7 @@ public abstract class ProtocolBaseCase extends ClientBaseCase {
 
   // Just to make sure the sequence is being handled correctly
   @Test
-  public void testMixedSetsAndUpdates() throws Exception {
+  void testMixedSetsAndUpdates() throws Exception {
     int keySize = 100;
     List<String> keys = new ArrayList<>(keySize);
     List<Future<Boolean>> setFutures = new ArrayList<>(keySize);
@@ -440,7 +440,7 @@ public abstract class ProtocolBaseCase extends ClientBaseCase {
   }
 
   @Test
-  public void testGetBulk() throws Exception {
+  void testGetBulk() throws Exception {
     Collection<String> keys = Arrays.asList("test1", "test2", "test3");
     assertEquals(0, client.getBulk(keys).size());
     assertTrue(client.set("test1", 5, "val1").get());
@@ -452,7 +452,7 @@ public abstract class ProtocolBaseCase extends ClientBaseCase {
   }
 
   @Test
-  public void testAsyncGetBulkWithTranscoderIterator() throws Exception {
+  void testAsyncGetBulkWithTranscoderIterator() throws Exception {
     ArrayList<String> keys = new ArrayList<>();
     keys.add("test1");
     keys.add("test2");
@@ -495,7 +495,7 @@ public abstract class ProtocolBaseCase extends ClientBaseCase {
   }
 
   @Test
-  public void testGetsBulk() throws Exception {
+  void testGetsBulk() throws Exception {
     Collection<String> keys = Arrays.asList("test1", "test2", "test3");
     assertEquals(0, client.getsBulk(keys).size());
     assertTrue(client.set("test1", 5, "val1").get());
@@ -509,7 +509,7 @@ public abstract class ProtocolBaseCase extends ClientBaseCase {
   }
 
   @Test
-  public void testAsyncGetsBulkWithTranscoderIterator() throws Exception {
+  void testAsyncGetsBulkWithTranscoderIterator() throws Exception {
     ArrayList<String> keys = new ArrayList<>();
     keys.add("test1");
     keys.add("test2");
@@ -556,7 +556,7 @@ public abstract class ProtocolBaseCase extends ClientBaseCase {
   }
 
   @Test
-  public void getCompositeExceptionFromBulkGetFuture() {
+  void getCompositeExceptionFromBulkGetFuture() {
     List<String> keys = new ArrayList<>();
     for (int i = 0; i < 210; i++) {
       keys.add("test" + i);
@@ -578,7 +578,7 @@ public abstract class ProtocolBaseCase extends ClientBaseCase {
   }
 
   @Test
-  public void testAvailableServers() {
+  void testAvailableServers() {
     if (USE_ZK) {
       return; // We don't know the server address priori
     }
@@ -589,7 +589,7 @@ public abstract class ProtocolBaseCase extends ClientBaseCase {
   }
 
   @Test
-  public void testUnavailableServers() {
+  void testUnavailableServers() {
     client.getVersions();
     assertEquals(Collections.emptyList(), client.getUnavailableServers());
   }
@@ -597,7 +597,7 @@ public abstract class ProtocolBaseCase extends ClientBaseCase {
   protected abstract String getExpectedVersionSource();
 
   @Test
-  public void testGetVersions() throws Exception {
+  void testGetVersions() throws Exception {
     if (USE_ZK) {
       return; // We don't know the server address priori
     }
@@ -609,13 +609,13 @@ public abstract class ProtocolBaseCase extends ClientBaseCase {
   }
 
   @Test
-  public void testNonexistentMutate() throws Exception {
+  void testNonexistentMutate() throws Exception {
     assertEquals(-1, client.incr("nonexistent", 1));
     assertEquals(-1, client.decr("nonexistent", 1));
   }
 
   @Test
-  public void testMutateWithDefault() throws Exception {
+  void testMutateWithDefault() throws Exception {
     assertEquals(3, client.incr("mtest", 1, 3));
     assertEquals(4, client.incr("mtest", 1, 3));
     assertEquals(3, client.decr("mtest", 1, 9));
@@ -623,7 +623,7 @@ public abstract class ProtocolBaseCase extends ClientBaseCase {
   }
 
   @Test
-  public void testMutateWithDefaultAndExp() throws Exception {
+  void testMutateWithDefaultAndExp() throws Exception {
     assertEquals(3, client.incr("mtest", 1, 3, 1));
     assertEquals(4, client.incr("mtest", 1, 3, 1));
     assertEquals(3, client.decr("mtest", 1, 9, 1));
@@ -633,7 +633,7 @@ public abstract class ProtocolBaseCase extends ClientBaseCase {
   }
 
   @Test
-  public void testAsyncIncrement() throws Exception {
+  void testAsyncIncrement() throws Exception {
     String k = "async-incr";
     assertTrue(client.set(k, 0, "5").get());
     Future<Long> f = client.asyncIncr(k, 1);
@@ -641,14 +641,14 @@ public abstract class ProtocolBaseCase extends ClientBaseCase {
   }
 
   @Test
-  public void testAsyncIncrementNonExistent() throws Exception {
+  void testAsyncIncrementNonExistent() throws Exception {
     String k = "async-incr-non-existent";
     Future<Long> f = client.asyncIncr(k, 1);
     assertEquals(-1, (long) f.get());
   }
 
   @Test
-  public void testAsyncDecrement() throws Exception {
+  void testAsyncDecrement() throws Exception {
     String k = "async-decr";
     assertTrue(client.set(k, 0, "5").get());
     Future<Long> f = client.asyncDecr(k, 1);
@@ -656,20 +656,20 @@ public abstract class ProtocolBaseCase extends ClientBaseCase {
   }
 
   @Test
-  public void testAsyncDecrementNonExistent() throws Exception {
+  void testAsyncDecrementNonExistent() throws Exception {
     String k = "async-decr-non-existent";
     Future<Long> f = client.asyncDecr(k, 1);
     assertEquals(-1, (long) f.get());
   }
 
   @Test
-  public void testConcurrentMutation() throws Throwable {
+  void testConcurrentMutation() throws Throwable {
     int num = SyncThread.getDistinctResultCount(10, () -> client.incr("mtest", 1, 11));
     assertEquals(10, num);
   }
 
   @Test
-  public void testImmediateDelete() throws Exception {
+  void testImmediateDelete() throws Exception {
     assertNull(client.get("test1"));
     assertTrue(client.set("test1", 5, "test1value").get());
     assertEquals("test1value", client.get("test1"));
@@ -678,7 +678,7 @@ public abstract class ProtocolBaseCase extends ClientBaseCase {
   }
 
   @Test
-  public void testFlush() throws Exception {
+  void testFlush() throws Exception {
     assertNull(client.get("test1"));
     assertTrue(client.set("test1", 5, "test1value").get());
     assertTrue(client.set("test2", 5, "test2value").get());
@@ -690,7 +690,7 @@ public abstract class ProtocolBaseCase extends ClientBaseCase {
   }
 
   @Test
-  public void testGracefulShutdown() throws Exception {
+  void testGracefulShutdown() throws Exception {
     for (int i = 0; i < 1000; i++) {
       client.set("t" + i, 10, i);
     }
@@ -711,7 +711,7 @@ public abstract class ProtocolBaseCase extends ClientBaseCase {
   }
 
   @Test
-  public void testSyncGetTimeouts() throws Exception {
+  void testSyncGetTimeouts() throws Exception {
     final String key = "timeoutTestKey";
     final String value = "timeoutTestValue";
     // Shutting down the default client to get one with a short timeout.
@@ -742,7 +742,7 @@ public abstract class ProtocolBaseCase extends ClientBaseCase {
   }
 
   @Test
-  public void testGracefulShutdownTooSlow() throws Exception {
+  void testGracefulShutdownTooSlow() throws Exception {
     final int size = 1000 * 1000;
     final byte[] data = new byte[size];
     new Random().nextBytes(data);
@@ -788,7 +788,7 @@ public abstract class ProtocolBaseCase extends ClientBaseCase {
   }
 
   @Test
-  public void testStupidlyLargeSetAndSizeOverride() throws Exception {
+  void testStupidlyLargeSetAndSizeOverride() throws Exception {
     Random r = new Random();
     SerializingTranscoder st = new SerializingTranscoder(Integer.MAX_VALUE);
 
@@ -814,7 +814,7 @@ public abstract class ProtocolBaseCase extends ClientBaseCase {
   }
 
   @Test
-  public void testStupidlyLargeSet() throws Exception {
+  void testStupidlyLargeSet() throws Exception {
     Random r = new Random();
     SerializingTranscoder st = new SerializingTranscoder();
     st.setCompressionThreshold(Integer.MAX_VALUE);
@@ -838,7 +838,7 @@ public abstract class ProtocolBaseCase extends ClientBaseCase {
   }
 
   @Test
-  public void testQueueAfterShutdown() throws Exception {
+  void testQueueAfterShutdown() throws Exception {
     client.shutdown();
     try {
       Object o = client.get("k");
@@ -851,7 +851,7 @@ public abstract class ProtocolBaseCase extends ClientBaseCase {
   }
 
   @Test
-  public void testMultiReqAfterShutdown() throws Exception {
+  void testMultiReqAfterShutdown() throws Exception {
     client.shutdown();
     try {
       Map<String, ?> m = client.getBulk(Arrays.asList("k1", "k2", "k3"));
@@ -864,7 +864,7 @@ public abstract class ProtocolBaseCase extends ClientBaseCase {
   }
 
   @Test
-  public void testBroadcastAfterShutdown() throws Exception {
+  void testBroadcastAfterShutdown() throws Exception {
     client.shutdown();
     try {
       Future<?> f = client.flush();
@@ -877,7 +877,7 @@ public abstract class ProtocolBaseCase extends ClientBaseCase {
   }
 
   @Test
-  public void testABunchOfCancelledOperations() throws Exception {
+  void testABunchOfCancelledOperations() throws Exception {
     final String k = "bunchOCancel";
     Collection<Future<?>> futures = new ArrayList<>();
     for (int i = 0; i < 1000; i++) {
@@ -894,7 +894,7 @@ public abstract class ProtocolBaseCase extends ClientBaseCase {
   }
 
   @Test
-  public void testUTF8Key() throws Exception {
+  void testUTF8Key() throws Exception {
     final String key = "junit.Здравствуйте." + System.currentTimeMillis();
     final String value = "Skiing rocks if you can find the time to go!";
 
@@ -905,7 +905,7 @@ public abstract class ProtocolBaseCase extends ClientBaseCase {
   }
 
   @Test
-  public void testUTF8KeyDelete() throws Exception {
+  void testUTF8KeyDelete() throws Exception {
     final String key = "junit.Здравствуйте." + System.currentTimeMillis();
     final String value = "Skiing rocks if you can find the time to go!";
 
@@ -915,7 +915,7 @@ public abstract class ProtocolBaseCase extends ClientBaseCase {
   }
 
   @Test
-  public void testUTF8MultiGet() throws Exception {
+  void testUTF8MultiGet() throws Exception {
     final String value = "Skiing rocks if you can find the time to go!";
     Collection<String> keys = new ArrayList<>();
     for (int i = 0; i < 50; i++) {
@@ -934,7 +934,7 @@ public abstract class ProtocolBaseCase extends ClientBaseCase {
   }
 
   @Test
-  public void testUTF8Value() throws Exception {
+  void testUTF8Value() throws Exception {
     final String key = "junit.plaintext." + System.currentTimeMillis();
     final String value = "Здравствуйте Здравствуйте Здравствуйте "
             + "Skiing rocks if you can find the time to go!";
@@ -946,7 +946,7 @@ public abstract class ProtocolBaseCase extends ClientBaseCase {
   }
 
   @Test
-  public void testAppend() throws Exception {
+  void testAppend() throws Exception {
     final String key = "append.key";
     assertTrue(client.set(key, 5, "test").get());
     assertTrue(client.append(0, key, "es").get());
@@ -954,7 +954,7 @@ public abstract class ProtocolBaseCase extends ClientBaseCase {
   }
 
   @Test
-  public void testPrepend() throws Exception {
+  void testPrepend() throws Exception {
     final String key = "prepend.key";
     assertTrue(client.set(key, 5, "test").get());
     assertTrue(client.prepend(0, key, "es").get());
@@ -962,14 +962,14 @@ public abstract class ProtocolBaseCase extends ClientBaseCase {
   }
 
   @Test
-  public void testAppendNoSuchKey() throws Exception {
+  void testAppendNoSuchKey() throws Exception {
     final String key = "append.missing";
     assertFalse(client.append(0, key, "es").get());
     assertNull(client.get(key));
   }
 
   @Test
-  public void testPrependNoSuchKey() throws Exception {
+  void testPrependNoSuchKey() throws Exception {
     final String key = "prepend.missing";
     assertFalse(client.prepend(0, key, "es").get());
     assertNull(client.get(key));

--- a/src/test/java/net/spy/memcached/QueueOverflowTest.java
+++ b/src/test/java/net/spy/memcached/QueueOverflowTest.java
@@ -28,7 +28,7 @@ import static org.junit.jupiter.api.Assertions.fail;
  * So this test is no longer necessary.
  */
 @Disabled
-public class QueueOverflowTest extends ClientBaseCase {
+class QueueOverflowTest extends ClientBaseCase {
 
   @Override
   protected void initClient() throws Exception {
@@ -97,12 +97,12 @@ public class QueueOverflowTest extends ClientBaseCase {
   }
 
   @Test
-  public void testOverflowingInputQueue() throws Exception {
+  void testOverflowingInputQueue() throws Exception {
     runOverflowTest(new byte[]{1});
   }
 
   @Test
-  public void testOverflowingWriteQueue() throws Exception {
+  void testOverflowingWriteQueue() throws Exception {
     byte[] b = new byte[8192];
     Random r = new Random();
     r.nextBytes(b);
@@ -110,7 +110,7 @@ public class QueueOverflowTest extends ClientBaseCase {
   }
 
   @Test
-  public void testOverflowingReadQueue() throws Exception {
+  void testOverflowingReadQueue() throws Exception {
     byte[] b = new byte[8192];
     Random r = new Random();
     r.nextBytes(b);

--- a/src/test/java/net/spy/memcached/RedistributeFailureModeTest.java
+++ b/src/test/java/net/spy/memcached/RedistributeFailureModeTest.java
@@ -14,7 +14,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class RedistributeFailureModeTest extends ClientBaseCase {
+class RedistributeFailureModeTest extends ClientBaseCase {
 
   private String serverList;
 
@@ -54,7 +54,7 @@ public class RedistributeFailureModeTest extends ClientBaseCase {
 
   // Just to make sure the sequence is being handled correctly
   @Test
-  public void testMixedSetsAndUpdates() throws Exception {
+  void testMixedSetsAndUpdates() throws Exception {
     int keySize = 100;
     List<String> keys = new ArrayList<>(keySize);
     List<Future<Boolean>> setFutures = new ArrayList<>(keySize);

--- a/src/test/java/net/spy/memcached/SocketTest.java
+++ b/src/test/java/net/spy/memcached/SocketTest.java
@@ -8,7 +8,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class SocketTest {
+class SocketTest {
   private ArcusClient client;
   private final String ZK_STRING = "127.0.0.1:2181";
   private final String SERVICE_CODE = "test";
@@ -21,7 +21,7 @@ public class SocketTest {
   }
 
   @Test
-  public void testSocketKeepAliveTest() throws SocketException {
+  void testSocketKeepAliveTest() throws SocketException {
     Collection<MemcachedNode> allNodes =
             client.getAllNodes();
     for (MemcachedNode node : allNodes) {

--- a/src/test/java/net/spy/memcached/TimeoutTest.java
+++ b/src/test/java/net/spy/memcached/TimeoutTest.java
@@ -8,7 +8,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.fail;
 
-public class TimeoutTest {
+class TimeoutTest {
   private MemcachedClient client = null;
 
   @BeforeEach
@@ -44,32 +44,32 @@ public class TimeoutTest {
   }
 
   @Test
-  public void testCasTimeout() {
+  void testCasTimeout() {
     tryTimeout("cas", () -> client.cas("k", 1, "blah"));
   }
 
   @Test
-  public void testGetsTimeout() {
+  void testGetsTimeout() {
     tryTimeout("gets", () -> client.gets("k"));
   }
 
   @Test
-  public void testGetTimeout() {
+  void testGetTimeout() {
     tryTimeout("get", () -> client.get("k"));
   }
 
   @Test
-  public void testGetBulkTimeout() {
+  void testGetBulkTimeout() {
     tryTimeout("getbulk", () -> client.getBulk(Arrays.asList("k", "k2")));
   }
 
   @Test
-  public void testIncrTimeout() {
+  void testIncrTimeout() {
     tryTimeout("incr", () -> client.incr("k", 1));
   }
 
   @Test
-  public void testIncrWithDefTimeout() {
+  void testIncrWithDefTimeout() {
     tryTimeout("incrWithDef", () -> client.incr("k", 1, 5));
   }
 

--- a/src/test/java/net/spy/memcached/compat/log/LoggingTest.java
+++ b/src/test/java/net/spy/memcached/compat/log/LoggingTest.java
@@ -17,7 +17,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 /**
  * Make sure logging is enabled.
  */
-public class LoggingTest {
+class LoggingTest {
 
   private Logger logger = null;
 
@@ -33,7 +33,7 @@ public class LoggingTest {
    * Make sure logging is enabled.
    */
   @Test
-  public void testDebugLogging() {
+  void testDebugLogging() {
 //  assertTrue("Debug logging is not enabled", logger.isDebugEnabled());
     logger.debug("debug message");
   }
@@ -42,7 +42,7 @@ public class LoggingTest {
    * Make sure info is enabled, and test it.
    */
   @Test
-  public void testInfoLogging() {
+  void testInfoLogging() {
     assertTrue(logger.isInfoEnabled());
     logger.info("info message");
   }
@@ -51,7 +51,7 @@ public class LoggingTest {
    * Test other log stuff.
    */
   @Test
-  public void testOtherLogging() {
+  void testOtherLogging() {
     logger.warn("warn message");
     logger.warn("test %s", "message");
     logger.error("error message");
@@ -66,7 +66,7 @@ public class LoggingTest {
    * Make sure we're using log4j.
    */
   @Test
-  public void testLog4j() {
+  void testLog4j() {
 //  Logger l=LoggerFactory.getLogger(getClass());
 //  assertEquals("net.spy.compat.log.Log4JLogger", l.getClass().getName());
   }
@@ -75,7 +75,7 @@ public class LoggingTest {
    * Test the sun logger.
    */
   @Test
-  public void testSunLogger() {
+  void testSunLogger() {
     Logger l = new SunLogger(getClass().getName());
     assertFalse(l.isDebugEnabled());
     l.debug("debug message");
@@ -94,7 +94,7 @@ public class LoggingTest {
    * Test the default logger.
    */
   @Test
-  public void testMyLogger() {
+  void testMyLogger() {
     Logger l = new DefaultLogger(getClass().getName());
     assertFalse(l.isDebugEnabled());
     l.debug("debug message");
@@ -120,7 +120,7 @@ public class LoggingTest {
    * Test stringing levels.
    */
   @Test
-  public void testLevelStrings() {
+  void testLevelStrings() {
     assertEquals("{LogLevel:  DEBUG}", String.valueOf(Level.DEBUG));
     assertEquals("{LogLevel:  INFO}", String.valueOf(Level.INFO));
     assertEquals("{LogLevel:  WARN}", String.valueOf(Level.WARN));
@@ -137,7 +137,7 @@ public class LoggingTest {
    * Test picking up an exception argument.
    */
   @Test
-  public void testExceptionArg() throws Exception {
+  void testExceptionArg() throws Exception {
     Object[] args = new Object[]{"a", 42, new Exception("test")};
     Throwable t = ((AbstractLogger) logger).getThrowable(args);
     assertNotNull(t);
@@ -148,7 +148,7 @@ public class LoggingTest {
    * Test when the last argument is not an exception.
    */
   @Test
-  public void testNoExceptionArg() throws Exception {
+  void testNoExceptionArg() throws Exception {
     Object[] args = new Object[]{"a", 42, new Exception("test"), "x"};
     Throwable t = ((AbstractLogger) logger).getThrowable(args);
     assertNull(t);

--- a/src/test/java/net/spy/memcached/internal/CheckedOperationTimeoutExceptionTest.java
+++ b/src/test/java/net/spy/memcached/internal/CheckedOperationTimeoutExceptionTest.java
@@ -34,14 +34,14 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
-public class CheckedOperationTimeoutExceptionTest {
+class CheckedOperationTimeoutExceptionTest {
 
   private final long duration = 1;
   private final TimeUnit unit = TimeUnit.MILLISECONDS;
   private final long elapsed = 5;
 
   @Test
-  public void testSingleOperation() {
+  void testSingleOperation() {
     Operation op = buildOp(11211);
     Exception e = new CheckedOperationTimeoutException(duration, unit, elapsed, op);
 
@@ -52,7 +52,7 @@ public class CheckedOperationTimeoutExceptionTest {
   }
 
   @Test
-  public void testNullNode() {
+  void testNullNode() {
     Operation op = new TestOperation();
     Exception e = new CheckedOperationTimeoutException(duration, unit, elapsed, op);
 
@@ -63,7 +63,7 @@ public class CheckedOperationTimeoutExceptionTest {
   }
 
   @Test
-  public void testNullOperation() {
+  void testNullOperation() {
     try {
       Exception e = new CheckedOperationTimeoutException(duration, unit, elapsed, (Operation) null);
       fail("NullPointerException is NOT thrown... " + e.getMessage());
@@ -74,7 +74,7 @@ public class CheckedOperationTimeoutExceptionTest {
   }
 
   @Test
-  public void testMultipleOperation() {
+  void testMultipleOperation() {
     Collection<Operation> ops = new ArrayList<>();
     ops.add(buildOp(11211));
     ops.add(buildOp(64212));

--- a/src/test/java/net/spy/memcached/internal/SingleElementInfiniteIteratorTest.java
+++ b/src/test/java/net/spy/memcached/internal/SingleElementInfiniteIteratorTest.java
@@ -7,7 +7,7 @@ import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
-public class SingleElementInfiniteIteratorTest {
+class SingleElementInfiniteIteratorTest {
   private static final String CONSTANT = "foo";
   private SingleElementInfiniteIterator<String> iterator;
 
@@ -17,7 +17,7 @@ public class SingleElementInfiniteIteratorTest {
   }
 
   @Test
-  public void testHasNextAndNext() {
+  void testHasNextAndNext() {
     for (int i = 0; i < 100; ++i) {
       assertTrue(iterator.hasNext());
       assertSame(CONSTANT, iterator.next());
@@ -25,7 +25,7 @@ public class SingleElementInfiniteIteratorTest {
   }
 
   @Test
-  public void testRemove() {
+  void testRemove() {
     try {
       iterator.remove();
       fail("Expected UnsupportedOperationException on a remove.");

--- a/src/test/java/net/spy/memcached/protocol/TCPMemcachedNodeImplTest.java
+++ b/src/test/java/net/spy/memcached/protocol/TCPMemcachedNodeImplTest.java
@@ -39,7 +39,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 /**
  * Test the TCPMemcachedNodeImpl
  */
-public class TCPMemcachedNodeImplTest {
+class TCPMemcachedNodeImplTest {
 
   @SuppressWarnings("unchecked")
   private Queue<Operation> getQueue(String queueFieldName, TCPMemcachedNodeImpl node)
@@ -58,7 +58,7 @@ public class TCPMemcachedNodeImplTest {
   }
 
   @Test
-  public void testMoveOperations() throws Exception {
+  void testMoveOperations() throws Exception {
     // given
     final int fromReadOpCount = 5,
               fromWriteOpCount = 5,

--- a/src/test/java/net/spy/memcached/protocol/ascii/BaseOpTest.java
+++ b/src/test/java/net/spy/memcached/protocol/ascii/BaseOpTest.java
@@ -36,17 +36,17 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 /**
  * Test the basic operation buffer handling stuff.
  */
-public class BaseOpTest {
+class BaseOpTest {
 
   @Test
-  public void testAssertions() {
+  void testAssertions() {
     assertThrows(AssertionError.class, () -> {
       assert false;
     });
   }
 
   @Test
-  public void testDataReadType() throws Exception {
+  void testDataReadType() throws Exception {
     SimpleOp op = new SimpleOp(OperationReadType.DATA);
     assertSame(OperationReadType.DATA, op.getReadType());
     // Make sure lines aren't handled
@@ -56,7 +56,7 @@ public class BaseOpTest {
   }
 
   @Test
-  public void testLineReadType() throws Exception {
+  void testLineReadType() throws Exception {
     SimpleOp op = new SimpleOp(OperationReadType.LINE);
     assertSame(OperationReadType.LINE, op.getReadType());
     // Make sure lines aren't handled
@@ -65,7 +65,7 @@ public class BaseOpTest {
   }
 
   @Test
-  public void testLineParser() throws Exception {
+  void testLineParser() throws Exception {
     String input = "This is a multiline string\r\nhere is line two\r\n";
     ByteBuffer b = ByteBuffer.wrap(input.getBytes());
     SimpleOp op = new SimpleOp(OperationReadType.LINE);
@@ -82,7 +82,7 @@ public class BaseOpTest {
   }
 
   @Test
-  public void testPartialLine() throws Exception {
+  void testPartialLine() throws Exception {
     String input1 = "this is a ";
     String input2 = "test\r\n";
     ByteBuffer b = ByteBuffer.allocate(20);

--- a/src/test/java/net/spy/memcached/protocol/ascii/OperationFactoryTest.java
+++ b/src/test/java/net/spy/memcached/protocol/ascii/OperationFactoryTest.java
@@ -10,7 +10,7 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertSame;
 
-public class OperationFactoryTest extends OperationFactoryTestBase {
+class OperationFactoryTest extends OperationFactoryTestBase {
 
   @Override
   protected OperationFactory getOperationFactory() {

--- a/src/test/java/net/spy/memcached/protocol/binary/OperationFactoryTest.java
+++ b/src/test/java/net/spy/memcached/protocol/binary/OperationFactoryTest.java
@@ -7,7 +7,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class OperationFactoryTest extends OperationFactoryTestBase {
+class OperationFactoryTest extends OperationFactoryTestBase {
 
   @Override
   protected OperationFactory getOperationFactory() {

--- a/src/test/java/net/spy/memcached/protocol/binary/OperationTest.java
+++ b/src/test/java/net/spy/memcached/protocol/binary/OperationTest.java
@@ -10,10 +10,10 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 /**
  * Test operation stuff.
  */
-public class OperationTest {
+class OperationTest {
 
   @Test
-  public void testIntegerDecode() {
+  void testIntegerDecode() {
     assertEquals(129,
             decodeInt(new byte[]{0, 0, 0, (byte) 0x81}, 0));
     assertEquals(129 * 256,
@@ -25,7 +25,7 @@ public class OperationTest {
   }
 
   @Test
-  public void testUnsignedIntegerDecode() {
+  void testUnsignedIntegerDecode() {
     assertEquals(129,
             decodeUnsignedInt(new byte[]{0, 0, 0, (byte) 0x81}, 0));
     assertEquals(129 * 256,
@@ -37,7 +37,7 @@ public class OperationTest {
   }
 
   @Test
-  public void testOperationStatusString() {
+  void testOperationStatusString() {
     String s = String.valueOf(OperationImpl.STATUS_OK);
     assertEquals("{OperationStatus success=true:  OK}", s);
   }

--- a/src/test/java/net/spy/memcached/transcoders/BaseSerializingTranscoderTest.java
+++ b/src/test/java/net/spy/memcached/transcoders/BaseSerializingTranscoderTest.java
@@ -22,7 +22,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 /**
  * Base tests of the base serializing transcoder stuff.
  */
-public class BaseSerializingTranscoderTest {
+class BaseSerializingTranscoderTest {
 
   private Exposer ex;
 
@@ -32,12 +32,12 @@ public class BaseSerializingTranscoderTest {
   }
 
   @Test
-  public void testValidCharacterSet() {
+  void testValidCharacterSet() {
     ex.setCharset("KOI8");
   }
 
   @Test
-  public void testInvalidCharacterSet() {
+  void testInvalidCharacterSet() {
     try {
       ex.setCharset("Dustin's Kick Ass Character Set");
     } catch (RuntimeException e) {
@@ -46,7 +46,7 @@ public class BaseSerializingTranscoderTest {
   }
 
   @Test
-  public void testCompressNull() {
+  void testCompressNull() {
     try {
       ex.compress(null);
       fail("Expected an assertion error");
@@ -56,17 +56,17 @@ public class BaseSerializingTranscoderTest {
   }
 
   @Test
-  public void testDecodeStringNull() {
+  void testDecodeStringNull() {
     assertNull(ex.decodeString(null));
   }
 
   @Test
-  public void testDeserializeNull() {
+  void testDeserializeNull() {
     assertNull(ex.deserialize(null));
   }
 
   @Test
-  public void testEncodeStringNull() {
+  void testEncodeStringNull() {
     try {
       ex.encodeString(null);
       fail("Expected an assertion error");
@@ -76,7 +76,7 @@ public class BaseSerializingTranscoderTest {
   }
 
   @Test
-  public void testSerializeNull() {
+  void testSerializeNull() {
     try {
       ex.serialize(null);
       fail("Expected an assertion error");
@@ -86,12 +86,12 @@ public class BaseSerializingTranscoderTest {
   }
 
   @Test
-  public void testDecompressNull() {
+  void testDecompressNull() {
     assertNull(ex.decompress(null));
   }
 
   @Test
-  public void testUndeserializable() throws Exception {
+  void testUndeserializable() throws Exception {
     byte[] data = {
       -84, -19, 0, 5, 115, 114, 0, 4, 84, 101, 115, 116, 2, 61, 102,
       -87, -28, 17, 52, 30, 2, 0, 1, 73, 0, 9, 115, 111, 109, 101,
@@ -101,13 +101,13 @@ public class BaseSerializingTranscoderTest {
   }
 
   @Test
-  public void testDeserializable() throws Exception {
+  void testDeserializable() throws Exception {
     byte[] data = {-84, -19, 0, 5, 116, 0, 5, 104, 101, 108, 108, 111};
     assertEquals("hello", ex.deserialize(data));
   }
 
   @Test
-  public void testBadCharsetDecode() {
+  void testBadCharsetDecode() {
     ex.overrideCharsetSet("Some Crap");
     try {
       ex.encodeString("Woo!");
@@ -119,7 +119,7 @@ public class BaseSerializingTranscoderTest {
   }
 
   @Test
-  public void testBadCharsetEncode() {
+  void testBadCharsetEncode() {
     ex.overrideCharsetSet("Some Crap");
     try {
       ex.decodeString("Woo!".getBytes());
@@ -131,7 +131,7 @@ public class BaseSerializingTranscoderTest {
   }
 
   @Test
-  public void testDifferentClassLoaderMakeDifferentValue() throws Exception {
+  void testDifferentClassLoaderMakeDifferentValue() throws Exception {
     // load CustomEntry class with custom class loader.
     CustomClassLoader customClassLoader = new CustomClassLoader();
     customClassLoader.findClass("net.spy.memcached.transcoders." +

--- a/src/test/java/net/spy/memcached/transcoders/BaseTranscoderCase.java
+++ b/src/test/java/net/spy/memcached/transcoders/BaseTranscoderCase.java
@@ -17,7 +17,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 /**
  * Basic behavior validation for all transcoders that work with objects.
  */
-public abstract class BaseTranscoderCase {
+abstract class BaseTranscoderCase {
 
   private Transcoder<Object> tc;
 
@@ -31,7 +31,7 @@ public abstract class BaseTranscoderCase {
   }
 
   @Test
-  public void testSomethingBigger() throws Exception {
+  void testSomethingBigger() throws Exception {
     Collection<Date> dates = new ArrayList<>();
     for (int i = 0; i < 1024; i++) {
       dates.add(new Date());
@@ -41,52 +41,52 @@ public abstract class BaseTranscoderCase {
   }
 
   @Test
-  public void testDate() throws Exception {
+  void testDate() throws Exception {
     Date d = new Date();
     CachedData cd = tc.encode(d);
     assertEquals(d, tc.decode(cd));
   }
 
   @Test
-  public void testLong() throws Exception {
+  void testLong() throws Exception {
     assertEquals(923L, tc.decode(tc.encode(923L)));
   }
 
   @Test
-  public void testInt() throws Exception {
+  void testInt() throws Exception {
     assertEquals(923, tc.decode(tc.encode(923)));
   }
 
   @Test
-  public void testShort() throws Exception {
+  void testShort() throws Exception {
     assertEquals((short) 923, tc.decode(tc.encode((short) 923)));
   }
 
   @Test
-  public void testChar() throws Exception {
+  void testChar() throws Exception {
     assertEquals('c', tc.decode(tc.encode('c')));
   }
 
   @Test
-  public void testBoolean() throws Exception {
+  void testBoolean() throws Exception {
     assertSame(Boolean.TRUE, tc.decode(tc.encode(true)));
     assertSame(Boolean.FALSE, tc.decode(tc.encode(false)));
   }
 
   @Test
-  public void testByte() throws Exception {
+  void testByte() throws Exception {
     assertEquals((byte) -127, tc.decode(tc.encode((byte) -127)));
   }
 
   @Test
-  public void testStringBuilder() throws Exception {
+  void testStringBuilder() throws Exception {
     StringBuilder sb = new StringBuilder("test");
     StringBuilder sb2 = (StringBuilder) tc.decode(tc.encode(sb));
     assertEquals(sb.toString(), sb2.toString());
   }
 
   @Test
-  public void testStringBuffer() throws Exception {
+  void testStringBuffer() throws Exception {
     StringBuffer sb = new StringBuffer("test");
     StringBuffer sb2 = (StringBuffer) tc.decode(tc.encode(sb));
     assertEquals(sb.toString(), sb2.toString());
@@ -98,7 +98,7 @@ public abstract class BaseTranscoderCase {
   }
 
   @Test
-  public void testFloat() throws Exception {
+  void testFloat() throws Exception {
     assertFloat(0f);
     assertFloat(Float.MIN_VALUE);
     assertFloat(Float.MAX_VALUE);
@@ -114,7 +114,7 @@ public abstract class BaseTranscoderCase {
   }
 
   @Test
-  public void testDouble() throws Exception {
+  void testDouble() throws Exception {
     assertDouble(0d);
     assertDouble(Double.MIN_VALUE);
     assertDouble(Double.MAX_VALUE);
@@ -142,7 +142,7 @@ public abstract class BaseTranscoderCase {
     */
 
   @Test
-  public void testLongEncoding() throws Exception {
+  void testLongEncoding() throws Exception {
     assertLong(Long.MIN_VALUE);
     assertLong(1);
     assertLong(23852);
@@ -159,7 +159,7 @@ public abstract class BaseTranscoderCase {
   }
 
   @Test
-  public void testIntEncoding() throws Exception {
+  void testIntEncoding() throws Exception {
     assertInt(Integer.MIN_VALUE);
     assertInt(83526);
     assertInt(1);
@@ -170,13 +170,13 @@ public abstract class BaseTranscoderCase {
   }
 
   @Test
-  public void testBooleanEncoding() throws Exception {
+  void testBooleanEncoding() throws Exception {
     assertTrue((Boolean) tc.decode(tc.encode(true)));
     assertFalse((Boolean) tc.decode(tc.encode(false)));
   }
 
   @Test
-  public void testByteArray() throws Exception {
+  void testByteArray() throws Exception {
     byte[] a = {'a', 'b', 'c'};
     CachedData cd = tc.encode(a);
     assertTrue(Arrays.equals(a, cd.getData()));
@@ -184,7 +184,7 @@ public abstract class BaseTranscoderCase {
   }
 
   @Test
-  public void testStrings() throws Exception {
+  void testStrings() throws Exception {
     String s1 = "This is a simple test string.";
     CachedData cd = tc.encode(s1);
     assertEquals(getStringFlags(), cd.getFlags());
@@ -192,7 +192,7 @@ public abstract class BaseTranscoderCase {
   }
 
   @Test
-  public void testUTF8String() throws Exception {
+  void testUTF8String() throws Exception {
     String s1 = "\u2013\u00f3\u2013\u00a5\u2014\u00c4\u2013\u221e\u2013"
             + "\u2264\u2014\u00c5\u2014\u00c7\u2013\u2264\u2014\u00c9\u2013"
             + "\u03c0, \u2013\u00ba\u2013\u220f\u2014\u00c4.";

--- a/src/test/java/net/spy/memcached/transcoders/CachedDataTest.java
+++ b/src/test/java/net/spy/memcached/transcoders/CachedDataTest.java
@@ -9,10 +9,10 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 /**
  * Test a couple aspects of CachedData.
  */
-public class CachedDataTest {
+class CachedDataTest {
 
   @Test
-  public void testToString() throws Exception {
+  void testToString() throws Exception {
     String exp = "{CachedData flags=13 data=[84, 104, 105, 115, 32, 105, "
             + "115, 32, 97, 32, 115, 105, 109, 112, 108, 101, 32, 116, 101, "
             + "115, 116, 32, 115, 116, 114, 105, 110, 103, 46] eFlag=null }";

--- a/src/test/java/net/spy/memcached/transcoders/IntegerTranscoderTest.java
+++ b/src/test/java/net/spy/memcached/transcoders/IntegerTranscoderTest.java
@@ -11,7 +11,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 /**
  * Test the integer transcoder.
  */
-public class IntegerTranscoderTest {
+class IntegerTranscoderTest {
 
   private IntegerTranscoder tc = null;
 
@@ -21,12 +21,12 @@ public class IntegerTranscoderTest {
   }
 
   @Test
-  public void testInt() throws Exception {
+  void testInt() throws Exception {
     assertEquals(923, tc.decode(tc.encode(923)).intValue());
   }
 
   @Test
-  public void testBadFlags() throws Exception {
+  void testBadFlags() throws Exception {
     CachedData cd = tc.encode(9284);
     assertNull(tc.decode(new CachedData(cd.getFlags() + 1, cd.getData(),
             CachedData.MAX_SIZE)));

--- a/src/test/java/net/spy/memcached/transcoders/LongTranscoderTest.java
+++ b/src/test/java/net/spy/memcached/transcoders/LongTranscoderTest.java
@@ -11,7 +11,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 /**
  * Test the long transcoder.
  */
-public class LongTranscoderTest {
+class LongTranscoderTest {
 
   private LongTranscoder tc = null;
 
@@ -21,12 +21,12 @@ public class LongTranscoderTest {
   }
 
   @Test
-  public void testLong() throws Exception {
+  void testLong() throws Exception {
     assertEquals(923, tc.decode(tc.encode(923L)).longValue());
   }
 
   @Test
-  public void testBadFlags() throws Exception {
+  void testBadFlags() throws Exception {
     CachedData cd = tc.encode(9284L);
     assertNull(tc.decode(new CachedData(cd.getFlags() + 1, cd.getData(),
             CachedData.MAX_SIZE)));

--- a/src/test/java/net/spy/memcached/transcoders/SerializingTranscoderTest.java
+++ b/src/test/java/net/spy/memcached/transcoders/SerializingTranscoderTest.java
@@ -19,7 +19,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 /**
  * Test the serializing transcoder.
  */
-public class SerializingTranscoderTest extends BaseTranscoderCase {
+class SerializingTranscoderTest extends BaseTranscoderCase {
 
   private SerializingTranscoder tc;
   private TranscoderUtils tu;
@@ -32,7 +32,7 @@ public class SerializingTranscoderTest extends BaseTranscoderCase {
   }
 
   @Test
-  public void testNonserializable() throws Exception {
+  void testNonserializable() throws Exception {
     try {
       tc.encode(new Object());
       fail("Processed a non-serializable object.");
@@ -42,7 +42,7 @@ public class SerializingTranscoderTest extends BaseTranscoderCase {
   }
 
   @Test
-  public void testCompressedStringNotSmaller() throws Exception {
+  void testCompressedStringNotSmaller() throws Exception {
     String s1 = "This is a test simple string that will not be compressed.";
     // Reduce the compression threshold so it'll attempt to compress it.
     tc.setCompressionThreshold(8);
@@ -54,7 +54,7 @@ public class SerializingTranscoderTest extends BaseTranscoderCase {
   }
 
   @Test
-  public void testCompressedString() throws Exception {
+  void testCompressedString() throws Exception {
     // This one will actually compress
     String s1 = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
     tc.setCompressionThreshold(8);
@@ -65,7 +65,7 @@ public class SerializingTranscoderTest extends BaseTranscoderCase {
   }
 
   @Test
-  public void testObject() throws Exception {
+  void testObject() throws Exception {
     Calendar c = Calendar.getInstance();
     CachedData cd = tc.encode(c);
     assertEquals(SerializingTranscoder.SERIALIZED, cd.getFlags());
@@ -73,7 +73,7 @@ public class SerializingTranscoderTest extends BaseTranscoderCase {
   }
 
   @Test
-  public void testCompressedObject() throws Exception {
+  void testCompressedObject() throws Exception {
     tc.setCompressionThreshold(8);
     Calendar c = Calendar.getInstance();
     CachedData cd = tc.encode(c);
@@ -83,7 +83,7 @@ public class SerializingTranscoderTest extends BaseTranscoderCase {
   }
 
   @Test
-  public void testUnencodeable() throws Exception {
+  void testUnencodeable() throws Exception {
     try {
       CachedData cd = tc.encode(new Object());
       fail("Should fail to serialize, got" + cd);
@@ -93,7 +93,7 @@ public class SerializingTranscoderTest extends BaseTranscoderCase {
   }
 
   @Test
-  public void testUndecodeable() throws Exception {
+  void testUndecodeable() throws Exception {
     CachedData cd = new CachedData(
             Integer.MAX_VALUE &
                     ~(SerializingTranscoder.COMPRESSED
@@ -104,7 +104,7 @@ public class SerializingTranscoderTest extends BaseTranscoderCase {
   }
 
   @Test
-  public void testUndecodeableSerialized() throws Exception {
+  void testUndecodeableSerialized() throws Exception {
     CachedData cd = new CachedData(SerializingTranscoder.SERIALIZED,
             tu.encodeInt(Integer.MAX_VALUE),
             tc.getMaxSize());
@@ -112,7 +112,7 @@ public class SerializingTranscoderTest extends BaseTranscoderCase {
   }
 
   @Test
-  public void testUndecodeableCompressed() throws Exception {
+  void testUndecodeableCompressed() throws Exception {
     CachedData cd = new CachedData(
             SerializingTranscoder.COMPRESSED,
             tu.encodeInt(Integer.MAX_VALUE),

--- a/src/test/java/net/spy/memcached/transcoders/TranscoderUtilsTest.java
+++ b/src/test/java/net/spy/memcached/transcoders/TranscoderUtilsTest.java
@@ -11,7 +11,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 /**
  * Some test coverage for transcoder utils.
  */
-public class TranscoderUtilsTest {
+class TranscoderUtilsTest {
 
   private TranscoderUtils tu;
   private final byte[] oversizeBytes = new byte[16];
@@ -22,7 +22,7 @@ public class TranscoderUtilsTest {
   }
 
   @Test
-  public void testBooleanOverflow() {
+  void testBooleanOverflow() {
     try {
       boolean b = tu.decodeBoolean(oversizeBytes);
       fail("Got " + b + " expected assertion.");
@@ -32,7 +32,7 @@ public class TranscoderUtilsTest {
   }
 
   @Test
-  public void testByteOverflow() {
+  void testByteOverflow() {
     try {
       byte b = tu.decodeByte(oversizeBytes);
       fail("Got " + b + " expected assertion.");
@@ -42,7 +42,7 @@ public class TranscoderUtilsTest {
   }
 
   @Test
-  public void testIntOverflow() {
+  void testIntOverflow() {
     try {
       int b = tu.decodeInt(oversizeBytes);
       fail("Got " + b + " expected assertion.");
@@ -52,7 +52,7 @@ public class TranscoderUtilsTest {
   }
 
   @Test
-  public void testLongOverflow() {
+  void testLongOverflow() {
     try {
       long b = tu.decodeLong(oversizeBytes);
       fail("Got " + b + " expected assertion.");
@@ -62,12 +62,12 @@ public class TranscoderUtilsTest {
   }
 
   @Test
-  public void testPackedLong() {
+  void testPackedLong() {
     assertEquals("[1]", Arrays.toString(tu.encodeLong(1)));
   }
 
   @Test
-  public void testUnpackedLong() {
+  void testUnpackedLong() {
     assertEquals("[0, 0, 0, 0, 0, 0, 0, 1]",
             Arrays.toString(new TranscoderUtils(false).encodeLong(1)));
   }

--- a/src/test/java/net/spy/memcached/transcoders/WhalinTranscoderTest.java
+++ b/src/test/java/net/spy/memcached/transcoders/WhalinTranscoderTest.java
@@ -19,7 +19,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 /**
  * Test the serializing transcoder.
  */
-public class WhalinTranscoderTest extends BaseTranscoderCase {
+class WhalinTranscoderTest extends BaseTranscoderCase {
 
   private WhalinTranscoder tc;
   private TranscoderUtils tu;
@@ -32,7 +32,7 @@ public class WhalinTranscoderTest extends BaseTranscoderCase {
   }
 
   @Test
-  public void testNonserializable() throws Exception {
+  void testNonserializable() throws Exception {
     try {
       tc.encode(new Object());
       fail("Processed a non-serializable object.");
@@ -42,7 +42,7 @@ public class WhalinTranscoderTest extends BaseTranscoderCase {
   }
 
   @Test
-  public void testCompressedStringNotSmaller() throws Exception {
+  void testCompressedStringNotSmaller() throws Exception {
     String s1 = "This is a test simple string that will not be compressed.";
     // Reduce the compression threshold so it'll attempt to compress it.
     tc.setCompressionThreshold(8);
@@ -54,7 +54,7 @@ public class WhalinTranscoderTest extends BaseTranscoderCase {
   }
 
   @Test
-  public void testCompressedString() throws Exception {
+  void testCompressedString() throws Exception {
     // This one will actually compress
     String s1 = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
     tc.setCompressionThreshold(8);
@@ -67,7 +67,7 @@ public class WhalinTranscoderTest extends BaseTranscoderCase {
   }
 
   @Test
-  public void testObject() throws Exception {
+  void testObject() throws Exception {
     Calendar c = Calendar.getInstance();
     CachedData cd = tc.encode(c);
     assertEquals(WhalinTranscoder.SERIALIZED, cd.getFlags());
@@ -75,7 +75,7 @@ public class WhalinTranscoderTest extends BaseTranscoderCase {
   }
 
   @Test
-  public void testCompressedObject() throws Exception {
+  void testCompressedObject() throws Exception {
     tc.setCompressionThreshold(8);
     Calendar c = Calendar.getInstance();
     CachedData cd = tc.encode(c);
@@ -85,7 +85,7 @@ public class WhalinTranscoderTest extends BaseTranscoderCase {
   }
 
   @Test
-  public void testUnencodeable() throws Exception {
+  void testUnencodeable() throws Exception {
     try {
       CachedData cd = tc.encode(new Object());
       fail("Should fail to serialize, got" + cd);
@@ -95,7 +95,7 @@ public class WhalinTranscoderTest extends BaseTranscoderCase {
   }
 
   @Test
-  public void testUndecodeable() throws Exception {
+  void testUndecodeable() throws Exception {
     CachedData cd = new CachedData(
             Integer.MAX_VALUE &
                     ~(WhalinTranscoder.COMPRESSED | WhalinTranscoder.SERIALIZED),
@@ -105,7 +105,7 @@ public class WhalinTranscoderTest extends BaseTranscoderCase {
   }
 
   @Test
-  public void testUndecodeableSerialized() throws Exception {
+  void testUndecodeableSerialized() throws Exception {
     CachedData cd = new CachedData(WhalinTranscoder.SERIALIZED,
             tu.encodeInt(Integer.MAX_VALUE),
             tc.getMaxSize());
@@ -113,7 +113,7 @@ public class WhalinTranscoderTest extends BaseTranscoderCase {
   }
 
   @Test
-  public void testUndecodeableCompressed() throws Exception {
+  void testUndecodeableCompressed() throws Exception {
     CachedData cd = new CachedData(WhalinTranscoder.COMPRESSED,
             tu.encodeInt(Integer.MAX_VALUE),
             tc.getMaxSize());

--- a/src/test/java/net/spy/memcached/transcoders/WhalinV1TranscoderTest.java
+++ b/src/test/java/net/spy/memcached/transcoders/WhalinV1TranscoderTest.java
@@ -9,7 +9,7 @@ import org.junit.jupiter.api.BeforeEach;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class WhalinV1TranscoderTest extends BaseTranscoderCase {
+class WhalinV1TranscoderTest extends BaseTranscoderCase {
 
   @BeforeEach
   protected void setUp() throws Exception {
@@ -17,7 +17,7 @@ public class WhalinV1TranscoderTest extends BaseTranscoderCase {
   }
 
   @Override
-  public void testByteArray() throws Exception {
+  void testByteArray() throws Exception {
     byte[] a = {'a', 'b', 'c'};
 
     CachedData cd = getTranscoder().encode(a);

--- a/src/test/java/net/spy/memcached/util/BTreeUtilTest.java
+++ b/src/test/java/net/spy/memcached/util/BTreeUtilTest.java
@@ -24,17 +24,17 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class BTreeUtilTest {
+class BTreeUtilTest {
 
   @Test
-  public void testAA() {
+  void testAA() {
 
     System.out.println(Arrays.toString("".getBytes()));
 
   }
 
   @Test
-  public void testFromByteArraysToHex() throws Exception {
+  void testFromByteArraysToHex() throws Exception {
     byte[] byteArray1 = {0, 'F', 'C', 0, 0};
     assertEquals("0x0046430000", BTreeUtil.toHex(byteArray1));
 
@@ -49,7 +49,7 @@ public class BTreeUtilTest {
   }
 
   @Test
-  public void testFromHexToByteArrays() throws Exception {
+  void testFromHexToByteArrays() throws Exception {
     byte[] byteArray1 = {0, 'F', 'C', 0, 0};
     assertTrue(Arrays.equals(byteArray1,
             BTreeUtil.hexStringToByteArrays("0x0046430000")));
@@ -68,7 +68,7 @@ public class BTreeUtilTest {
   }
 
   @Test
-  public void testCompareSameLengthByteArrays() throws Exception {
+  void testCompareSameLengthByteArrays() throws Exception {
     byte[] array1 = {0, 0, 1, 0};
     byte[] array2 = {0, 0, 0, 0};
     byte[] array3 = {0, 0, 1, 0};
@@ -79,7 +79,7 @@ public class BTreeUtilTest {
   }
 
   @Test
-  public void testCompareDifferentLengthByteArrays() throws Exception {
+  void testCompareDifferentLengthByteArrays() throws Exception {
     byte[] array1 = {0, 0, 1};
     byte[] array2 = {0, 0, 1, 0};
 
@@ -88,14 +88,14 @@ public class BTreeUtilTest {
   }
 
   @Test
-  public void testInValidSizeBkey() {
+  void testInValidSizeBkey() {
     assertThrows(IllegalArgumentException.class, () -> {
       BTreeUtil.validateBkey(new byte[32]);
     });
   }
 
   @Test
-  public void testMinusLongBkey() {
+  void testMinusLongBkey() {
     final long bkey = -1;
     assertThrows(IllegalArgumentException.class, () -> {
       BTreeUtil.validateBkey(bkey);

--- a/src/test/java/net/spy/memcached/util/CacheLoaderTest.java
+++ b/src/test/java/net/spy/memcached/util/CacheLoaderTest.java
@@ -26,7 +26,7 @@ import static org.jmock.AbstractExpectations.returnValue;
 /**
  * Test the cache loader.
  */
-public class CacheLoaderTest {
+class CacheLoaderTest {
 
   private ExecutorService es = null;
   private Mockery context;
@@ -45,7 +45,7 @@ public class CacheLoaderTest {
   }
 
   @Test
-  public void testSimpleLoading() throws Exception {
+  void testSimpleLoading() throws Exception {
     MemcachedClientIF m = context.mock(MemcachedClientIF.class);
 
     LoadCounter sl = new LoadCounter();

--- a/src/test/manual/net/spy/memcached/ArcusClientConnectTest.java
+++ b/src/test/manual/net/spy/memcached/ArcusClientConnectTest.java
@@ -22,7 +22,7 @@ import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.BeforeEach;
 
-public class ArcusClientConnectTest {
+class ArcusClientConnectTest {
 
   @BeforeEach
   protected void setUp() throws Exception {
@@ -31,7 +31,7 @@ public class ArcusClientConnectTest {
   }
 
   @Test
-  public void testOpenAndWait() {
+  void testOpenAndWait() {
     ArcusClient client = ArcusClient.createArcusClient(BaseIntegrationTest.ZK_ADDRESS,
             BaseIntegrationTest.SERVICE_CODE);
     client.shutdown();

--- a/src/test/manual/net/spy/memcached/ArcusClientCreateTest.java
+++ b/src/test/manual/net/spy/memcached/ArcusClientCreateTest.java
@@ -19,7 +19,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
-public class ArcusClientCreateTest {
+class ArcusClientCreateTest {
 
   private static final String clientName = "TEST";
   private static final String hostName = "localhost/127.0.0.1:11211";
@@ -38,7 +38,7 @@ public class ArcusClientCreateTest {
   }
 
   @Test
-  public void testCreateClientWithCustomName() throws IOException {
+  void testCreateClientWithCustomName() throws IOException {
     ArcusClient arcusClient = new ArcusClient(new DefaultConnectionFactory(), clientName, addrs);
 
     Collection<MemcachedNode> nodes = arcusClient.getAllNodes();
@@ -49,7 +49,7 @@ public class ArcusClientCreateTest {
   }
 
   @Test
-  public void testCreateClientWithDefaultName() throws IOException {
+  void testCreateClientWithDefaultName() throws IOException {
     ArcusClient arcusClient = new ArcusClient(new DefaultConnectionFactory(), addrs);
 
     Collection<MemcachedNode> nodes = arcusClient.getAllNodes();
@@ -62,7 +62,7 @@ public class ArcusClientCreateTest {
   }
 
   @Test
-  public void testCreateClientNullName() throws IOException {
+  void testCreateClientNullName() throws IOException {
     assertThrows(NullPointerException.class, () -> {
       new ArcusClient(new DefaultConnectionFactory(), null, addrs);
     });

--- a/src/test/manual/net/spy/memcached/ArcusClientFrontCacheTest.java
+++ b/src/test/manual/net/spy/memcached/ArcusClientFrontCacheTest.java
@@ -27,7 +27,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
-public class ArcusClientFrontCacheTest {
+class ArcusClientFrontCacheTest {
 
   @BeforeEach
   protected void setUp() throws Exception {
@@ -36,7 +36,7 @@ public class ArcusClientFrontCacheTest {
   }
 
   @Test
-  public void testCreateSingleClient() {
+  void testCreateSingleClient() {
     ConnectionFactoryBuilder cfb = new ConnectionFactoryBuilder();
     cfb.setFrontCacheExpireTime(10);
     cfb.setMaxFrontCacheElements(10);
@@ -46,7 +46,7 @@ public class ArcusClientFrontCacheTest {
   }
 
   @Test
-  public void testCreatePool() {
+  void testCreatePool() {
     ConnectionFactoryBuilder cfb = new ConnectionFactoryBuilder();
     cfb.setFrontCacheExpireTime(10);
     cfb.setMaxFrontCacheElements(10);
@@ -56,7 +56,7 @@ public class ArcusClientFrontCacheTest {
   }
 
   @Test
-  public void testKV() {
+  void testKV() {
     ConnectionFactoryBuilder cfb = new ConnectionFactoryBuilder();
     cfb.setFrontCacheExpireTime(10);
     cfb.setMaxFrontCacheElements(10);

--- a/src/test/manual/net/spy/memcached/ArcusClientNotExistsServiceCodeTest.java
+++ b/src/test/manual/net/spy/memcached/ArcusClientNotExistsServiceCodeTest.java
@@ -24,10 +24,10 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.fail;
 
 @Disabled
-public class ArcusClientNotExistsServiceCodeTest {
+class ArcusClientNotExistsServiceCodeTest {
 
   @Test
-  public void testNotExistsServiceCode() {
+  void testNotExistsServiceCode() {
     if (!BaseIntegrationTest.USE_ZK) {
       return;
     }

--- a/src/test/manual/net/spy/memcached/ArcusClientPoolCreateTest.java
+++ b/src/test/manual/net/spy/memcached/ArcusClientPoolCreateTest.java
@@ -15,7 +15,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
-public class ArcusClientPoolCreateTest {
+class ArcusClientPoolCreateTest {
 
   private static final int POOL_SIZE = 3;
   private static final int CACHE_NODE_SIZE = 3;
@@ -27,7 +27,7 @@ public class ArcusClientPoolCreateTest {
   }
 
   @Test
-  public void testCreateClientPool() throws NoSuchFieldException, IllegalAccessException {
+  void testCreateClientPool() throws NoSuchFieldException, IllegalAccessException {
     //Create first ArcusClientPool instance.
     ArcusClientPool clientPool = ArcusClient.createArcusClientPool(BaseIntegrationTest.ZK_ADDRESS,
             BaseIntegrationTest.SERVICE_CODE, POOL_SIZE);

--- a/src/test/manual/net/spy/memcached/ArcusClientPoolReconnectTest.java
+++ b/src/test/manual/net/spy/memcached/ArcusClientPoolReconnectTest.java
@@ -22,10 +22,10 @@ import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 @Disabled
-public class ArcusClientPoolReconnectTest {
+class ArcusClientPoolReconnectTest {
 
   @Test
-  public void testOpenAndWait() {
+  void testOpenAndWait() {
     ArcusClientPool client = ArcusClient.createArcusClientPool(BaseIntegrationTest.ZK_ADDRESS,
             BaseIntegrationTest.SERVICE_CODE, 2);
 

--- a/src/test/manual/net/spy/memcached/ArcusClientPoolShutdownTest.java
+++ b/src/test/manual/net/spy/memcached/ArcusClientPoolShutdownTest.java
@@ -27,10 +27,10 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @Disabled
-public class ArcusClientPoolShutdownTest {
+class ArcusClientPoolShutdownTest {
 
   @Test
-  public void testOpenAndWait() {
+  void testOpenAndWait() {
     if (!BaseIntegrationTest.USE_ZK) {
       return;
     }

--- a/src/test/manual/net/spy/memcached/ArcusClientReconnectTest.java
+++ b/src/test/manual/net/spy/memcached/ArcusClientReconnectTest.java
@@ -22,10 +22,10 @@ import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 @Disabled
-public class ArcusClientReconnectTest {
+class ArcusClientReconnectTest {
 
   @Test
-  public void testOpenAndWait() {
+  void testOpenAndWait() {
     if (!BaseIntegrationTest.USE_ZK) {
       return;
     }

--- a/src/test/manual/net/spy/memcached/ArcusClientShutdownTest.java
+++ b/src/test/manual/net/spy/memcached/ArcusClientShutdownTest.java
@@ -27,10 +27,10 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @Disabled
-public class ArcusClientShutdownTest {
+class ArcusClientShutdownTest {
 
   @Test
-  public void testOpenAndWait() {
+  void testOpenAndWait() {
     if (!BaseIntegrationTest.USE_ZK) {
       return;
     }

--- a/src/test/manual/net/spy/memcached/LongKeyTest/BaseLongKeyTest.java
+++ b/src/test/manual/net/spy/memcached/LongKeyTest/BaseLongKeyTest.java
@@ -24,7 +24,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
-public class BaseLongKeyTest extends BaseIntegrationTest {
+class BaseLongKeyTest extends BaseIntegrationTest {
 
   private final int keySize = 200;
   private final List<String> keys = new ArrayList<>();
@@ -46,7 +46,7 @@ public class BaseLongKeyTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testKV_Long() throws Exception {
+  void testKV_Long() throws Exception {
     // KV Set
     assertTrue(mc.set(keys.get(0), 10, "value1").get());
 
@@ -58,7 +58,7 @@ public class BaseLongKeyTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testSet_Long() throws Exception {
+  void testSet_Long() throws Exception {
     // Set Collection Create & Insert
     assertTrue(mc.asyncSopInsert(keys.get(0), 10L, new CollectionAttributes()).get());
 
@@ -75,7 +75,7 @@ public class BaseLongKeyTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testMap_Long() throws Exception {
+  void testMap_Long() throws Exception {
     // Map Collection Create & Insert
     assertTrue(mc.asyncMopInsert(keys.get(0), "mkey1", 10L, new CollectionAttributes()).get());
 
@@ -92,7 +92,7 @@ public class BaseLongKeyTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testList_Long() throws Exception {
+  void testList_Long() throws Exception {
     // List Collection Create & Insert
     assertTrue(mc.asyncLopInsert(keys.get(0), 0, 10L, new CollectionAttributes()).get());
 
@@ -109,7 +109,7 @@ public class BaseLongKeyTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testBtree_Long() throws Exception {
+  void testBtree_Long() throws Exception {
     // BTree Collection Create & Insert
     assertTrue(mc.asyncBopInsert(keys.get(0), 10, null, 10L,
             new CollectionAttributes()).get());
@@ -128,7 +128,7 @@ public class BaseLongKeyTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testKV_BulkGet_Long() throws Exception {
+  void testKV_BulkGet_Long() throws Exception {
     // KV Set
     for (int i = 0; i < keySize; i++) {
       assertTrue(mc.set(keys.get(i), 60, "value" + i).get());
@@ -149,7 +149,7 @@ public class BaseLongKeyTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testBtree_MGet_Long() throws Exception {
+  void testBtree_MGet_Long() throws Exception {
     // BTree Collection Create & Insert
     for (int i = 0; i < keySize; i++) {
       assertTrue(mc.asyncBopInsert(keys.get(i), 10, null, 10L,
@@ -169,7 +169,7 @@ public class BaseLongKeyTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testBtree_SMGet_Long() throws Exception {
+  void testBtree_SMGet_Long() throws Exception {
     // BTree Collection Create & Insert
     for (int i = 0; i < keySize; i++) {
       assertTrue(mc.asyncBopInsert(keys.get(i), i, null, "VALUE" + i,

--- a/src/test/manual/net/spy/memcached/MultibyteKeyTest.java
+++ b/src/test/manual/net/spy/memcached/MultibyteKeyTest.java
@@ -82,7 +82,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.fail;
 
-public class MultibyteKeyTest {
+class MultibyteKeyTest {
   private static final String MULTIBYTE_KEY = "아커스프리픽스:아커스멀티바이트키스트링";
   private final AsciiOperationFactory opFact = new AsciiOperationFactory();
   private byte[] testData;
@@ -109,7 +109,7 @@ public class MultibyteKeyTest {
   }
 
   @Test
-  public void getsTest() {
+  void getsTest() {
     try {
       opFact.gets(MULTIBYTE_KEY, new GetsOperation.Callback() {
         @Override
@@ -130,7 +130,7 @@ public class MultibyteKeyTest {
   }
 
   @Test
-  public void collectionInsertOperationImplTest() {
+  void collectionInsertOperationImplTest() {
     try {
       opFact.collectionInsert(MULTIBYTE_KEY, MULTIBYTE_KEY, new CollectionInsert<Integer>() {
         @Override
@@ -144,7 +144,7 @@ public class MultibyteKeyTest {
   }
 
   @Test
-  public void collectionGetOperationImplTest() {
+  void collectionGetOperationImplTest() {
     try {
       opFact.collectionGet(MULTIBYTE_KEY, new CollectionGet() {
         @Override
@@ -184,7 +184,7 @@ public class MultibyteKeyTest {
   }
 
   @Test
-  public void CASOperationImplTest() {
+  void CASOperationImplTest() {
     try {
       opFact.cas(StoreType.add, MULTIBYTE_KEY, 1L, 0, 0, testData, genericCallback).initialize();
     } catch (java.nio.BufferOverflowException e) {
@@ -193,7 +193,7 @@ public class MultibyteKeyTest {
   }
 
   @Test
-  public void ConcatenationOperationTest() {
+  void ConcatenationOperationTest() {
     try {
       opFact.cat(ConcatenationType.append, 1L, MULTIBYTE_KEY, testData, genericCallback)
           .initialize();
@@ -204,7 +204,7 @@ public class MultibyteKeyTest {
   }
 
   @Test
-  public void BTreeFindPositionWithGetOperationImplTest() {
+  void BTreeFindPositionWithGetOperationImplTest() {
     try {
       opFact.bopFindPositionWithGet(MULTIBYTE_KEY,
           new BTreeFindPositionWithGet(1L, BTreeOrder.ASC, 0),
@@ -215,7 +215,7 @@ public class MultibyteKeyTest {
   }
 
   @Test
-  public void SetExistOperationImplTest() {
+  void SetExistOperationImplTest() {
     try {
       Transcoder<Object> tc = new CollectionTranscoder();
       opFact.collectionExist(MULTIBYTE_KEY, "",
@@ -231,7 +231,7 @@ public class MultibyteKeyTest {
   }
 
   @Test
-  public void CollectionMutateOperationImplTest() {
+  void CollectionMutateOperationImplTest() {
     try {
       opFact.collectionMutate(MULTIBYTE_KEY, "",
           new CollectionMutate() {
@@ -251,7 +251,7 @@ public class MultibyteKeyTest {
   }
 
   @Test
-  public void getAttrTest() {
+  void getAttrTest() {
     try {
       opFact.getAttr(MULTIBYTE_KEY, new GetAttrOperation.Callback() {
         @Override
@@ -272,7 +272,7 @@ public class MultibyteKeyTest {
   }
 
   @Test
-  public void MutatorOperationImplTest() {
+  void MutatorOperationImplTest() {
     try {
       opFact.mutate(Mutator.incr, MULTIBYTE_KEY, 1, 1L, 0, genericCallback).initialize();
     } catch (java.nio.BufferOverflowException e) {
@@ -281,7 +281,7 @@ public class MultibyteKeyTest {
   }
 
   @Test
-  public void BTreeSortMergeGetOperationImplTest() {
+  void BTreeSortMergeGetOperationImplTest() {
     try {
       opFact.bopsmget(
               new BTreeSMGetWithLongTypeBkey<>(null,
@@ -313,7 +313,7 @@ public class MultibyteKeyTest {
   }
 
   @Test
-  public void BTreeSortMergeGetOperationOldImplTest() {
+  void BTreeSortMergeGetOperationOldImplTest() {
     try {
       opFact.bopsmget(
               new BTreeSMGetWithLongTypeBkeyOld<>(null,
@@ -341,7 +341,7 @@ public class MultibyteKeyTest {
   }
 
   @Test
-  public void CollectionPipedInsertOperationImplTest() {
+  void CollectionPipedInsertOperationImplTest() {
     CollectionPipedInsertOperation.Callback cpsCallback =
         new CollectionPipedInsertOperation.Callback() {
           @Override
@@ -409,7 +409,7 @@ public class MultibyteKeyTest {
   }
 
   @Test
-  public void DeleteOperationImplTest() {
+  void DeleteOperationImplTest() {
     try {
       opFact.delete(MULTIBYTE_KEY, genericCallback).initialize();
     } catch (java.nio.BufferOverflowException e) {
@@ -418,7 +418,7 @@ public class MultibyteKeyTest {
   }
 
   @Test
-  public void ExtendedBTreeGetOperationImplTest() {
+  void ExtendedBTreeGetOperationImplTest() {
     byte[] from = new byte[]{0, 0};
     byte[] to = new byte[]{10, 10};
     try {
@@ -443,7 +443,7 @@ public class MultibyteKeyTest {
   }
 
   @Test
-  public void CollectionDeleteOperationImplTest() {
+  void CollectionDeleteOperationImplTest() {
     try {
       opFact.collectionDelete(MULTIBYTE_KEY,
           new BTreeDelete(1L, false),
@@ -462,7 +462,7 @@ public class MultibyteKeyTest {
   }
 
   @Test
-  public void CollectionBulkInsertOperationImplTest() {
+  void CollectionBulkInsertOperationImplTest() {
     CollectionBulkInsert<Integer> insert = null;
     CollectionBulkInsertOperation.Callback cbsCallback =
         new CollectionBulkInsertOperation.Callback() {
@@ -510,7 +510,7 @@ public class MultibyteKeyTest {
   }
 
   @Test
-  public void BTreeGetBulkOperationImplTest() {
+  void BTreeGetBulkOperationImplTest() {
     try {
       opFact.bopGetBulk(
           new BTreeGetBulkWithLongTypeBkey<Integer>(null,
@@ -540,7 +540,7 @@ public class MultibyteKeyTest {
   }
 
   @Test
-  public void BTreeGetByPositionOperationImplTest() {
+  void BTreeGetByPositionOperationImplTest() {
     try {
       opFact.bopGetByPosition(MULTIBYTE_KEY,
           new BTreeGetByPosition(BTreeOrder.ASC, 0),
@@ -564,7 +564,7 @@ public class MultibyteKeyTest {
   }
 
   @Test
-  public void CollectionUpdateOperationImplTest() {
+  void CollectionUpdateOperationImplTest() {
     try {
       opFact.collectionUpdate(MULTIBYTE_KEY, MULTIBYTE_KEY,
               new BTreeUpdate<>(new Random().nextInt(), ElementFlagUpdate.RESET_FLAG, false),
@@ -575,7 +575,7 @@ public class MultibyteKeyTest {
   }
 
   @Test
-  public void CollectionPipedUpdateOperationImplTest() {
+  void CollectionPipedUpdateOperationImplTest() {
     List<Element<Integer>> elementsList = new ArrayList<>();
     for (int i = 0; i < 10; i++) {
       elementsList.add(new Element<>(
@@ -604,7 +604,7 @@ public class MultibyteKeyTest {
   }
 
   @Test
-  public void CollectionCreateOperationImplTest() {
+  void CollectionCreateOperationImplTest() {
     try {
       opFact.collectionCreate(MULTIBYTE_KEY,
               new BTreeCreate(0, 0, 10000L, CollectionOverflowAction.error, true, false),
@@ -615,7 +615,7 @@ public class MultibyteKeyTest {
   }
 
   @Test
-  public void CollectionCountOperationImplTest() {
+  void CollectionCountOperationImplTest() {
     try {
       opFact.collectionCount(MULTIBYTE_KEY,
               new BTreeCount(0L, 10L, ElementFlagFilter.DO_NOT_FILTER),
@@ -626,7 +626,7 @@ public class MultibyteKeyTest {
   }
 
   @Test
-  public void CollectionPipedExistOperationImplTest() {
+  void CollectionPipedExistOperationImplTest() {
     List<Integer> objectList = new ArrayList<>();
     for (int i = 0; i < 10; i++) {
       objectList.add(new Random().nextInt());
@@ -653,7 +653,7 @@ public class MultibyteKeyTest {
   }
 
   @Test
-  public void BTreeInsertAndGetOperationImplTest() {
+  void BTreeInsertAndGetOperationImplTest() {
     try {
       opFact.bopInsertAndGet(MULTIBYTE_KEY,
               new BTreeInsertAndGet<>(1L, new byte[]{0, 0}, new Random().nextInt(),
@@ -677,7 +677,7 @@ public class MultibyteKeyTest {
   }
 
   @Test
-  public void SetAttrOperationImplTest() {
+  void SetAttrOperationImplTest() {
     try {
       opFact.setAttr(MULTIBYTE_KEY, new Attributes(), genericCallback).initialize();
     } catch (java.nio.BufferOverflowException e) {
@@ -686,7 +686,7 @@ public class MultibyteKeyTest {
   }
 
   @Test
-  public void BTreeFindPositionOperationImplTest() {
+  void BTreeFindPositionOperationImplTest() {
     try {
       opFact.bopFindPosition(MULTIBYTE_KEY,
           new BTreeFindPosition(1L, BTreeOrder.ASC),

--- a/src/test/manual/net/spy/memcached/btreesmget/ByteArrayBKeySMGetErrorTest.java
+++ b/src/test/manual/net/spy/memcached/btreesmget/ByteArrayBKeySMGetErrorTest.java
@@ -39,7 +39,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
-public class ByteArrayBKeySMGetErrorTest extends BaseIntegrationTest {
+class ByteArrayBKeySMGetErrorTest extends BaseIntegrationTest {
 
   private static final List<String> KEY_LIST = new ArrayList<>();
 
@@ -71,7 +71,7 @@ public class ByteArrayBKeySMGetErrorTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testDuplicated() {
+  void testDuplicated() {
     // insert test data
     try {
       assertTrue(mc.asyncBopInsert(KEY_LIST.get(0),
@@ -127,7 +127,7 @@ public class ByteArrayBKeySMGetErrorTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testBkeyMismatch() {
+  void testBkeyMismatch() {
     // insert test data
     try {
       CollectionAttributes attr = new CollectionAttributes();
@@ -182,7 +182,7 @@ public class ByteArrayBKeySMGetErrorTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testTrimmed() {
+  void testTrimmed() {
     // insert test data
     try {
       CollectionAttributes attr = new CollectionAttributes();
@@ -248,7 +248,7 @@ public class ByteArrayBKeySMGetErrorTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testOutOfRange() {
+  void testOutOfRange() {
     // insert test data
     try {
       CollectionAttributes attr = new CollectionAttributes();
@@ -311,7 +311,7 @@ public class ByteArrayBKeySMGetErrorTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testDuplicated2() {
+  void testDuplicated2() {
     // insert test data
     try {
       assertTrue(mc.asyncBopInsert(KEY_LIST.get(0), 1, null,

--- a/src/test/manual/net/spy/memcached/btreesmget/ByteArrayBKeySMGetIrregularEflagTest.java
+++ b/src/test/manual/net/spy/memcached/btreesmget/ByteArrayBKeySMGetIrregularEflagTest.java
@@ -30,7 +30,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.fail;
 
-public class ByteArrayBKeySMGetIrregularEflagTest extends BaseIntegrationTest {
+class ByteArrayBKeySMGetIrregularEflagTest extends BaseIntegrationTest {
 
   private final String key1 = "ByteArrayBKeySMGetIrregularEflagTest1"
           + (Math.abs(new Random().nextInt(99)) + 100);
@@ -42,7 +42,7 @@ public class ByteArrayBKeySMGetIrregularEflagTest extends BaseIntegrationTest {
   private final Object value = "valvalvalvalvalvalvalvalvalval";
 
   @Test
-  public void testGetAll_1() {
+  void testGetAll_1() {
     ArrayList<String> testKeyList = new ArrayList<>();
     testKeyList.add(key1);
     testKeyList.add(key2);

--- a/src/test/manual/net/spy/memcached/btreesmget/ByteArrayBKeySMGetTest.java
+++ b/src/test/manual/net/spy/memcached/btreesmget/ByteArrayBKeySMGetTest.java
@@ -40,7 +40,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
-public class ByteArrayBKeySMGetTest extends BaseIntegrationTest {
+class ByteArrayBKeySMGetTest extends BaseIntegrationTest {
 
   private final String KEY = this.getClass().getSimpleName();
   private List<String> keyList = null;
@@ -61,7 +61,7 @@ public class ByteArrayBKeySMGetTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testSMGetMissAll() {
+  void testSMGetMissAll() {
     try {
       keyList = new ArrayList<>();
       for (int i = 0; i < 10; i++) {
@@ -105,7 +105,7 @@ public class ByteArrayBKeySMGetTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testSMGetHitAll() {
+  void testSMGetHitAll() {
     try {
       keyList = new ArrayList<>();
       for (int i = 0; i < 50; i++) {
@@ -167,7 +167,7 @@ public class ByteArrayBKeySMGetTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testSMGetHitAllWithOffsetMoreCount() {
+  void testSMGetHitAllWithOffsetMoreCount() {
     try {
       keyList = new ArrayList<>();
       for (int i = 0; i < 50; i++) {
@@ -229,7 +229,7 @@ public class ByteArrayBKeySMGetTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testSMGetHitAllWithOffsetExactCount() {
+  void testSMGetHitAllWithOffsetExactCount() {
     try {
       keyList = new ArrayList<>();
       for (int i = 0; i < 10; i++) {
@@ -291,7 +291,7 @@ public class ByteArrayBKeySMGetTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testSMGetHitAllWithOffsetLessThanCount() {
+  void testSMGetHitAllWithOffsetLessThanCount() {
     try {
       keyList = new ArrayList<>();
       for (int i = 0; i < 9; i++) {
@@ -353,7 +353,7 @@ public class ByteArrayBKeySMGetTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testSMGetHitAllDesc() {
+  void testSMGetHitAllDesc() {
     try {
       keyList = new ArrayList<>();
       for (int i = 0; i < 10; i++) {
@@ -401,7 +401,7 @@ public class ByteArrayBKeySMGetTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testSMGetHitHalf() {
+  void testSMGetHitHalf() {
     try {
       keyList = new ArrayList<>();
       for (int i = 0; i < 10; i++) {
@@ -450,7 +450,7 @@ public class ByteArrayBKeySMGetTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testSMGetHitHalfDesc() {
+  void testSMGetHitHalfDesc() {
     try {
       keyList = new ArrayList<>();
       for (int i = 0; i < 10; i++) {
@@ -499,7 +499,7 @@ public class ByteArrayBKeySMGetTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testPerformanceGet1000KeysWithoutOffset() {
+  void testPerformanceGet1000KeysWithoutOffset() {
     try {
       keyList = new ArrayList<>();
       for (int i = 0; i < 1000; i++) {
@@ -558,7 +558,7 @@ public class ByteArrayBKeySMGetTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testSMGetWithMassiveKeys() {
+  void testSMGetWithMassiveKeys() {
     int testSize = 100;
 
     try {

--- a/src/test/manual/net/spy/memcached/btreesmget/SMGetErrorTest.java
+++ b/src/test/manual/net/spy/memcached/btreesmget/SMGetErrorTest.java
@@ -41,7 +41,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
-public class SMGetErrorTest extends BaseIntegrationTest {
+class SMGetErrorTest extends BaseIntegrationTest {
 
   private static final List<String> KEY_LIST = new ArrayList<>();
 
@@ -73,7 +73,7 @@ public class SMGetErrorTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testDuplicated() {
+  void testDuplicated() {
     // insert test data
     try {
       assertTrue(mc.asyncBopInsert(KEY_LIST.get(0), 1, null,
@@ -120,7 +120,7 @@ public class SMGetErrorTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testBkeyMismatch() {
+  void testBkeyMismatch() {
     // insert test data
     try {
       CollectionAttributes attr = new CollectionAttributes();
@@ -173,7 +173,7 @@ public class SMGetErrorTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testTrimmed() {
+  void testTrimmed() {
     // insert test data
     try {
       CollectionAttributes attr = new CollectionAttributes();
@@ -262,7 +262,7 @@ public class SMGetErrorTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testOutOfRange() {
+  void testOutOfRange() {
     // insert test data
     try {
       CollectionAttributes attr = new CollectionAttributes();
@@ -351,7 +351,7 @@ public class SMGetErrorTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testDuplicated2() {
+  void testDuplicated2() {
     // insert test data
     try {
       assertTrue(mc.asyncBopInsert(KEY_LIST.get(0), 1, null,
@@ -396,7 +396,7 @@ public class SMGetErrorTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testUnreadable() {
+  void testUnreadable() {
     // insert test data
     try {
       CollectionAttributes attr = new CollectionAttributes();
@@ -445,7 +445,7 @@ public class SMGetErrorTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testInvalidArgumentException() {
+  void testInvalidArgumentException() {
     ArrayList<String> testKeyList = new ArrayList<>();
     testKeyList.add(KEY_LIST.get(0));
     testKeyList.add(KEY_LIST.get(1));

--- a/src/test/manual/net/spy/memcached/btreesmget/SMGetTest.java
+++ b/src/test/manual/net/spy/memcached/btreesmget/SMGetTest.java
@@ -40,7 +40,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
-public class SMGetTest extends BaseIntegrationTest {
+class SMGetTest extends BaseIntegrationTest {
 
   private final String KEY = this.getClass().getSimpleName();
   private List<String> keyList = null;
@@ -60,7 +60,7 @@ public class SMGetTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testSMGetMissAll() {
+  void testSMGetMissAll() {
     try {
       keyList = new ArrayList<>();
       for (int i = 0; i < 10; i++) {
@@ -101,7 +101,7 @@ public class SMGetTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testSMGetHitAll() {
+  void testSMGetHitAll() {
     try {
       keyList = new ArrayList<>();
       for (int i = 0; i < 50; i++) {
@@ -158,7 +158,7 @@ public class SMGetTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testSMGetHitAllWithOffsetMoreCount() {
+  void testSMGetHitAllWithOffsetMoreCount() {
     try {
       keyList = new ArrayList<>();
       for (int i = 0; i < 50; i++) {
@@ -215,7 +215,7 @@ public class SMGetTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testSMGetHitAllWithOffsetExactCount() {
+  void testSMGetHitAllWithOffsetExactCount() {
     try {
       keyList = new ArrayList<>();
       for (int i = 0; i < 10; i++) {
@@ -272,7 +272,7 @@ public class SMGetTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testSMGetHitAllWithOffsetLessThanCount() {
+  void testSMGetHitAllWithOffsetLessThanCount() {
     try {
       keyList = new ArrayList<>();
       for (int i = 0; i < 9; i++) {
@@ -329,7 +329,7 @@ public class SMGetTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testSMGetHitAllDesc() {
+  void testSMGetHitAllDesc() {
     try {
       keyList = new ArrayList<>();
       for (int i = 0; i < 10; i++) {
@@ -374,7 +374,7 @@ public class SMGetTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testSMGetHitHalf() {
+  void testSMGetHitHalf() {
     try {
       keyList = new ArrayList<>();
       for (int i = 0; i < 10; i++) {
@@ -421,7 +421,7 @@ public class SMGetTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testSMGetHitHalfDesc() {
+  void testSMGetHitHalfDesc() {
     try {
       keyList = new ArrayList<>();
       for (int i = 0; i < 10; i++) {
@@ -467,7 +467,7 @@ public class SMGetTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testPerformanceGet1000KeysWithoutOffset() {
+  void testPerformanceGet1000KeysWithoutOffset() {
     try {
       keyList = new ArrayList<>();
       for (int i = 0; i < 1000; i++) {
@@ -523,7 +523,7 @@ public class SMGetTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testSMGetWithMassiveKeys() {
+  void testSMGetWithMassiveKeys() {
     int testSize = 2000;
 
     try {
@@ -579,7 +579,7 @@ public class SMGetTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testSMGetWithElementMultiFlagsFilter() {
+  void testSMGetWithElementMultiFlagsFilter() {
     int testSize = 2000;
 
     try {
@@ -633,7 +633,7 @@ public class SMGetTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testByteArrayBkeySMGetWithElementMultiFlagsFilter() {
+  void testByteArrayBkeySMGetWithElementMultiFlagsFilter() {
     int testSize = 2000;
 
     try {
@@ -692,7 +692,7 @@ public class SMGetTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testSMGetOverflowMaxCount() {
+  void testSMGetOverflowMaxCount() {
     try {
       mc.asyncBopSortMergeGet(keyList, 0, 1000,
               ElementFlagFilter.DO_NOT_FILTER, 0, 1001);

--- a/src/test/manual/net/spy/memcached/btreesmget/SMGetWithCombinationEflagTest.java
+++ b/src/test/manual/net/spy/memcached/btreesmget/SMGetWithCombinationEflagTest.java
@@ -39,7 +39,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
-public class SMGetWithCombinationEflagTest extends BaseIntegrationTest {
+class SMGetWithCombinationEflagTest extends BaseIntegrationTest {
 
   private final String KEY = this.getClass().getSimpleName();
   private List<String> keyList = null;
@@ -64,7 +64,7 @@ public class SMGetWithCombinationEflagTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testSMGetMissAll() {
+  void testSMGetMissAll() {
     try {
       keyList = new ArrayList<>();
       for (int i = 0; i < 10; i++) {
@@ -105,7 +105,7 @@ public class SMGetWithCombinationEflagTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testSMGetHitAll() {
+  void testSMGetHitAll() {
     try {
       keyList = new ArrayList<>();
       for (int i = 0; i < 50; i++) {
@@ -167,7 +167,7 @@ public class SMGetWithCombinationEflagTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testSMGetHitAllWithOffsetMoreCount() {
+  void testSMGetHitAllWithOffsetMoreCount() {
     try {
       keyList = new ArrayList<>();
       for (int i = 0; i < 50; i++) {
@@ -229,7 +229,7 @@ public class SMGetWithCombinationEflagTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testSMGetHitAllWithOffsetExactCount() {
+  void testSMGetHitAllWithOffsetExactCount() {
     try {
       keyList = new ArrayList<>();
       for (int i = 0; i < 10; i++) {
@@ -291,7 +291,7 @@ public class SMGetWithCombinationEflagTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testSMGetHitAllWithOffsetLessThanCount() {
+  void testSMGetHitAllWithOffsetLessThanCount() {
     try {
       keyList = new ArrayList<>();
       for (int i = 0; i < 9; i++) {
@@ -353,7 +353,7 @@ public class SMGetWithCombinationEflagTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testSMGetHitAllDesc() {
+  void testSMGetHitAllDesc() {
     try {
       keyList = new ArrayList<>();
       for (int i = 0; i < 10; i++) {
@@ -403,7 +403,7 @@ public class SMGetWithCombinationEflagTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testSMGetHitHalf() {
+  void testSMGetHitHalf() {
     try {
       keyList = new ArrayList<>();
       for (int i = 0; i < 10; i++) {
@@ -454,7 +454,7 @@ public class SMGetWithCombinationEflagTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testSMGetHitHalfDesc() {
+  void testSMGetHitHalfDesc() {
     try {
       keyList = new ArrayList<>();
       for (int i = 0; i < 10; i++) {
@@ -505,7 +505,7 @@ public class SMGetWithCombinationEflagTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testPerformanceGet1000KeysWithoutOffset() {
+  void testPerformanceGet1000KeysWithoutOffset() {
     try {
       keyList = new ArrayList<>();
       for (int i = 0; i < 1000; i++) {
@@ -567,7 +567,7 @@ public class SMGetWithCombinationEflagTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testSMGetWithMassiveKeys() {
+  void testSMGetWithMassiveKeys() {
     int testSize = 100;
 
     try {

--- a/src/test/manual/net/spy/memcached/btreesmget/SMGetWithEflagTest.java
+++ b/src/test/manual/net/spy/memcached/btreesmget/SMGetWithEflagTest.java
@@ -39,7 +39,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
-public class SMGetWithEflagTest extends BaseIntegrationTest {
+class SMGetWithEflagTest extends BaseIntegrationTest {
 
   private final String KEY = this.getClass().getSimpleName();
   private List<String> keyList = null;
@@ -60,7 +60,7 @@ public class SMGetWithEflagTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testSMGetMissAll() {
+  void testSMGetMissAll() {
     try {
       keyList = new ArrayList<>();
       for (int i = 0; i < 10; i++) {
@@ -101,7 +101,7 @@ public class SMGetWithEflagTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testSMGetHitAll() {
+  void testSMGetHitAll() {
     try {
       keyList = new ArrayList<>();
       for (int i = 0; i < 50; i++) {
@@ -158,7 +158,7 @@ public class SMGetWithEflagTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testSMGetHitAllWithOffsetMoreCount() {
+  void testSMGetHitAllWithOffsetMoreCount() {
     try {
       keyList = new ArrayList<>();
       for (int i = 0; i < 50; i++) {
@@ -215,7 +215,7 @@ public class SMGetWithEflagTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testSMGetHitAllWithOffsetExactCount() {
+  void testSMGetHitAllWithOffsetExactCount() {
     try {
       keyList = new ArrayList<>();
       for (int i = 0; i < 10; i++) {
@@ -272,7 +272,7 @@ public class SMGetWithEflagTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testSMGetHitAllWithOffsetLessThanCount() {
+  void testSMGetHitAllWithOffsetLessThanCount() {
     try {
       keyList = new ArrayList<>();
       for (int i = 0; i < 9; i++) {
@@ -329,7 +329,7 @@ public class SMGetWithEflagTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testSMGetHitAllDesc() {
+  void testSMGetHitAllDesc() {
     try {
       keyList = new ArrayList<>();
       for (int i = 0; i < 10; i++) {
@@ -374,7 +374,7 @@ public class SMGetWithEflagTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testSMGetHitHalf() {
+  void testSMGetHitHalf() {
     try {
       keyList = new ArrayList<>();
       for (int i = 0; i < 10; i++) {
@@ -420,7 +420,7 @@ public class SMGetWithEflagTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testSMGetHitHalfDesc() {
+  void testSMGetHitHalfDesc() {
     try {
       keyList = new ArrayList<>();
       for (int i = 0; i < 10; i++) {
@@ -466,7 +466,7 @@ public class SMGetWithEflagTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testPerformanceGet1000KeysWithoutOffset() {
+  void testPerformanceGet1000KeysWithoutOffset() {
     try {
       keyList = new ArrayList<>();
       for (int i = 0; i < 1000; i++) {
@@ -522,7 +522,7 @@ public class SMGetWithEflagTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testSMGetWithMassiveKeys() {
+  void testSMGetWithMassiveKeys() {
     int testSize = 100;
 
     try {

--- a/src/test/manual/net/spy/memcached/bulkoperation/BopInsertBulkMultipleBoundaryTest.java
+++ b/src/test/manual/net/spy/memcached/bulkoperation/BopInsertBulkMultipleBoundaryTest.java
@@ -33,10 +33,10 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class BopInsertBulkMultipleBoundaryTest extends BaseIntegrationTest {
+class BopInsertBulkMultipleBoundaryTest extends BaseIntegrationTest {
 
   @Test
-  public void testBopGet_Overflow() throws Exception {
+  void testBopGet_Overflow() throws Exception {
     String key = "MyBopOverflowtestKey23";
     String value = "MyValue";
 

--- a/src/test/manual/net/spy/memcached/bulkoperation/BopInsertBulkMultipleTest.java
+++ b/src/test/manual/net/spy/memcached/bulkoperation/BopInsertBulkMultipleTest.java
@@ -35,10 +35,10 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
-public class BopInsertBulkMultipleTest extends BaseIntegrationTest {
+class BopInsertBulkMultipleTest extends BaseIntegrationTest {
 
   @Test
-  public void testInsertAndGet() {
+  void testInsertAndGet() {
     String key = "MyBopKey32";
     String value = "MyValue";
 
@@ -102,7 +102,7 @@ public class BopInsertBulkMultipleTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testErrorCount() {
+  void testErrorCount() {
     String key = "MyBopKeyErrorCount";
     String value = "MyValue";
 

--- a/src/test/manual/net/spy/memcached/bulkoperation/BopInsertBulkTest.java
+++ b/src/test/manual/net/spy/memcached/bulkoperation/BopInsertBulkTest.java
@@ -35,12 +35,12 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
-public class BopInsertBulkTest extends BaseIntegrationTest {
+class BopInsertBulkTest extends BaseIntegrationTest {
 
   private static final byte[] EFLAG = new byte[]{0, 0, 1, 1};
 
   @Test
-  public void testInsertAndGet() {
+  void testInsertAndGet() {
     String value = "MyValue";
     long bkey = Long.MAX_VALUE;
 
@@ -103,7 +103,7 @@ public class BopInsertBulkTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testInsertAndGetByteArrayBkey() {
+  void testInsertAndGetByteArrayBkey() {
     String value = "MyValue";
     byte[] bkey = new byte[]{0, 1, 1, 1};
 
@@ -167,7 +167,7 @@ public class BopInsertBulkTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testInsertAndGetWithEflag() {
+  void testInsertAndGetWithEflag() {
     String value = "MyValue";
     long bkey = Long.MAX_VALUE;
 
@@ -230,7 +230,7 @@ public class BopInsertBulkTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testInsertAndGetByteArrayBkeyWithEflag() {
+  void testInsertAndGetByteArrayBkeyWithEflag() {
     String value = "MyValue";
     byte[] bkey = new byte[]{0, 1, 1, 1};
 
@@ -294,7 +294,7 @@ public class BopInsertBulkTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testKeyAttributes() {
+  void testKeyAttributes() {
     String value = "MyValue";
     long bkey = Long.MAX_VALUE;
 
@@ -342,7 +342,7 @@ public class BopInsertBulkTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testErrorCount() {
+  void testErrorCount() {
     String value = "MyValue";
     long bkey = Long.MAX_VALUE;
 

--- a/src/test/manual/net/spy/memcached/bulkoperation/BopPipeUpdateTest.java
+++ b/src/test/manual/net/spy/memcached/bulkoperation/BopPipeUpdateTest.java
@@ -40,7 +40,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
-public class BopPipeUpdateTest extends BaseIntegrationTest {
+class BopPipeUpdateTest extends BaseIntegrationTest {
 
   private static final String KEY = BopPipeUpdateTest.class.getSimpleName();
   private static final int elementCount = 1200;
@@ -87,7 +87,7 @@ public class BopPipeUpdateTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testBopPipeUpdateValue() {
+  void testBopPipeUpdateValue() {
 
     List<Element<Object>> updateElements = new ArrayList<>();
     for (int i = 0; i < elementCount; i++) {
@@ -124,7 +124,7 @@ public class BopPipeUpdateTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testBopPipeUpdateEFlags() {
+  void testBopPipeUpdateEFlags() {
 
     byte[] NEW_BYTE_EFLAG = new byte[]{1, 1};
 
@@ -166,7 +166,7 @@ public class BopPipeUpdateTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testBopPipeUpdateEFlagsReset() {
+  void testBopPipeUpdateEFlagsReset() {
 
     List<Element<Object>> updateElements = new ArrayList<>();
     for (int i = 0; i < elementCount; i++) {
@@ -205,7 +205,7 @@ public class BopPipeUpdateTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testBopPipeUpdateNotFoundElement() {
+  void testBopPipeUpdateNotFoundElement() {
 
     try {
       assertTrue(mc.asyncBopDelete(KEY, 0L, 1000L,
@@ -253,7 +253,7 @@ public class BopPipeUpdateTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testBopPipeUpdateNotFoundKey() {
+  void testBopPipeUpdateNotFoundKey() {
 
     String key2 = "NEW_BopPipeUpdateTest";
 

--- a/src/test/manual/net/spy/memcached/bulkoperation/BulkDeleteTest.java
+++ b/src/test/manual/net/spy/memcached/bulkoperation/BulkDeleteTest.java
@@ -34,9 +34,9 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
-public class BulkDeleteTest extends BaseIntegrationTest {
+class BulkDeleteTest extends BaseIntegrationTest {
   @Test
-  public void testNullAndEmptyKeyDelete() {
+  void testNullAndEmptyKeyDelete() {
     // DELETE null key
     try {
       List<String> keys = null;
@@ -54,7 +54,7 @@ public class BulkDeleteTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testInsertAndDelete() {
+  void testInsertAndDelete() {
     String value = "MyValue";
 
     int TEST_COUNT = 64;
@@ -104,7 +104,7 @@ public class BulkDeleteTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testDeleteNotFoundKey() {
+  void testDeleteNotFoundKey() {
     int TEST_COUNT = 64;
 
     try {

--- a/src/test/manual/net/spy/memcached/bulkoperation/BulkSetVariousTypeTest.java
+++ b/src/test/manual/net/spy/memcached/bulkoperation/BulkSetVariousTypeTest.java
@@ -32,7 +32,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
-public class BulkSetVariousTypeTest extends BaseIntegrationTest {
+class BulkSetVariousTypeTest extends BaseIntegrationTest {
 
   private static class MyBean implements Serializable {
     private static final long serialVersionUID = -5977830942924286134L;
@@ -65,7 +65,7 @@ public class BulkSetVariousTypeTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testInsertAndGet() {
+  void testInsertAndGet() {
     Object[] valueList = {1.0, 1000, 1000L, "String",
         new MyBean("beanName")};
     String keyPrefix = "TypeTestKey";

--- a/src/test/manual/net/spy/memcached/bulkoperation/BulkStoreTest.java
+++ b/src/test/manual/net/spy/memcached/bulkoperation/BulkStoreTest.java
@@ -39,10 +39,10 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
-public class BulkStoreTest extends BaseIntegrationTest {
+class BulkStoreTest extends BaseIntegrationTest {
 
   @Test
-  public void testZeroSizedKeys() {
+  void testZeroSizedKeys() {
     try {
       mc.asyncStoreBulk(StoreType.set, new ArrayList<>(0),
               60, "value");
@@ -67,7 +67,7 @@ public class BulkStoreTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testSetAndGet2() {
+  void testSetAndGet2() {
     int KEY_SIZE = 10;
 
     try {
@@ -123,7 +123,7 @@ public class BulkStoreTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testSetAndGet() {
+  void testSetAndGet() {
     String value = "MyValue";
 
     int KEY_SIZE = 10;
@@ -181,7 +181,7 @@ public class BulkStoreTest extends BaseIntegrationTest {
 
 
   @Test
-  public void testAddAndGet() {
+  void testAddAndGet() {
     String value = "MyValue";
 
     int KEY_SIZE = 10;
@@ -231,7 +231,7 @@ public class BulkStoreTest extends BaseIntegrationTest {
 
 
   @Test
-  public void testReplaceAndGet() {
+  void testReplaceAndGet() {
     String value = "MyValue";
 
     int KEY_SIZE = 10;
@@ -280,7 +280,7 @@ public class BulkStoreTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testStoreWithTranscoder() {
+  void testStoreWithTranscoder() {
     String value = "MyValue";
     Transcoder<Object> transcoder = new WhalinTranscoder();
 
@@ -330,7 +330,7 @@ public class BulkStoreTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testStoreWithTranscoder2() {
+  void testStoreWithTranscoder2() {
     Transcoder<Object> transcoder = new WhalinTranscoder();
 
     int KEY_SIZE = 10;
@@ -380,7 +380,7 @@ public class BulkStoreTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testSetWithTranscoder() {
+  void testSetWithTranscoder() {
     String value = "MyValue";
     Transcoder<Object> transcoder = new WhalinTranscoder();
 
@@ -431,7 +431,7 @@ public class BulkStoreTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testSetWithTranscoder2() {
+  void testSetWithTranscoder2() {
     Transcoder<Object> transcoder = new WhalinTranscoder();
 
     int KEY_SIZE = 10;

--- a/src/test/manual/net/spy/memcached/bulkoperation/LopInsertBulkMultipleValueTest.java
+++ b/src/test/manual/net/spy/memcached/bulkoperation/LopInsertBulkMultipleValueTest.java
@@ -35,7 +35,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
-public class LopInsertBulkMultipleValueTest extends BaseIntegrationTest {
+class LopInsertBulkMultipleValueTest extends BaseIntegrationTest {
 
   private String key = "LopInsertBulkMultipleValueTest";
 
@@ -47,7 +47,7 @@ public class LopInsertBulkMultipleValueTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testInsertAndGet() {
+  void testInsertAndGet() {
     String value = "MyValue";
 
     int valueCount = 500;
@@ -108,7 +108,7 @@ public class LopInsertBulkMultipleValueTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testErrorCount() {
+  void testErrorCount() {
     int valueCount = 1200;
     Object[] valueList = new Object[valueCount];
     for (int i = 0; i < valueList.length; i++) {

--- a/src/test/manual/net/spy/memcached/bulkoperation/LopInsertBulkTest.java
+++ b/src/test/manual/net/spy/memcached/bulkoperation/LopInsertBulkTest.java
@@ -33,10 +33,10 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
-public class LopInsertBulkTest extends BaseIntegrationTest {
+class LopInsertBulkTest extends BaseIntegrationTest {
 
   @Test
-  public void testInsertAndGet() {
+  void testInsertAndGet() {
     String value = "MyValue";
     int keySize = 500;
 
@@ -94,7 +94,7 @@ public class LopInsertBulkTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testCountError() {
+  void testCountError() {
     String value = "MyValue";
 
     int keySize = 1200;

--- a/src/test/manual/net/spy/memcached/bulkoperation/MopInsertBulkMultipleTest.java
+++ b/src/test/manual/net/spy/memcached/bulkoperation/MopInsertBulkMultipleTest.java
@@ -33,10 +33,10 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
-public class MopInsertBulkMultipleTest extends BaseIntegrationTest {
+class MopInsertBulkMultipleTest extends BaseIntegrationTest {
 
   @Test
-  public void testInsertAndGet() {
+  void testInsertAndGet() {
     String key = "MyMopKey32";
     String value = "MyValue";
 
@@ -97,7 +97,7 @@ public class MopInsertBulkMultipleTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testErrorCount() {
+  void testErrorCount() {
     String key = "MyMopKeyErrorCount";
     String value = "MyValue";
 

--- a/src/test/manual/net/spy/memcached/bulkoperation/MopInsertBulkTest.java
+++ b/src/test/manual/net/spy/memcached/bulkoperation/MopInsertBulkTest.java
@@ -32,12 +32,12 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
-public class MopInsertBulkTest extends BaseIntegrationTest {
+class MopInsertBulkTest extends BaseIntegrationTest {
 
   private final String MKEY = "mkey";
 
   @Test
-  public void testInsertAndGet() {
+  void testInsertAndGet() {
     String value = "MyValue";
     int keySize = 500;
 
@@ -95,7 +95,7 @@ public class MopInsertBulkTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testCountError() {
+  void testCountError() {
     String value = "MyValue";
 
     int keySize = 1200;

--- a/src/test/manual/net/spy/memcached/bulkoperation/PipeInsertTest.java
+++ b/src/test/manual/net/spy/memcached/bulkoperation/PipeInsertTest.java
@@ -38,7 +38,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
-public class PipeInsertTest extends BaseIntegrationTest {
+class PipeInsertTest extends BaseIntegrationTest {
 
   private static final String KEY = PipeInsertTest.class.getSimpleName();
 
@@ -58,7 +58,7 @@ public class PipeInsertTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testBopPipeInsert() {
+  void testBopPipeInsert() {
     int elementCount = 5000;
 
     List<Element<Object>> elements = new ArrayList<>();
@@ -91,7 +91,7 @@ public class PipeInsertTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testBopPipeInsert2() {
+  void testBopPipeInsert2() {
     int elementCount = 5000;
     Map<Long, Object> elements = new TreeMap<>();
     for (long i = 0; i < elementCount; i++) {
@@ -125,7 +125,7 @@ public class PipeInsertTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testLopPipeInsert() {
+  void testLopPipeInsert() {
     int elementCount = 5000;
 
     List<Object> elements = new ArrayList<>(elementCount);
@@ -160,7 +160,7 @@ public class PipeInsertTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testLopPipeInsertIndex() {
+  void testLopPipeInsertIndex() {
     int elementCount = 3;
     List<Object> middleElements = new ArrayList<>(elementCount);
     List<Object> headerElements = new ArrayList<>(elementCount);
@@ -208,7 +208,7 @@ public class PipeInsertTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testMopPipeInsert() {
+  void testMopPipeInsert() {
     int elementCount = 5000;
 
     Map<String, Object> elements = new TreeMap<>();

--- a/src/test/manual/net/spy/memcached/bulkoperation/SopInsertBulkMultipleValueTest.java
+++ b/src/test/manual/net/spy/memcached/bulkoperation/SopInsertBulkMultipleValueTest.java
@@ -34,10 +34,10 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
-public class SopInsertBulkMultipleValueTest extends BaseIntegrationTest {
+class SopInsertBulkMultipleValueTest extends BaseIntegrationTest {
 
   @Test
-  public void testInsertAndGet() {
+  void testInsertAndGet() {
     String key = "testInsertAndGet";
     String prefix = "MyValue";
 
@@ -103,7 +103,7 @@ public class SopInsertBulkMultipleValueTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testErrorCount() {
+  void testErrorCount() {
     String key = "testErrorCount";
     int valueCount = 1200;
     Object[] valueList = new Object[valueCount];

--- a/src/test/manual/net/spy/memcached/bulkoperation/SopInsertBulkTest.java
+++ b/src/test/manual/net/spy/memcached/bulkoperation/SopInsertBulkTest.java
@@ -33,12 +33,12 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
-public class SopInsertBulkTest extends BaseIntegrationTest {
+class SopInsertBulkTest extends BaseIntegrationTest {
 
   private String KEY = SopInsertBulkTest.class.getSimpleName();
 
   @Test
-  public void testInsertAndGet() {
+  void testInsertAndGet() {
     String value = "MyValue";
     int keySize = 500;
     String[] keys = new String[keySize];
@@ -102,7 +102,7 @@ public class SopInsertBulkTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testErrorCount() {
+  void testErrorCount() {
     String value = "MyValue";
     int keySize = 1200;
 

--- a/src/test/manual/net/spy/memcached/collection/CollectionFutureTest.java
+++ b/src/test/manual/net/spy/memcached/collection/CollectionFutureTest.java
@@ -31,7 +31,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class CollectionFutureTest extends BaseIntegrationTest {
+class CollectionFutureTest extends BaseIntegrationTest {
 
   private String key = "CollectionFutureTest";
 
@@ -43,7 +43,7 @@ public class CollectionFutureTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testAfterSuccess() throws Exception {
+  void testAfterSuccess() throws Exception {
     CollectionFuture<Boolean> future;
     OperationStatus status;
 
@@ -64,7 +64,7 @@ public class CollectionFutureTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testAfterFailure() throws Exception {
+  void testAfterFailure() throws Exception {
     CollectionFuture<Map<Long, Element<Object>>> future;
     OperationStatus status;
 

--- a/src/test/manual/net/spy/memcached/collection/CollectionMaxElementSize.java
+++ b/src/test/manual/net/spy/memcached/collection/CollectionMaxElementSize.java
@@ -29,7 +29,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
-public class CollectionMaxElementSize extends BaseIntegrationTest {
+class CollectionMaxElementSize extends BaseIntegrationTest {
 
   private String key = "CollectionMaxElementSize";
 
@@ -41,7 +41,7 @@ public class CollectionMaxElementSize extends BaseIntegrationTest {
   }
 
   @Test
-  public void testLargeSize() throws Exception {
+  void testLargeSize() throws Exception {
     int largeSize = 16 * 1024 - 2; //16KB
     StringBuilder sb = new StringBuilder();
     for (int i = 0; i < largeSize; i++) {
@@ -58,7 +58,7 @@ public class CollectionMaxElementSize extends BaseIntegrationTest {
   }
 
   @Test
-  public void testExceed() throws Exception {
+  void testExceed() throws Exception {
     CollectionFuture<Boolean> future;
     future = mc.asyncLopInsert(key, -1, "test", new CollectionAttributes());
     assertTrue(future.get(1000, TimeUnit.MILLISECONDS));

--- a/src/test/manual/net/spy/memcached/collection/ElementFlagFilterTest.java
+++ b/src/test/manual/net/spy/memcached/collection/ElementFlagFilterTest.java
@@ -24,10 +24,10 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.fail;
 
-public class ElementFlagFilterTest {
+class ElementFlagFilterTest {
 
   @Test
-  public void testValidate1() {
+  void testValidate1() {
     try {
       new ElementFlagFilter(null, null);
     } catch (NullPointerException e) {
@@ -37,7 +37,7 @@ public class ElementFlagFilterTest {
   }
 
   @Test
-  public void testValidate2() {
+  void testValidate2() {
     try {
       new ElementFlagFilter(null, "".getBytes());
     } catch (NullPointerException e) {
@@ -47,7 +47,7 @@ public class ElementFlagFilterTest {
   }
 
   @Test
-  public void testValidate3() {
+  void testValidate3() {
     try {
       new ElementFlagFilter(CompOperands.Equal, null);
     } catch (NullPointerException e) {
@@ -57,7 +57,7 @@ public class ElementFlagFilterTest {
   }
 
   @Test
-  public void testZeroLengthCompValue() {
+  void testZeroLengthCompValue() {
     try {
       ElementFlagFilter filter = new ElementFlagFilter(
               CompOperands.Equal, "".getBytes());
@@ -72,7 +72,7 @@ public class ElementFlagFilterTest {
   }
 
   @Test
-  public void testZeroLengthBitCompValue() {
+  void testZeroLengthBitCompValue() {
     try {
       ElementFlagFilter filter = new ElementFlagFilter(
               CompOperands.Equal, "A".getBytes());
@@ -89,7 +89,7 @@ public class ElementFlagFilterTest {
   }
 
   @Test
-  public void testConstruct() {
+  void testConstruct() {
     String src = "ABC";
 
     ElementFlagFilter filter = new ElementFlagFilter(CompOperands.Equal,

--- a/src/test/manual/net/spy/memcached/collection/attribute/BTreeGetAttrTest.java
+++ b/src/test/manual/net/spy/memcached/collection/attribute/BTreeGetAttrTest.java
@@ -31,7 +31,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
-public class BTreeGetAttrTest extends BaseIntegrationTest {
+class BTreeGetAttrTest extends BaseIntegrationTest {
 
   private final String KEY = this.getClass().getSimpleName();
   private final String VALUE = "VALUE";
@@ -53,7 +53,7 @@ public class BTreeGetAttrTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testGetTrimmedTest() {
+  void testGetTrimmedTest() {
     try {
       // create with default.
       CollectionAttributes attribute = new CollectionAttributes();
@@ -91,7 +91,7 @@ public class BTreeGetAttrTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testGetMinMaxBkeyTest() {
+  void testGetMinMaxBkeyTest() {
     try {
       assertTrue(mc.asyncBopCreate(KEY, ElementValueType.STRING,
               new CollectionAttributes()).get());
@@ -125,7 +125,7 @@ public class BTreeGetAttrTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testGetMinMaxBkeyByBytesTest() {
+  void testGetMinMaxBkeyByBytesTest() {
     try {
       assertTrue(mc.asyncBopCreate(KEY, ElementValueType.STRING,
               new CollectionAttributes()).get());
@@ -162,7 +162,7 @@ public class BTreeGetAttrTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testGetOverflowAttrTest() {
+  void testGetOverflowAttrTest() {
     try {
       assertTrue(mc.asyncBopCreate(KEY, ElementValueType.STRING,
               new CollectionAttributes()).get());

--- a/src/test/manual/net/spy/memcached/collection/attribute/GetAttrTest.java
+++ b/src/test/manual/net/spy/memcached/collection/attribute/GetAttrTest.java
@@ -31,12 +31,12 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class GetAttrTest extends BaseIntegrationTest {
+class GetAttrTest extends BaseIntegrationTest {
 
   private final String[] list = {"hello1", "hello2", "hello3"};
 
   @Test
-  public void testGetAttr_KV() throws Exception {
+  void testGetAttr_KV() throws Exception {
     String key = "testGetAttr_KV";
 
     mc.set(key, 100, "v").get();
@@ -50,7 +50,7 @@ public class GetAttrTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testGetAttr_ModifiedAttribute() throws Exception {
+  void testGetAttr_ModifiedAttribute() throws Exception {
     String key = "getattr_modified_attribute";
 
     addToList(key, list);
@@ -74,7 +74,7 @@ public class GetAttrTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testGetAttr_DefaultAttribute() throws Exception {
+  void testGetAttr_DefaultAttribute() throws Exception {
     String key = "getattr_default_attribute";
 
     addToList(key, list);
@@ -95,7 +95,7 @@ public class GetAttrTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testGetAttr_KeyNotFound() throws Exception {
+  void testGetAttr_KeyNotFound() throws Exception {
     CollectionFuture<CollectionAttributes> future = mc
             .asyncGetAttr("NOT_EXISTS");
 

--- a/src/test/manual/net/spy/memcached/collection/attribute/MaxBkeyRangeTest.java
+++ b/src/test/manual/net/spy/memcached/collection/attribute/MaxBkeyRangeTest.java
@@ -35,7 +35,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
-public class MaxBkeyRangeTest extends BaseIntegrationTest {
+class MaxBkeyRangeTest extends BaseIntegrationTest {
 
   private final String KEY = this.getClass().getSimpleName();
   private final long BKEY = 1;
@@ -59,7 +59,7 @@ public class MaxBkeyRangeTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testMaxBkeyRangeTest() {
+  void testMaxBkeyRangeTest() {
     try {
       // create with default.
       CollectionAttributes attribute = new CollectionAttributes();
@@ -125,7 +125,7 @@ public class MaxBkeyRangeTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testMaxBkeyRangeByBytesTest() {
+  void testMaxBkeyRangeByBytesTest() {
     try {
       // create with default.
       CollectionAttributes attribute = new CollectionAttributes();

--- a/src/test/manual/net/spy/memcached/collection/attribute/SetAttrTest.java
+++ b/src/test/manual/net/spy/memcached/collection/attribute/SetAttrTest.java
@@ -20,10 +20,10 @@ import net.spy.memcached.collection.BaseIntegrationTest;
 
 import org.junit.jupiter.api.Test;
 
-public class SetAttrTest extends BaseIntegrationTest {
+class SetAttrTest extends BaseIntegrationTest {
 
   @Test
-  public void testSetAttr() throws Exception {
+  void testSetAttr() throws Exception {
     // TODO: implement
   }
 

--- a/src/test/manual/net/spy/memcached/collection/attribute/UnReadableBTreeTest.java
+++ b/src/test/manual/net/spy/memcached/collection/attribute/UnReadableBTreeTest.java
@@ -36,7 +36,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
-public class UnReadableBTreeTest extends BaseIntegrationTest {
+class UnReadableBTreeTest extends BaseIntegrationTest {
 
   private final String KEY = this.getClass().getSimpleName();
   private final String VALUE = "VALUE";
@@ -58,7 +58,7 @@ public class UnReadableBTreeTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testCreateUnreadableBTreeTest() {
+  void testCreateUnreadableBTreeTest() {
     try {
       // create unreadable empty
       CollectionAttributes attribute = new CollectionAttributes();
@@ -106,7 +106,7 @@ public class UnReadableBTreeTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testCreateReadableBTreeTest() {
+  void testCreateReadableBTreeTest() {
     try {
       // create readable empty
       CollectionAttributes attribute = new CollectionAttributes();

--- a/src/test/manual/net/spy/memcached/collection/attribute/UnReadableExtendedBTreeTest.java
+++ b/src/test/manual/net/spy/memcached/collection/attribute/UnReadableExtendedBTreeTest.java
@@ -37,7 +37,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
-public class UnReadableExtendedBTreeTest extends BaseIntegrationTest {
+class UnReadableExtendedBTreeTest extends BaseIntegrationTest {
 
   private final String KEY = this.getClass().getSimpleName();
   private final String VALUE = "VALUE";
@@ -59,7 +59,7 @@ public class UnReadableExtendedBTreeTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testCreateUnreadableExtendedBTreeTest() {
+  void testCreateUnreadableExtendedBTreeTest() {
     try {
       // create unreadable empty
       CollectionAttributes attribute = new CollectionAttributes();
@@ -110,7 +110,7 @@ public class UnReadableExtendedBTreeTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testCreateReadableExtendedBTreeTest() {
+  void testCreateReadableExtendedBTreeTest() {
     try {
       // create readable empty
       CollectionAttributes attribute = new CollectionAttributes();

--- a/src/test/manual/net/spy/memcached/collection/attribute/UnReadableListTest.java
+++ b/src/test/manual/net/spy/memcached/collection/attribute/UnReadableListTest.java
@@ -34,7 +34,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
-public class UnReadableListTest extends BaseIntegrationTest {
+class UnReadableListTest extends BaseIntegrationTest {
 
   private final String KEY = this.getClass().getSimpleName();
   private final String VALUE = "VALUE";
@@ -56,7 +56,7 @@ public class UnReadableListTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testCreateUnreadableListTest() {
+  void testCreateUnreadableListTest() {
     try {
       // create unreadable empty
       CollectionAttributes attribute = new CollectionAttributes();
@@ -102,7 +102,7 @@ public class UnReadableListTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testCreateReadableListTest() {
+  void testCreateReadableListTest() {
     try {
       // create readable empty
       CollectionAttributes attribute = new CollectionAttributes();

--- a/src/test/manual/net/spy/memcached/collection/attribute/UnReadableMapTest.java
+++ b/src/test/manual/net/spy/memcached/collection/attribute/UnReadableMapTest.java
@@ -34,7 +34,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
-public class UnReadableMapTest extends BaseIntegrationTest {
+class UnReadableMapTest extends BaseIntegrationTest {
 
   private final String KEY = this.getClass().getSimpleName();
   private final String MKEY = "MKEY";
@@ -56,7 +56,7 @@ public class UnReadableMapTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testCreateUnreadableMapTest() {
+  void testCreateUnreadableMapTest() {
     try {
       // create unreadable empty
       CollectionAttributes attribute = new CollectionAttributes();
@@ -103,7 +103,7 @@ public class UnReadableMapTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testCreateReadableMapTest() {
+  void testCreateReadableMapTest() {
     try {
       // create readable empty
       CollectionAttributes attribute = new CollectionAttributes();

--- a/src/test/manual/net/spy/memcached/collection/attribute/UnReadableSetTest.java
+++ b/src/test/manual/net/spy/memcached/collection/attribute/UnReadableSetTest.java
@@ -34,7 +34,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
-public class UnReadableSetTest extends BaseIntegrationTest {
+class UnReadableSetTest extends BaseIntegrationTest {
 
   private final String KEY = this.getClass().getSimpleName();
   private final String VALUE = "VALUE";
@@ -56,7 +56,7 @@ public class UnReadableSetTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testCreateUnreadableSetTest() {
+  void testCreateUnreadableSetTest() {
     try {
       // create unreadable empty
       CollectionAttributes attribute = new CollectionAttributes();
@@ -103,7 +103,7 @@ public class UnReadableSetTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testCreateReadableSetTest() {
+  void testCreateReadableSetTest() {
     try {
       // create readable empty
       CollectionAttributes attribute = new CollectionAttributes();

--- a/src/test/manual/net/spy/memcached/collection/btree/BKeyObjectTest.java
+++ b/src/test/manual/net/spy/memcached/collection/btree/BKeyObjectTest.java
@@ -16,7 +16,7 @@ public class BKeyObjectTest {
   public final static byte[] byteArrayBkey = {0x35};
 
   @Test
-  public void createLongBkey() {
+  void createLongBkey() {
     final BKeyObject bKeyObject = new BKeyObject(longBkey);
 
     assertEquals(longBkey, (long) bKeyObject.getLongBKey());
@@ -29,7 +29,7 @@ public class BKeyObjectTest {
   }
 
   @Test
-  public void createByteArrayBkey() {
+  void createByteArrayBkey() {
     final BKeyObject bKeyObject = new BKeyObject(byteArrayBkey);
 
     assertEquals(byteArrayBkey, bKeyObject.getByteArrayBKeyRaw());
@@ -41,7 +41,7 @@ public class BKeyObjectTest {
   }
 
   @Test
-  public void compareLongBkeyTest() {
+  void compareLongBkeyTest() {
     BKeyObject bKeyObject = new BKeyObject(longBkey);
     BKeyObject another = new BKeyObject(longBkey);
 
@@ -49,7 +49,7 @@ public class BKeyObjectTest {
   }
 
   @Test
-  public void compareByteArrayBkeyTest() {
+  void compareByteArrayBkeyTest() {
     BKeyObject bKeyObject = new BKeyObject(byteArrayBkey);
     BKeyObject another = new BKeyObject(byteArrayBkey);
 
@@ -57,7 +57,7 @@ public class BKeyObjectTest {
   }
 
   @Test
-  public void compareDifferentTypeTest() {
+  void compareDifferentTypeTest() {
     final BKeyObject bKeyObject = new BKeyObject(longBkey);
     final BKeyObject another = new BKeyObject(byteArrayBkey);
 

--- a/src/test/manual/net/spy/memcached/collection/btree/BopDeleteTest.java
+++ b/src/test/manual/net/spy/memcached/collection/btree/BopDeleteTest.java
@@ -35,7 +35,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class BopDeleteTest extends BaseIntegrationTest {
+class BopDeleteTest extends BaseIntegrationTest {
 
   private String key = "UnReadableBTreeTest";
 
@@ -62,20 +62,20 @@ public class BopDeleteTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testBopDelete_NoKey() throws Exception {
+  void testBopDelete_NoKey() throws Exception {
     assertFalse(mc.asyncBopDelete("no_key", 0,
             ElementFlagFilter.DO_NOT_FILTER, false).get(1000,
             TimeUnit.MILLISECONDS));
   }
 
   @Test
-  public void testBopDelete_OutOfRange() throws Exception {
+  void testBopDelete_OutOfRange() throws Exception {
     assertFalse(mc.asyncBopDelete(key, 11, ElementFlagFilter.DO_NOT_FILTER,
             false).get(1000, TimeUnit.MILLISECONDS));
   }
 
   @Test
-  public void testBopDelete_DeleteByBestEffort() throws Exception {
+  void testBopDelete_DeleteByBestEffort() throws Exception {
     // Delete items(2..11) in the list
     assertTrue(mc.asyncBopDelete(key, 2, 11,
             ElementFlagFilter.DO_NOT_FILTER, 0, false).get(1000,
@@ -92,7 +92,7 @@ public class BopDeleteTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testBopDelete_DeletedDropped() throws Exception {
+  void testBopDelete_DeletedDropped() throws Exception {
     // Delete all items in the list
     assertTrue(mc.asyncBopDelete(key, 0, items9.length,
             ElementFlagFilter.DO_NOT_FILTER, 0, true).get(1000,
@@ -104,7 +104,7 @@ public class BopDeleteTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testBopDeleteWithSingleBkey() throws Exception {
+  void testBopDeleteWithSingleBkey() throws Exception {
     mc.delete(key).get();
 
     byte[] bkey = new byte[]{(byte) 1};

--- a/src/test/manual/net/spy/memcached/collection/btree/BopFindPositionTest.java
+++ b/src/test/manual/net/spy/memcached/collection/btree/BopFindPositionTest.java
@@ -31,7 +31,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
-public class BopFindPositionTest extends BaseIntegrationTest {
+class BopFindPositionTest extends BaseIntegrationTest {
 
   private String key = "BopFindPositionTest";
   private String invalidKey = "InvalidBopFindPositionTest";
@@ -55,7 +55,7 @@ public class BopFindPositionTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testLongBKeyAsc() throws Exception {
+  void testLongBKeyAsc() throws Exception {
     // insert
     CollectionAttributes attrs = new CollectionAttributes();
     for (long each : longBkeys) {
@@ -75,7 +75,7 @@ public class BopFindPositionTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testLongBKeyDesc() throws Exception {
+  void testLongBKeyDesc() throws Exception {
     // insert
     CollectionAttributes attrs = new CollectionAttributes();
     for (long each : longBkeys) {
@@ -96,7 +96,7 @@ public class BopFindPositionTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testByteArrayBKeyAsc() throws Exception {
+  void testByteArrayBKeyAsc() throws Exception {
     // insert
     CollectionAttributes attrs = new CollectionAttributes();
     for (byte[] each : byteArrayBkeys) {
@@ -116,7 +116,7 @@ public class BopFindPositionTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testByteArrayBKeyDesc() throws Exception {
+  void testByteArrayBKeyDesc() throws Exception {
     // insert
     CollectionAttributes attrs = new CollectionAttributes();
     for (byte[] each : byteArrayBkeys) {
@@ -137,7 +137,7 @@ public class BopFindPositionTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testUnsuccessfulResponses() throws Exception {
+  void testUnsuccessfulResponses() throws Exception {
     mc.delete(invalidKey).get();
     mc.delete(kvKey).get();
 

--- a/src/test/manual/net/spy/memcached/collection/btree/BopFindPositionWithGetTest.java
+++ b/src/test/manual/net/spy/memcached/collection/btree/BopFindPositionWithGetTest.java
@@ -35,7 +35,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class BopFindPositionWithGetTest extends BaseIntegrationTest {
+class BopFindPositionWithGetTest extends BaseIntegrationTest {
 
   private String key = "BopFindPositionWithGetTest";
   private String invalidKey = "InvalidBopFindPositionWithGetTest";
@@ -49,7 +49,7 @@ public class BopFindPositionWithGetTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testLongBKeyAsc() throws Exception {
+  void testLongBKeyAsc() throws Exception {
     long longBkey, resultBkey;
     int totCount = 100;
     int pwgCount = 10;
@@ -97,7 +97,7 @@ public class BopFindPositionWithGetTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testLongBKeyDesc() throws Exception {
+  void testLongBKeyDesc() throws Exception {
     long longBkey, resultBkey;
     int totCount = 100;
     int pwgCount = 10;
@@ -145,7 +145,7 @@ public class BopFindPositionWithGetTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testByteArrayBKeyAsc() throws Exception {
+  void testByteArrayBKeyAsc() throws Exception {
     byte[] byteBkey, resultBkey;
     int totCount = 100;
     int pwgCount = 10;
@@ -198,7 +198,7 @@ public class BopFindPositionWithGetTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testByteArrayBKeyDesc() throws Exception {
+  void testByteArrayBKeyDesc() throws Exception {
     byte[] byteBkey, resultBkey;
     int totCount = 100;
     int pwgCount = 10;
@@ -251,7 +251,7 @@ public class BopFindPositionWithGetTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testUnsuccessfulResponses() throws Exception {
+  void testUnsuccessfulResponses() throws Exception {
     mc.delete(invalidKey).get();
     mc.delete(kvKey).get();
 

--- a/src/test/manual/net/spy/memcached/collection/btree/BopGetBulkTest.java
+++ b/src/test/manual/net/spy/memcached/collection/btree/BopGetBulkTest.java
@@ -40,7 +40,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
-public class BopGetBulkTest extends BaseIntegrationTest {
+class BopGetBulkTest extends BaseIntegrationTest {
 
   private final List<String> keyList = new ArrayList<String>() {
     private static final long serialVersionUID = -4044682425313432602L;
@@ -74,7 +74,7 @@ public class BopGetBulkTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testGetBulkLongBkeyGetAll() {
+  void testGetBulkLongBkeyGetAll() {
     try {
       ElementFlagFilter filter = ElementFlagFilter.DO_NOT_FILTER;
 
@@ -133,7 +133,7 @@ public class BopGetBulkTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testGetBulkNotFoundAll() {
+  void testGetBulkNotFoundAll() {
     try {
       for (int i = 0; i < keyList.size(); i++) {
         mc.delete(keyList.get(i)).get();
@@ -180,7 +180,7 @@ public class BopGetBulkTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testGetBulkNotFoundMixed() {
+  void testGetBulkNotFoundMixed() {
     try {
       // delete some data.
       for (int i = 0; i < keyList.size(); i++) {
@@ -250,7 +250,7 @@ public class BopGetBulkTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testErrorArguments() {
+  void testErrorArguments() {
     try {
       Map<String, BTreeGetResult<Long, Object>> results = null;
       CollectionGetBulkFuture<Map<String, BTreeGetResult<Long, Object>>> f = null;
@@ -280,7 +280,7 @@ public class BopGetBulkTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testUnreadable() {
+  void testUnreadable() {
     try {
       Map<String, BTreeGetResult<Long, Object>> results = null;
       CollectionGetBulkFuture<Map<String, BTreeGetResult<Long, Object>>> f = null;
@@ -304,7 +304,7 @@ public class BopGetBulkTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testNotFoundElement() {
+  void testNotFoundElement() {
     try {
       Map<String, BTreeGetResult<Long, Object>> results = null;
       CollectionGetBulkFuture<Map<String, BTreeGetResult<Long, Object>>> f = null;
@@ -333,7 +333,7 @@ public class BopGetBulkTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testTypeMismatch() {
+  void testTypeMismatch() {
     try {
       Map<String, BTreeGetResult<Long, Object>> results = null;
       CollectionGetBulkFuture<Map<String, BTreeGetResult<Long, Object>>> f = null;
@@ -354,7 +354,7 @@ public class BopGetBulkTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testBKeyMismatch() {
+  void testBKeyMismatch() {
     try {
       Map<String, BTreeGetResult<Long, Object>> results = null;
       CollectionGetBulkFuture<Map<String, BTreeGetResult<Long, Object>>> f = null;

--- a/src/test/manual/net/spy/memcached/collection/btree/BopGetByPositionTest.java
+++ b/src/test/manual/net/spy/memcached/collection/btree/BopGetByPositionTest.java
@@ -38,7 +38,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
-public class BopGetByPositionTest extends BaseIntegrationTest {
+class BopGetByPositionTest extends BaseIntegrationTest {
 
   private String key = "BopGetByPositionTest";
   private String invalidKey = "InvalidBopGetByPositionTest";
@@ -78,7 +78,7 @@ public class BopGetByPositionTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testLongBKeySingle() throws Exception {
+  void testLongBKeySingle() throws Exception {
     // insert
     CollectionAttributes attrs = new CollectionAttributes();
     for (long each : longBkeys) {
@@ -108,7 +108,7 @@ public class BopGetByPositionTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testLongBKeySingleWithoutEflag() throws Exception {
+  void testLongBKeySingleWithoutEflag() throws Exception {
     // insert
     CollectionAttributes attrs = new CollectionAttributes();
     for (long each : longBkeys) {
@@ -138,7 +138,7 @@ public class BopGetByPositionTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testLongBKeyMultiple() throws Exception {
+  void testLongBKeyMultiple() throws Exception {
     // insert
     CollectionAttributes attrs = new CollectionAttributes();
     for (long each : longBkeys) {
@@ -171,7 +171,7 @@ public class BopGetByPositionTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testLongBKeyMultipleReversed() throws Exception {
+  void testLongBKeyMultipleReversed() throws Exception {
     // insert
     CollectionAttributes attrs = new CollectionAttributes();
     for (long each : longBkeys) {
@@ -204,7 +204,7 @@ public class BopGetByPositionTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testByteArrayBKeySingle() throws Exception {
+  void testByteArrayBKeySingle() throws Exception {
     // insert
     CollectionAttributes attrs = new CollectionAttributes();
     for (byte[] each : byteArrayBkeys) {
@@ -234,7 +234,7 @@ public class BopGetByPositionTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testByteArrayBKeySingleWithoutEflag() throws Exception {
+  void testByteArrayBKeySingleWithoutEflag() throws Exception {
     // insert
     CollectionAttributes attrs = new CollectionAttributes();
     for (byte[] each : byteArrayBkeys) {
@@ -264,7 +264,7 @@ public class BopGetByPositionTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testByteArrayBKeyMultiple() throws Exception {
+  void testByteArrayBKeyMultiple() throws Exception {
     // insert
     CollectionAttributes attrs = new CollectionAttributes();
     for (byte[] each : byteArrayBkeys) {
@@ -297,7 +297,7 @@ public class BopGetByPositionTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testByteArrayBKeyMultipleReversed() throws Exception {
+  void testByteArrayBKeyMultipleReversed() throws Exception {
     // insert
     CollectionAttributes attrs = new CollectionAttributes();
     for (byte[] each : byteArrayBkeys) {
@@ -330,7 +330,7 @@ public class BopGetByPositionTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testUnsuccessfulResponses() throws Exception {
+  void testUnsuccessfulResponses() throws Exception {
     mc.delete(invalidKey).get();
     mc.delete(kvKey).get();
 
@@ -388,7 +388,7 @@ public class BopGetByPositionTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testAscDesc() throws Exception {
+  void testAscDesc() throws Exception {
     // insert
     CollectionAttributes attrs = new CollectionAttributes();
     for (long each : longBkeys) {
@@ -478,7 +478,7 @@ public class BopGetByPositionTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testInvalidArgumentException() throws Exception {
+  void testInvalidArgumentException() throws Exception {
     // insert
     CollectionAttributes attrs = new CollectionAttributes();
     for (long each : longBkeys) {

--- a/src/test/manual/net/spy/memcached/collection/btree/BopGetExceptionTest.java
+++ b/src/test/manual/net/spy/memcached/collection/btree/BopGetExceptionTest.java
@@ -32,7 +32,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class BopGetExceptionTest extends BaseIntegrationTest {
+class BopGetExceptionTest extends BaseIntegrationTest {
 
   private String key = "BopGetExceptionTest";
 
@@ -47,7 +47,7 @@ public class BopGetExceptionTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testBopGet_OutOfBound() throws Exception {
+  void testBopGet_OutOfBound() throws Exception {
     // Create a list and add 10 items in it
     addToBTree(key, items10);
 
@@ -66,7 +66,7 @@ public class BopGetExceptionTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testBopGet_NoKey() throws Exception {
+  void testBopGet_NoKey() throws Exception {
     // Querying to non-existing collection
     Map<Long, Element<Long>> rmap = mc.asyncBopGet(key, 0, 100,
             ElementFlagFilter.DO_NOT_FILTER, 0, 10, false, false,

--- a/src/test/manual/net/spy/memcached/collection/btree/BopGetIrregularEflagTest.java
+++ b/src/test/manual/net/spy/memcached/collection/btree/BopGetIrregularEflagTest.java
@@ -30,7 +30,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.fail;
 
-public class BopGetIrregularEflagTest extends BaseIntegrationTest {
+class BopGetIrregularEflagTest extends BaseIntegrationTest {
 
   private final String key = "BopGetIrregularEflagTest";
 
@@ -39,7 +39,7 @@ public class BopGetIrregularEflagTest extends BaseIntegrationTest {
   private final Object value = "valvalvalvalvalvalvalvalvalval";
 
   @Test
-  public void testGetAll_1() {
+  void testGetAll_1() {
     try {
       mc.delete(key).get();
       mc.asyncBopInsert(key, 0, eFlag, value + "0",
@@ -66,7 +66,7 @@ public class BopGetIrregularEflagTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testGetAll_2() {
+  void testGetAll_2() {
     try {
       mc.delete(key).get();
       mc.asyncBopInsert(key, 0, null, value + "0",
@@ -93,7 +93,7 @@ public class BopGetIrregularEflagTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testGetAll_3() {
+  void testGetAll_3() {
     try {
       mc.delete(key).get();
       mc.asyncBopInsert(key, 0, eFlag, value + "0",
@@ -120,7 +120,7 @@ public class BopGetIrregularEflagTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testGetAll_4() {
+  void testGetAll_4() {
     try {
       mc.delete(key).get();
       mc.asyncBopInsert(key, 0, null, value + "0",

--- a/src/test/manual/net/spy/memcached/collection/btree/BopGetOffsetSupportTest.java
+++ b/src/test/manual/net/spy/memcached/collection/btree/BopGetOffsetSupportTest.java
@@ -32,7 +32,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class BopGetOffsetSupportTest extends BaseIntegrationTest {
+class BopGetOffsetSupportTest extends BaseIntegrationTest {
 
   private String key = "BopGetOffsetSupportTest";
 
@@ -46,7 +46,7 @@ public class BopGetOffsetSupportTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testBopGetOffset_Normal() throws Exception {
+  void testBopGetOffset_Normal() throws Exception {
     // Create a list and add 10 items in it
     addToBTree(key, items10);
 
@@ -75,7 +75,7 @@ public class BopGetOffsetSupportTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testBopGetOffset_More() throws Exception {
+  void testBopGetOffset_More() throws Exception {
     // Create a list and add 10 items in it
     addToBTree(key, items10);
 

--- a/src/test/manual/net/spy/memcached/collection/btree/BopGetSortTest.java
+++ b/src/test/manual/net/spy/memcached/collection/btree/BopGetSortTest.java
@@ -32,7 +32,7 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class BopGetSortTest extends BaseIntegrationTest {
+class BopGetSortTest extends BaseIntegrationTest {
 
   private String key = "BopGetSortTest";
 
@@ -46,7 +46,7 @@ public class BopGetSortTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testBopGet_Asc() throws Exception {
+  void testBopGet_Asc() throws Exception {
     // Create a list and add 10 items in it
     addToBTree(key, items10);
 
@@ -82,7 +82,7 @@ public class BopGetSortTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testBopGet_Desc() throws Exception {
+  void testBopGet_Desc() throws Exception {
     // Create a list and add 10 items in it
     addToBTree(key, items10);
 

--- a/src/test/manual/net/spy/memcached/collection/btree/BopInsertAndGetTest.java
+++ b/src/test/manual/net/spy/memcached/collection/btree/BopInsertAndGetTest.java
@@ -36,7 +36,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class BopInsertAndGetTest extends BaseIntegrationTest {
+class BopInsertAndGetTest extends BaseIntegrationTest {
 
   private String key = "BopStoreAndGetTest";
   private String invalidKey = "InvalidBopStoreAndGetTest";
@@ -60,7 +60,7 @@ public class BopInsertAndGetTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testInsertAndGetNotTrimmed() throws Exception {
+  void testInsertAndGetNotTrimmed() throws Exception {
     //given
     CollectionAttributes attrs = new CollectionAttributes();
     attrs.setMaxCount(longBkeys.length + 1);
@@ -78,7 +78,7 @@ public class BopInsertAndGetTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testInsertAndGetTrimmedLongBKey() throws Exception {
+  void testInsertAndGetTrimmedLongBKey() throws Exception {
     // insert test data
     CollectionAttributes attrs = new CollectionAttributes();
     attrs.setMaxCount(10);
@@ -117,7 +117,7 @@ public class BopInsertAndGetTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testInsertAndGetTrimmedByteArrayBKey() throws Exception {
+  void testInsertAndGetTrimmedByteArrayBKey() throws Exception {
     // insert test data
     CollectionAttributes attrs = new CollectionAttributes();
     attrs.setMaxCount(10);
@@ -161,7 +161,7 @@ public class BopInsertAndGetTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testInsertAndGetTrimmedLongBKeyLargest() throws Exception {
+  void testInsertAndGetTrimmedLongBKeyLargest() throws Exception {
     // insert test data
     CollectionAttributes attrs = new CollectionAttributes();
     attrs.setMaxCount(10);
@@ -200,7 +200,7 @@ public class BopInsertAndGetTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testInsertAndGetTrimmedByteArrayBKeyLargest() throws Exception {
+  void testInsertAndGetTrimmedByteArrayBKeyLargest() throws Exception {
     // insert test data
     CollectionAttributes attrs = new CollectionAttributes();
     attrs.setMaxCount(10);
@@ -244,7 +244,7 @@ public class BopInsertAndGetTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testUpsertAndGetTrimmedLongBKey() throws Exception {
+  void testUpsertAndGetTrimmedLongBKey() throws Exception {
     // insert test data
     CollectionAttributes attrs = new CollectionAttributes();
     attrs.setMaxCount(10);
@@ -283,7 +283,7 @@ public class BopInsertAndGetTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testUpsertAndGetTrimmedByteArrayBKey() throws Exception {
+  void testUpsertAndGetTrimmedByteArrayBKey() throws Exception {
     // insert test data
     CollectionAttributes attrs = new CollectionAttributes();
     attrs.setMaxCount(10);
@@ -327,7 +327,7 @@ public class BopInsertAndGetTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testUpsertAndGetTrimmedLongBKeyLargest() throws Exception {
+  void testUpsertAndGetTrimmedLongBKeyLargest() throws Exception {
     // insert test data
     CollectionAttributes attrs = new CollectionAttributes();
     attrs.setMaxCount(10);
@@ -366,7 +366,7 @@ public class BopInsertAndGetTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testUpsertAndGetTrimmedByteArrayBKeyLargest() throws Exception {
+  void testUpsertAndGetTrimmedByteArrayBKeyLargest() throws Exception {
     // insert test data
     CollectionAttributes attrs = new CollectionAttributes();
     attrs.setMaxCount(10);
@@ -410,7 +410,7 @@ public class BopInsertAndGetTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testInsertAndGetTrimmedOtherResponses() throws Exception {
+  void testInsertAndGetTrimmedOtherResponses() throws Exception {
     // insert test data
     CollectionAttributes attrs = new CollectionAttributes();
     attrs.setMaxCount(10);
@@ -463,7 +463,7 @@ public class BopInsertAndGetTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testUpsertAndGetTrimmedOtherResponses() throws Exception {
+  void testUpsertAndGetTrimmedOtherResponses() throws Exception {
     // insert test data
     CollectionAttributes attrs = new CollectionAttributes();
     attrs.setMaxCount(10);

--- a/src/test/manual/net/spy/memcached/collection/btree/BopInsertAndGetWithElementFlagTest.java
+++ b/src/test/manual/net/spy/memcached/collection/btree/BopInsertAndGetWithElementFlagTest.java
@@ -34,7 +34,7 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class BopInsertAndGetWithElementFlagTest extends BaseIntegrationTest {
+class BopInsertAndGetWithElementFlagTest extends BaseIntegrationTest {
 
   private final String KEY = this.getClass().getSimpleName();
   private final long BKEY = 10L;
@@ -56,7 +56,7 @@ public class BopInsertAndGetWithElementFlagTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testBopInsertAndGetWithEFlag() throws Exception {
+  void testBopInsertAndGetWithEFlag() throws Exception {
     assertTrue(mc.asyncBopInsert(KEY, BKEY, FLAG, VALUE,
             new CollectionAttributes()).get());
 
@@ -69,7 +69,7 @@ public class BopInsertAndGetWithElementFlagTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testBopInsertAndGetWithoutEFlag() throws Exception {
+  void testBopInsertAndGetWithoutEFlag() throws Exception {
     assertTrue(mc.asyncBopInsert(KEY, BKEY, null, VALUE,
             new CollectionAttributes()).get());
 
@@ -82,7 +82,7 @@ public class BopInsertAndGetWithElementFlagTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testBopInsertAndRangedGetWithEFlag() throws Exception {
+  void testBopInsertAndRangedGetWithEFlag() throws Exception {
 
     // insert 3 bkeys
     assertTrue(mc.asyncBopInsert(KEY, BKEY, FLAG, VALUE,
@@ -103,7 +103,7 @@ public class BopInsertAndGetWithElementFlagTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testBopInsertAndRangedGetWithoutEFlag() throws Exception {
+  void testBopInsertAndRangedGetWithoutEFlag() throws Exception {
 
     // insert 3 bkeys
     assertTrue(mc.asyncBopInsert(KEY, BKEY, null, VALUE,
@@ -124,7 +124,7 @@ public class BopInsertAndGetWithElementFlagTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testGetAllOfNotFlaggedBkeys() throws Exception {
+  void testGetAllOfNotFlaggedBkeys() throws Exception {
     // insert 3 bkeys
     assertTrue(mc.asyncBopInsert(KEY, BKEY, null, VALUE,
             new CollectionAttributes()).get());
@@ -149,7 +149,7 @@ public class BopInsertAndGetWithElementFlagTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testBopInsertAndRangedGetWithEFlags() throws Exception {
+  void testBopInsertAndRangedGetWithEFlags() throws Exception {
 
     assertTrue(mc.asyncBopInsert(KEY, BKEY, new byte[]{0}, VALUE,
             new CollectionAttributes()).get());

--- a/src/test/manual/net/spy/memcached/collection/btree/BopInsertWhenKeyExists.java
+++ b/src/test/manual/net/spy/memcached/collection/btree/BopInsertWhenKeyExists.java
@@ -36,7 +36,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class BopInsertWhenKeyExists extends BaseIntegrationTest {
+class BopInsertWhenKeyExists extends BaseIntegrationTest {
 
   private String key = "BopInsertWhenKeyExists";
 
@@ -52,7 +52,7 @@ public class BopInsertWhenKeyExists extends BaseIntegrationTest {
   }
 
   @Test
-  public void testBopInsert_unreadable_largestTrim() throws Exception {
+  void testBopInsert_unreadable_largestTrim() throws Exception {
     // insert with unreadable
     CollectionAttributes attr = new CollectionAttributes();
     attr.setReadable(false);
@@ -78,7 +78,7 @@ public class BopInsertWhenKeyExists extends BaseIntegrationTest {
   }
 
   @Test
-  public void testBopInsert_Normal() throws Exception {
+  void testBopInsert_Normal() throws Exception {
     // Create a list and add it 9 items
     addToBTree(key, items9);
 
@@ -105,7 +105,7 @@ public class BopInsertWhenKeyExists extends BaseIntegrationTest {
   }
 
   @Test
-  public void testBopInsert_SameItem() throws Exception {
+  void testBopInsert_SameItem() throws Exception {
     // Create a list and add it 9 items
     addToBTree(key, items9);
 
@@ -126,7 +126,7 @@ public class BopInsertWhenKeyExists extends BaseIntegrationTest {
   }
 
   @Test
-  public void testBopInsert_SameBkey() throws Exception {
+  void testBopInsert_SameBkey() throws Exception {
     // Create a list and add it 9 items
     addToBTree(key, items9);
 

--- a/src/test/manual/net/spy/memcached/collection/btree/BopInsertWhenKeyNotExist.java
+++ b/src/test/manual/net/spy/memcached/collection/btree/BopInsertWhenKeyNotExist.java
@@ -28,7 +28,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
-public class BopInsertWhenKeyNotExist extends BaseIntegrationTest {
+class BopInsertWhenKeyNotExist extends BaseIntegrationTest {
 
   private String key = "BopInsertWhenKeyNotExist";
 
@@ -51,7 +51,7 @@ public class BopInsertWhenKeyNotExist extends BaseIntegrationTest {
    * </pre>
    */
   @Test
-  public void testBopInsert_nokey_01() throws Exception {
+  void testBopInsert_nokey_01() throws Exception {
     insertToFail(key, true, null);
   }
 
@@ -62,7 +62,7 @@ public class BopInsertWhenKeyNotExist extends BaseIntegrationTest {
    * </pre>
    */
   @Test
-  public void testBopInsert_nokey_02() throws Exception {
+  void testBopInsert_nokey_02() throws Exception {
     assertFalse(insertToSucceed(key, false, items9[0]));
   }
 
@@ -73,7 +73,7 @@ public class BopInsertWhenKeyNotExist extends BaseIntegrationTest {
    * </pre>
    */
   @Test
-  public void testBopInsert_nokey_04() throws Exception {
+  void testBopInsert_nokey_04() throws Exception {
     assertFalse(insertToSucceed(key, false, items9[0]));
   }
 
@@ -84,7 +84,7 @@ public class BopInsertWhenKeyNotExist extends BaseIntegrationTest {
    * </pre>
    */
   @Test
-  public void testBopInsert_nokey_05() throws Exception {
+  void testBopInsert_nokey_05() throws Exception {
     assertTrue(insertToSucceed(key, true, items9[0]));
   }
 

--- a/src/test/manual/net/spy/memcached/collection/btree/BopOverflowActionTest.java
+++ b/src/test/manual/net/spy/memcached/collection/btree/BopOverflowActionTest.java
@@ -38,7 +38,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
-public class BopOverflowActionTest extends BaseIntegrationTest {
+class BopOverflowActionTest extends BaseIntegrationTest {
 
   private String key = "BopGetBoundaryTest";
   private List<String> keyList = new ArrayList<>();
@@ -82,7 +82,7 @@ public class BopOverflowActionTest extends BaseIntegrationTest {
 //  }
 
   @Test
-  public void testBopGet_Overflow() throws Exception {
+  void testBopGet_Overflow() throws Exception {
     // Create a B+ Tree
     mc.asyncBopInsert(key, 0, null, "item0", new CollectionAttributes()).get();
 
@@ -118,7 +118,7 @@ public class BopOverflowActionTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testBopGet_LargestTrim() throws Exception {
+  void testBopGet_LargestTrim() throws Exception {
     // Create a B+ Tree
     mc.asyncBopInsert(key, 0, null, "item0", new CollectionAttributes()).get();
 
@@ -154,7 +154,7 @@ public class BopOverflowActionTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testBopGet_SmallestTrim() throws Exception {
+  void testBopGet_SmallestTrim() throws Exception {
     // Create a B+ Tree
     mc.asyncBopInsert(key, 0, null, "item0", new CollectionAttributes()).get();
 
@@ -190,7 +190,7 @@ public class BopOverflowActionTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testBopGet_SmallestTrim_OutOfRange() throws Exception {
+  void testBopGet_SmallestTrim_OutOfRange() throws Exception {
     // Create a set
     mc.asyncBopInsert(key, 1, null, "item1", new CollectionAttributes()).get();
 
@@ -208,7 +208,7 @@ public class BopOverflowActionTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testBopGet_LargestTrim_OutOfRange() throws Exception {
+  void testBopGet_LargestTrim_OutOfRange() throws Exception {
     // Create a set
     mc.asyncBopInsert(key, 1, null, "item1", new CollectionAttributes()).get();
 
@@ -226,7 +226,7 @@ public class BopOverflowActionTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testBopGet_AvailableOverflowAction() throws Exception {
+  void testBopGet_AvailableOverflowAction() throws Exception {
     // Create a set
     mc.asyncBopInsert(key, 0, null, "item0", new CollectionAttributes()).get();
 
@@ -261,7 +261,7 @@ public class BopOverflowActionTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testBopGet_notAvailableOverflowAction() {
+  void testBopGet_notAvailableOverflowAction() {
     CollectionAttributes attributesForCreate = new CollectionAttributes();
 
     // create

--- a/src/test/manual/net/spy/memcached/collection/btree/BopServerMessageTest.java
+++ b/src/test/manual/net/spy/memcached/collection/btree/BopServerMessageTest.java
@@ -37,7 +37,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class BopServerMessageTest extends BaseIntegrationTest {
+class BopServerMessageTest extends BaseIntegrationTest {
 
   private String key = "BopServerMessageTest";
 
@@ -56,7 +56,7 @@ public class BopServerMessageTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testNotFound() throws Exception {
+  void testNotFound() throws Exception {
     CollectionFuture<Map<Long, Element<Object>>> future = mc.asyncBopGet(
             key, 0, ElementFlagFilter.DO_NOT_FILTER, false, false);
     assertNull(future.get(1000, TimeUnit.MILLISECONDS));
@@ -67,7 +67,7 @@ public class BopServerMessageTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testNotFoundElement() throws Exception {
+  void testNotFoundElement() throws Exception {
     CollectionFuture<Boolean> future = mc.asyncBopInsert(
         key, 0, null, 0, new CollectionAttributes());
     assertTrue(future.get(1000, TimeUnit.MILLISECONDS));
@@ -82,7 +82,7 @@ public class BopServerMessageTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testCreatedStored() throws Exception {
+  void testCreatedStored() throws Exception {
     CollectionFuture<Boolean> future = mc.asyncBopInsert(
         key, 0, null, 0, new CollectionAttributes());
     assertTrue(future.get(1000, TimeUnit.MILLISECONDS));
@@ -93,7 +93,7 @@ public class BopServerMessageTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testStored() throws Exception {
+  void testStored() throws Exception {
     CollectionFuture<Boolean> future = mc.asyncBopInsert(
         key, 0, null, 0, new CollectionAttributes());
     assertTrue(future.get(1000, TimeUnit.MILLISECONDS));
@@ -107,7 +107,7 @@ public class BopServerMessageTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testOutOfRange() throws Exception {
+  void testOutOfRange() throws Exception {
     CollectionFuture<Boolean> future = mc.asyncBopInsert(
         key, 1, null, "aaa", new CollectionAttributes());
     assertTrue(future.get(1000, TimeUnit.MILLISECONDS));
@@ -125,7 +125,7 @@ public class BopServerMessageTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testOverflowed() throws Exception {
+  void testOverflowed() throws Exception {
     CollectionFuture<Boolean> future = mc.asyncBopInsert(
         key, 0, null, "aaa", new CollectionAttributes());
     assertTrue(future.get(1000, TimeUnit.MILLISECONDS));
@@ -143,7 +143,7 @@ public class BopServerMessageTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testElementExists() throws Exception {
+  void testElementExists() throws Exception {
     // create
     CollectionFuture<Boolean> future = mc.asyncBopInsert(
         key, 0, null, "aaa", new CollectionAttributes());
@@ -159,7 +159,7 @@ public class BopServerMessageTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testDeletedDropped() throws Exception {
+  void testDeletedDropped() throws Exception {
     // create
     CollectionFuture<Boolean> future = mc.asyncBopInsert(
         key, 0, null, "aaa", new CollectionAttributes());
@@ -175,7 +175,7 @@ public class BopServerMessageTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testDeleted() throws Exception {
+  void testDeleted() throws Exception {
     // create
     CollectionFuture<Boolean> future = mc.asyncBopInsert(
         key, 0, null, "aaa", new CollectionAttributes());
@@ -195,7 +195,7 @@ public class BopServerMessageTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testDeletedDroppedAfterRetrieval() throws Exception {
+  void testDeletedDroppedAfterRetrieval() throws Exception {
     // create
     CollectionFuture<Boolean> future = mc.asyncBopInsert(
         key, 0, null, "aaa", new CollectionAttributes());
@@ -212,7 +212,7 @@ public class BopServerMessageTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testDeletedAfterRetrieval() throws Exception {
+  void testDeletedAfterRetrieval() throws Exception {
     // create
     CollectionFuture<Boolean> future = mc.asyncBopInsert(
         key, 0, null, "aaa", new CollectionAttributes());

--- a/src/test/manual/net/spy/memcached/collection/btree/BopSortMergeOldTest.java
+++ b/src/test/manual/net/spy/memcached/collection/btree/BopSortMergeOldTest.java
@@ -37,7 +37,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
-public class BopSortMergeOldTest extends BaseIntegrationTest {
+class BopSortMergeOldTest extends BaseIntegrationTest {
 
   private final List<String> keyList3 = new ArrayList<>();
   private final List<String> keyList2 = new ArrayList<>();
@@ -65,7 +65,7 @@ public class BopSortMergeOldTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testBopSortMergeOldDesc1() throws Exception {
+  void testBopSortMergeOldDesc1() throws Exception {
     long bkeyFrom;
     long bkeyTo;
 
@@ -215,7 +215,7 @@ public class BopSortMergeOldTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testBopSortMergeOldDesc2() throws Exception {
+  void testBopSortMergeOldDesc2() throws Exception {
     long bkeyFrom;
     long bkeyTo;
 
@@ -383,7 +383,7 @@ public class BopSortMergeOldTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testBopSortMergeOldDesc3() throws Exception {
+  void testBopSortMergeOldDesc3() throws Exception {
     long bkeyFrom;
     long bkeyTo;
 
@@ -455,7 +455,7 @@ public class BopSortMergeOldTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testBopSortMergeOldDesc4() throws Exception {
+  void testBopSortMergeOldDesc4() throws Exception {
 
     // insert test data
     // key list (maxcount = 10)

--- a/src/test/manual/net/spy/memcached/collection/btree/BopSortMergeTest.java
+++ b/src/test/manual/net/spy/memcached/collection/btree/BopSortMergeTest.java
@@ -41,7 +41,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
-public class BopSortMergeTest extends BaseIntegrationTest {
+class BopSortMergeTest extends BaseIntegrationTest {
 
   private final List<String> keyList3 = new ArrayList<>();
   private final List<String> keyList2 = new ArrayList<>();
@@ -68,7 +68,7 @@ public class BopSortMergeTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testBopSortMergeAscDuplicate1() throws Exception {
+  void testBopSortMergeAscDuplicate1() throws Exception {
     long bkeyFrom;
     long bkeyTo;
     int queryCount;
@@ -157,7 +157,7 @@ public class BopSortMergeTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testBopSortMergeAscUnique1() throws Exception {
+  void testBopSortMergeAscUnique1() throws Exception {
     long bkeyFrom;
     long bkeyTo;
     int queryCount;
@@ -249,7 +249,7 @@ public class BopSortMergeTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testBopSortMergeDescDuplicate1() throws Exception {
+  void testBopSortMergeDescDuplicate1() throws Exception {
     long bkeyFrom;
     long bkeyTo;
 
@@ -417,7 +417,7 @@ public class BopSortMergeTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testBopSortMergeDescUnique1() throws Exception {
+  void testBopSortMergeDescUnique1() throws Exception {
     long bkeyFrom;
     long bkeyTo;
 
@@ -587,7 +587,7 @@ public class BopSortMergeTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testBopSortMergeAscDuplicate2() throws Exception {
+  void testBopSortMergeAscDuplicate2() throws Exception {
     long bkeyFrom;
     long bkeyTo;
     int queryCount;
@@ -676,7 +676,7 @@ public class BopSortMergeTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testBopSortMergeAscUnique2() throws Exception {
+  void testBopSortMergeAscUnique2() throws Exception {
     long bkeyFrom;
     long bkeyTo;
     int queryCount;
@@ -768,7 +768,7 @@ public class BopSortMergeTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testBopSortMergeDescDuplicate2() throws Exception {
+  void testBopSortMergeDescDuplicate2() throws Exception {
     long bkeyFrom;
     long bkeyTo;
 
@@ -936,7 +936,7 @@ public class BopSortMergeTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testBopSortMergeDescUnique2() throws Exception {
+  void testBopSortMergeDescUnique2() throws Exception {
     long bkeyFrom;
     long bkeyTo;
 
@@ -1108,7 +1108,7 @@ public class BopSortMergeTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testBopSortMergeDescDuplicate3() throws Exception {
+  void testBopSortMergeDescDuplicate3() throws Exception {
     // insert test data
     // key list (maxcount = 10)
     CollectionAttributes attrs = new CollectionAttributes();
@@ -1203,7 +1203,7 @@ public class BopSortMergeTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testBopSortMergeDescUnique3() throws Exception {
+  void testBopSortMergeDescUnique3() throws Exception {
     // insert test data
     // key list (maxcount = 10)
     CollectionAttributes attrs = new CollectionAttributes();

--- a/src/test/manual/net/spy/memcached/collection/btree/BopUpdateTest.java
+++ b/src/test/manual/net/spy/memcached/collection/btree/BopUpdateTest.java
@@ -35,7 +35,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
-public class BopUpdateTest extends BaseIntegrationTest {
+class BopUpdateTest extends BaseIntegrationTest {
 
   private final String KEY = this.getClass().getSimpleName();
 
@@ -70,7 +70,7 @@ public class BopUpdateTest extends BaseIntegrationTest {
   //
 
   @Test
-  public void testUpdateZeroLengthEflag() {
+  void testUpdateZeroLengthEflag() {
     byte[] eflag = new byte[]{0, 0, 0, 0};
 
     try {
@@ -91,7 +91,7 @@ public class BopUpdateTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testUpdatePaddingRequired() {
+  void testUpdatePaddingRequired() {
     byte[] eflag = new byte[]{1, 0, 0, 0};
 
     try {
@@ -112,7 +112,7 @@ public class BopUpdateTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testUpdateExceededLengthEFlag() {
+  void testUpdateExceededLengthEFlag() {
     byte[] eflag = "1234567890123456789012345678901234567890".getBytes();
 
     try {
@@ -132,7 +132,7 @@ public class BopUpdateTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testUpdateNotExistsKey() {
+  void testUpdateNotExistsKey() {
     try {
       // update value only
       assertFalse(mc.asyncBopUpdate(KEY, BKEY, null, VALUE).get());
@@ -155,7 +155,7 @@ public class BopUpdateTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testExistsKey() {
+  void testExistsKey() {
     try {
       //
       // insert one
@@ -248,7 +248,7 @@ public class BopUpdateTest extends BaseIntegrationTest {
   // with bitop
   //
   @Test
-  public void testExistsKeyWithBitOp() {
+  void testExistsKeyWithBitOp() {
     try {
       //
       // insert one

--- a/src/test/manual/net/spy/memcached/collection/btree/BopUpsertTest.java
+++ b/src/test/manual/net/spy/memcached/collection/btree/BopUpsertTest.java
@@ -27,7 +27,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
-public class BopUpsertTest extends BaseIntegrationTest {
+class BopUpsertTest extends BaseIntegrationTest {
 
   private final String KEY = this.getClass().getSimpleName();
   private final long BKEY = 10;
@@ -48,7 +48,7 @@ public class BopUpsertTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testUpsertNotExistsKey() {
+  void testUpsertNotExistsKey() {
     try {
       boolean result = mc.asyncBopUpsert(KEY, BKEY, "eflag".getBytes(),
               "VALUE", new CollectionAttributes()).get();

--- a/src/test/manual/net/spy/memcached/collection/btree/ElementTest.java
+++ b/src/test/manual/net/spy/memcached/collection/btree/ElementTest.java
@@ -10,12 +10,12 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
-public class ElementTest {
+class ElementTest {
 
   private static final String VALUE = "testValue";
 
   @Test
-  public void createWithLongBkeyAndEFlag() {
+  void createWithLongBkeyAndEFlag() {
     //given
     long bkey = 1;
     byte[] eflag = {0x34};
@@ -33,7 +33,7 @@ public class ElementTest {
   }
 
   @Test
-  public void createWithByteArrayBkeyAndEFlag() {
+  void createWithByteArrayBkeyAndEFlag() {
     //given
     byte[] bkey = {0x3F};
     byte[] eflag = {0x34};
@@ -51,7 +51,7 @@ public class ElementTest {
   }
 
   @Test
-  public void createWithLongBkeyAndElementFlagUpdate() {
+  void createWithLongBkeyAndElementFlagUpdate() {
     //given
     long bkey = 1;
     byte[] eflag = {0x34};
@@ -69,7 +69,7 @@ public class ElementTest {
   }
 
   @Test
-  public void createWithByteArrayBkeyAndElementFlagUpdate() {
+  void createWithByteArrayBkeyAndElementFlagUpdate() {
     //given
     byte[] bkey = {0x3F};
     byte[] eflag = {0x34};

--- a/src/test/manual/net/spy/memcached/collection/btree/SMGetElementTest.java
+++ b/src/test/manual/net/spy/memcached/collection/btree/SMGetElementTest.java
@@ -9,14 +9,14 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class SMGetElementTest {
+class SMGetElementTest {
 
   private static final String KEY = "test";
   private static final String VALUE = "testValue";
   private static final byte[] EFLAG = {1, 8, 16, 32, 64};
 
   @Test
-  public void createWithLongBkey() {
+  void createWithLongBkey() {
     //given
     long bkey = 1;
 
@@ -31,7 +31,7 @@ public class SMGetElementTest {
   }
 
   @Test
-  public void createWithByteArrayBkey() {
+  void createWithByteArrayBkey() {
     //given
     byte[] bkey = {0x34};
 
@@ -46,7 +46,7 @@ public class SMGetElementTest {
   }
 
   @Test
-  public void compareToTest() {
+  void compareToTest() {
     //given
     long bkey = 2;
 
@@ -58,7 +58,7 @@ public class SMGetElementTest {
   }
 
   @Test
-  public void compareBkeyToTest() {
+  void compareBkeyToTest() {
     //given
     long bkey = 2;
     long anotherBkey = 1;

--- a/src/test/manual/net/spy/memcached/collection/btree/SMGetTrimKeyTest.java
+++ b/src/test/manual/net/spy/memcached/collection/btree/SMGetTrimKeyTest.java
@@ -7,12 +7,12 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-public class SMGetTrimKeyTest {
+class SMGetTrimKeyTest {
 
   private static final String KEY = "test";
 
   @Test
-  public void createWithLongBkey() {
+  void createWithLongBkey() {
     //given
     long bkey = 1;
     final SMGetTrimKey trimKey = new SMGetTrimKey(KEY, bkey);
@@ -24,7 +24,7 @@ public class SMGetTrimKeyTest {
   }
 
   @Test
-  public void createWithByteArrayBkey() {
+  void createWithByteArrayBkey() {
     //given
     byte[] bkey = {0x34};
     final SMGetTrimKey trimKey = new SMGetTrimKey(KEY, bkey);
@@ -36,7 +36,7 @@ public class SMGetTrimKeyTest {
   }
 
   @Test
-  public void compareToTest() {
+  void compareToTest() {
     //given
     long bkey = 2;
 

--- a/src/test/manual/net/spy/memcached/collection/btree/longbkey/BopCountWithElementFlagFilterTest.java
+++ b/src/test/manual/net/spy/memcached/collection/btree/longbkey/BopCountWithElementFlagFilterTest.java
@@ -34,7 +34,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
-public class BopCountWithElementFlagFilterTest extends BaseIntegrationTest {
+class BopCountWithElementFlagFilterTest extends BaseIntegrationTest {
 
   private final String KEY = this.getClass().getSimpleName();
   private final byte[] BKEY = new byte[]{(byte) 1};
@@ -56,7 +56,7 @@ public class BopCountWithElementFlagFilterTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testGetBKeyCountFromInvalidKey() {
+  void testGetBKeyCountFromInvalidKey() {
     try {
       ElementFlagFilter filter = new ElementFlagFilter(
               CompOperands.GreaterThan, "1".getBytes());
@@ -75,7 +75,7 @@ public class BopCountWithElementFlagFilterTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testGetBKeyCountFromInvalidType() {
+  void testGetBKeyCountFromInvalidType() {
     try {
       ElementFlagFilter filter = new ElementFlagFilter(
               CompOperands.Equal, "eflag".getBytes());
@@ -100,7 +100,7 @@ public class BopCountWithElementFlagFilterTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testGetBKeyCountFromNotEmpty() {
+  void testGetBKeyCountFromNotEmpty() {
     try {
       ElementFlagFilter filter = new ElementFlagFilter(
               CompOperands.Equal, "eflag".getBytes());
@@ -136,7 +136,7 @@ public class BopCountWithElementFlagFilterTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testGetBKeyCountFromNotEmpty2() {
+  void testGetBKeyCountFromNotEmpty2() {
     try {
       ElementFlagFilter filter = new ElementFlagFilter(
               CompOperands.Equal, "eflag".getBytes());
@@ -171,7 +171,7 @@ public class BopCountWithElementFlagFilterTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testGetBKeyCountFromNotEmpty3() {
+  void testGetBKeyCountFromNotEmpty3() {
     try {
       ElementFlagFilter filter = new ElementFlagFilter(
               CompOperands.Equal, "eflag".getBytes());

--- a/src/test/manual/net/spy/memcached/collection/btree/longbkey/BopGetBulkTest.java
+++ b/src/test/manual/net/spy/memcached/collection/btree/longbkey/BopGetBulkTest.java
@@ -41,7 +41,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
-public class BopGetBulkTest extends BaseIntegrationTest {
+class BopGetBulkTest extends BaseIntegrationTest {
 
   private final List<String> keyList = new ArrayList<String>() {
     private static final long serialVersionUID = -4044682425313432602L;
@@ -85,7 +85,7 @@ public class BopGetBulkTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testGetBulkLongBkeyGetAll() {
+  void testGetBulkLongBkeyGetAll() {
     try {
       ElementFlagFilter filter = ElementFlagFilter.DO_NOT_FILTER;
 
@@ -149,7 +149,7 @@ public class BopGetBulkTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testGetBulkNotFoundAll() {
+  void testGetBulkNotFoundAll() {
     try {
       for (int i = 0; i < keyList.size(); i++) {
         mc.delete(keyList.get(i)).get();
@@ -198,7 +198,7 @@ public class BopGetBulkTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testGetBulkNotFoundMixed() {
+  void testGetBulkNotFoundMixed() {
     try {
       // delete some data.
       for (int i = 0; i < keyList.size(); i++) {
@@ -273,7 +273,7 @@ public class BopGetBulkTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testErrorArguments() {
+  void testErrorArguments() {
     try {
       Map<String, BTreeGetResult<ByteArrayBKey, Object>> results = null;
       CollectionGetBulkFuture<Map<String, BTreeGetResult<ByteArrayBKey, Object>>> f = null;
@@ -314,7 +314,7 @@ public class BopGetBulkTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testUnreadable() {
+  void testUnreadable() {
     try {
       Map<String, BTreeGetResult<ByteArrayBKey, Object>> results = null;
       CollectionGetBulkFuture<Map<String, BTreeGetResult<ByteArrayBKey, Object>>> f = null;
@@ -338,7 +338,7 @@ public class BopGetBulkTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testNotFoundElement() {
+  void testNotFoundElement() {
     try {
       Map<String, BTreeGetResult<ByteArrayBKey, Object>> results = null;
       CollectionGetBulkFuture<Map<String, BTreeGetResult<ByteArrayBKey, Object>>> f = null;
@@ -367,7 +367,7 @@ public class BopGetBulkTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testTypeMismatch() {
+  void testTypeMismatch() {
     try {
       Map<String, BTreeGetResult<ByteArrayBKey, Object>> results = null;
       CollectionGetBulkFuture<Map<String, BTreeGetResult<ByteArrayBKey, Object>>> f = null;
@@ -388,7 +388,7 @@ public class BopGetBulkTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testBKeyMismatch() {
+  void testBKeyMismatch() {
     try {
       Map<String, BTreeGetResult<ByteArrayBKey, Object>> results = null;
       CollectionGetBulkFuture<Map<String, BTreeGetResult<ByteArrayBKey, Object>>> f = null;

--- a/src/test/manual/net/spy/memcached/collection/btree/longbkey/BopGetIrregularEflagTest.java
+++ b/src/test/manual/net/spy/memcached/collection/btree/longbkey/BopGetIrregularEflagTest.java
@@ -31,7 +31,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.fail;
 
-public class BopGetIrregularEflagTest extends BaseIntegrationTest {
+class BopGetIrregularEflagTest extends BaseIntegrationTest {
 
   private final String key = "BopGetIrregularEflagTest";
 
@@ -40,7 +40,7 @@ public class BopGetIrregularEflagTest extends BaseIntegrationTest {
   private final Object value = "valvalvalvalvalvalvalvalvalval";
 
   @Test
-  public void testGetAll_1() {
+  void testGetAll_1() {
     try {
       mc.delete(key).get();
       mc.asyncBopInsert(key, new byte[]{0}, eFlag, value + "0",
@@ -70,7 +70,7 @@ public class BopGetIrregularEflagTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testGetAll_2() {
+  void testGetAll_2() {
     try {
       mc.delete(key).get();
       mc.asyncBopInsert(key, new byte[]{0}, null, value + "0",
@@ -99,7 +99,7 @@ public class BopGetIrregularEflagTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testGetAll_3() {
+  void testGetAll_3() {
     try {
       mc.delete(key).get();
       mc.asyncBopInsert(key, new byte[]{0}, eFlag, value + "0",
@@ -128,7 +128,7 @@ public class BopGetIrregularEflagTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testGetAll_4() {
+  void testGetAll_4() {
     try {
       mc.delete(key).get();
       mc.asyncBopInsert(key, new byte[]{0}, null, value + "0",

--- a/src/test/manual/net/spy/memcached/collection/btree/longbkey/BopGetTest.java
+++ b/src/test/manual/net/spy/memcached/collection/btree/longbkey/BopGetTest.java
@@ -33,7 +33,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class BopGetTest extends BaseIntegrationTest {
+class BopGetTest extends BaseIntegrationTest {
 
   private static final String KEY = BopGetTest.class.getSimpleName();
 
@@ -53,7 +53,7 @@ public class BopGetTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testBopGet() throws Exception {
+  void testBopGet() throws Exception {
 
     byte[] bkey = new byte[]{(byte) 1};
 

--- a/src/test/manual/net/spy/memcached/collection/btree/longbkey/BopInsertAndGetWithElementFlagTest.java
+++ b/src/test/manual/net/spy/memcached/collection/btree/longbkey/BopInsertAndGetWithElementFlagTest.java
@@ -34,7 +34,7 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class BopInsertAndGetWithElementFlagTest extends BaseIntegrationTest {
+class BopInsertAndGetWithElementFlagTest extends BaseIntegrationTest {
 
   private final String KEY = this.getClass().getSimpleName();
   private final byte[] BKEY = new byte[]{(byte) 1};
@@ -60,7 +60,7 @@ public class BopInsertAndGetWithElementFlagTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testSingleLongBkeyWithEFlag() throws Exception {
+  void testSingleLongBkeyWithEFlag() throws Exception {
 
     // insert one
     assertTrue(mc.asyncBopInsert(KEY, BKEY, FLAG, VALUE,
@@ -92,7 +92,7 @@ public class BopInsertAndGetWithElementFlagTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testMultipleLongBkeyWithEFlag() throws Exception {
+  void testMultipleLongBkeyWithEFlag() throws Exception {
 
     // insert 3 elements
     assertTrue(mc.asyncBopInsert(KEY, BKEY, FLAG, VALUE,

--- a/src/test/manual/net/spy/memcached/collection/btree/longbkey/BopUpdateTest.java
+++ b/src/test/manual/net/spy/memcached/collection/btree/longbkey/BopUpdateTest.java
@@ -30,7 +30,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
-public class BopUpdateTest extends BaseIntegrationTest {
+class BopUpdateTest extends BaseIntegrationTest {
 
   private final String KEY = this.getClass().getSimpleName();
   private final byte[] BKEY = new byte[]{(byte) 1};
@@ -53,7 +53,7 @@ public class BopUpdateTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testNotExistsUpdateWithValue() {
+  void testNotExistsUpdateWithValue() {
     try {
       assertFalse(mc.asyncBopUpdate(KEY, BKEY,
               new ElementFlagUpdate(new byte[]{0}), VALUE).get());
@@ -66,7 +66,7 @@ public class BopUpdateTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testNotExistsUpdateWithoutValue() {
+  void testNotExistsUpdateWithoutValue() {
     try {
       assertFalse(mc.asyncBopUpdate(KEY, BKEY,
               new ElementFlagUpdate(new byte[]{0}), null).get());
@@ -79,7 +79,7 @@ public class BopUpdateTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testExistsUpdateWithValue() {
+  void testExistsUpdateWithValue() {
     try {
       assertTrue(mc.asyncBopInsert(KEY, BKEY, null, VALUE,
               new CollectionAttributes()).get());
@@ -95,7 +95,7 @@ public class BopUpdateTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testExistsUpdateWithoutValue() {
+  void testExistsUpdateWithoutValue() {
     try {
       assertTrue(mc.asyncBopInsert(KEY, BKEY, null, VALUE,
               new CollectionAttributes()).get());
@@ -119,7 +119,7 @@ public class BopUpdateTest extends BaseIntegrationTest {
   //
 
   @Test
-  public void testNotExistsUpdateUsingBitOpWithValue() {
+  void testNotExistsUpdateUsingBitOpWithValue() {
     try {
       assertFalse(mc.asyncBopUpdate(
               KEY,
@@ -132,7 +132,7 @@ public class BopUpdateTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testNotExistsUpdateUsingBitOpWithoutValue() {
+  void testNotExistsUpdateUsingBitOpWithoutValue() {
     try {
       assertFalse(mc.asyncBopUpdate(
               KEY,
@@ -145,7 +145,7 @@ public class BopUpdateTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testExistsUpdateUsingBitOpWithValue() {
+  void testExistsUpdateUsingBitOpWithValue() {
     try {
       assertTrue(mc.asyncBopInsert(KEY, BKEY, EFLAG.getBytes(),
               VALUE, new CollectionAttributes()).get());
@@ -161,7 +161,7 @@ public class BopUpdateTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testExistsUpdateUsingBitOpWithoutValue() {
+  void testExistsUpdateUsingBitOpWithoutValue() {
     try {
       assertTrue(mc.asyncBopInsert(KEY, BKEY, EFLAG.getBytes(),
               VALUE, new CollectionAttributes()).get());

--- a/src/test/manual/net/spy/memcached/collection/btree/longbkey/BopUpsertTest.java
+++ b/src/test/manual/net/spy/memcached/collection/btree/longbkey/BopUpsertTest.java
@@ -35,7 +35,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class BopUpsertTest extends BaseIntegrationTest {
+class BopUpsertTest extends BaseIntegrationTest {
 
   private final String KEY = this.getClass().getSimpleName();
   private final byte[] BKEY = new byte[]{(byte) 1};
@@ -59,7 +59,7 @@ public class BopUpsertTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testUpsertExistsValueOnly() throws Exception {
+  void testUpsertExistsValueOnly() throws Exception {
     // insert one
     assertTrue(mc.asyncBopInsert(KEY, BKEY, FLAG, VALUE,
             new CollectionAttributes()).get());
@@ -94,7 +94,7 @@ public class BopUpsertTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testUpsertNotExistsValueOnly() throws Exception {
+  void testUpsertNotExistsValueOnly() throws Exception {
     // upsert
     assertTrue(mc.asyncBopUpsert(KEY, BKEY, null, VALUE2,
             new CollectionAttributes()).get());
@@ -112,7 +112,7 @@ public class BopUpsertTest extends BaseIntegrationTest {
     }
   }
   @Test
-  public void testUpsertExistsEFlagOnly() throws Exception {
+  void testUpsertExistsEFlagOnly() throws Exception {
     // insert one
     assertTrue(mc.asyncBopInsert(KEY, BKEY, FLAG, VALUE,
             new CollectionAttributes()).get());

--- a/src/test/manual/net/spy/memcached/collection/list/LopBulkAPITest.java
+++ b/src/test/manual/net/spy/memcached/collection/list/LopBulkAPITest.java
@@ -36,7 +36,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.fail;
 
-public class LopBulkAPITest extends BaseIntegrationTest {
+class LopBulkAPITest extends BaseIntegrationTest {
 
   private final String key = "LopBulkAPITest33";
   private final List<Object> valueList = new ArrayList<>();
@@ -61,7 +61,7 @@ public class LopBulkAPITest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testBulk() throws Exception {
+  void testBulk() throws Exception {
     for (int i = 0; i < 10; i++) {
       mc.asyncLopDelete(key, 0, 4000, true).get(1000,
               TimeUnit.MILLISECONDS);
@@ -89,7 +89,7 @@ public class LopBulkAPITest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testBulkFailed() {
+  void testBulkFailed() {
     try {
       mc.asyncLopDelete(key, 0, 4000, true).get(1000,
               TimeUnit.MILLISECONDS);
@@ -115,7 +115,7 @@ public class LopBulkAPITest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testBulkEmptyList() {
+  void testBulkEmptyList() {
     try {
       CollectionFuture<Map<Integer, CollectionOperationStatus>> future = mc
               .asyncLopPipedInsertBulk(key, 0, new ArrayList<>(0),

--- a/src/test/manual/net/spy/memcached/collection/list/LopDeleteTest.java
+++ b/src/test/manual/net/spy/memcached/collection/list/LopDeleteTest.java
@@ -31,7 +31,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class LopDeleteTest extends BaseIntegrationTest {
+class LopDeleteTest extends BaseIntegrationTest {
 
   private String key = "LopDeleteTest";
 
@@ -58,19 +58,19 @@ public class LopDeleteTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testLopDelete_NoKey() throws Exception {
+  void testLopDelete_NoKey() throws Exception {
     assertFalse(mc.asyncLopDelete("no_key", 0, false).get(1000,
             TimeUnit.MILLISECONDS));
   }
 
   @Test
-  public void testLopDelete_OutOfRange() throws Exception {
+  void testLopDelete_OutOfRange() throws Exception {
     assertFalse(mc.asyncLopDelete(key, 11, false).get(1000,
             TimeUnit.MILLISECONDS));
   }
 
   @Test
-  public void testLopDelete_DeleteByBestEffort() throws Exception {
+  void testLopDelete_DeleteByBestEffort() throws Exception {
     // Delete items(2..11) in the list
     assertTrue(mc.asyncLopDelete(key, 2, 11, false).get(1000,
             TimeUnit.MILLISECONDS));
@@ -86,7 +86,7 @@ public class LopDeleteTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testLopDelete_DeletedDropped() throws Exception {
+  void testLopDelete_DeletedDropped() throws Exception {
     // Delete all items in the list
     assertTrue(mc.asyncLopDelete(key, 0, items9.length, true).get(1000,
             TimeUnit.MILLISECONDS));

--- a/src/test/manual/net/spy/memcached/collection/list/LopGetTest.java
+++ b/src/test/manual/net/spy/memcached/collection/list/LopGetTest.java
@@ -31,7 +31,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class LopGetTest extends BaseIntegrationTest {
+class LopGetTest extends BaseIntegrationTest {
 
   private String key = "LopGetTest";
 
@@ -58,7 +58,7 @@ public class LopGetTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testLopGet_NoKey() throws Exception {
+  void testLopGet_NoKey() throws Exception {
     List<Object> rlist = mc.asyncLopGet("no_key", 0, false, false).get(
             1000, TimeUnit.MILLISECONDS);
 
@@ -67,7 +67,7 @@ public class LopGetTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testLopGet_OutOfRange() throws Exception {
+  void testLopGet_OutOfRange() throws Exception {
     List<Object> list = mc.asyncLopGet(key, 20, false, false).get(1000,
             TimeUnit.MILLISECONDS);
     assertNotNull(list);
@@ -75,7 +75,7 @@ public class LopGetTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testLopGet_GetByBestEffort() throws Exception {
+  void testLopGet_GetByBestEffort() throws Exception {
     // Retrieve items(2..11) in the list
     List<Object> rlist = mc.asyncLopGet(key, 2, 11, false, false).get(1000,
             TimeUnit.MILLISECONDS);
@@ -89,7 +89,7 @@ public class LopGetTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testLopGet_GetWithDeletion() throws Exception {
+  void testLopGet_GetWithDeletion() throws Exception {
     CollectionAttributes attrs = null;
     List<Object> rlist = null;
 

--- a/src/test/manual/net/spy/memcached/collection/list/LopInsertBoundary.java
+++ b/src/test/manual/net/spy/memcached/collection/list/LopInsertBoundary.java
@@ -32,7 +32,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class LopInsertBoundary extends BaseIntegrationTest {
+class LopInsertBoundary extends BaseIntegrationTest {
 
   private String key = "LopInsertBoundary";
 
@@ -59,13 +59,13 @@ public class LopInsertBoundary extends BaseIntegrationTest {
   }
 
   @Test
-  public void testLopInsert_IndexOutOfRange() throws Exception {
+  void testLopInsert_IndexOutOfRange() throws Exception {
     assertFalse(mc.asyncLopInsert(key, 11, 11L, null).get(1000,
             TimeUnit.MILLISECONDS));
   }
 
   @Test
-  public void testLopInsert_PrependTailTrim() throws Exception {
+  void testLopInsert_PrependTailTrim() throws Exception {
     // Default overflowaction for lists is 'tail_trim'
 
     // Insert an item
@@ -87,7 +87,7 @@ public class LopInsertBoundary extends BaseIntegrationTest {
   }
 
   @Test
-  public void testLopInsert_PrependHeadTrim() throws Exception {
+  void testLopInsert_PrependHeadTrim() throws Exception {
     assertTrue(mc.asyncSetAttr(key,
             new CollectionAttributes(null, null, CollectionOverflowAction.head_trim)).get(1000,
             TimeUnit.MILLISECONDS));
@@ -111,7 +111,7 @@ public class LopInsertBoundary extends BaseIntegrationTest {
   }
 
   @Test
-  public void testLopInsert_PrependOverflowError() throws Exception {
+  void testLopInsert_PrependOverflowError() throws Exception {
     assertTrue(mc.asyncSetAttr(key,
             new CollectionAttributes(null, null, CollectionOverflowAction.error))
             .get(1000, TimeUnit.MILLISECONDS));
@@ -125,7 +125,7 @@ public class LopInsertBoundary extends BaseIntegrationTest {
   }
 
   @Test
-  public void testLopInsert_AppendTailTrim() throws Exception {
+  void testLopInsert_AppendTailTrim() throws Exception {
     // Default overflowaction for lists is 'tail_trim'
 
     // Insert an item
@@ -147,7 +147,7 @@ public class LopInsertBoundary extends BaseIntegrationTest {
   }
 
   @Test
-  public void testLopInsert_AppendHeadTrim() throws Exception {
+  void testLopInsert_AppendHeadTrim() throws Exception {
     assertTrue(mc.asyncSetAttr(key,
             new CollectionAttributes(null, null, CollectionOverflowAction.head_trim)).get(1000,
             TimeUnit.MILLISECONDS));
@@ -171,7 +171,7 @@ public class LopInsertBoundary extends BaseIntegrationTest {
   }
 
   @Test
-  public void testLopInsert_AppendOverflowError() throws Exception {
+  void testLopInsert_AppendOverflowError() throws Exception {
     assertTrue(mc.asyncSetAttr(key,
             new CollectionAttributes(null, null, CollectionOverflowAction.error))
             .get(1000, TimeUnit.MILLISECONDS));
@@ -185,7 +185,7 @@ public class LopInsertBoundary extends BaseIntegrationTest {
   }
 
   @Test
-  public void testLopInsert_InsertTailTrim() throws Exception {
+  void testLopInsert_InsertTailTrim() throws Exception {
     // Default overflowaction for lists is 'tail_trim'
 
     // Insert an item
@@ -206,7 +206,7 @@ public class LopInsertBoundary extends BaseIntegrationTest {
   }
 
   @Test
-  public void testLopInsert_InsertHeadTrim() throws Exception {
+  void testLopInsert_InsertHeadTrim() throws Exception {
     assertTrue(mc.asyncSetAttr(key,
             new CollectionAttributes(null, null, CollectionOverflowAction.head_trim)).get(1000,
             TimeUnit.MILLISECONDS));
@@ -229,7 +229,7 @@ public class LopInsertBoundary extends BaseIntegrationTest {
   }
 
   @Test
-  public void testLopInsert_InsertOverflowError() throws Exception {
+  void testLopInsert_InsertOverflowError() throws Exception {
     assertTrue(mc.asyncSetAttr(key,
             new CollectionAttributes(null, null, CollectionOverflowAction.error))
             .get(1000, TimeUnit.MILLISECONDS));
@@ -243,7 +243,7 @@ public class LopInsertBoundary extends BaseIntegrationTest {
   }
 
   @Test
-  public void testLopInsert_SetMaxCountUnderCurrentSize() throws Exception {
+  void testLopInsert_SetMaxCountUnderCurrentSize() throws Exception {
     assertTrue(mc.asyncSetAttr(key,
             new CollectionAttributes(null, null, CollectionOverflowAction.error))
             .get(1000, TimeUnit.MILLISECONDS));

--- a/src/test/manual/net/spy/memcached/collection/list/LopInsertDataType.java
+++ b/src/test/manual/net/spy/memcached/collection/list/LopInsertDataType.java
@@ -33,7 +33,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
-public class LopInsertDataType extends BaseIntegrationTest {
+class LopInsertDataType extends BaseIntegrationTest {
 
   private String key = "LopInsertDataType";
   private Random rand = new Random(new Date().getTime());
@@ -46,7 +46,7 @@ public class LopInsertDataType extends BaseIntegrationTest {
   }
 
   @Test
-  public void testLopInsert_ElementCountLimit() throws Exception {
+  void testLopInsert_ElementCountLimit() throws Exception {
     byte[] tooBigByte = new byte[1024 * 1024];
     for (int i = 0; i < tooBigByte.length; i++) {
       tooBigByte[i] = (byte) rand.nextInt(255);
@@ -64,7 +64,7 @@ public class LopInsertDataType extends BaseIntegrationTest {
   }
 
   @Test
-  public void testLopInsert_SameDataType() throws Exception {
+  void testLopInsert_SameDataType() throws Exception {
     // First, create a list and insert one item in it
     assertTrue(mc.asyncLopInsert(key, 0, "a string",
             new CollectionAttributes()).get(1000, TimeUnit.MILLISECONDS));
@@ -85,7 +85,7 @@ public class LopInsertDataType extends BaseIntegrationTest {
   }
 
   @Test
-  public void testLopInsert_DifferentDataType() throws Exception {
+  void testLopInsert_DifferentDataType() throws Exception {
     // First, create a list and insert one item in it
     assertTrue(mc.asyncLopInsert(key, -1, "a string",
             new CollectionAttributes()).get(1000, TimeUnit.MILLISECONDS));
@@ -111,7 +111,7 @@ public class LopInsertDataType extends BaseIntegrationTest {
   }
 
   @Test
-  public void testLopInsert_DifferentDataType_ErrorCase() throws Exception {
+  void testLopInsert_DifferentDataType_ErrorCase() throws Exception {
     // First, create a list and insert one item in it
     assertTrue(mc.asyncLopInsert(key, 0, 'a',
             new CollectionAttributes()).get(1000, TimeUnit.MILLISECONDS));

--- a/src/test/manual/net/spy/memcached/collection/list/LopInsertWhenKeyExists.java
+++ b/src/test/manual/net/spy/memcached/collection/list/LopInsertWhenKeyExists.java
@@ -29,7 +29,7 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class LopInsertWhenKeyExists extends BaseIntegrationTest {
+class LopInsertWhenKeyExists extends BaseIntegrationTest {
 
   private String key = "LopInsertWhenKeyExists";
 
@@ -44,7 +44,7 @@ public class LopInsertWhenKeyExists extends BaseIntegrationTest {
   }
 
   @Test
-  public void testLopInsert_Normal() throws Exception {
+  void testLopInsert_Normal() throws Exception {
     // Create a list and add it 9 items
     addToList(key, items9);
 
@@ -69,7 +69,7 @@ public class LopInsertWhenKeyExists extends BaseIntegrationTest {
   }
 
   @Test
-  public void testLopInsert_SameItem() throws Exception {
+  void testLopInsert_SameItem() throws Exception {
     // Create a list and add it 8 items
     addToList(key, items8);
 

--- a/src/test/manual/net/spy/memcached/collection/list/LopInsertWhenKeyNotExist.java
+++ b/src/test/manual/net/spy/memcached/collection/list/LopInsertWhenKeyNotExist.java
@@ -28,7 +28,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
-public class LopInsertWhenKeyNotExist extends BaseIntegrationTest {
+class LopInsertWhenKeyNotExist extends BaseIntegrationTest {
 
   private String key = "LopInsertWhenKeyNotExist";
 
@@ -49,7 +49,7 @@ public class LopInsertWhenKeyNotExist extends BaseIntegrationTest {
    * </pre>
    */
   @Test
-  public void testLopInsert_nokey_01() throws Exception {
+  void testLopInsert_nokey_01() throws Exception {
     insertToFail(key, -1, true, null);
   }
 
@@ -60,7 +60,7 @@ public class LopInsertWhenKeyNotExist extends BaseIntegrationTest {
    * </pre>
    */
   @Test
-  public void testLopInsert_nokey_02() throws Exception {
+  void testLopInsert_nokey_02() throws Exception {
     boolean success = insertToSucceed(key, -1, false, "some value");
 
     assertFalse(success);
@@ -73,7 +73,7 @@ public class LopInsertWhenKeyNotExist extends BaseIntegrationTest {
    * </pre>
    */
   @Test
-  public void testLopInsert_nokey_03() throws Exception {
+  void testLopInsert_nokey_03() throws Exception {
     assertFalse(insertToSucceed(key, 0, false, "some value"));
   }
 
@@ -84,7 +84,7 @@ public class LopInsertWhenKeyNotExist extends BaseIntegrationTest {
    * </pre>
    */
   @Test
-  public void testLopInsert_nokey_04() throws Exception {
+  void testLopInsert_nokey_04() throws Exception {
     assertFalse(insertToSucceed(key, 0, false, "some value"));
   }
 
@@ -95,7 +95,7 @@ public class LopInsertWhenKeyNotExist extends BaseIntegrationTest {
    * </pre>
    */
   @Test
-  public void testLopInsert_nokey_05() throws Exception {
+  void testLopInsert_nokey_05() throws Exception {
     assertTrue(insertToSucceed(key, 0, true, "some value"));
   }
 
@@ -106,7 +106,7 @@ public class LopInsertWhenKeyNotExist extends BaseIntegrationTest {
    * </pre>
    */
   @Test
-  public void testLopInsert_nokey_06() throws Exception {
+  void testLopInsert_nokey_06() throws Exception {
     assertTrue(insertToSucceed(key, -1, true, "some value"));
   }
 
@@ -117,7 +117,7 @@ public class LopInsertWhenKeyNotExist extends BaseIntegrationTest {
    * </pre>
    */
   @Test
-  public void testLopInsert_nokey_07() throws Exception {
+  void testLopInsert_nokey_07() throws Exception {
     // Prepare 3 items
     String[] items = {"item01", "item02", "item03"};
     for (String item : items) {

--- a/src/test/manual/net/spy/memcached/collection/list/LopOverflowActionTest.java
+++ b/src/test/manual/net/spy/memcached/collection/list/LopOverflowActionTest.java
@@ -31,7 +31,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class LopOverflowActionTest extends BaseIntegrationTest {
+class LopOverflowActionTest extends BaseIntegrationTest {
 
   private String key = "LopOverflowActionTest";
   private List<String> keyList = new ArrayList<>();
@@ -45,7 +45,7 @@ public class LopOverflowActionTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testLopGet_Maxcount() throws Exception {
+  void testLopGet_Maxcount() throws Exception {
     // Test
     for (int maxcount = 100; maxcount <= 200; maxcount += 100) {
       // Create a list
@@ -71,7 +71,7 @@ public class LopOverflowActionTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testLopGet_Overflow() throws Exception {
+  void testLopGet_Overflow() throws Exception {
     // Create a List
     mc.asyncLopInsert(key, 0, "item0", new CollectionAttributes()).get();
 
@@ -102,7 +102,7 @@ public class LopOverflowActionTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testLopGet_HeadTrim() throws Exception {
+  void testLopGet_HeadTrim() throws Exception {
     // Create a List
     mc.asyncLopInsert(key, 0, "item0", new CollectionAttributes()).get();
 
@@ -132,7 +132,7 @@ public class LopOverflowActionTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testLopGet_TailTrim() throws Exception {
+  void testLopGet_TailTrim() throws Exception {
     // Create a List
     mc.asyncLopInsert(key, 0, "item0", new CollectionAttributes()).get();
 
@@ -162,7 +162,7 @@ public class LopOverflowActionTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testLopGet_HeadTrim_OutOfRange() throws Exception {
+  void testLopGet_HeadTrim_OutOfRange() throws Exception {
     // Create a set
     mc.asyncLopInsert(key, 1, "item1", new CollectionAttributes()).get();
 
@@ -179,7 +179,7 @@ public class LopOverflowActionTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testLopGet_TailTrim_OutOfRange() throws Exception {
+  void testLopGet_TailTrim_OutOfRange() throws Exception {
     // Create a set
     mc.asyncLopInsert(key, 1, "item1", new CollectionAttributes()).get();
 
@@ -196,7 +196,7 @@ public class LopOverflowActionTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testLopGet_AvailableOverflowAction() throws Exception {
+  void testLopGet_AvailableOverflowAction() throws Exception {
     // Create a set
     mc.asyncLopInsert(key, 0, "item0", new CollectionAttributes()).get();
 

--- a/src/test/manual/net/spy/memcached/collection/list/LopServerMessageTest.java
+++ b/src/test/manual/net/spy/memcached/collection/list/LopServerMessageTest.java
@@ -34,7 +34,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class LopServerMessageTest extends BaseIntegrationTest {
+class LopServerMessageTest extends BaseIntegrationTest {
 
   private String key = "LopServerMessageTest";
 
@@ -46,7 +46,7 @@ public class LopServerMessageTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testNotFound() throws Exception {
+  void testNotFound() throws Exception {
     CollectionFuture<List<Object>> future = mc.asyncLopGet(key, 0, false, false);
     assertNull(future.get(1000, TimeUnit.MILLISECONDS));
 
@@ -56,7 +56,7 @@ public class LopServerMessageTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testCreatedStored() throws Exception {
+  void testCreatedStored() throws Exception {
     CollectionFuture<Boolean> future = mc.asyncLopInsert(key, 0, 0, new CollectionAttributes());
     assertTrue(future.get(1000, TimeUnit.MILLISECONDS));
 
@@ -66,7 +66,7 @@ public class LopServerMessageTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testStored() throws Exception {
+  void testStored() throws Exception {
     CollectionFuture<Boolean> future = mc.asyncLopInsert(key, 0, 0, new CollectionAttributes());
     assertTrue(future.get(1000, TimeUnit.MILLISECONDS));
 
@@ -79,7 +79,7 @@ public class LopServerMessageTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testOutOfRange() throws Exception {
+  void testOutOfRange() throws Exception {
     CollectionFuture<Boolean> future = mc.asyncLopInsert(key, 1, 1, new CollectionAttributes());
     assertFalse(future.get(1000, TimeUnit.MILLISECONDS));
 
@@ -89,7 +89,7 @@ public class LopServerMessageTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testOutOfRange2() throws Exception {
+  void testOutOfRange2() throws Exception {
     CollectionFuture<Boolean> future = mc.asyncLopInsert(key, 0, 0, new CollectionAttributes());
     assertTrue(future.get(1000, TimeUnit.MILLISECONDS));
 
@@ -106,7 +106,7 @@ public class LopServerMessageTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testOverflowed() throws Exception {
+  void testOverflowed() throws Exception {
     CollectionFuture<Boolean> future = mc.asyncLopInsert(key, 0, 0, new CollectionAttributes());
     assertTrue(future.get(1000, TimeUnit.MILLISECONDS));
 
@@ -126,7 +126,7 @@ public class LopServerMessageTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testDeletedDropped() throws Exception {
+  void testDeletedDropped() throws Exception {
     // create
     CollectionFuture<Boolean> future = mc.asyncLopInsert(key, 0, "aaa", new CollectionAttributes());
     assertTrue(future.get(1000, TimeUnit.MILLISECONDS));
@@ -141,7 +141,7 @@ public class LopServerMessageTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testDeleted() throws Exception {
+  void testDeleted() throws Exception {
     // create
     CollectionFuture<Boolean> future = mc.asyncLopInsert(key, 0, "aaa", new CollectionAttributes());
     assertTrue(future.get(1000, TimeUnit.MILLISECONDS));
@@ -160,7 +160,7 @@ public class LopServerMessageTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testDeletedDroppedAfterRetrieval() throws Exception {
+  void testDeletedDroppedAfterRetrieval() throws Exception {
     // create
     CollectionFuture<Boolean> future = mc.asyncLopInsert(key, 0, "aaa", new CollectionAttributes());
     assertTrue(future.get(1000, TimeUnit.MILLISECONDS));
@@ -175,7 +175,7 @@ public class LopServerMessageTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testDeletedAfterRetrieval() throws Exception {
+  void testDeletedAfterRetrieval() throws Exception {
     // create
     CollectionFuture<Boolean> future = mc.asyncLopInsert(key, 0, "aaa", new CollectionAttributes());
     assertTrue(future.get(1000, TimeUnit.MILLISECONDS));

--- a/src/test/manual/net/spy/memcached/collection/map/MopBulkAPITest.java
+++ b/src/test/manual/net/spy/memcached/collection/map/MopBulkAPITest.java
@@ -34,7 +34,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.fail;
 
-public class MopBulkAPITest extends BaseIntegrationTest {
+class MopBulkAPITest extends BaseIntegrationTest {
 
   private final String key = "MopBulkAPITest33";
   private final Map<String, Object> elements = new HashMap<>();
@@ -57,7 +57,7 @@ public class MopBulkAPITest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testBulk() throws Exception {
+  void testBulk() throws Exception {
     for (int i = 0; i < 10; i++) {
       mc.delete(key).get();
       bulk();
@@ -84,7 +84,7 @@ public class MopBulkAPITest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testBulkFailed() {
+  void testBulkFailed() {
     try {
       mc.asyncMopDelete(key, true).get(1000,
               TimeUnit.MILLISECONDS);
@@ -110,7 +110,7 @@ public class MopBulkAPITest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testBulkEmptyElements() {
+  void testBulkEmptyElements() {
     try {
       CollectionFuture<Map<Integer, CollectionOperationStatus>> future = mc
               .asyncMopPipedInsertBulk(key, new HashMap<>(),
@@ -128,7 +128,7 @@ public class MopBulkAPITest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testUpdateBulk() {
+  void testUpdateBulk() {
     try {
       mc.asyncMopDelete(key, true).get(1000,
               TimeUnit.MILLISECONDS);

--- a/src/test/manual/net/spy/memcached/collection/map/MopDeleteTest.java
+++ b/src/test/manual/net/spy/memcached/collection/map/MopDeleteTest.java
@@ -32,7 +32,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class MopDeleteTest extends BaseIntegrationTest {
+class MopDeleteTest extends BaseIntegrationTest {
 
   private String key = "MopDeleteTest";
 
@@ -59,12 +59,12 @@ public class MopDeleteTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testMopDelete_NoKey() throws Exception {
+  void testMopDelete_NoKey() throws Exception {
     assertFalse(mc.asyncMopDelete("no_key", false).get(1000, TimeUnit.MILLISECONDS));
   }
 
   @Test
-  public void testMopDelete_NoMkey() throws Exception {
+  void testMopDelete_NoMkey() throws Exception {
     assertFalse(mc.asyncMopDelete(key, "11", false).get(1000, TimeUnit.MILLISECONDS));
   }
 
@@ -82,7 +82,7 @@ public class MopDeleteTest extends BaseIntegrationTest {
 //  }
 
   @Test
-  public void testMopDelete_DeleteByBestEffort() throws Exception {
+  void testMopDelete_DeleteByBestEffort() throws Exception {
     // Delete items(2..11) in the map
     for (int i = 2; i < 12; i++) {
       mc.asyncMopDelete(key, String.valueOf(i), false).get(1000,
@@ -101,7 +101,7 @@ public class MopDeleteTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testMopDelete_DeletedDropped() throws Exception {
+  void testMopDelete_DeletedDropped() throws Exception {
     // Delete all items in the list
     assertTrue(mc.asyncMopDelete(key, true).get(1000, TimeUnit.MILLISECONDS));
 

--- a/src/test/manual/net/spy/memcached/collection/map/MopGetTest.java
+++ b/src/test/manual/net/spy/memcached/collection/map/MopGetTest.java
@@ -33,7 +33,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class MopGetTest extends BaseIntegrationTest {
+class MopGetTest extends BaseIntegrationTest {
 
   private String key = "MopGetTest";
 
@@ -60,7 +60,7 @@ public class MopGetTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testMopGet_NoKey() throws Exception {
+  void testMopGet_NoKey() throws Exception {
     Map<String, Object> rmap = mc.asyncMopGet("no_key", false, false).get(
             1000, TimeUnit.MILLISECONDS);
 
@@ -69,7 +69,7 @@ public class MopGetTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testMopGet_NoMkey() throws Exception {
+  void testMopGet_NoMkey() throws Exception {
     Map<String, Object> map = mc.asyncMopGet(key, "20", false, false).get(1000,
             TimeUnit.MILLISECONDS);
     assertNotNull(map);
@@ -77,7 +77,7 @@ public class MopGetTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testMopGet_GetByBestEffort() throws Exception {
+  void testMopGet_GetByBestEffort() throws Exception {
     // Retrieve items(2..11) in the list
     List<String> mkeyList = new ArrayList<>();
     for (int i = 2; i < 12; i++) {
@@ -95,7 +95,7 @@ public class MopGetTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testMopGet_GetWithDeletion() throws Exception {
+  void testMopGet_GetWithDeletion() throws Exception {
     CollectionAttributes attrs = null;
     Map<String, Object> rmap = null;
     List<String> mkeyList = new ArrayList<>();

--- a/src/test/manual/net/spy/memcached/collection/map/MopInsertWhenKeyExists.java
+++ b/src/test/manual/net/spy/memcached/collection/map/MopInsertWhenKeyExists.java
@@ -29,7 +29,7 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class MopInsertWhenKeyExists extends BaseIntegrationTest {
+class MopInsertWhenKeyExists extends BaseIntegrationTest {
 
   private String key = "MopInsertWhenKeyExists";
 
@@ -44,7 +44,7 @@ public class MopInsertWhenKeyExists extends BaseIntegrationTest {
   }
 
   @Test
-  public void testMopInsert_Normal() throws Exception {
+  void testMopInsert_Normal() throws Exception {
     // Create a list and add it 9 items
     addToMap(key, items9);
 
@@ -72,7 +72,7 @@ public class MopInsertWhenKeyExists extends BaseIntegrationTest {
   }
 
   @Test
-  public void testMopInsert_SameField() throws Exception {
+  void testMopInsert_SameField() throws Exception {
     // Create a list and add it 9 items
     addToMap(key, items9);
 

--- a/src/test/manual/net/spy/memcached/collection/map/MopInsertWhenKeyNotExist.java
+++ b/src/test/manual/net/spy/memcached/collection/map/MopInsertWhenKeyNotExist.java
@@ -28,7 +28,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
-public class MopInsertWhenKeyNotExist extends BaseIntegrationTest {
+class MopInsertWhenKeyNotExist extends BaseIntegrationTest {
 
   private String key = "MopInsertWhenKeyNotExist";
 
@@ -51,7 +51,7 @@ public class MopInsertWhenKeyNotExist extends BaseIntegrationTest {
    * </pre>
    */
   @Test
-  public void testMopInsert_nokey_01() throws Exception {
+  void testMopInsert_nokey_01() throws Exception {
     insertToFail(key, true, null);
   }
 
@@ -62,7 +62,7 @@ public class MopInsertWhenKeyNotExist extends BaseIntegrationTest {
    * </pre>
    */
   @Test
-  public void testMopInsert_nokey_02() throws Exception {
+  void testMopInsert_nokey_02() throws Exception {
     assertFalse(insertToSucceed(key, false, items9[0]));
   }
 
@@ -73,7 +73,7 @@ public class MopInsertWhenKeyNotExist extends BaseIntegrationTest {
    * </pre>
    */
   @Test
-  public void testMopInsert_nokey_04() throws Exception {
+  void testMopInsert_nokey_04() throws Exception {
     assertFalse(insertToSucceed(key, false, items9[0]));
   }
 
@@ -84,7 +84,7 @@ public class MopInsertWhenKeyNotExist extends BaseIntegrationTest {
    * </pre>
    */
   @Test
-  public void testMopInsert_nokey_05() throws Exception {
+  void testMopInsert_nokey_05() throws Exception {
     assertTrue(insertToSucceed(key, true, items9[0]));
   }
 

--- a/src/test/manual/net/spy/memcached/collection/map/MopOverflowActionTest.java
+++ b/src/test/manual/net/spy/memcached/collection/map/MopOverflowActionTest.java
@@ -34,7 +34,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
-public class MopOverflowActionTest extends BaseIntegrationTest {
+class MopOverflowActionTest extends BaseIntegrationTest {
 
   private String key = "MopOverflowActionTest";
   private List<String> keyList = new ArrayList<>();
@@ -47,7 +47,7 @@ public class MopOverflowActionTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testMopGet_Maxcount() throws Exception {
+  void testMopGet_Maxcount() throws Exception {
     // Test
     for (int maxcount = 100; maxcount <= 200; maxcount += 100) {
       // Create a map
@@ -73,7 +73,7 @@ public class MopOverflowActionTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testMopGet_Overflow() throws Exception {
+  void testMopGet_Overflow() throws Exception {
     // Create a map
     mc.asyncMopInsert(key, "0", "item0", new CollectionAttributes()).get();
 
@@ -104,7 +104,7 @@ public class MopOverflowActionTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testMopGet_AvailableOverflowAction() throws Exception {
+  void testMopGet_AvailableOverflowAction() throws Exception {
     // Create a set
     mc.asyncMopInsert(key, "0", "item0", new CollectionAttributes()).get();
 
@@ -138,7 +138,7 @@ public class MopOverflowActionTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testMopGet_notAvailableOverflowAction() {
+  void testMopGet_notAvailableOverflowAction() {
     CollectionAttributes attributesForCreate = new CollectionAttributes();
     Map<String, Object> elem = new TreeMap<>();
     elem.put("0", "item0");

--- a/src/test/manual/net/spy/memcached/collection/map/MopServerMessageTest.java
+++ b/src/test/manual/net/spy/memcached/collection/map/MopServerMessageTest.java
@@ -34,7 +34,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class MopServerMessageTest extends BaseIntegrationTest {
+class MopServerMessageTest extends BaseIntegrationTest {
 
   private final String key = "MopServerMessageTest";
 
@@ -46,7 +46,7 @@ public class MopServerMessageTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testNotFound() throws Exception {
+  void testNotFound() throws Exception {
     CollectionFuture<Map<String, Object>> future;
     future = mc.asyncMopGet(key, false, false);
     assertNull(future.get(1000, TimeUnit.MILLISECONDS));
@@ -57,7 +57,7 @@ public class MopServerMessageTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testCreatedStored() throws Exception {
+  void testCreatedStored() throws Exception {
     CollectionFuture<Boolean> future;
     future = mc.asyncMopInsert(key, "0", 0, new CollectionAttributes());
     assertTrue(future.get(1000, TimeUnit.MILLISECONDS));
@@ -68,7 +68,7 @@ public class MopServerMessageTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testStored() throws Exception {
+  void testStored() throws Exception {
     CollectionFuture<Boolean> future;
     future = mc.asyncMopInsert(key, "0", 0, new CollectionAttributes());
     assertTrue(future.get(1000, TimeUnit.MILLISECONDS));
@@ -82,7 +82,7 @@ public class MopServerMessageTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testOverflowed() throws Exception {
+  void testOverflowed() throws Exception {
     CollectionFuture<Boolean> future;
     future = mc.asyncMopInsert(key, "0", 0, new CollectionAttributes());
     assertTrue(future.get(1000, TimeUnit.MILLISECONDS));
@@ -103,7 +103,7 @@ public class MopServerMessageTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testDeletedDropped() throws Exception {
+  void testDeletedDropped() throws Exception {
     // create
     CollectionFuture<Boolean> future;
     future = mc.asyncMopInsert(key, "0", "aaa", new CollectionAttributes());
@@ -119,7 +119,7 @@ public class MopServerMessageTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testDeleted() throws Exception {
+  void testDeleted() throws Exception {
     // create
     CollectionFuture<Boolean> future;
     future = mc.asyncMopInsert(key, "0", "aaa", new CollectionAttributes());
@@ -139,7 +139,7 @@ public class MopServerMessageTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testDeletedDroppedAfterRetrieval() throws Exception {
+  void testDeletedDroppedAfterRetrieval() throws Exception {
     // create
     CollectionFuture<Boolean> future;
     future = mc.asyncMopInsert(key, "0", "aaa", new CollectionAttributes());
@@ -156,7 +156,7 @@ public class MopServerMessageTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testDeletedAfterRetrieval() throws Exception {
+  void testDeletedAfterRetrieval() throws Exception {
     // create
     CollectionFuture<Boolean> future;
     future = mc.asyncMopInsert(key, "0", "aaa", new CollectionAttributes());

--- a/src/test/manual/net/spy/memcached/collection/map/MopUpdateTest.java
+++ b/src/test/manual/net/spy/memcached/collection/map/MopUpdateTest.java
@@ -32,7 +32,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
-public class MopUpdateTest extends BaseIntegrationTest {
+class MopUpdateTest extends BaseIntegrationTest {
 
   private final String KEY = this.getClass().getSimpleName();
 
@@ -57,7 +57,7 @@ public class MopUpdateTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testUpdateNotExistsKey() {
+  void testUpdateNotExistsKey() {
     try {
       // update value
       assertFalse(mc.asyncMopUpdate(KEY, mkey, VALUE).get());
@@ -68,7 +68,7 @@ public class MopUpdateTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testExistsKey() {
+  void testExistsKey() {
     try {
       // insert one
       assertTrue(mc.asyncMopInsert(KEY, mkey, VALUE,

--- a/src/test/manual/net/spy/memcached/collection/map/MopUpsertTest.java
+++ b/src/test/manual/net/spy/memcached/collection/map/MopUpsertTest.java
@@ -18,7 +18,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
-public class MopUpsertTest extends BaseIntegrationTest {
+class MopUpsertTest extends BaseIntegrationTest {
 
   private final String KEY = this.getClass().getSimpleName();
   private final String MKEY = "upsertTestMkey";
@@ -44,7 +44,7 @@ public class MopUpsertTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testUpsertIfKeyExists() {
+  void testUpsertIfKeyExists() {
     try {
       // given
       assertTrue(mc.asyncMopInsert(KEY, MKEY, VALUE, collectionAttributes).get());
@@ -67,7 +67,7 @@ public class MopUpsertTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testUpsertIfKeyDoesNotExist() {
+  void testUpsertIfKeyDoesNotExist() {
     try {
       // given & when
       CollectionFuture<Boolean> future =

--- a/src/test/manual/net/spy/memcached/collection/set/SopBulkAPITest.java
+++ b/src/test/manual/net/spy/memcached/collection/set/SopBulkAPITest.java
@@ -35,7 +35,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.fail;
 
-public class SopBulkAPITest extends BaseIntegrationTest {
+class SopBulkAPITest extends BaseIntegrationTest {
 
   private final String key = "SopBulkAPITest";
   private final List<Object> valueList = new ArrayList<>();
@@ -54,7 +54,7 @@ public class SopBulkAPITest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testBulk() throws Exception {
+  void testBulk() throws Exception {
     for (int i = 0; i < 10; i++) {
       mc.delete(key).get();
       bulk();
@@ -82,7 +82,7 @@ public class SopBulkAPITest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testBulkFailed() {
+  void testBulkFailed() {
     try {
       for (Object v : valueList) {
         mc.asyncSopDelete(key, v, false).get();
@@ -106,7 +106,7 @@ public class SopBulkAPITest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testBulkEmptySet() {
+  void testBulkEmptySet() {
     try {
       for (Object v : valueList) {
         mc.asyncSopDelete(key, v, false).get();

--- a/src/test/manual/net/spy/memcached/collection/set/SopDeleteTest.java
+++ b/src/test/manual/net/spy/memcached/collection/set/SopDeleteTest.java
@@ -29,7 +29,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class SopDeleteTest extends BaseIntegrationTest {
+class SopDeleteTest extends BaseIntegrationTest {
 
   private static final String KEY = SopDeleteTest.class.getSimpleName();
 
@@ -49,13 +49,13 @@ public class SopDeleteTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testSopDelete0() throws InterruptedException,
+  void testSopDelete0() throws InterruptedException,
           ExecutionException {
     testSopDelete(0);
   }
 
   @Test
-  public void testSopDelete1() throws InterruptedException,
+  void testSopDelete1() throws InterruptedException,
           ExecutionException {
     testSopDelete(1);
   }

--- a/src/test/manual/net/spy/memcached/collection/set/SopExistTest.java
+++ b/src/test/manual/net/spy/memcached/collection/set/SopExistTest.java
@@ -30,7 +30,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class SopExistTest extends BaseIntegrationTest {
+class SopExistTest extends BaseIntegrationTest {
 
   private final String key = "SopExistTest";
   private final String value = "value";
@@ -43,7 +43,7 @@ public class SopExistTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testExist() throws Exception {
+  void testExist() throws Exception {
     Boolean result = mc.asyncSopInsert(key, value,
             new CollectionAttributes()).get(1000, TimeUnit.MILLISECONDS);
     assertTrue(result);
@@ -55,7 +55,7 @@ public class SopExistTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testNotExist() throws Exception {
+  void testNotExist() throws Exception {
     Boolean result = mc.asyncSopInsert(key, value,
             new CollectionAttributes()).get(1000, TimeUnit.MILLISECONDS);
     assertTrue(result);
@@ -67,7 +67,7 @@ public class SopExistTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testNotFound() throws Exception {
+  void testNotFound() throws Exception {
     CollectionFuture<Boolean> future = mc.asyncSopExist(key, value);
     assertFalse(future.get(1000, TimeUnit.MILLISECONDS));
     assertEquals(CollectionResponse.NOT_FOUND, future.getOperationStatus()
@@ -75,7 +75,7 @@ public class SopExistTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testUnreadabled() throws Exception {
+  void testUnreadabled() throws Exception {
     CollectionAttributes attrs = new CollectionAttributes();
     attrs.setReadable(false);
 

--- a/src/test/manual/net/spy/memcached/collection/set/SopInsertWhenKeyExists.java
+++ b/src/test/manual/net/spy/memcached/collection/set/SopInsertWhenKeyExists.java
@@ -29,7 +29,7 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class SopInsertWhenKeyExists extends BaseIntegrationTest {
+class SopInsertWhenKeyExists extends BaseIntegrationTest {
 
   private String key = "SopInsertWhenKeyExists";
 
@@ -44,7 +44,7 @@ public class SopInsertWhenKeyExists extends BaseIntegrationTest {
   }
 
   @Test
-  public void testSopInsert_Normal() throws Exception {
+  void testSopInsert_Normal() throws Exception {
     // Create a list and add it 9 items
     addToSet(key, items9);
 
@@ -70,7 +70,7 @@ public class SopInsertWhenKeyExists extends BaseIntegrationTest {
   }
 
   @Test
-  public void testSopInsert_SameItem() throws Exception {
+  void testSopInsert_SameItem() throws Exception {
     // Create a list and add it 9 items
     addToSet(key, items9);
 

--- a/src/test/manual/net/spy/memcached/collection/set/SopInsertWhenKeyNotExist.java
+++ b/src/test/manual/net/spy/memcached/collection/set/SopInsertWhenKeyNotExist.java
@@ -28,7 +28,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
-public class SopInsertWhenKeyNotExist extends BaseIntegrationTest {
+class SopInsertWhenKeyNotExist extends BaseIntegrationTest {
 
   private String key = "SopInsertWhenKeyNotExist";
 
@@ -46,7 +46,7 @@ public class SopInsertWhenKeyNotExist extends BaseIntegrationTest {
    * </pre>
    */
   @Test
-  public void testSopInsert_nokey_01() throws Exception {
+  void testSopInsert_nokey_01() throws Exception {
     insertToFail(key, true, false, null);
   }
 
@@ -57,7 +57,7 @@ public class SopInsertWhenKeyNotExist extends BaseIntegrationTest {
    * </pre>
    */
   @Test
-  public void testSopInsert_nokey_02() throws Exception {
+  void testSopInsert_nokey_02() throws Exception {
     assertFalse(insertToSucceed(key, false, true, "some value"));
   }
 
@@ -68,7 +68,7 @@ public class SopInsertWhenKeyNotExist extends BaseIntegrationTest {
    * </pre>
    */
   @Test
-  public void testSopInsert_nokey_04() throws Exception {
+  void testSopInsert_nokey_04() throws Exception {
     assertFalse(insertToSucceed(key, false, false, "some value"));
   }
 
@@ -79,7 +79,7 @@ public class SopInsertWhenKeyNotExist extends BaseIntegrationTest {
    * </pre>
    */
   @Test
-  public void testSopInsert_nokey_05() throws Exception {
+  void testSopInsert_nokey_05() throws Exception {
     assertTrue(insertToSucceed(key, true, true, "some value"));
   }
 

--- a/src/test/manual/net/spy/memcached/collection/set/SopOverflowActionTest.java
+++ b/src/test/manual/net/spy/memcached/collection/set/SopOverflowActionTest.java
@@ -33,7 +33,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
-public class SopOverflowActionTest extends BaseIntegrationTest {
+class SopOverflowActionTest extends BaseIntegrationTest {
 
   private String key = "SopOverflowActionTest";
   private List<String> keyList = new ArrayList<>();
@@ -46,7 +46,7 @@ public class SopOverflowActionTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testSopGet_Maxcount() throws Exception {
+  void testSopGet_Maxcount() throws Exception {
     // Test
     for (int maxcount = 50000; maxcount <= 10000; maxcount += 1000) {
       // Create a B+ Tree
@@ -81,7 +81,7 @@ public class SopOverflowActionTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testSopGet_AvailableOverflowAction() throws Exception {
+  void testSopGet_AvailableOverflowAction() throws Exception {
     // Create a set
     mc.asyncSopInsert(key, "item0", new CollectionAttributes()).get();
 
@@ -115,7 +115,7 @@ public class SopOverflowActionTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testSopGet_notAvailableOverflowAction() {
+  void testSopGet_notAvailableOverflowAction() {
     CollectionAttributes attributesForCreate = new CollectionAttributes();
 
     // insert

--- a/src/test/manual/net/spy/memcached/collection/set/SopPipedExistTest.java
+++ b/src/test/manual/net/spy/memcached/collection/set/SopPipedExistTest.java
@@ -35,7 +35,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
-public class SopPipedExistTest extends BaseIntegrationTest {
+class SopPipedExistTest extends BaseIntegrationTest {
 
   private final String KEY = this.getClass().getSimpleName();
   private final String VALUE1 = "VALUE1";
@@ -60,7 +60,7 @@ public class SopPipedExistTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testPipedExist() {
+  void testPipedExist() {
     try {
       assertTrue(mc.asyncSopCreate(KEY, ElementValueType.STRING,
               new CollectionAttributes()).get());
@@ -105,7 +105,7 @@ public class SopPipedExistTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testPipedExistWithOneValue() {
+  void testPipedExistWithOneValue() {
     try {
       assertTrue(mc.asyncSopCreate(KEY, ElementValueType.STRING,
               new CollectionAttributes()).get());
@@ -140,7 +140,7 @@ public class SopPipedExistTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testMaxPipedExist() {
+  void testMaxPipedExist() {
     try {
       List<Object> findValues = new ArrayList<>();
 
@@ -178,7 +178,7 @@ public class SopPipedExistTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testPipedExistNotExistsKey() {
+  void testPipedExistNotExistsKey() {
     try {
       List<Object> findValues = new ArrayList<>();
       findValues.add(VALUE1);
@@ -204,7 +204,7 @@ public class SopPipedExistTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testPipedExistOneNotExistsKey() {
+  void testPipedExistOneNotExistsKey() {
     try {
       List<Object> findValues = new ArrayList<>();
       findValues.add(VALUE1);
@@ -225,7 +225,7 @@ public class SopPipedExistTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testPipedExistTypeMismatchedKey() {
+  void testPipedExistTypeMismatchedKey() {
     try {
       assertTrue(mc.set(KEY, 10, VALUE1).get());
 
@@ -252,7 +252,7 @@ public class SopPipedExistTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testPipedExistOneTypeMismatchedKey() {
+  void testPipedExistOneTypeMismatchedKey() {
     try {
       assertTrue(mc.set(KEY, 10, VALUE1).get());
 

--- a/src/test/manual/net/spy/memcached/collection/set/SopServerMessageTest.java
+++ b/src/test/manual/net/spy/memcached/collection/set/SopServerMessageTest.java
@@ -34,7 +34,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class SopServerMessageTest extends BaseIntegrationTest {
+class SopServerMessageTest extends BaseIntegrationTest {
 
   private String key = "SopServerMessageTest";
 
@@ -47,7 +47,7 @@ public class SopServerMessageTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testNotFound() throws Exception {
+  void testNotFound() throws Exception {
     CollectionFuture<Set<Object>> future = mc.asyncSopGet(key, 1, false, false);
     assertNull(future.get(1000, TimeUnit.MILLISECONDS));
 
@@ -57,7 +57,7 @@ public class SopServerMessageTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testCreatedStored() throws Exception {
+  void testCreatedStored() throws Exception {
     CollectionFuture<Boolean> future = mc.asyncSopInsert(key, "aaa", new CollectionAttributes());
     assertTrue(future.get(1000, TimeUnit.MILLISECONDS));
 
@@ -67,7 +67,7 @@ public class SopServerMessageTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testStored() throws Exception {
+  void testStored() throws Exception {
     CollectionFuture<Boolean> future = mc.asyncSopInsert(key, "aaa", new CollectionAttributes());
     assertTrue(future.get(1000, TimeUnit.MILLISECONDS));
 
@@ -80,7 +80,7 @@ public class SopServerMessageTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testOverflowed() throws Exception {
+  void testOverflowed() throws Exception {
     CollectionFuture<Boolean> future = mc.asyncSopInsert(key, "aaa", new CollectionAttributes());
     assertTrue(future.get(1000, TimeUnit.MILLISECONDS));
 
@@ -97,7 +97,7 @@ public class SopServerMessageTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testElementExists() throws Exception {
+  void testElementExists() throws Exception {
     CollectionFuture<Boolean> future = mc.asyncSopInsert(key, "aaa", new CollectionAttributes());
     assertTrue(future.get(1000, TimeUnit.MILLISECONDS));
 
@@ -110,7 +110,7 @@ public class SopServerMessageTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testDeletedDropped() throws Exception {
+  void testDeletedDropped() throws Exception {
     // create
     CollectionFuture<Boolean> future = mc.asyncSopInsert(key, "aaa", new CollectionAttributes());
     assertTrue(future.get(1000, TimeUnit.MILLISECONDS));
@@ -125,7 +125,7 @@ public class SopServerMessageTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testDeleted() throws Exception {
+  void testDeleted() throws Exception {
     // create
     CollectionFuture<Boolean> future = mc.asyncSopInsert(key, "aaa", new CollectionAttributes());
     assertTrue(future.get(1000, TimeUnit.MILLISECONDS));
@@ -144,7 +144,7 @@ public class SopServerMessageTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testDeletedDroppedAfterRetrieval() throws Exception {
+  void testDeletedDroppedAfterRetrieval() throws Exception {
     // create
     CollectionFuture<Boolean> future = mc.asyncSopInsert(key, "aaa", new CollectionAttributes());
     assertTrue(future.get(1000, TimeUnit.MILLISECONDS));
@@ -159,7 +159,7 @@ public class SopServerMessageTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testDeletedAfterRetrieval() throws Exception {
+  void testDeletedAfterRetrieval() throws Exception {
     // create
     CollectionFuture<Boolean> future = mc.asyncSopInsert(key, "aaa", new CollectionAttributes());
     assertTrue(future.get(1000, TimeUnit.MILLISECONDS));

--- a/src/test/manual/net/spy/memcached/emptycollection/BTreeDeleteWithFilterTest.java
+++ b/src/test/manual/net/spy/memcached/emptycollection/BTreeDeleteWithFilterTest.java
@@ -30,7 +30,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
-public class BTreeDeleteWithFilterTest extends BaseIntegrationTest {
+class BTreeDeleteWithFilterTest extends BaseIntegrationTest {
 
   private final String KEY = this.getClass().getSimpleName();
   private final long BKEY = 10L;
@@ -51,7 +51,7 @@ public class BTreeDeleteWithFilterTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testDeleteWithMatchedFilter() {
+  void testDeleteWithMatchedFilter() {
     try {
       ElementFlagFilter filter = new ElementFlagFilter(
               CompOperands.Equal, FLAG.getBytes());
@@ -78,7 +78,7 @@ public class BTreeDeleteWithFilterTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testDeleteWithUnMatchedFilter() {
+  void testDeleteWithUnMatchedFilter() {
     try {
       ElementFlagFilter filter = new ElementFlagFilter(
               CompOperands.Equal, "aa".getBytes());

--- a/src/test/manual/net/spy/memcached/emptycollection/BTreeGetWithFilterTest.java
+++ b/src/test/manual/net/spy/memcached/emptycollection/BTreeGetWithFilterTest.java
@@ -35,7 +35,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
-public class BTreeGetWithFilterTest extends BaseIntegrationTest {
+class BTreeGetWithFilterTest extends BaseIntegrationTest {
 
   private final String KEY = this.getClass().getSimpleName();
   private final long BKEY = 10L;
@@ -60,7 +60,7 @@ public class BTreeGetWithFilterTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testGetWithDeleteAndWithoutDropWithFilter() {
+  void testGetWithDeleteAndWithoutDropWithFilter() {
     try {
       ElementFlagFilter filter = new ElementFlagFilter(
               CompOperands.Equal, "flag".getBytes());
@@ -91,7 +91,7 @@ public class BTreeGetWithFilterTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testGetWithDeleteAndWithDropWithFilter() {
+  void testGetWithDeleteAndWithDropWithFilter() {
     try {
       ElementFlagFilter filter = new ElementFlagFilter(
               CompOperands.Equal, "flag".getBytes());
@@ -121,7 +121,7 @@ public class BTreeGetWithFilterTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testRangedGetWithtDeleteAndWithoutDropWithFilter() {
+  void testRangedGetWithtDeleteAndWithoutDropWithFilter() {
     try {
       ElementFlagFilter filter = new ElementFlagFilter(
               CompOperands.Equal, "flag".getBytes());
@@ -151,7 +151,7 @@ public class BTreeGetWithFilterTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testRangedGetWithtDeleteAndWithDropWithFilter() {
+  void testRangedGetWithtDeleteAndWithDropWithFilter() {
     try {
       ElementFlagFilter filter = new ElementFlagFilter(
               CompOperands.Equal, "flag".getBytes());
@@ -180,7 +180,7 @@ public class BTreeGetWithFilterTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testRangedGetWithtDeleteAndWithDeleteWithFilter() {
+  void testRangedGetWithtDeleteAndWithDeleteWithFilter() {
     try {
       ElementFlagFilter filter = new ElementFlagFilter(
               CompOperands.Equal, "flag".getBytes());

--- a/src/test/manual/net/spy/memcached/emptycollection/CreateEmptyBTreeTest.java
+++ b/src/test/manual/net/spy/memcached/emptycollection/CreateEmptyBTreeTest.java
@@ -30,7 +30,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
-public class CreateEmptyBTreeTest extends BaseIntegrationTest {
+class CreateEmptyBTreeTest extends BaseIntegrationTest {
 
   private final String KEY = this.getClass().getSimpleName();
 
@@ -50,7 +50,7 @@ public class CreateEmptyBTreeTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testCreateEmptyWithDefaultAttribute() {
+  void testCreateEmptyWithDefaultAttribute() {
     try {
       // create empty
       CollectionAttributes attribute = new CollectionAttributes();
@@ -71,7 +71,7 @@ public class CreateEmptyBTreeTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testCreateEmptyWithSpecifiedAttribute() {
+  void testCreateEmptyWithSpecifiedAttribute() {
     try {
       // create empty
       CollectionAttributes attribute = new CollectionAttributes();

--- a/src/test/manual/net/spy/memcached/emptycollection/CreateEmptyListTest.java
+++ b/src/test/manual/net/spy/memcached/emptycollection/CreateEmptyListTest.java
@@ -30,7 +30,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
-public class CreateEmptyListTest extends BaseIntegrationTest {
+class CreateEmptyListTest extends BaseIntegrationTest {
 
   private final String KEY = this.getClass().getSimpleName();
 
@@ -50,7 +50,7 @@ public class CreateEmptyListTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testCreateEmptyWithDefaultAttribute() {
+  void testCreateEmptyWithDefaultAttribute() {
     try {
       // create empty
       CollectionAttributes attribute = new CollectionAttributes();
@@ -72,7 +72,7 @@ public class CreateEmptyListTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testCreateEmptyWithSpecifiedAttribute() {
+  void testCreateEmptyWithSpecifiedAttribute() {
     try {
       // create empty
       CollectionAttributes attribute = new CollectionAttributes();

--- a/src/test/manual/net/spy/memcached/emptycollection/CreateEmptyMapTest.java
+++ b/src/test/manual/net/spy/memcached/emptycollection/CreateEmptyMapTest.java
@@ -30,7 +30,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
-public class CreateEmptyMapTest extends BaseIntegrationTest {
+class CreateEmptyMapTest extends BaseIntegrationTest {
 
   private final String KEY = this.getClass().getSimpleName();
 
@@ -50,7 +50,7 @@ public class CreateEmptyMapTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testCreateEmptyWithDefaultAttribute() {
+  void testCreateEmptyWithDefaultAttribute() {
     try {
       // create empty
       CollectionAttributes attribute = new CollectionAttributes();
@@ -71,7 +71,7 @@ public class CreateEmptyMapTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testCreateEmptyWithSpecifiedAttribute() {
+  void testCreateEmptyWithSpecifiedAttribute() {
     try {
       // create empty
       CollectionAttributes attribute = new CollectionAttributes();

--- a/src/test/manual/net/spy/memcached/emptycollection/CreateEmptySetTest.java
+++ b/src/test/manual/net/spy/memcached/emptycollection/CreateEmptySetTest.java
@@ -30,7 +30,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
-public class CreateEmptySetTest extends BaseIntegrationTest {
+class CreateEmptySetTest extends BaseIntegrationTest {
 
   private final String KEY = this.getClass().getSimpleName();
 
@@ -50,7 +50,7 @@ public class CreateEmptySetTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testCreateEmptyWithDefaultAttribute() {
+  void testCreateEmptyWithDefaultAttribute() {
     try {
       // create empty
       CollectionAttributes attribute = new CollectionAttributes();
@@ -72,7 +72,7 @@ public class CreateEmptySetTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testCreateEmptyWithSpecifiedAttribute() {
+  void testCreateEmptyWithSpecifiedAttribute() {
     try {
       // create empty
       CollectionAttributes attribute = new CollectionAttributes();

--- a/src/test/manual/net/spy/memcached/emptycollection/GetCountBTreeTest.java
+++ b/src/test/manual/net/spy/memcached/emptycollection/GetCountBTreeTest.java
@@ -34,7 +34,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
-public class GetCountBTreeTest extends BaseIntegrationTest {
+class GetCountBTreeTest extends BaseIntegrationTest {
 
   private final String KEY = this.getClass().getSimpleName();
   private final long BKEY = 10L;
@@ -55,7 +55,7 @@ public class GetCountBTreeTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testGetBKeyCountFromInvalidKey() {
+  void testGetBKeyCountFromInvalidKey() {
     try {
       CollectionFuture<Integer> future = mc.asyncBopGetItemCount(
               "INVALIDKEY", BKEY, BKEY, ElementFlagFilter.DO_NOT_FILTER);
@@ -71,7 +71,7 @@ public class GetCountBTreeTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testGetBKeyCountFromInvalidType() {
+  void testGetBKeyCountFromInvalidType() {
     try {
       // insert value into set
       Boolean insertResult = mc.asyncSopInsert(KEY, "value",
@@ -93,7 +93,7 @@ public class GetCountBTreeTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testGetBKeyCountUnreadable() {
+  void testGetBKeyCountUnreadable() {
     try {
       CollectionAttributes attributes = new CollectionAttributes();
       attributes.setReadable(false);
@@ -117,7 +117,7 @@ public class GetCountBTreeTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testGetBKeyCountFromInvalidBKeyType() {
+  void testGetBKeyCountFromInvalidBKeyType() {
     try {
       // insert an item
       Boolean insertResult = mc.asyncBopInsert(KEY, new byte[]{0},
@@ -139,7 +139,7 @@ public class GetCountBTreeTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testGetBKeyCountFromNotEmpty() {
+  void testGetBKeyCountFromNotEmpty() {
     try {
       // check not exists
       assertNull(mc.asyncGetAttr(KEY).get());
@@ -172,7 +172,7 @@ public class GetCountBTreeTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testGetBKeyCountFromNotEmpty2() {
+  void testGetBKeyCountFromNotEmpty2() {
     try {
       // check not exists
       assertNull(mc.asyncGetAttr(KEY).get());
@@ -203,7 +203,7 @@ public class GetCountBTreeTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testGetBKeyCountByNotExistsBKey() {
+  void testGetBKeyCountByNotExistsBKey() {
     try {
       // check not exists
       assertNull(mc.asyncGetAttr(KEY).get());
@@ -234,7 +234,7 @@ public class GetCountBTreeTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testGetBKeyCountByNotExistsRange() {
+  void testGetBKeyCountByNotExistsRange() {
     try {
       // check not exists
       assertNull(mc.asyncGetAttr(KEY).get());

--- a/src/test/manual/net/spy/memcached/emptycollection/GetCountBTreeTestWithElementFlagFilterTest.java
+++ b/src/test/manual/net/spy/memcached/emptycollection/GetCountBTreeTestWithElementFlagFilterTest.java
@@ -34,7 +34,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
-public class GetCountBTreeTestWithElementFlagFilterTest extends BaseIntegrationTest {
+class GetCountBTreeTestWithElementFlagFilterTest extends BaseIntegrationTest {
 
   private final String KEY = this.getClass().getSimpleName();
   private final long BKEY = 10L;
@@ -55,7 +55,7 @@ public class GetCountBTreeTestWithElementFlagFilterTest extends BaseIntegrationT
   }
 
   @Test
-  public void testGetBKeyCountFromInvalidKey() {
+  void testGetBKeyCountFromInvalidKey() {
     try {
       ElementFlagFilter filter = new ElementFlagFilter(
               CompOperands.GreaterThan, "1".getBytes());
@@ -74,7 +74,7 @@ public class GetCountBTreeTestWithElementFlagFilterTest extends BaseIntegrationT
   }
 
   @Test
-  public void testGetBKeyCountFromInvalidType() {
+  void testGetBKeyCountFromInvalidType() {
     try {
       ElementFlagFilter filter = new ElementFlagFilter(
               CompOperands.Equal, "eflag".getBytes());
@@ -99,7 +99,7 @@ public class GetCountBTreeTestWithElementFlagFilterTest extends BaseIntegrationT
   }
 
   @Test
-  public void testGetBKeyCountFromNotEmpty() {
+  void testGetBKeyCountFromNotEmpty() {
     try {
       ElementFlagFilter filter = new ElementFlagFilter(
               CompOperands.Equal, "eflag".getBytes());
@@ -135,7 +135,7 @@ public class GetCountBTreeTestWithElementFlagFilterTest extends BaseIntegrationT
   }
 
   @Test
-  public void testGetBKeyCountFromNotEmpty2() {
+  void testGetBKeyCountFromNotEmpty2() {
     try {
       ElementFlagFilter filter = new ElementFlagFilter(
               CompOperands.Equal, "eflag".getBytes());
@@ -169,7 +169,7 @@ public class GetCountBTreeTestWithElementFlagFilterTest extends BaseIntegrationT
   }
 
   @Test
-  public void testGetBKeyCountFromNotEmpty3() {
+  void testGetBKeyCountFromNotEmpty3() {
     try {
       ElementFlagFilter filter = new ElementFlagFilter(
               CompOperands.Equal, "eflag".getBytes());
@@ -205,7 +205,7 @@ public class GetCountBTreeTestWithElementFlagFilterTest extends BaseIntegrationT
   }
 
   @Test
-  public void testGetBKeyCountByNotExistsBKey() {
+  void testGetBKeyCountByNotExistsBKey() {
     try {
       ElementFlagFilter filter = new ElementFlagFilter(
               CompOperands.Equal, "eflag".getBytes());
@@ -239,7 +239,7 @@ public class GetCountBTreeTestWithElementFlagFilterTest extends BaseIntegrationT
   }
 
   @Test
-  public void testGetBKeyCountByNotExistsRange() {
+  void testGetBKeyCountByNotExistsRange() {
     try {
       ElementFlagFilter filter = new ElementFlagFilter(
               CompOperands.Equal, "eflag".getBytes());

--- a/src/test/manual/net/spy/memcached/emptycollection/GetWithDropBTreeTest.java
+++ b/src/test/manual/net/spy/memcached/emptycollection/GetWithDropBTreeTest.java
@@ -32,7 +32,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
-public class GetWithDropBTreeTest extends BaseIntegrationTest {
+class GetWithDropBTreeTest extends BaseIntegrationTest {
 
   private final String KEY = this.getClass().getSimpleName();
   private final long BKEY = 10L;
@@ -50,7 +50,7 @@ public class GetWithDropBTreeTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testGetWithoutDeleteAndDrop() {
+  void testGetWithoutDeleteAndDrop() {
     try {
       // check attr
       assertEquals(Long.valueOf(1), mc.asyncGetAttr(KEY).get()
@@ -78,7 +78,7 @@ public class GetWithDropBTreeTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testGetWithDeleteAndWithoutDrop() {
+  void testGetWithDeleteAndWithoutDrop() {
     try {
       // check attr
       assertEquals(Long.valueOf(1), mc.asyncGetAttr(KEY).get()
@@ -106,7 +106,7 @@ public class GetWithDropBTreeTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testGetWithDeleteAndWithDrop() {
+  void testGetWithDeleteAndWithDrop() {
     try {
       // check attr
       assertEquals(Long.valueOf(1), mc.asyncGetAttr(KEY).get()

--- a/src/test/manual/net/spy/memcached/emptycollection/GetWithDropListTest.java
+++ b/src/test/manual/net/spy/memcached/emptycollection/GetWithDropListTest.java
@@ -31,7 +31,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
-public class GetWithDropListTest extends BaseIntegrationTest {
+class GetWithDropListTest extends BaseIntegrationTest {
 
   private final String KEY = this.getClass().getSimpleName();
   private final int INDEX = 0;
@@ -49,7 +49,7 @@ public class GetWithDropListTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testGetWithoutDeleteAndDrop() {
+  void testGetWithoutDeleteAndDrop() {
     try {
       // check attr
       assertEquals(Long.valueOf(1), mc.asyncGetAttr(KEY).get()
@@ -73,7 +73,7 @@ public class GetWithDropListTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testGetWithDeleteAndWithoutDrop() {
+  void testGetWithDeleteAndWithoutDrop() {
     try {
       // check attr
       assertEquals(Long.valueOf(1), mc.asyncGetAttr(KEY).get()
@@ -101,7 +101,7 @@ public class GetWithDropListTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testGetWithDeleteAndWithDrop() {
+  void testGetWithDeleteAndWithDrop() {
     try {
       // check attr
       assertEquals(Long.valueOf(1), mc.asyncGetAttr(KEY).get()

--- a/src/test/manual/net/spy/memcached/emptycollection/GetWithDropMapTest.java
+++ b/src/test/manual/net/spy/memcached/emptycollection/GetWithDropMapTest.java
@@ -30,7 +30,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
-public class GetWithDropMapTest extends BaseIntegrationTest {
+class GetWithDropMapTest extends BaseIntegrationTest {
 
   private final String KEY = this.getClass().getSimpleName();
   private final String MKEY = "mkey";
@@ -48,7 +48,7 @@ public class GetWithDropMapTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testGetWithoutDeleteAndDrop() {
+  void testGetWithoutDeleteAndDrop() {
     try {
       // check attr
       assertEquals(Long.valueOf(1), mc.asyncGetAttr(KEY).get()
@@ -74,7 +74,7 @@ public class GetWithDropMapTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testGetWithDeleteAndWithoutDrop() {
+  void testGetWithDeleteAndWithoutDrop() {
     try {
       // check attr
       assertEquals(Long.valueOf(1), mc.asyncGetAttr(KEY).get()
@@ -100,7 +100,7 @@ public class GetWithDropMapTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testGetWithDeleteAndWithDrop() {
+  void testGetWithDeleteAndWithDrop() {
     try {
       // check attr
       assertEquals(Long.valueOf(1), mc.asyncGetAttr(KEY).get()

--- a/src/test/manual/net/spy/memcached/emptycollection/GetWithDropSetTest.java
+++ b/src/test/manual/net/spy/memcached/emptycollection/GetWithDropSetTest.java
@@ -30,7 +30,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
-public class GetWithDropSetTest extends BaseIntegrationTest {
+class GetWithDropSetTest extends BaseIntegrationTest {
 
   private final String KEY = this.getClass().getSimpleName();
   private final int VALUE = 1234567890;
@@ -47,7 +47,7 @@ public class GetWithDropSetTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testGetWithoutDeleteAndDrop() {
+  void testGetWithoutDeleteAndDrop() {
     try {
       // check attr
       assertEquals(Long.valueOf(1), mc.asyncGetAttr(KEY).get()
@@ -71,7 +71,7 @@ public class GetWithDropSetTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testGetWithDeleteAndWithoutDrop() {
+  void testGetWithDeleteAndWithoutDrop() {
     try {
       // check attr
       assertEquals(Long.valueOf(1), mc.asyncGetAttr(KEY).get()
@@ -96,7 +96,7 @@ public class GetWithDropSetTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testGetWithDeleteAndWithDrop() {
+  void testGetWithDeleteAndWithDrop() {
     try {
       // check attr
       assertEquals(Long.valueOf(1), mc.asyncGetAttr(KEY).get()

--- a/src/test/manual/net/spy/memcached/emptycollection/InsertBTreeWithAttrAndEFlagTest.java
+++ b/src/test/manual/net/spy/memcached/emptycollection/InsertBTreeWithAttrAndEFlagTest.java
@@ -32,7 +32,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
-public class InsertBTreeWithAttrAndEFlagTest extends BaseIntegrationTest {
+class InsertBTreeWithAttrAndEFlagTest extends BaseIntegrationTest {
 
   private final String KEY = this.getClass().getSimpleName();
   private final long BKEY = 10;
@@ -54,7 +54,7 @@ public class InsertBTreeWithAttrAndEFlagTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testInsertWithAttributeAndWithoutFilter() {
+  void testInsertWithAttributeAndWithoutFilter() {
     try {
       // check not exists
       assertNull(mc.asyncGetAttr(KEY).get());
@@ -85,7 +85,7 @@ public class InsertBTreeWithAttrAndEFlagTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testInsertWithDefaultAttributeAndWithoutFilter() {
+  void testInsertWithDefaultAttributeAndWithoutFilter() {
     try {
       // check not exists
       assertNull(mc.asyncGetAttr(KEY).get());
@@ -108,7 +108,7 @@ public class InsertBTreeWithAttrAndEFlagTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testInsertWithAttributeAndFilter() {
+  void testInsertWithAttributeAndFilter() {
     try {
       // check not exists
       assertNull(mc.asyncGetAttr(KEY).get());
@@ -141,7 +141,7 @@ public class InsertBTreeWithAttrAndEFlagTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testInsertWithAttributeAndInvalidFilter() {
+  void testInsertWithAttributeAndInvalidFilter() {
     try {
       // check not exists
       assertNull(mc.asyncGetAttr(KEY).get());

--- a/src/test/manual/net/spy/memcached/emptycollection/InsertListWithAttrTest.java
+++ b/src/test/manual/net/spy/memcached/emptycollection/InsertListWithAttrTest.java
@@ -30,7 +30,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
-public class InsertListWithAttrTest extends BaseIntegrationTest {
+class InsertListWithAttrTest extends BaseIntegrationTest {
 
   private final String KEY = this.getClass().getSimpleName();
   private final int INDEX = 0;
@@ -52,7 +52,7 @@ public class InsertListWithAttrTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testInsertWithAttribute() {
+  void testInsertWithAttribute() {
     try {
       // check not exists
       assertNull(mc.asyncGetAttr(KEY).get());
@@ -83,7 +83,7 @@ public class InsertListWithAttrTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testInsertWithDefaultAttribute() {
+  void testInsertWithDefaultAttribute() {
     try {
       // check not exists
       assertNull(mc.asyncGetAttr(KEY).get());

--- a/src/test/manual/net/spy/memcached/emptycollection/InsertMapWithAttrTest.java
+++ b/src/test/manual/net/spy/memcached/emptycollection/InsertMapWithAttrTest.java
@@ -30,7 +30,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
-public class InsertMapWithAttrTest extends BaseIntegrationTest {
+class InsertMapWithAttrTest extends BaseIntegrationTest {
 
   private final String KEY = this.getClass().getSimpleName();
   private final String MKEY = "mkey";
@@ -52,7 +52,7 @@ public class InsertMapWithAttrTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testInsertWithAttribute() {
+  void testInsertWithAttribute() {
     try {
       // check not exists
       assertNull(mc.asyncGetAttr(KEY).get());
@@ -83,7 +83,7 @@ public class InsertMapWithAttrTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testInsertWithDefaultAttribute() {
+  void testInsertWithDefaultAttribute() {
     try {
       // check not exists
       assertNull(mc.asyncGetAttr(KEY).get());

--- a/src/test/manual/net/spy/memcached/emptycollection/InsertSetWithAttrTest.java
+++ b/src/test/manual/net/spy/memcached/emptycollection/InsertSetWithAttrTest.java
@@ -30,7 +30,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
-public class InsertSetWithAttrTest extends BaseIntegrationTest {
+class InsertSetWithAttrTest extends BaseIntegrationTest {
 
   private final String KEY = this.getClass().getSimpleName();
   private final int EXPIRE_TIME_IN_SEC = 1;
@@ -51,7 +51,7 @@ public class InsertSetWithAttrTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testInsertWithAttribute() {
+  void testInsertWithAttribute() {
     try {
       // check not exists
       assertNull(mc.asyncGetAttr(KEY).get());
@@ -81,7 +81,7 @@ public class InsertSetWithAttrTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testInsertWithDefaultAttribute() {
+  void testInsertWithDefaultAttribute() {
     try {
       // check not exists
       assertNull(mc.asyncGetAttr(KEY).get());

--- a/src/test/manual/net/spy/memcached/emptycollection/PipedBulkInsertBTreeWithAttrTest.java
+++ b/src/test/manual/net/spy/memcached/emptycollection/PipedBulkInsertBTreeWithAttrTest.java
@@ -38,7 +38,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
-public class PipedBulkInsertBTreeWithAttrTest extends BaseIntegrationTest {
+class PipedBulkInsertBTreeWithAttrTest extends BaseIntegrationTest {
 
   private final String KEY = this.getClass().getSimpleName();
   private final long BKEY = 10;
@@ -60,7 +60,7 @@ public class PipedBulkInsertBTreeWithAttrTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testInsertWithAttribute() {
+  void testInsertWithAttribute() {
     try {
       // check not exists
       assertNull(mc.asyncGetAttr(KEY).get());
@@ -96,7 +96,7 @@ public class PipedBulkInsertBTreeWithAttrTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testInsertWithDefaultAttribute() {
+  void testInsertWithDefaultAttribute() {
     try {
       // check not exists
       assertNull(mc.asyncGetAttr(KEY).get());
@@ -124,7 +124,7 @@ public class PipedBulkInsertBTreeWithAttrTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testInsertWithoutAttributeCreate() {
+  void testInsertWithoutAttributeCreate() {
     try {
       // check not exists
       assertNull(mc.asyncGetAttr(KEY).get());
@@ -150,7 +150,7 @@ public class PipedBulkInsertBTreeWithAttrTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testInsertWithoutAttributeDoNotCreate() {
+  void testInsertWithoutAttributeDoNotCreate() {
     try {
       // check not exists
       assertNull(mc.asyncGetAttr(KEY).get());
@@ -174,7 +174,7 @@ public class PipedBulkInsertBTreeWithAttrTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testInsertWithEflag() {
+  void testInsertWithEflag() {
     try {
       byte[] eflag = new byte[]{0, 1, 0, 1};
       List<Element<Object>> elements = new ArrayList<>();
@@ -204,7 +204,7 @@ public class PipedBulkInsertBTreeWithAttrTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testInsertWithEflagLongBkey() {
+  void testInsertWithEflagLongBkey() {
     try {
       byte[] eflag = new byte[]{0, 1, 0, 1};
 

--- a/src/test/manual/net/spy/memcached/emptycollection/PipedBulkInsertListWithAttrTest.java
+++ b/src/test/manual/net/spy/memcached/emptycollection/PipedBulkInsertListWithAttrTest.java
@@ -33,7 +33,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
-public class PipedBulkInsertListWithAttrTest extends BaseIntegrationTest {
+class PipedBulkInsertListWithAttrTest extends BaseIntegrationTest {
 
   private final String KEY = this.getClass().getSimpleName();
   private final int INDEX = 0;
@@ -55,7 +55,7 @@ public class PipedBulkInsertListWithAttrTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testInsertWithAttribute() {
+  void testInsertWithAttribute() {
     try {
       // check not exists
       assertNull(mc.asyncGetAttr(KEY).get());
@@ -98,7 +98,7 @@ public class PipedBulkInsertListWithAttrTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testInsertWithDefaultAttribute() {
+  void testInsertWithDefaultAttribute() {
     try {
       // check not exists
       assertNull(mc.asyncGetAttr(KEY).get());
@@ -134,7 +134,7 @@ public class PipedBulkInsertListWithAttrTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testInsertWithoutAttributeCreate() {
+  void testInsertWithoutAttributeCreate() {
     try {
       // check not exists
       assertNull(mc.asyncGetAttr(KEY).get());
@@ -168,7 +168,7 @@ public class PipedBulkInsertListWithAttrTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testInsertWithoutAttributeDoNotCreate() {
+  void testInsertWithoutAttributeDoNotCreate() {
     try {
       // check not exists
       assertNull(mc.asyncGetAttr(KEY).get());

--- a/src/test/manual/net/spy/memcached/emptycollection/PipedBulkInsertMapWithAttrTest.java
+++ b/src/test/manual/net/spy/memcached/emptycollection/PipedBulkInsertMapWithAttrTest.java
@@ -32,7 +32,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
-public class PipedBulkInsertMapWithAttrTest extends BaseIntegrationTest {
+class PipedBulkInsertMapWithAttrTest extends BaseIntegrationTest {
 
   private final String KEY = this.getClass().getSimpleName();
   private final String MKEY = "10";
@@ -54,7 +54,7 @@ public class PipedBulkInsertMapWithAttrTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testInsertWithAttribute() {
+  void testInsertWithAttribute() {
     try {
       // check not exists
       assertNull(mc.asyncGetAttr(KEY).get());
@@ -90,7 +90,7 @@ public class PipedBulkInsertMapWithAttrTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testInsertWithDefaultAttribute() {
+  void testInsertWithDefaultAttribute() {
     try {
       // check not exists
       assertNull(mc.asyncGetAttr(KEY).get());
@@ -118,7 +118,7 @@ public class PipedBulkInsertMapWithAttrTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testInsertWithoutAttributeCreate() {
+  void testInsertWithoutAttributeCreate() {
     try {
       // check not exists
       assertNull(mc.asyncGetAttr(KEY).get());
@@ -144,7 +144,7 @@ public class PipedBulkInsertMapWithAttrTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testInsertWithoutAttributeDoNotCreate() {
+  void testInsertWithoutAttributeDoNotCreate() {
     try {
       // check not exists
       assertNull(mc.asyncGetAttr(KEY).get());

--- a/src/test/manual/net/spy/memcached/emptycollection/PipedBulkInsertSetWithAttrTest.java
+++ b/src/test/manual/net/spy/memcached/emptycollection/PipedBulkInsertSetWithAttrTest.java
@@ -34,7 +34,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
-public class PipedBulkInsertSetWithAttrTest extends BaseIntegrationTest {
+class PipedBulkInsertSetWithAttrTest extends BaseIntegrationTest {
 
   private final String KEY = this.getClass().getSimpleName();
   private final int EXPIRE_TIME_IN_SEC = 1;
@@ -55,7 +55,7 @@ public class PipedBulkInsertSetWithAttrTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testInsertWithAttribute() {
+  void testInsertWithAttribute() {
     try {
       // check not exists
       assertNull(mc.asyncGetAttr(KEY).get());
@@ -96,7 +96,7 @@ public class PipedBulkInsertSetWithAttrTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testInsertWithDefaultAttribute() {
+  void testInsertWithDefaultAttribute() {
     try {
       // check not exists
       assertNull(mc.asyncGetAttr(KEY).get());
@@ -130,7 +130,7 @@ public class PipedBulkInsertSetWithAttrTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testInsertWithoutAttributeCreate() {
+  void testInsertWithoutAttributeCreate() {
     try {
       // check not exists
       assertNull(mc.asyncGetAttr(KEY).get());
@@ -162,7 +162,7 @@ public class PipedBulkInsertSetWithAttrTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testInsertWithoutAttributeDoNotCreate() {
+  void testInsertWithoutAttributeDoNotCreate() {
     try {
       // check not exists
       assertNull(mc.asyncGetAttr(KEY).get());

--- a/src/test/manual/net/spy/memcached/emptycollection/ProtocolBTreeDeleteTest.java
+++ b/src/test/manual/net/spy/memcached/emptycollection/ProtocolBTreeDeleteTest.java
@@ -23,10 +23,10 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-public class ProtocolBTreeDeleteTest {
+class ProtocolBTreeDeleteTest {
 
   @Test
-  public void testStringify() {
+  void testStringify() {
     // default setting : dropIfEmpty = true
 
     assertEquals("10 drop",

--- a/src/test/manual/net/spy/memcached/emptycollection/ProtocolBTreeGetTest.java
+++ b/src/test/manual/net/spy/memcached/emptycollection/ProtocolBTreeGetTest.java
@@ -23,12 +23,12 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-public class ProtocolBTreeGetTest {
+class ProtocolBTreeGetTest {
 
   private static final long bkey = 10;
 
   @Test
-  public void testStringify() {
+  void testStringify() {
     assertEquals("10 drop", (new BTreeGet(bkey, true, true,
             ElementFlagFilter.DO_NOT_FILTER)).stringify());
     assertEquals("10 delete", (new BTreeGet(bkey, true,

--- a/src/test/manual/net/spy/memcached/emptycollection/ProtocolListDeleteTest.java
+++ b/src/test/manual/net/spy/memcached/emptycollection/ProtocolListDeleteTest.java
@@ -22,10 +22,10 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-public class ProtocolListDeleteTest {
+class ProtocolListDeleteTest {
 
   @Test
-  public void testStringify() {
+  void testStringify() {
     // default setting : dropIfEmpty = true
 
     assertEquals("10 drop",

--- a/src/test/manual/net/spy/memcached/emptycollection/ProtocolListGetTest.java
+++ b/src/test/manual/net/spy/memcached/emptycollection/ProtocolListGetTest.java
@@ -22,12 +22,12 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-public class ProtocolListGetTest {
+class ProtocolListGetTest {
 
   private static final int index = 10;
 
   @Test
-  public void testStringify() {
+  void testStringify() {
     assertEquals("10 drop",
             (new ListGet(index, true, true)).stringify());
     assertEquals("10 delete", (new ListGet(index, true,

--- a/src/test/manual/net/spy/memcached/emptycollection/ProtocolMapDeleteTest.java
+++ b/src/test/manual/net/spy/memcached/emptycollection/ProtocolMapDeleteTest.java
@@ -25,10 +25,10 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-public class ProtocolMapDeleteTest {
+class ProtocolMapDeleteTest {
 
   @Test
-  public void testStringify() {
+  void testStringify() {
     List<String> mkeyList = new ArrayList<>();
     mkeyList.add("mkey");
 

--- a/src/test/manual/net/spy/memcached/emptycollection/ProtocolMapGetTest.java
+++ b/src/test/manual/net/spy/memcached/emptycollection/ProtocolMapGetTest.java
@@ -25,12 +25,12 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-public class ProtocolMapGetTest {
+class ProtocolMapGetTest {
 
   private final String MKEY = "mkey";
 
   @Test
-  public void testStringify() {
+  void testStringify() {
     // default setting : dropIfEmpty = true
 
     List<String> mkeyList = new ArrayList<>();

--- a/src/test/manual/net/spy/memcached/emptycollection/ProtocolSetDeleteTest.java
+++ b/src/test/manual/net/spy/memcached/emptycollection/ProtocolSetDeleteTest.java
@@ -25,12 +25,12 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-public class ProtocolSetDeleteTest {
+class ProtocolSetDeleteTest {
   private final Object value = "value";
   private final Transcoder<Object> testTranscoder = new CollectionTranscoder();
 
   @Test
-  public void testStringify() {
+  void testStringify() {
     // default setting : dropIfEmpty = true
 
     SetDelete<Object> del = new SetDelete<>(value, false, testTranscoder);
@@ -53,7 +53,7 @@ public class ProtocolSetDeleteTest {
   }
 
   @Test
-  public void testGetAdditionalArgs() {
+  void testGetAdditionalArgs() {
     byte[] expected = new byte[]{'v', 'a', 'l', 'u', 'e'};
     SetDelete<Object> del = new SetDelete<>(value, false, testTranscoder);
     assertArrayEquals(expected, del.getAdditionalArgs());

--- a/src/test/manual/net/spy/memcached/emptycollection/ProtocolSetExistTest.java
+++ b/src/test/manual/net/spy/memcached/emptycollection/ProtocolSetExistTest.java
@@ -25,18 +25,18 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-public class ProtocolSetExistTest {
+class ProtocolSetExistTest {
   private final Object value = "value";
   private final Transcoder<Object> testTranscoder = new CollectionTranscoder();
 
   @Test
-  public void testStringify() {
+  void testStringify() {
     SetExist<Object> exist = new SetExist<>(value, testTranscoder);
     assertEquals("5", exist.stringify());
   }
 
   @Test
-  public void testGetAdditionalArgs() {
+  void testGetAdditionalArgs() {
     SetExist<Object> exist = new SetExist<>(value, testTranscoder);
     assertArrayEquals(new byte[]{'v', 'a', 'l', 'u', 'e'}, exist.getAdditionalArgs());
   }

--- a/src/test/manual/net/spy/memcached/emptycollection/ProtocolSetGetTest.java
+++ b/src/test/manual/net/spy/memcached/emptycollection/ProtocolSetGetTest.java
@@ -22,12 +22,12 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-public class ProtocolSetGetTest {
+class ProtocolSetGetTest {
 
   private static final int count = 10;
 
   @Test
-  public void testStringify() {
+  void testStringify() {
     assertEquals("10 drop",
             (new SetGet(count, true, true)).stringify());
     assertEquals("10 delete",

--- a/src/test/manual/net/spy/memcached/emptycollection/VariousTypeTest.java
+++ b/src/test/manual/net/spy/memcached/emptycollection/VariousTypeTest.java
@@ -38,7 +38,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
-public class VariousTypeTest extends BaseIntegrationTest {
+class VariousTypeTest extends BaseIntegrationTest {
 
   private final String KEY = this.getClass().getSimpleName();
   private final long BKEY = 10;
@@ -60,7 +60,7 @@ public class VariousTypeTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testString() {
+  void testString() {
     try {
       String value = "VALUE";
 
@@ -85,7 +85,7 @@ public class VariousTypeTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testLong() {
+  void testLong() {
     try {
       long value = 1234567890L;
 
@@ -110,7 +110,7 @@ public class VariousTypeTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testInteger() {
+  void testInteger() {
     try {
       int value = 1234567890;
 
@@ -135,7 +135,7 @@ public class VariousTypeTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testBoolean() {
+  void testBoolean() {
     try {
       boolean value = false;
 
@@ -160,7 +160,7 @@ public class VariousTypeTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testDate() {
+  void testDate() {
     try {
       Date value = new Date();
 
@@ -185,7 +185,7 @@ public class VariousTypeTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testByte() {
+  void testByte() {
     try {
       byte value = 0x00;
 
@@ -210,7 +210,7 @@ public class VariousTypeTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testFloat() {
+  void testFloat() {
     try {
       float value = 1234567890;
 
@@ -235,7 +235,7 @@ public class VariousTypeTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testDouble() {
+  void testDouble() {
     try {
       double value = 1234567890;
 
@@ -260,7 +260,7 @@ public class VariousTypeTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testByteArray() {
+  void testByteArray() {
     try {
       byte[] value = "value".getBytes();
 
@@ -286,7 +286,7 @@ public class VariousTypeTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testOtherObjects() {
+  void testOtherObjects() {
     try {
       UserDefinedClass value = new UserDefinedClass();
 
@@ -311,7 +311,7 @@ public class VariousTypeTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testList() {
+  void testList() {
     try {
       List<String> value = new ArrayList<>();
       value.add("Hello");

--- a/src/test/manual/net/spy/memcached/flushbyprefix/FlushByPrefixTest.java
+++ b/src/test/manual/net/spy/memcached/flushbyprefix/FlushByPrefixTest.java
@@ -27,7 +27,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
-public class FlushByPrefixTest extends BaseIntegrationTest {
+class FlushByPrefixTest extends BaseIntegrationTest {
 
   private final String PREFIX = "prefix";
   private final String DELIMITER = ":";
@@ -35,7 +35,7 @@ public class FlushByPrefixTest extends BaseIntegrationTest {
   private final String VALUE = "value";
 
   @Test
-  public void testFlushByPrefix() {
+  void testFlushByPrefix() {
     try {
       Boolean setResult = mc.set(PREFIX + DELIMITER + KEY, 60, VALUE)
               .get();
@@ -55,7 +55,7 @@ public class FlushByPrefixTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testFlushByPrefix1Depth() {
+  void testFlushByPrefix1Depth() {
     try {
       for (int i = 0; i < 10; i++) {
         Boolean setResult = mc.set(PREFIX + DELIMITER + KEY + i, 60,
@@ -80,7 +80,7 @@ public class FlushByPrefixTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testFlushByMultiPrefix() {
+  void testFlushByMultiPrefix() {
     try {
       for (int i = 0; i < 10; i++) {
         for (int prefix2 = 0; prefix2 < 10; prefix2++) {

--- a/src/test/manual/net/spy/memcached/frontcache/LocalCacheManagerTest.java
+++ b/src/test/manual/net/spy/memcached/frontcache/LocalCacheManagerTest.java
@@ -35,7 +35,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 
-public class LocalCacheManagerTest {
+class LocalCacheManagerTest {
 
   private ArcusClient client;
 
@@ -63,7 +63,7 @@ public class LocalCacheManagerTest {
   }
 
   @Test
-  public void testGet() throws Exception {
+  void testGet() throws Exception {
     for (String k : keys) {
       client.set(k, 2, k + "_value").get();
     }
@@ -104,7 +104,7 @@ public class LocalCacheManagerTest {
   }
 
   @Test
-  public void testGetBulk() throws Exception {
+  void testGetBulk() throws Exception {
     for (String k : keys) {
       client.set(k, 2, k + "_value").get();
     }
@@ -142,7 +142,7 @@ public class LocalCacheManagerTest {
   }
 
   @Test
-  public void testAsyncGetBulk() throws Exception {
+  void testAsyncGetBulk() throws Exception {
     for (String k : keys) {
       client.set(k, 2, k + "_value").get();
     }
@@ -183,7 +183,7 @@ public class LocalCacheManagerTest {
   }
 
   @Test
-  public void testBulkPartial() throws Exception {
+  void testBulkPartial() throws Exception {
     String[] keySet1 = new String[keys.size() / 2];
     String[] keySet2 = new String[keys.size() / 2];
 

--- a/src/test/manual/net/spy/memcached/ops/OperationStatusTest.java
+++ b/src/test/manual/net/spy/memcached/ops/OperationStatusTest.java
@@ -8,7 +8,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-public class OperationStatusTest extends BaseIntegrationTest {
+class OperationStatusTest extends BaseIntegrationTest {
   private static final int EXP = 100;
 
   @BeforeEach
@@ -19,7 +19,7 @@ public class OperationStatusTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testStore_success() throws Exception {
+  void testStore_success() throws Exception {
     //given
     String value = "value1";
     String replaceValue = "value2";
@@ -45,7 +45,7 @@ public class OperationStatusTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testStore_fail() throws Exception {
+  void testStore_fail() throws Exception {
     //given
     String value = "value1";
     String replaceValue = "value2";
@@ -71,7 +71,7 @@ public class OperationStatusTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testIncrAndDecr_success() throws Exception {
+  void testIncrAndDecr_success() throws Exception {
     //given
     String key = "key";
     String value = "65";
@@ -88,7 +88,7 @@ public class OperationStatusTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testIncrAndDecr_fail() throws Exception {
+  void testIncrAndDecr_fail() throws Exception {
     //given
     int value = 1;
     int value2 = 2;
@@ -105,7 +105,7 @@ public class OperationStatusTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testDelete_success() throws Exception {
+  void testDelete_success() throws Exception {
     //given
     String value = "example";
 
@@ -119,7 +119,7 @@ public class OperationStatusTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testDelete_fail() throws Exception {
+  void testDelete_fail() throws Exception {
     //given
     String value = "example";
 

--- a/src/test/manual/net/spy/memcached/test/AuthTest.java
+++ b/src/test/manual/net/spy/memcached/test/AuthTest.java
@@ -10,7 +10,7 @@ import net.spy.memcached.compat.SpyObject;
 /**
  * Authentication functional test.
  */
-public class AuthTest extends SpyObject implements Runnable {
+class AuthTest extends SpyObject implements Runnable {
 
   private final String username;
   private final String password;

--- a/src/test/manual/net/spy/memcached/test/ExcessivelyLargeGetTest.java
+++ b/src/test/manual/net/spy/memcached/test/ExcessivelyLargeGetTest.java
@@ -21,7 +21,7 @@ import net.spy.memcached.util.CacheLoader;
  * demonstrates the problems, I don't believe it generally demonstrates good
  * behavior for a unit test.
  */
-public class ExcessivelyLargeGetTest extends SpyObject implements Runnable {
+class ExcessivelyLargeGetTest extends SpyObject implements Runnable {
 
   // How many keys to do
   private static final int N = 25000;

--- a/src/test/manual/net/spy/memcached/test/LoaderTest.java
+++ b/src/test/manual/net/spy/memcached/test/LoaderTest.java
@@ -13,7 +13,7 @@ import net.spy.memcached.util.CacheLoader;
 /**
  * Loader performance test.
  */
-public class LoaderTest extends SpyObject implements Runnable {
+class LoaderTest extends SpyObject implements Runnable {
 
   private final int count;
   private MemcachedClient client;

--- a/src/test/manual/net/spy/memcached/test/MemcachedThreadBench.java
+++ b/src/test/manual/net/spy/memcached/test/MemcachedThreadBench.java
@@ -29,7 +29,7 @@ import static org.junit.jupiter.api.Assertions.fail;
  * Adaptation of http://code.google.com/p/spcached/wiki/benchmarktool
  */
 @Disabled
-public class MemcachedThreadBench {
+class MemcachedThreadBench {
 
   private static class WorkerStat {
     private int start, runs;
@@ -43,7 +43,7 @@ public class MemcachedThreadBench {
   }
 
   @Test
-  public void testCrap() throws Exception {
+  void testCrap() throws Exception {
     main(new String[]{"10000", "100", "11211", "100"});
   }
 

--- a/src/test/manual/net/spy/memcached/test/MemoryFullTest.java
+++ b/src/test/manual/net/spy/memcached/test/MemoryFullTest.java
@@ -15,7 +15,7 @@ import net.spy.memcached.ops.OperationException;
  *
  * memcached -U 11200 -p 11200 -m 32 -M
  */
-public final class MemoryFullTest {
+final class MemoryFullTest {
 
   private MemoryFullTest() {
   }

--- a/src/test/manual/net/spy/memcached/test/MultiNodeFailureTest.java
+++ b/src/test/manual/net/spy/memcached/test/MultiNodeFailureTest.java
@@ -9,7 +9,7 @@ import net.spy.memcached.MemcachedClient;
  * This is an attempt to reproduce a problem where a server fails during a
  * series of gets.
  */
-public final class MultiNodeFailureTest {
+final class MultiNodeFailureTest {
 
   private MultiNodeFailureTest() {
   }

--- a/src/test/manual/net/spy/memcached/test/MutateWithDefaultTest.java
+++ b/src/test/manual/net/spy/memcached/test/MutateWithDefaultTest.java
@@ -27,7 +27,7 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.fail;
 
-public class MutateWithDefaultTest extends BaseIntegrationTest {
+class MutateWithDefaultTest extends BaseIntegrationTest {
 
   private String key = "MutateWithDefaultTest";
 
@@ -39,7 +39,7 @@ public class MutateWithDefaultTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testIncr() {
+  void testIncr() {
     try {
       long v;
       Future<Long> future = mc.asyncIncr(key, 1);
@@ -59,7 +59,7 @@ public class MutateWithDefaultTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testDecr() {
+  void testDecr() {
     try {
       long v;
 
@@ -80,7 +80,7 @@ public class MutateWithDefaultTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testIncrWithDefault() {
+  void testIncrWithDefault() {
     try {
 
       Future<Long> future = mc.asyncIncr(key, 1, 100, 10);
@@ -100,7 +100,7 @@ public class MutateWithDefaultTest extends BaseIntegrationTest {
   }
 
   @Test
-  public void testDecrWithDefault() {
+  void testDecrWithDefault() {
     try {
 
       Future<Long> future = mc.asyncDecr(key, 1, 100, 10);

--- a/src/test/manual/net/spy/memcached/test/ObserverToy.java
+++ b/src/test/manual/net/spy/memcached/test/ObserverToy.java
@@ -14,7 +14,7 @@ import net.spy.memcached.MemcachedClient;
  * This expects a server on port 11212 that's somewhat unstable so it can report
  * and what-not.
  */
-public final class ObserverToy {
+final class ObserverToy {
 
   private ObserverToy() {
   }

--- a/src/test/manual/net/spy/memcached/test/SASLConnectReconnect.java
+++ b/src/test/manual/net/spy/memcached/test/SASLConnectReconnect.java
@@ -27,7 +27,7 @@ import static org.junit.jupiter.api.Assertions.fail;
  *
  * @author Matt Ingenthron <ingenthr@cep.net>
  */
-public class SASLConnectReconnect {
+class SASLConnectReconnect {
 
   private MemcachedClient mc = null;
 


### PR DESCRIPTION
### 🔗 Related Issue

<!-- Please link related issue. ex) https://github.com/naver/arcus-java-client/issues/{issue_number} -->
- https://github.com/jam2in/arcus-works/issues/599

### ⌨️ What I did

<!-- Please describe this PR and what you've been working on. -->
- Junit3 에서 존재하던 테스트 메서드 접근제한자 규칙이 Junit5 에서 사라짐에 따라 불필요한 접근제어자를 제거하였습니다.

**변경 후 test 개수 905 개로 동일합니다**