### PR TITLE
 INTERNAL: tidy operation codes

### DIFF
--- a/src/main/java/net/spy/memcached/protocol/ascii/BTreeGetBulkOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/BTreeGetBulkOperationImpl.java
@@ -132,7 +132,7 @@ public final class BTreeGetBulkOperationImpl extends OperationImpl implements
   }
 
   @Override
-  public final void handleRead(ByteBuffer bb) {
+  public void handleRead(ByteBuffer bb) {
     if (lookingFor == '\0' && data == null) {
       while (bb.hasRemaining()) {
         byte b = bb.get();

--- a/src/main/java/net/spy/memcached/protocol/ascii/BTreeSortMergeGetOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/BTreeSortMergeGetOperationImpl.java
@@ -149,7 +149,7 @@ public final class BTreeSortMergeGetOperationImpl extends OperationImpl implemen
   }
 
   @Override
-  public final void handleRead(ByteBuffer bb) {
+  public void handleRead(ByteBuffer bb) {
     switch (readState) {
       case VALUE:
         readValue(bb);

--- a/src/main/java/net/spy/memcached/protocol/ascii/CollectionCreateOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/CollectionCreateOperationImpl.java
@@ -52,8 +52,6 @@ public final class CollectionCreateOperationImpl extends OperationImpl
           true, "CREATED", CollectionResponse.CREATED);
   private static final OperationStatus EXISTS = new CollectionOperationStatus(
           false, "EXISTS", CollectionResponse.EXISTS);
-  private static final OperationStatus SERVER_ERROR = new CollectionOperationStatus(
-          false, "SERVER_ERROR", CollectionResponse.SERVER_ERROR);
 
   private final String key;
   private final CollectionCreate collectionCreate;
@@ -92,7 +90,7 @@ public final class CollectionCreateOperationImpl extends OperationImpl
       return;
     }
     /* ENABLE_MIGRATION end */
-    getCallback().receivedStatus(matchStatus(line, CREATED, EXISTS, SERVER_ERROR));
+    getCallback().receivedStatus(matchStatus(line, CREATED, EXISTS));
     transitionState(OperationState.COMPLETE);
   }
 

--- a/src/main/java/net/spy/memcached/protocol/ascii/CollectionGetOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/CollectionGetOperationImpl.java
@@ -149,7 +149,7 @@ public final class CollectionGetOperationImpl extends OperationImpl
   }
 
   @Override
-  public final void handleRead(ByteBuffer bb) {
+  public void handleRead(ByteBuffer bb) {
     // Decode a collection data header.
     if (lookingFor == '\0' && data == null) {
       while (bb.hasRemaining()) {
@@ -166,10 +166,9 @@ public final class CollectionGetOperationImpl extends OperationImpl
           tokens.add(byteBuffer.toString());
           byteBuffer.reset();
 
-          if (eFlagIndex >= 0) {
-            if (tokens.size() == eFlagIndex + 1 && tokens.get(eFlagIndex).startsWith("0x")) {
-              eHeadCount++;
-            }
+          if (eFlagIndex >= 0 &&
+                  tokens.size() == eFlagIndex + 1 && tokens.get(eFlagIndex).startsWith("0x")) {
+            eHeadCount++;
           }
           if (tokens.size() == eHeadCount) {
             collectionGet.decodeElemHeader(tokens);

--- a/src/main/java/net/spy/memcached/protocol/ascii/CollectionPipedUpdateOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/CollectionPipedUpdateOperationImpl.java
@@ -61,8 +61,6 @@ public final class CollectionPipedUpdateOperationImpl extends OperationImpl impl
           false, "BKEY_MISMATCH", CollectionResponse.BKEY_MISMATCH);
   private static final OperationStatus EFLAG_MISMATCH = new CollectionOperationStatus(
           false, "EFLAG_MISMATCH", CollectionResponse.EFLAG_MISMATCH);
-  private static final OperationStatus SERVER_ERROR = new CollectionOperationStatus(
-          false, "SERVER_ERROR", CollectionResponse.SERVER_ERROR);
 
   private final String key;
   private final CollectionPipedUpdate<?> update;
@@ -114,7 +112,7 @@ public final class CollectionPipedUpdateOperationImpl extends OperationImpl impl
     if (update.isNotPiped()) {
       OperationStatus status = matchStatus(line, UPDATED, NOT_FOUND,
               NOT_FOUND_ELEMENT, NOTHING_TO_UPDATE, TYPE_MISMATCH,
-              BKEY_MISMATCH, EFLAG_MISMATCH, SERVER_ERROR);
+              BKEY_MISMATCH, EFLAG_MISMATCH);
       if (status.isSuccess()) {
         cb.receivedStatus((successAll) ? END : FAILED_END);
       } else {
@@ -154,7 +152,7 @@ public final class CollectionPipedUpdateOperationImpl extends OperationImpl impl
     } else {
       OperationStatus status = matchStatus(line, UPDATED, NOT_FOUND,
               NOT_FOUND_ELEMENT, NOTHING_TO_UPDATE, TYPE_MISMATCH,
-              BKEY_MISMATCH, EFLAG_MISMATCH, SERVER_ERROR);
+              BKEY_MISMATCH, EFLAG_MISMATCH);
 
       if (!status.isSuccess()) {
         cb.gotStatus(index, status);

--- a/src/main/java/net/spy/memcached/protocol/ascii/CollectionUpdateOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/CollectionUpdateOperationImpl.java
@@ -61,8 +61,6 @@ public final class CollectionUpdateOperationImpl extends OperationImpl implement
           false, "BKEY_MISMATCH", CollectionResponse.BKEY_MISMATCH);
   private static final OperationStatus EFLAG_MISMATCH = new CollectionOperationStatus(
           false, "EFLAG_MISMATCH", CollectionResponse.EFLAG_MISMATCH);
-  private static final OperationStatus SERVER_ERROR = new CollectionOperationStatus(
-          false, "SERVER_ERROR", CollectionResponse.SERVER_ERROR);
 
   private final String key;
   private final String subkey; // e.g.) 0 or 0x00
@@ -104,7 +102,7 @@ public final class CollectionUpdateOperationImpl extends OperationImpl implement
     /* ENABLE_MIGRATION end */
     OperationStatus status = matchStatus(line, UPDATED, NOT_FOUND, NOT_FOUND_ELEMENT,
             NOTHING_TO_UPDATE, TYPE_MISMATCH, BKEY_MISMATCH,
-            EFLAG_MISMATCH, SERVER_ERROR);
+            EFLAG_MISMATCH);
     getCallback().receivedStatus(status);
     transitionState(OperationState.COMPLETE);
   }


### PR DESCRIPTION
### 🔗 Related Issue

<!-- Please link related issue. ex) https://github.com/naver/arcus-java-client/issues/{issue_number} -->
- https://github.com/jam2in/arcus-works/issues/623

### ⌨️ What I did

<!-- Please describe this PR and what you've been working on. -->
- final 클래스에 불필요하게 선언된 final 메서드 표시를 제거합니다.
- handleLine에서 SERVER_ERROR는 현재 읽을 수 없는 상태이므로 상태 체크에서 제거합니다.