### PR TITLE
INTERNAL: changeRole logic when repl nodes updated.

### DIFF
--- a/src/main/java/net/spy/memcached/ArcusReplKetamaNodeLocator.java
+++ b/src/main/java/net/spy/memcached/ArcusReplKetamaNodeLocator.java
@@ -235,13 +235,8 @@ public class ArcusReplKetamaNodeLocator extends SpyObject implements NodeLocator
     }
   }
 
-  public void update(Collection<MemcachedNode> toAttach, Collection<MemcachedNode> toDelete) {
-    update(toAttach, toDelete, new ArrayList<>(0));
-  }
-
   public void update(Collection<MemcachedNode> toAttach,
-                     Collection<MemcachedNode> toDelete,
-                     Collection<MemcachedReplicaGroup> changeRoleGroups) {
+                     Collection<MemcachedNode> toDelete) {
     /* We must keep the following execution order
      * - first, remove nodes.
      * - second, change role.
@@ -258,11 +253,6 @@ public class ArcusReplKetamaNodeLocator extends SpyObject implements NodeLocator
         } catch (IOException e) {
           getLogger().error("Failed to closeChannel the node : " + node);
         }
-      }
-
-      // Change role
-      for (MemcachedReplicaGroup g : changeRoleGroups) {
-        g.changeRole();
       }
 
       // Add memcached nodes.

--- a/src/main/java/net/spy/memcached/MemcachedConnection.java
+++ b/src/main/java/net/spy/memcached/MemcachedConnection.java
@@ -549,8 +549,10 @@ public final class MemcachedConnection extends SpyObject {
         }
       }
     }
+
     // Update the hash.
-    ((ArcusReplKetamaNodeLocator) locator).update(attachNodes, removeNodes, changeRoleGroups);
+    changeRoleGroups.forEach(MemcachedReplicaGroup::changeRole);
+    locator.update(attachNodes, removeNodes);
 
     // do task after locator update
     for (Task task : taskList) {

--- a/src/main/java/net/spy/memcached/MemcachedReplicaGroupImpl.java
+++ b/src/main/java/net/spy/memcached/MemcachedReplicaGroupImpl.java
@@ -65,6 +65,10 @@ public class MemcachedReplicaGroupImpl extends MemcachedReplicaGroup {
     return false;
   }
 
+  /**
+   * Only invoked for switchover or failover groups
+   * @return true if role change is successful
+   */
   public boolean changeRole() {
         /* role change */
     MemcachedNode tmpNode = this.masterNode;
@@ -76,6 +80,8 @@ public class MemcachedReplicaGroupImpl extends MemcachedReplicaGroup {
       this.setMasterCandidate(null);
     }
 
+    // Switch the previous master node to the first elem in slave node list.
+    // Because new slave node is added to list in locator already.
     if (tmpNode != null) { // previous master node
       ((ArcusReplNodeAddress) tmpNode.getSocketAddress()).setMaster(false);
       this.slaveNodes.add(tmpNode);


### PR DESCRIPTION
### 🔗 Related Issue

https://github.com/jam2in/arcus-works/issues/598

### ⌨️ What I did

기존 ReplLocator의 update 메서드는
오버로딩되어 아래의 두 가지를 가진다.
-  `public void update(Collection<MemcachedNode> toAttach, Collection<MemcachedNode> toDelete)`
- `public void update(Collection<MemcachedNode> toAttach,
                     Collection<MemcachedNode> toDelete,
                     Collection<MemcachedReplicaGroup> changeRoleGroups)`

실제로 캐시 리스트 update 시 사용시 호출되는 것은 두번째 메서드이고
Locator 인터페이스로부터 상속 받은 메서드는 첫번째 메서드이다.

위 두 메서드를 분리해서 사용하지 않고 
1번 메서드로 통일하기 위한 목적을 가진 PR이다.

통일을 해야 추후 `locator.update(...)`를 통해 
Repl과 Relp이 적용되지 않은 경우를 한번에 다룰 수 있다.

changeRoleGroups 인자는 switch over 또는 fail over가 발생한 Repl 그룹을 컬렉션에 모아둔다.
추후 master <-> slave 간의 역할 변경을 수행하기 위함이다.

정리하자면 하나의 메서드를 사용하기 위해 update의
changeRoleGroups 인자를 제거하는 PR이다.

### 로직 설명
switch over 또는 fail over인 경우는 oldSlave에 newMaster가 존재한다.
즉, attachNodes에 master node가 될 노드는 없고 새로운 Slave가 될 노드는 존재할 수 있다.

기존 로직은 locator 내에서 remove -> changeRole -> add 순으로 로직을 처리한다.
중간에 changeRole을 하게 되면 old master는 slave로
master candidate인 slave는 new master로 승격한다.

기존 로직의 예를 들면 아래와 같다.
- master canditate : b
- 삭제 예정 slave : d
```
------기존----------------remove---------------changeRole---------slave노드add
(M : a, S : b, c, d) -> (M : a, S : b, c) -> (M : b, S : c, a)
```

변경된 로직은 changeRole -> remove -> add 순으로 update를 진행한다.
```
------기존----------------changeRole---------------remove---------slave노드add
(M : a, S : b, c, d) -> (M : b, S : c, d, a) -> (M : b, S : c, a)
```

참고로 remove 로직은 MemcachedReplicaGroupImpl의
deleteMemcachedNode 에서 수행한다.