### PR TITLE
INTERNAL: Suppress-warning for `this-escape`

### DIFF
--- a/src/main/java/net/spy/memcached/ArcusClient.java
+++ b/src/main/java/net/spy/memcached/ArcusClient.java
@@ -348,6 +348,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
    * @param addrs socket addresses for the memcached servers
    * @throws IOException if connections cannot be established
    */
+  @SuppressWarnings("this-escape")
   public ArcusClient(ConnectionFactory cf, String name, List<InetSocketAddress> addrs)
           throws IOException {
     super(cf, name, addrs);

--- a/src/main/java/net/spy/memcached/MemcachedClient.java
+++ b/src/main/java/net/spy/memcached/MemcachedClient.java
@@ -190,6 +190,7 @@ public class MemcachedClient extends SpyThread
    * @param addrs the socket addresses
    * @throws IOException if connections cannot be established
    */
+  @SuppressWarnings("this-escape")
   public MemcachedClient(ConnectionFactory cf, String name, List<InetSocketAddress> addrs)
           throws IOException {
     if (cf == null) {


### PR DESCRIPTION
### 🔗 Related Issue

<!-- Please link related issue. ex) https://github.com/naver/arcus-java-client/issues/{issue_number} -->
- https://github.com/jam2in/arcus-works/issues/568

### ⌨️ What I did

<!-- Please describe this PR and what you've been working on. -->
- `ArcusClient`, `MemcachedClient` 에 `suppress-warning` 을 적용하였습니다.

`ArcusClient` 의 경우에는 위 처럼 메서드를 따로 호출해야 하는 경우 다른 필드들도 public 으로 접근제어를 변경해야합니다.
`MemcachedClient` 의 경우에는 상속을 하는 클래스가 많아서 이를 위와 같은 방식, 메서드를 떼어내는 방식으로 수정하게 되면 수정 사항이 많아집니다.
또한 `MemcachedClient` 는 현재 상속을 하고 있기 때문에 final class 를 적용할 수 없습니다.
`ArcusClient` 또한 상속 가능성이 있다고 말씀해 주셔서 모두 `suppress-warning` 을 적용하였습니다.