### PR TITLE
INTERNAL: Divide thread method from constructor

### DIFF
--- a/src/main/java/net/spy/memcached/ArcusClient.java
+++ b/src/main/java/net/spy/memcached/ArcusClient.java
@@ -321,6 +321,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
     }
 
     CacheManager exe = new CacheManager(hostPorts, serviceCode, cfb, poolSize, waitTimeForConnect);
+    exe.start();
     return new ArcusClientPool(poolSize, exe.getAC());
   }
 

--- a/src/main/java/net/spy/memcached/CacheManager.java
+++ b/src/main/java/net/spy/memcached/CacheManager.java
@@ -142,12 +142,15 @@ public class CacheManager extends SpyThread implements Watcher,
 
     this.startup = false;
 
-    setName("Cache Manager IO for " + serviceCode + "@" + hostPort);
-    setDaemon(true);
-    start();
-
     getLogger().info("CacheManager started. (" + serviceCode + "@" + hostPort + ")");
 
+  }
+
+  @Override
+  public synchronized void start() {
+    setName("Cache Manager IO for " + serviceCode + "@" + zkConnectString);
+    setDaemon(true);
+    super.start();
   }
 
   private String getCacheListZPath() {

--- a/src/main/java/net/spy/memcached/auth/AuthThread.java
+++ b/src/main/java/net/spy/memcached/auth/AuthThread.java
@@ -26,7 +26,6 @@ public class AuthThread extends SpyThread {
     opFact = o;
     authDescriptor = a;
     node = n;
-    start();
   }
 
   @Override

--- a/src/main/java/net/spy/memcached/auth/AuthThreadMonitor.java
+++ b/src/main/java/net/spy/memcached/auth/AuthThreadMonitor.java
@@ -39,6 +39,7 @@ public class AuthThreadMonitor extends SpyObject {
     interruptOldAuth(node);
     AuthThread newSASLAuthenticator = new AuthThread(conn, opFact,
             authDescriptor, node);
+    newSASLAuthenticator.start();
     nodeMap.put(node, newSASLAuthenticator);
   }
 

--- a/src/main/java/net/spy/memcached/compat/SyncThread.java
+++ b/src/main/java/net/spy/memcached/compat/SyncThread.java
@@ -29,11 +29,15 @@ public class SyncThread<T> extends SpyThread {
    */
   public SyncThread(CyclicBarrier b, Callable<T> c) {
     super("SyncThread");
-    setDaemon(true);
     callable = c;
     barrier = b;
     latch = new CountDownLatch(1);
-    start();
+  }
+
+  @Override
+  public synchronized void start() {
+    setDaemon(true);
+    super.start();
   }
 
   /**
@@ -81,7 +85,9 @@ public class SyncThread<T> extends SpyThread {
 
     CyclicBarrier barrier = new CyclicBarrier(num);
     for (int i = 0; i < num; i++) {
-      rv.add(new SyncThread<>(barrier, callable));
+      SyncThread<T> syncThread = new SyncThread<>(barrier, callable);
+      syncThread.start();
+      rv.add(syncThread);
     }
 
     for (SyncThread<T> t : rv) {


### PR DESCRIPTION
### 🔗 Related Issue

<!-- Please link related issue. ex) https://github.com/naver/arcus-java-client/issues/{issue_number} -->
- https://github.com/jam2in/arcus-works/issues/568

### ⌨️ What I did

<!-- Please describe this PR and what you've been working on. -->
- final class 가 아닌 class 의 생성자에서 thread의 메서드 를 호출하여 `this-escape` warning 이 발생합니다. 따라서 이를 피하기 위해 생성자가 아닌 생성자를 호출하는 곳에서 thread 의 메서드를 따로 호출하도록 하였습니다.

https://www.baeldung.com/java-thread-constructor
https://stackoverflow.com/questions/5623285/why-not-to-start-a-thread-in-the-constructor-how-to-terminate