### PR TITLE
INTERNAL: Make final class which is not inherit

### DIFF
--- a/src/main/java/net/spy/memcached/ArcusReplNodeAddress.java
+++ b/src/main/java/net/spy/memcached/ArcusReplNodeAddress.java
@@ -29,7 +29,7 @@ import java.util.Set;
 import net.spy.memcached.compat.log.Logger;
 import net.spy.memcached.compat.log.LoggerFactory;
 
-public class ArcusReplNodeAddress extends InetSocketAddress {
+public final class ArcusReplNodeAddress extends InetSocketAddress {
 
   private static final long serialVersionUID = -1555690881482453720L;
   private static final Logger arcusLogger = LoggerFactory.getLogger(ArcusReplNodeAddress.class);

--- a/src/main/java/net/spy/memcached/CacheManager.java
+++ b/src/main/java/net/spy/memcached/CacheManager.java
@@ -47,7 +47,7 @@ import org.apache.zookeeper.ZooKeeper;
  * memcached server in the remote machine. It also changes the
  * previous ketama node
  */
-public class CacheManager extends SpyThread implements Watcher,
+public final class CacheManager extends SpyThread implements Watcher,
         CacheMonitor.CacheMonitorListener, MigrationMonitor.MigrationMonitorListener {
   private static final String ARCUS_BASE_CACHE_LIST_ZPATH = "/arcus/cache_list/";
 

--- a/src/main/java/net/spy/memcached/CacheMonitor.java
+++ b/src/main/java/net/spy/memcached/CacheMonitor.java
@@ -31,7 +31,7 @@ import org.apache.zookeeper.ZooKeeper;
  * CacheMonitor monitors the changes of the cache server list
  * in the ZooKeeper node{@code (/arcus/cache_list/<service_code>)}.
  */
-public class CacheMonitor extends SpyObject implements Watcher,
+public final class CacheMonitor extends SpyObject implements Watcher,
         ChildrenCallback {
 
   private final ZooKeeper zk;

--- a/src/main/java/net/spy/memcached/MemcachedNodeROImpl.java
+++ b/src/main/java/net/spy/memcached/MemcachedNodeROImpl.java
@@ -26,7 +26,7 @@ import java.util.Collection;
 
 import net.spy.memcached.ops.Operation;
 
-public class MemcachedNodeROImpl implements MemcachedNode {
+public final class MemcachedNodeROImpl implements MemcachedNode {
 
   private final MemcachedNode root;
 

--- a/src/main/java/net/spy/memcached/MemcachedReplicaGroupImpl.java
+++ b/src/main/java/net/spy/memcached/MemcachedReplicaGroupImpl.java
@@ -18,7 +18,7 @@
 /* ENABLE_REPLICATION if */
 package net.spy.memcached;
 
-public class MemcachedReplicaGroupImpl extends MemcachedReplicaGroup {
+public final class MemcachedReplicaGroupImpl extends MemcachedReplicaGroup {
 
   public MemcachedReplicaGroupImpl(final MemcachedNode node) {
     super(getGroupNameFromNode(node));

--- a/src/main/java/net/spy/memcached/MemcachedReplicaGroupROImpl.java
+++ b/src/main/java/net/spy/memcached/MemcachedReplicaGroupROImpl.java
@@ -17,7 +17,7 @@
 /* ENABLE_REPLICATION if */
 package net.spy.memcached;
 
-public class MemcachedReplicaGroupROImpl extends MemcachedReplicaGroup {
+public final class MemcachedReplicaGroupROImpl extends MemcachedReplicaGroup {
   public MemcachedReplicaGroupROImpl(final MemcachedReplicaGroup group) {
     super(group.getGroupName());
     this.masterNode = new MemcachedNodeROImpl(group.getMasterNode());

--- a/src/main/java/net/spy/memcached/MigrationMonitor.java
+++ b/src/main/java/net/spy/memcached/MigrationMonitor.java
@@ -32,7 +32,7 @@ import org.apache.zookeeper.ZooKeeper;
  * MigrationMonitor monitors the changes of the cloud_stat
  * in the ZooKeeper node{@code (/arcus/cloud_stat/<service_code>)}.
  */
-public class MigrationMonitor extends SpyObject implements Watcher {
+public final class MigrationMonitor extends SpyObject implements Watcher {
 
   private final ZooKeeper zk;
 


### PR DESCRIPTION
### 🔗 Related Issue

<!-- Please link related issue. ex) https://github.com/naver/arcus-java-client/issues/{issue_number} -->
- https://github.com/jam2in/arcus-works/issues/568

### ⌨️ What I did

<!-- Please describe this PR and what you've been working on. -->
상속이 필요없는 클래스에 대해 final 클래스로 만듭니다.

`CacheMonitor`, `MigrationMonitor`, `MemcachedReplicationGroupImpl`, `CacheManager`, ArcusReplNodeAddress`,
`MemcachedNodeROImpl`, `MemcachedReplicaGroupImpl`, `MemcachedReplicaGroupROImpl` 클래스들을 final 로 변경합니다.