### PR TITLE
CLEANUP: Collection Btree

### DIFF
--- a/src/main/java/net/spy/memcached/collection/BTreeCount.java
+++ b/src/main/java/net/spy/memcached/collection/BTreeCount.java
@@ -20,14 +20,14 @@ import net.spy.memcached.util.BTreeUtil;
 
 public class BTreeCount extends CollectionCount {
 
-  private static final String command = "bop count";
+  private static final String COMMAND = "bop count";
 
   protected final String range;
 
   protected final ElementFlagFilter elementFlagFilter;
 
   public BTreeCount(long from, long to, ElementFlagFilter elementFlagFilter) {
-    this.range = String.valueOf(from) + ".." + String.valueOf(to);
+    this.range = from + ".." + to;
     this.elementFlagFilter = elementFlagFilter;
   }
 
@@ -37,13 +37,13 @@ public class BTreeCount extends CollectionCount {
   }
 
   public BTreeCount(long from, long to, ElementMultiFlagsFilter elementMultiFlagsFilter) {
-    this.range = String.valueOf(from) + ".." + String.valueOf(to);
-    this.elementFlagFilter = (ElementFlagFilter) elementMultiFlagsFilter;
+    this.range = from + ".." + to;
+    this.elementFlagFilter = elementMultiFlagsFilter;
   }
 
   public BTreeCount(byte[] from, byte[] to, ElementMultiFlagsFilter elementMultiFlagsFilter) {
     this.range = BTreeUtil.toHex(from) + ".." + BTreeUtil.toHex(to);
-    this.elementFlagFilter = (ElementFlagFilter) elementMultiFlagsFilter;
+    this.elementFlagFilter = elementMultiFlagsFilter;
   }
 
   public String stringify() {
@@ -64,6 +64,6 @@ public class BTreeCount extends CollectionCount {
   }
 
   public String getCommand() {
-    return command;
+    return COMMAND;
   }
 }

--- a/src/main/java/net/spy/memcached/collection/BTreeCreate.java
+++ b/src/main/java/net/spy/memcached/collection/BTreeCreate.java
@@ -18,7 +18,7 @@ package net.spy.memcached.collection;
 
 public class BTreeCreate extends CollectionCreate {
 
-  private static final String command = "bop create";
+  private static final String COMMAND = "bop create";
 
   public BTreeCreate(int flags, Integer expTime, Long maxCount,
                      CollectionOverflowAction overflowAction, Boolean readable, boolean noreply) {
@@ -26,6 +26,6 @@ public class BTreeCreate extends CollectionCreate {
   }
 
   public String getCommand() {
-    return command;
+    return COMMAND;
   }
 }

--- a/src/main/java/net/spy/memcached/collection/BTreeDelete.java
+++ b/src/main/java/net/spy/memcached/collection/BTreeDelete.java
@@ -20,7 +20,7 @@ import net.spy.memcached.util.BTreeUtil;
 
 public class BTreeDelete extends CollectionDelete {
 
-  private static final String command = "bop delete";
+  private static final String COMMAND = "bop delete";
   protected int count = -1;
 
   protected ElementFlagFilter elementFlagFilter;
@@ -38,12 +38,12 @@ public class BTreeDelete extends CollectionDelete {
   }
 
   public BTreeDelete(long from, long to, boolean noreply) {
-    this.range = String.valueOf(from) + ".." + String.valueOf(to);
+    this.range = from + ".." + to;
     this.noreply = noreply;
   }
 
   public BTreeDelete(long from, long to, int count, boolean noreply) {
-    this.range = String.valueOf(from) + ".." + String.valueOf(to);
+    this.range = from + ".." + to;
     this.count = count;
     this.noreply = noreply;
   }
@@ -77,14 +77,14 @@ public class BTreeDelete extends CollectionDelete {
                      ElementMultiFlagsFilter elementMultiFlagsFilter) {
     this(bkey, noreply);
     this.dropIfEmpty = dropIfEmpty;
-    this.elementFlagFilter = (ElementFlagFilter) elementMultiFlagsFilter;
+    this.elementFlagFilter = elementMultiFlagsFilter;
   }
 
   public BTreeDelete(long from, long to, int count, boolean noreply, boolean dropIfEmpty,
                      ElementMultiFlagsFilter elementMultiFlagsFilter) {
     this(from, to, count, noreply);
     this.dropIfEmpty = dropIfEmpty;
-    this.elementFlagFilter = (ElementFlagFilter) elementMultiFlagsFilter;
+    this.elementFlagFilter = elementMultiFlagsFilter;
   }
 
   public BTreeDelete(byte[] bkey, boolean noreply, boolean dropIfEmpty,
@@ -92,7 +92,7 @@ public class BTreeDelete extends CollectionDelete {
     this.range = BTreeUtil.toHex(bkey);
     this.noreply = noreply;
     this.dropIfEmpty = dropIfEmpty;
-    this.elementFlagFilter = (ElementFlagFilter) elementMultiFlagsFilter;
+    this.elementFlagFilter = elementMultiFlagsFilter;
   }
 
   public BTreeDelete(byte[] from, byte[] to, int count, boolean noreply, boolean dropIfEmpty,
@@ -101,7 +101,7 @@ public class BTreeDelete extends CollectionDelete {
     this.count = count;
     this.noreply = noreply;
     this.dropIfEmpty = dropIfEmpty;
-    this.elementFlagFilter = (ElementFlagFilter) elementMultiFlagsFilter;
+    this.elementFlagFilter = elementMultiFlagsFilter;
   }
 
   @Override
@@ -138,7 +138,7 @@ public class BTreeDelete extends CollectionDelete {
   }
 
   public String getCommand() {
-    return command;
+    return COMMAND;
   }
 
 }

--- a/src/main/java/net/spy/memcached/collection/BTreeFindPosition.java
+++ b/src/main/java/net/spy/memcached/collection/BTreeFindPosition.java
@@ -30,7 +30,7 @@ import net.spy.memcached.util.BTreeUtil;
  */
 public class BTreeFindPosition {
 
-  private static final String command = "bop position";
+  private static final String COMMAND = "bop position";
 
   private final String bkey;
   private final BTreeOrder order;
@@ -60,7 +60,7 @@ public class BTreeFindPosition {
   }
 
   public String getCommand() {
-    return command;
+    return COMMAND;
   }
 
   public BTreeOrder getOrder() {

--- a/src/main/java/net/spy/memcached/collection/BTreeFindPositionWithGet.java
+++ b/src/main/java/net/spy/memcached/collection/BTreeFindPositionWithGet.java
@@ -42,7 +42,7 @@ import net.spy.memcached.util.BTreeUtil;
  * - SERVER_ERROR
  */
 public class BTreeFindPositionWithGet extends CollectionGet {
-  private static final String command = "bop pwg";
+  private static final String COMMAND = "bop pwg";
 
   private final BKeyObject bkeyObject;
   private final BTreeOrder order;
@@ -81,7 +81,7 @@ public class BTreeFindPositionWithGet extends CollectionGet {
   }
 
   public String getCommand() {
-    return command;
+    return COMMAND;
   }
 
   public BKeyObject getBkeyObject() {

--- a/src/main/java/net/spy/memcached/collection/BTreeGet.java
+++ b/src/main/java/net/spy/memcached/collection/BTreeGet.java
@@ -22,7 +22,7 @@ import net.spy.memcached.util.BTreeUtil;
 
 public class BTreeGet extends CollectionGet {
 
-  private static final String command = "bop get";
+  private static final String COMMAND = "bop get";
   protected int offset = -1;
   protected int count = -1;
   protected ElementFlagFilter elementFlagFilter;
@@ -117,7 +117,7 @@ public class BTreeGet extends CollectionGet {
   }
 
   public String getCommand() {
-    return command;
+    return COMMAND;
   }
 
   @Override

--- a/src/main/java/net/spy/memcached/collection/BTreeGetBulk.java
+++ b/src/main/java/net/spy/memcached/collection/BTreeGetBulk.java
@@ -22,7 +22,7 @@ import net.spy.memcached.MemcachedNode;
 
 public interface BTreeGetBulk<T> {
 
-  int headerCount = 3;
+  int HEADER_COUNT = 3;
 
   void setKeySeparator(String keySeparator);
 

--- a/src/main/java/net/spy/memcached/collection/BTreeGetBulkImpl.java
+++ b/src/main/java/net/spy/memcached/collection/BTreeGetBulkImpl.java
@@ -134,7 +134,7 @@ public abstract class BTreeGetBulkImpl<T> implements BTreeGetBulk<T> {
   }
 
   public boolean headerReady(int spaceCount) {
-    return spaceCount == BTreeGetBulk.headerCount;
+    return spaceCount == BTreeGetBulk.HEADER_COUNT;
   }
 
   public int getDataLength() {

--- a/src/main/java/net/spy/memcached/collection/BTreeGetByPosition.java
+++ b/src/main/java/net/spy/memcached/collection/BTreeGetByPosition.java
@@ -35,10 +35,9 @@ public class BTreeGetByPosition extends CollectionGet {
 
   public static final int HEADER_EFLAG_POSITION = 1; // 0-based
 
-  private static final String command = "bop gbp";
+  private static final String COMMAND = "bop gbp";
 
   private final BTreeOrder order;
-  private final String range;
   private final int posFrom;
   private final int posTo;
   private BKeyObject bkey;
@@ -54,7 +53,7 @@ public class BTreeGetByPosition extends CollectionGet {
 
   public BTreeGetByPosition(BTreeOrder order, int posFrom, int posTo) {
     this.order = order;
-    this.range = String.valueOf(posFrom) + ".." + String.valueOf(posTo);
+    this.range = posFrom + ".." + posTo;
     this.posFrom = posFrom;
     this.posTo = posTo;
     this.eHeadCount = 2;
@@ -83,7 +82,7 @@ public class BTreeGetByPosition extends CollectionGet {
   }
 
   public String getCommand() {
-    return command;
+    return COMMAND;
   }
 
   @Override

--- a/src/main/java/net/spy/memcached/protocol/ascii/BTreeGetBulkOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/BTreeGetBulkOperationImpl.java
@@ -146,7 +146,7 @@ public final class BTreeGetBulkOperationImpl extends OperationImpl implements
             String itemHeader = byteBuffer.toString();
 
             String[] chunk = itemHeader.split(" ");
-            if (chunk.length == BTreeGetBulk.headerCount
+            if (chunk.length == BTreeGetBulk.HEADER_COUNT
                     && chunk[2].startsWith("0x")) {
               spaceCount--;
               byteBuffer.write(b);


### PR DESCRIPTION
### 🔗 Related Issue

<!-- Please link related issue. ex) https://github.com/naver/arcus-java-client/issues/{issue_number} -->
- 

### ⌨️ What I did

<!-- Please describe this PR and what you've been working on. -->
- Collection 폴더 하위의 btree 관련 파일을 sonarLint 규칙에 맞추어 수정하였습니다
- 상수인 변수 (final, interface 의 필드) 들을 네이밍 컨벤션에 맞추어 대문자로 변경하였습니다.
- 필요없는 케스팅 문법을 삭제하였습니다. (문자열에 숫자를 이어 붙이면 묵시적 변환)
- 상위 클래스 필드의 이름과 같은 필드의 이름을 변경했습니다. `range` -> `posRange`