### PR TITLE
REFACTOR: setMasterCandidate in MemcachedReplicagroup.

### DIFF
--- a/src/main/java/net/spy/memcached/MemcachedConnection.java
+++ b/src/main/java/net/spy/memcached/MemcachedConnection.java
@@ -488,7 +488,7 @@ public final class MemcachedConnection extends SpyObject {
           }
         }
       } else if (oldSlaveAddrs.contains(newMasterAddr)) {
-        oldGroup.setMasterCandidateByAddr(newMasterAddr);
+        oldGroup.setMasterCandidateByAddr(newMasterAddr.getIPPort());
         if (newSlaveAddrs.contains(oldMasterAddr)) {
           // Switchover
           if (oldMasterNode.hasNonIdempotentOperationInReadQ()) {

--- a/src/main/java/net/spy/memcached/MemcachedReplicaGroup.java
+++ b/src/main/java/net/spy/memcached/MemcachedReplicaGroup.java
@@ -80,10 +80,6 @@ public abstract class MemcachedReplicaGroup extends SpyObject {
     return masterCandidate;
   }
 
-  public void setMasterCandidate(MemcachedNode masterCandidate) {
-    this.masterCandidate = masterCandidate;
-  }
-
   public void setMasterCandidate() {
     if (!slaveNodes.isEmpty()) {
       this.masterCandidate = slaveNodes.get(0);
@@ -93,16 +89,7 @@ public abstract class MemcachedReplicaGroup extends SpyObject {
   public void setMasterCandidateByAddr(String address) {
     for (MemcachedNode node : this.getSlaveNodes()) {
       if (address.equals(((ArcusReplNodeAddress) node.getSocketAddress()).getIPPort())) {
-        this.setMasterCandidate(node);
-        break;
-      }
-    }
-  }
-
-  public void setMasterCandidateByAddr(ArcusReplNodeAddress address) {
-    for (MemcachedNode node : this.getSlaveNodes()) {
-      if (address.isSameAddress((ArcusReplNodeAddress) node.getSocketAddress())) {
-        this.setMasterCandidate(node);
+        this.masterCandidate = node;
         break;
       }
     }

--- a/src/main/java/net/spy/memcached/MemcachedReplicaGroupImpl.java
+++ b/src/main/java/net/spy/memcached/MemcachedReplicaGroupImpl.java
@@ -73,7 +73,7 @@ public final class MemcachedReplicaGroupImpl extends MemcachedReplicaGroup {
     if (this.masterNode != null) { // previous slave node
       ((ArcusReplNodeAddress) this.masterNode.getSocketAddress()).setMaster(true);
       this.slaveNodes.remove(this.masterNode);
-      this.setMasterCandidate(null);
+      this.masterCandidate = null;
     }
 
     if (tmpNode != null) { // previous master node


### PR DESCRIPTION
### 🔗 Related Issue

https://github.com/jam2in/arcus-works/issues/650

### ⌨️ What I did

삭제 시킨 메서드
- public void setMasterCandidate(MemcachedNode masterCandidate -> `this.masterCandidate = masterCandidate;`로 대체
- void setMasterCandidateByAddr(ArcusReplNodeAddress address) -> `setMasterCandidateByAddr(Addr인스턴스.getIPPort())` 호출로 대체
