### PR TITLE
INTERNAL: make callback field in BaseOperationImpl private

### DIFF
--- a/src/main/java/net/spy/memcached/protocol/BaseOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/BaseOperationImpl.java
@@ -52,7 +52,7 @@ public abstract class BaseOperationImpl extends SpyObject {
   private final AtomicBoolean callbacked = new AtomicBoolean(false);
   private String cancelCause = null;
   private OperationException exception = null;
-  protected OperationCallback callback = null;
+  private OperationCallback callback = null;
   private volatile MemcachedNode handlingNode = null;
 
   private OperationType opType = OperationType.UNDEFINED;

--- a/src/main/java/net/spy/memcached/protocol/ascii/OperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/OperationImpl.java
@@ -50,7 +50,7 @@ abstract class OperationImpl extends BaseOperationImpl implements Operation {
 
   protected OperationImpl(OperationCallback cb) {
     super();
-    callback = cb;
+    setCallback(cb);
   }
 
   /**


### PR DESCRIPTION
### 🔗 Related Issue

<!-- Please link related issue. ex) https://github.com/naver/arcus-java-client/issues/{issue_number} -->
- https://github.com/jam2in/arcus-works/issues/639

### ⌨️ What I did

<!-- Please describe this PR and what you've been working on. -->
- BaseOperationImpl의 callback 필드를 private으로 변경합니다.