### PR TITLE
REFACTOR: methods in MemcachedConnection invoked with updateReplConnection.

### DIFF
--- a/src/test/java/net/spy/memcached/MemcachedReplicaGroupTest.java
+++ b/src/test/java/net/spy/memcached/MemcachedReplicaGroupTest.java
@@ -1,0 +1,76 @@
+package net.spy.memcached;
+
+
+import java.net.InetSocketAddress;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+
+class MemcachedReplicaGroupTest {
+
+  @Test
+  void findChangedGroupsTest() {
+    List<ArcusReplNodeAddress> g0 = createReplList("g0", "192.168.0.1");
+    List<ArcusReplNodeAddress> g1 = createReplList("g1", "192.168.0.2");
+    List<MemcachedNode> old = new ArrayList<>();
+    setReplGroup(g0, old);
+    setReplGroup(g1, old);
+
+    List<InetSocketAddress> update = new ArrayList<>(g0);
+
+    Set<String> changedGroups = MemcachedReplicaGroup.findChangedGroups(update, old);
+    Assertions.assertEquals(1, changedGroups.size());
+    Assertions.assertTrue(changedGroups.contains("g1"));
+  }
+
+  @Test
+  void findAddrsOfChangedGroupsTest() {
+    List<ArcusReplNodeAddress> g0 = createReplList("g0", "192.168.0.1");
+    List<ArcusReplNodeAddress> g1 = createReplList("g1", "192.168.0.2");
+    List<MemcachedNode> old = new ArrayList<>();
+    setReplGroup(g0, old);
+    setReplGroup(g1, old);
+
+    List<InetSocketAddress> update = new ArrayList<>();
+    update.addAll(g0.subList(0, 2));
+    update.addAll(g1.subList(0, 2));
+
+    Set<String> changedGroups = MemcachedReplicaGroup.findChangedGroups(update, old);
+    List<InetSocketAddress> result
+            = MemcachedReplicaGroup.findAddrsOfChangedGroups(update, changedGroups);
+
+    Assertions.assertEquals(4, result.size());
+    Assertions.assertTrue(result.contains(g0.get(0)));
+    Assertions.assertTrue(result.contains(g0.get(1)));
+    Assertions.assertTrue(result.contains(g1.get(0)));
+    Assertions.assertTrue(result.contains(g1.get(1)));
+  }
+
+  private void setReplGroup(List<ArcusReplNodeAddress> group, List<MemcachedNode> old) {
+    List<MockMemcachedNode> collect = group.stream()
+            .map(MockMemcachedNode::new)
+            .collect(Collectors.toList());
+    MemcachedReplicaGroupImpl impl = null;
+    for (MockMemcachedNode node : collect) {
+      if (impl == null) {
+        impl = new MemcachedReplicaGroupImpl(node);
+      } else {
+        node.setReplicaGroup(impl);
+      }
+    }
+    old.addAll(collect);
+  }
+
+  private List<ArcusReplNodeAddress> createReplList(String group, String ip) {
+    List<ArcusReplNodeAddress> replList = new ArrayList<>();
+    replList.add(ArcusReplNodeAddress.create(group, true, ip + ":" + 11211));
+    replList.add(ArcusReplNodeAddress.create(group, false, ip + ":" + (11211 + 1)));
+    replList.add(ArcusReplNodeAddress.create(group, false, ip + ":" + (11211 + 2)));
+    return replList;
+  }
+}

--- a/src/test/java/net/spy/memcached/MockMemcachedNode.java
+++ b/src/test/java/net/spy/memcached/MockMemcachedNode.java
@@ -29,6 +29,7 @@ import net.spy.memcached.ops.Operation;
 
 public class MockMemcachedNode implements MemcachedNode {
   private final InetSocketAddress socketAddress;
+  private MemcachedReplicaGroup memcachedReplicaGroup;
 
   public SocketAddress getSocketAddress() {
     return socketAddress;
@@ -260,13 +261,12 @@ public class MockMemcachedNode implements MemcachedNode {
 
   @Override
   public void setReplicaGroup(MemcachedReplicaGroup g) {
-    // noop
+    this.memcachedReplicaGroup = g;
   }
 
   @Override
   public MemcachedReplicaGroup getReplicaGroup() {
-    // noop
-    return null;
+    return memcachedReplicaGroup;
   }
 
   @Override


### PR DESCRIPTION
### 🔗 Related Issue

https://github.com/jam2in/arcus-works/issues/598

### ⌨️ What I did

MemcachedConnection에 존재하는 아래 4가지 메서드들을
리팩토링 하고 위치를 ArcusReplNodeAddress로 옮겼습니다.
- findChangedGroups
- findAddrsOfChangedGroups
- getAddrsFromNodes
- getSlaveAddrsFromGroupAddrs

getAddrsFromNodes과 getSlaveAddrsFromGroupAddrs의
경우 내부적으로 사용되는 HashSet의 크기가 최대 2개입니다.
(두 메서드 모두 slave 노드들을 다루기  때문)

그래서 HashSet의 해시 테이블 부하계수를 디폴트(0.75)로 사용해도 상관 없을 것 같아
두 메서드의 구현을 좀 더 간결하게 변경하였습니다.