### PR TITLE
INTERNAL: re-interrupt method that can be caught

### DIFF
--- a/src/main/java/net/spy/memcached/CacheManager.java
+++ b/src/main/java/net/spy/memcached/CacheManager.java
@@ -200,6 +200,9 @@ public final class CacheManager extends SpyThread implements Watcher,
       shutdownZooKeeperClient();
       throw e;
     } catch (Exception e) {
+      if (e instanceof InterruptedException) {
+        Thread.currentThread().interrupt();
+      }
       shutdownZooKeeperClient();
       throw new InitializeClientException("Can't connect to zookeeper.", e);
     }
@@ -266,6 +269,9 @@ public final class CacheManager extends SpyThread implements Watcher,
       shutdownZooKeeperClient();
       throw e;
     } catch (Exception e) {
+      if (e instanceof InterruptedException) {
+        Thread.currentThread().interrupt();
+      }
       shutdownZooKeeperClient();
       throw new InitializeClientException("Can't initialize Arcus client.", e);
     }
@@ -748,6 +754,7 @@ public final class CacheManager extends SpyThread implements Watcher,
       zk.close();
       zk = null;
     } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
       getLogger().warn("An exception occured while closing ZooKeeper client.", e);
     }
   }


### PR DESCRIPTION
### 🔗 Related Issue

<!-- Please link related issue. ex) https://github.com/naver/arcus-java-client/issues/{issue_number} -->
- 

### ⌨️ What I did

<!-- Please describe this PR and what you've been working on. -->

- `InterruptedException` 이 발생하는 경우 `Thread.currentThread().interrupt();` 를 활용하여 상위 stack 에서 해당 스레드에서 Interrupt 가 발생하였다는것을 알립니다.