### PR TITLE
TEST: Feat not piped test

### DIFF
--- a/src/test/manual/net/spy/memcached/bulkoperation/BopInsertBulkTest.java
+++ b/src/test/manual/net/spy/memcached/bulkoperation/BopInsertBulkTest.java
@@ -374,4 +374,32 @@ class BopInsertBulkTest extends BaseIntegrationTest {
       fail();
     }
   }
+
+  @Test
+  void testBopInsertNotPiped() {
+    String value = "MyValue";
+    long bkey = Long.MAX_VALUE;
+    Future<Map<String, CollectionOperationStatus>> future;
+    Map<String, CollectionOperationStatus> errorList;
+    String[] keys = {"MyBopKeyA"};
+
+    try {
+      // DELETE
+      mc.delete(keys[0]).get();
+      // SET FAIL
+      future = mc.asyncBopInsertBulk(Arrays.asList(keys), bkey, null, value,
+              null);
+      errorList = future.get(20000L, TimeUnit.MILLISECONDS);
+      assertEquals(1, errorList.size());
+      // SET
+      future = mc.asyncBopInsertBulk(Arrays.asList(keys), bkey, null, value,
+              new CollectionAttributes());
+      errorList = future.get(20000L, TimeUnit.MILLISECONDS);
+      assertTrue(errorList.isEmpty(),
+              "Error list is not empty.");
+    } catch (Exception e) {
+      e.printStackTrace();
+      fail();
+    }
+  }
 }

--- a/src/test/manual/net/spy/memcached/bulkoperation/BopPipeUpdateTest.java
+++ b/src/test/manual/net/spy/memcached/bulkoperation/BopPipeUpdateTest.java
@@ -284,4 +284,29 @@ class BopPipeUpdateTest extends BaseIntegrationTest {
     }
 
   }
+
+  @Test
+  void testBopUpdateNotPiped() {
+    List<Element<Object>> updateElements = new ArrayList<>();
+    updateElements.add(new Element<>(0, "updated" + 0,
+              new ElementFlagUpdate(new byte[]{1, 1, 1, 1})));
+    CollectionFuture<Map<Integer, CollectionOperationStatus>> future;
+    Map<Integer, CollectionOperationStatus> errorList;
+
+    try {
+      // UPDATE
+      future = mc.asyncBopPipedUpdateBulk(KEY, updateElements);
+      errorList = future.get(5000L, TimeUnit.MILLISECONDS);
+      assertTrue(errorList.isEmpty());
+      // DELETE
+      mc.delete(KEY).get();
+      // UPDATE FAIL
+      future = mc.asyncBopPipedUpdateBulk(KEY, updateElements);
+      errorList = future.get(5000L, TimeUnit.MILLISECONDS);
+      assertEquals(1, errorList.size());
+    } catch (Exception e) {
+      e.printStackTrace();
+      fail(e.getMessage());
+    }
+  }
 }

--- a/src/test/manual/net/spy/memcached/collection/set/SopBulkAPITest.java
+++ b/src/test/manual/net/spy/memcached/collection/set/SopBulkAPITest.java
@@ -17,6 +17,7 @@
 package net.spy.memcached.collection.set;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -126,5 +127,27 @@ class SopBulkAPITest extends BaseIntegrationTest {
       fail(e.getMessage());
     }
     fail();
+  }
+
+  @Test
+  void testSopBulkNotPiped() {
+    CollectionFuture<Map<Integer, CollectionOperationStatus>> future;
+    Map<Integer, CollectionOperationStatus> errorList;
+    try {
+      mc.delete(key).get();
+      // INSERT FAIL
+      future = mc.asyncSopPipedInsertBulk(key, Arrays.asList(valueList.get(0)),
+                      null);
+      errorList = future.get(10000, TimeUnit.MILLISECONDS);
+      assertEquals(1, errorList.size());
+      // INSERT
+      future = mc.asyncSopPipedInsertBulk(key, Arrays.asList(valueList.get(0)),
+                      new CollectionAttributes());
+      errorList = future.get(10000, TimeUnit.MILLISECONDS);
+      assertEquals(0, errorList.size());
+    } catch (Exception e) {
+      e.printStackTrace();
+      fail(e.getMessage());
+    }
   }
 }


### PR DESCRIPTION
### 🔗 Related Issue

<!-- Please link related issue. ex) https://github.com/naver/arcus-java-client/issues/{issue_number} -->
- https://github.com/jam2in/arcus-works/issues/640

### ⌨️ What I did

<!-- Please describe this PR and what you've been working on. -->
- 파이프 operation들에 대해서 파이프 연산이 아닌 경우에 동작을 테스트 하였습니다.

`CollectionBulkInsertOperationImpl`은 `asyncBopInsertBulk`,
`CollectionPipedInsertOperationImpl`은 `asyncSopPipedInsertBulk`,
`CollectionPipedUpdateOperationImpl `은 `asyncBopPipedUpdateBulk`

각각 위에 연산에 대하여 위 연산들을 실행하는 테스트 파일에 테스트를 추가한다.
시나리오는 아이템을 하나씩만 주어 파이프와 벌크 연산의 handleLine 에서 isNotPiped()를 테스트한다.
이때 연산이 성공하는 경우와 연산이 실패하는 경우를 모두 다룬다.