### PR TITLE
INTERNAL: read while PIPE_ERROR received in the pipe operation

### DIFF
--- a/src/main/java/net/spy/memcached/protocol/ascii/OperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/OperationImpl.java
@@ -163,6 +163,9 @@ abstract class OperationImpl extends BaseOperationImpl implements Operation {
       } else { // OperationReadType.DATA
         handleRead(data);
       }
+      if (isPipeOperation() && getState() == OperationState.COMPLETE && hasErrored()) {
+        throw getException();
+      }
     }
   }
 


### PR DESCRIPTION
### 🔗 Related Issue

<!-- Please link related issue. ex) https://github.com/naver/arcus-java-client/issues/{issue_number} -->
- https://github.com/jam2in/arcus-works/issues/616

### ⌨️ What I did

<!-- Please describe this PR and what you've been working on. -->
- 본 PR에서는 파이프 연산 요청에서 에러(CLIENT_ERROR, ERROR, SERVER_ERROR) 응답 시 `PIPE_ERROR`를 끝까지 읽도록 변경한다.
- 기존에는 에러 응답 시 즉시 예외를 생성해 던졌기 때문에 `PIPE_ERROR`를 읽지 않았다.
- 동기 파이프 연산 처리 시 에러로 인해 수행되지 않은 연산을 failedResult를 통해 알려야 하는데, 기존 형태에서는 에러 시 바로 예외를 던지므로, 에러 발생으로 인해 수행되지 않은 연산에 대해 callback.gotStatus()를 호출할 수 없다.
- 따라서 `PIPE_ERROR`를 읽도록 변경만 해두고, 수행되지 않은 연산에 대한 gotStatus() 호출은 #795 에 추가하도록 한다.