### PR TITLE
INTERNAL: return empty map if response is NOT_FOUND_ELEMENT

### DIFF
--- a/src/main/java/net/spy/memcached/ArcusClient.java
+++ b/src/main/java/net/spy/memcached/ArcusClient.java
@@ -2736,7 +2736,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
               getLogger().warn("Unhandled state: " + status);
               cstatus = new CollectionOperationStatus(status);
             }
-            if (cstatus.isSuccess()) {
+            if (cstatus.isSuccess() || cstatus.getResponse() == CollectionResponse.NOT_FOUND_ELEMENT) {
               rv.setResult(result, cstatus);
               return;
             }

--- a/src/test/manual/net/spy/memcached/collection/btree/BopFindPositionWithGetTest.java
+++ b/src/test/manual/net/spy/memcached/collection/btree/BopFindPositionWithGetTest.java
@@ -294,7 +294,7 @@ class BopFindPositionWithGetTest extends BaseIntegrationTest {
     longBkey = 200;
     f = mc.asyncBopFindPositionWithGet(key, longBkey, BTreeOrder.ASC, 0);
     result = f.get();
-    assertNull(result);
+    assertEquals(0, result.size());
     assertEquals(CollectionResponse.NOT_FOUND_ELEMENT, f.getOperationStatus().getResponse());
 
     // BKEY_MISMATCH


### PR DESCRIPTION
### 🔗 Related Issue

<!-- Please link related issue. ex) https://github.com/naver/arcus-java-client/issues/{issue_number} -->
- https://github.com/jam2in/arcus-works/issues/425

### ⌨️ What I did

<!-- Please describe this PR and what you've been working on. -->
- bop find position with get 에서 not found element인 경우 empty map 반환하도록 변경합니다.