### PR TITLE
INTERNAL: stacktrace all exceptions

### DIFF
--- a/src/main/java/net/spy/memcached/ExceptionMessageFactory.java
+++ b/src/main/java/net/spy/memcached/ExceptionMessageFactory.java
@@ -70,6 +70,10 @@ public final class ExceptionMessageFactory {
   }
 
   public static String createCompositeMessage(List<Exception> exceptions) {
+    if (exceptions == null || exceptions.isEmpty()) {
+      throw new IllegalArgumentException("At least one exception must be specified");
+    }
+
     StringBuilder rv = new StringBuilder();
     rv.append("Multiple exceptions (");
     rv.append(exceptions.size());

--- a/src/main/java/net/spy/memcached/internal/CompositeException.java
+++ b/src/main/java/net/spy/memcached/internal/CompositeException.java
@@ -1,5 +1,7 @@
 package net.spy.memcached.internal;
 
+import java.io.PrintWriter;
+import java.io.StringWriter;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
@@ -10,13 +12,51 @@ public class CompositeException extends ExecutionException {
 
   private static final long serialVersionUID = -599478797582490012L;
   private final ArrayList<Exception> exceptions = new ArrayList<>();
+  private final Throwable cause;
 
-  CompositeException(List<Exception> exceptions) {
+  public CompositeException(List<Exception> exceptions) {
     super(ExceptionMessageFactory.createCompositeMessage(exceptions));
+
+    if (exceptions.size() > 1) {
+      StringWriter sw = new StringWriter();
+      sw.write(System.lineSeparator());
+      try (PrintWriter pw = new PrintWriter(sw)) {
+        for (Exception e : exceptions) {
+          e.printStackTrace(pw);
+        }
+      }
+
+      this.cause = new ExceptionOverview(sw.toString());
+    } else {
+      this.cause = exceptions.get(0);
+    }
     this.exceptions.addAll(exceptions);
   }
 
   public List<Exception> getExceptions() {
     return exceptions;
+  }
+
+  public int size() {
+    return exceptions.size();
+  }
+
+  @Override
+  public synchronized Throwable getCause() {
+    return cause;
+  }
+
+  static final class ExceptionOverview extends RuntimeException {
+
+    private static final long serialVersionUID = -641960514509105302L;
+
+    ExceptionOverview(String message) {
+      super(message);
+    }
+
+    @Override
+    public synchronized Throwable fillInStackTrace() {
+      return this;
+    }
   }
 }

--- a/src/test/java/net/spy/memcached/compat/log/LoggingTest.java
+++ b/src/test/java/net/spy/memcached/compat/log/LoggingTest.java
@@ -4,6 +4,13 @@ package net.spy.memcached.compat.log;
 
 // XXX:  This really needs to get log4j configured first.
 
+import java.util.ArrayList;
+import java.util.List;
+
+import net.spy.memcached.internal.CompositeException;
+import net.spy.memcached.ops.OperationErrorType;
+import net.spy.memcached.ops.OperationException;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -154,4 +161,24 @@ class LoggingTest {
     assertNull(t);
   }
 
+  @Test
+  void logCompositeException() {
+    List<Exception> exceptions = new ArrayList<>();
+    exceptions.add(new OperationException(OperationErrorType.SERVER, "msg1"));
+    exceptions.add(new OperationException(OperationErrorType.CLIENT, "msg2"));
+    CompositeException exception = new CompositeException(exceptions);
+
+    logger.error("failed to get", exception);
+  }
+
+  @Test
+  void slf4jCompositeException() {
+    List<Exception> exceptions = new ArrayList<>();
+    exceptions.add(new OperationException(OperationErrorType.SERVER, "msg1"));
+    exceptions.add(new OperationException(OperationErrorType.CLIENT, "msg2"));
+    CompositeException exception = new CompositeException(exceptions);
+
+    Log4JLogger log4JLogger = new Log4JLogger(getClass().getName());
+    log4JLogger.error("failed to get", exception);
+  }
 }

--- a/src/test/java/net/spy/memcached/internal/CompositeExceptionTest.java
+++ b/src/test/java/net/spy/memcached/internal/CompositeExceptionTest.java
@@ -1,0 +1,44 @@
+package net.spy.memcached.internal;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import net.spy.memcached.ops.OperationErrorType;
+import net.spy.memcached.ops.OperationException;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class CompositeExceptionTest {
+
+  @Test
+  void printStackTraceOfAllExceptions() {
+    List<Exception> exceptions = new ArrayList<>();
+    exceptions.add(new OperationException(OperationErrorType.SERVER, "msg1"));
+    exceptions.add(new OperationException(OperationErrorType.CLIENT, "msg2"));
+    Exception e = throwError1();
+    exceptions.add(e);
+    CompositeException compositeException = new CompositeException(exceptions);
+    String message = compositeException.getCause().getMessage();
+
+    assertTrue(message
+            .contains("OperationException: SERVER: msg1"));
+    assertTrue(message
+            .contains("OperationException: CLIENT: msg2"));
+    assertTrue(message
+            .contains("OperationException: SERVER: msg3"));
+    assertTrue(message
+            .contains("at net.spy.memcached.internal.CompositeExceptionTest.throwError2"));
+    assertTrue(message
+            .contains("at net.spy.memcached.internal.CompositeExceptionTest.throwError1"));
+  }
+
+  private Exception throwError1() {
+    return throwError2();
+  }
+
+  private Exception throwError2() {
+    return new OperationException(OperationErrorType.SERVER, "msg3");
+  }
+}


### PR DESCRIPTION
### 🔗 Related Issue

<!-- Please link related issue. ex) https://github.com/naver/arcus-java-client/issues/{issue_number} -->
- https://github.com/naver/arcus-java-client/pull/839#discussion_r1846040585

### ⌨️ What I did

<!-- Please describe this PR and what you've been working on. -->
- CompositeException 객체의 printStackTrace() 메서드를 통해 예외에 대한 스택을 확인할 때, 아래와 같이 각각의 예외들에 대한 stacktrace가 찍히도록 합니다.