### PR TITLE
Refator: Remove callback field

### DIFF
--- a/src/main/java/net/spy/memcached/protocol/ascii/CollectionBulkInsertOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/CollectionBulkInsertOperationImpl.java
@@ -62,7 +62,6 @@ public final class CollectionBulkInsertOperationImpl extends OperationImpl
           false, "BKEY_MISMATCH", CollectionResponse.BKEY_MISMATCH);
 
   private final CollectionBulkInsert<?> insert;
-  private final CollectionBulkInsertOperation.Callback cb;
 
   private int count;
   private int index = 0;
@@ -71,7 +70,6 @@ public final class CollectionBulkInsertOperationImpl extends OperationImpl
   public CollectionBulkInsertOperationImpl(CollectionBulkInsert<?> insert, OperationCallback cb) {
     super(cb);
     this.insert = insert;
-    this.cb = (Callback) cb;
     if (this.insert instanceof CollectionBulkInsert.ListBulkInsert) {
       setAPIType(APIType.LOP_INSERT);
     } else if (this.insert instanceof CollectionBulkInsert.SetBulkInsert) {
@@ -88,6 +86,9 @@ public final class CollectionBulkInsertOperationImpl extends OperationImpl
   public void handleLine(String line) {
     assert getState() == OperationState.READING
             : "Read ``" + line + "'' when in " + getState() + " state";
+    CollectionBulkInsertOperation.Callback cb =
+            (CollectionBulkInsertOperation.Callback) getCallback();
+
     /* ENABLE_REPLICATION if */
     if (hasSwitchedOver(line)) {
       this.insert.setNextOpIndex(index);

--- a/src/main/java/net/spy/memcached/protocol/ascii/CollectionPipedExistOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/CollectionPipedExistOperationImpl.java
@@ -56,7 +56,6 @@ public final class CollectionPipedExistOperationImpl extends OperationImpl imple
 
   private final String key;
   private final SetPipedExist<?> setPipedExist;
-  private final CollectionPipedExistOperation.Callback cb;
 
   private int count;
   private int index = 0;
@@ -67,7 +66,6 @@ public final class CollectionPipedExistOperationImpl extends OperationImpl imple
     super(cb);
     this.key = key;
     this.setPipedExist = collectionExist;
-    this.cb = (Callback) cb;
     if (this.setPipedExist instanceof SetPipedExist) {
       setAPIType(APIType.SOP_EXIST);
     }
@@ -78,6 +76,8 @@ public final class CollectionPipedExistOperationImpl extends OperationImpl imple
   public void handleLine(String line) {
     assert getState() == OperationState.READING : "Read ``" + line
             + "'' when in " + getState() + " state";
+    CollectionPipedExistOperation.Callback cb =
+            (CollectionPipedExistOperation.Callback) getCallback();
 
     /* ENABLE_MIGRATION if */
     if (hasNotMyKey(line)) {

--- a/src/main/java/net/spy/memcached/protocol/ascii/CollectionPipedInsertOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/CollectionPipedInsertOperationImpl.java
@@ -64,7 +64,6 @@ public final class CollectionPipedInsertOperationImpl extends OperationImpl
 
   private final String key;
   private final CollectionPipedInsert<?> insert;
-  private final CollectionPipedInsertOperation.Callback cb;
 
   private int count;
   private int index = 0;
@@ -75,7 +74,6 @@ public final class CollectionPipedInsertOperationImpl extends OperationImpl
     super(cb);
     this.key = key;
     this.insert = insert;
-    this.cb = (Callback) cb;
     if (this.insert instanceof CollectionPipedInsert.ListPipedInsert) {
       setAPIType(APIType.LOP_INSERT);
     } else if (this.insert instanceof CollectionPipedInsert.SetPipedInsert) {
@@ -94,6 +92,8 @@ public final class CollectionPipedInsertOperationImpl extends OperationImpl
   public void handleLine(String line) {
     assert getState() == OperationState.READING
             : "Read ``" + line + "'' when in " + getState() + " state";
+    CollectionPipedInsertOperation.Callback cb =
+            (CollectionPipedInsertOperation.Callback) getCallback();
 
     /* ENABLE_REPLICATION if */
     if (hasSwitchedOver(line)) {

--- a/src/main/java/net/spy/memcached/protocol/ascii/CollectionPipedUpdateOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/CollectionPipedUpdateOperationImpl.java
@@ -66,7 +66,6 @@ public final class CollectionPipedUpdateOperationImpl extends OperationImpl impl
 
   private final String key;
   private final CollectionPipedUpdate<?> update;
-  private final CollectionPipedUpdateOperation.Callback cb;
 
   private int count;
   private int index = 0;
@@ -77,7 +76,6 @@ public final class CollectionPipedUpdateOperationImpl extends OperationImpl impl
     super(cb);
     this.key = key;
     this.update = update;
-    this.cb = (Callback) cb;
     if (this.update instanceof BTreePipedUpdate) {
       setAPIType(APIType.BOP_UPDATE);
     } else if (this.update instanceof MapPipedUpdate) {
@@ -90,6 +88,8 @@ public final class CollectionPipedUpdateOperationImpl extends OperationImpl impl
   public void handleLine(String line) {
     assert getState() == OperationState.READING : "Read ``" + line
             + "'' when in " + getState() + " state";
+    CollectionPipedUpdateOperation.Callback cb =
+            (CollectionPipedUpdateOperation.Callback) getCallback();
 
     /* ENABLE_REPLICATION if */
     if (hasSwitchedOver(line)) {

--- a/src/main/java/net/spy/memcached/protocol/ascii/GetAttrOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/GetAttrOperationImpl.java
@@ -50,18 +50,19 @@ class GetAttrOperationImpl extends OperationImpl implements GetAttrOperation {
           CollectionResponse.ATTR_ERROR_NOT_FOUND);
 
   protected final String key;
-  protected final GetAttrOperation.Callback cb;
 
   public GetAttrOperationImpl(String key, GetAttrOperation.Callback cb) {
     super(cb);
     this.key = key;
-    this.cb = cb;
     setAPIType(APIType.GETATTR);
     setOperationType(OperationType.READ);
   }
 
   @Override
   public void handleLine(String line) {
+    GetAttrOperation.Callback cb =
+            (GetAttrOperation.Callback) getCallback();
+
     /* ENABLE_MIGRATION if */
     if (hasNotMyKey(line)) {
       addRedirectSingleKeyOperation(line, key);


### PR DESCRIPTION
### 🔗 Related Issue

<!-- Please link related issue. ex) https://github.com/naver/arcus-java-client/issues/{issue_number} -->
- https://github.com/jam2in/arcus-works/issues/623

### ⌨️ What I did

<!-- Please describe this PR and what you've been working on. -->
- 다른 `Impl` 에서 구현하고 있는 방식과 동일하게 `callback` 을 `Impl` class 필드에서 저장하고 쓰는 방식에서 `handleLine()`시에 상위 객체에서 가져와서 캐스팅을 하는 방식으로 통일하였습니다.