### PR TITLE
INTERNAL: Limit bulk get keys size

### DIFF
--- a/src/main/java/net/spy/memcached/protocol/ascii/AsciiMemcachedNodeImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/AsciiMemcachedNodeImpl.java
@@ -31,6 +31,9 @@ import net.spy.memcached.protocol.TCPMemcachedNodeImpl;
  * Memcached node for the ASCII protocol.
  */
 public final class AsciiMemcachedNodeImpl extends TCPMemcachedNodeImpl {
+
+  private static final int GET_BULK_CHUNK_SIZE = 200;
+
   public AsciiMemcachedNodeImpl(String name,
                                 SocketAddress sa,
                                 int bufSize, BlockingQueue<Operation> rq,
@@ -42,34 +45,38 @@ public final class AsciiMemcachedNodeImpl extends TCPMemcachedNodeImpl {
 
   @Override
   protected void optimize() {
-    // make sure there are at least two get operations in a row before
-    // attempting to optimize them.
     Operation nxtOp = writeQ.peek();
-    if (nxtOp instanceof GetOperation && nxtOp.getAPIType() != APIType.MGET) {
-      optimizedOp = writeQ.remove();
-      nxtOp = writeQ.peek();
-      if (nxtOp instanceof GetOperation && nxtOp.getAPIType() != APIType.MGET) {
-        OptimizedGetImpl og = new OptimizedGetImpl(
-                (GetOperation) optimizedOp);
-        optimizedOp = og;
+    if (!(nxtOp instanceof GetOperation) || nxtOp.getAPIType() == APIType.MGET) {
+      return;
+    }
 
-        do {
-          GetOperationImpl o = (GetOperationImpl) writeQ.remove();
-          if (!o.isCancelled()) {
-            og.addOperation(o);
-          }
-          nxtOp = writeQ.peek();
-        } while (nxtOp instanceof GetOperation &&
-                nxtOp.getAPIType() != APIType.MGET);
+    int cnt = ((GetOperation) nxtOp).getKeys().size();
+    optimizedOp = writeQ.remove();
+    nxtOp = writeQ.peek();
+    OptimizedGetImpl og = null;
 
-        // Initialize the new mega get
-        optimizedOp.initialize();
-        assert optimizedOp.getState() == OperationState.WRITE_QUEUED;
-        ProxyCallback pcb = (ProxyCallback) og.getCallback();
-        getLogger().debug("Set up %s with %s keys and %s callbacks",
-                this, pcb.numKeys(), pcb.numCallbacks());
+    while (nxtOp instanceof GetOperation && nxtOp.getAPIType() != APIType.MGET) {
+      cnt += ((GetOperation) nxtOp).getKeys().size();
+      if (cnt > GET_BULK_CHUNK_SIZE) {
+        break;
       }
+      GetOperationImpl currentOp = (GetOperationImpl) writeQ.remove();
+      if (!currentOp.isCancelled()) {
+        if (og == null) {
+          og = new OptimizedGetImpl((GetOperation) optimizedOp);
+          optimizedOp = og;
+        }
+        og.addOperation(currentOp);
+      }
+      nxtOp = writeQ.peek();
+    }
+    // Initialize the new mega get
+    if (og != null) {
+      optimizedOp.initialize();
+      assert optimizedOp.getState() == OperationState.WRITE_QUEUED;
+      ProxyCallback pcb = (ProxyCallback) optimizedOp.getCallback();
+      getLogger().debug("Set up %s with %s keys and %s callbacks",
+              this, pcb.numKeys(), pcb.numCallbacks());
     }
   }
-
 }

--- a/src/test/java/net/spy/memcached/OptimizeTest.java
+++ b/src/test/java/net/spy/memcached/OptimizeTest.java
@@ -1,0 +1,57 @@
+package net.spy.memcached;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Future;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class OptimizeTest {
+
+  private ArcusClientPool client;
+  private List<String> keys;
+
+  @BeforeEach
+  void setUp() throws Exception {
+    ConnectionFactoryBuilder builder = new ConnectionFactoryBuilder();
+    builder.setShouldOptimize(true);
+    // Get a connection with the get optimization.
+    client = ArcusClient.createArcusClientPool("127.0.0.1:2181", "test", builder, 1);
+
+    keys = new ArrayList<>(10000);
+    for (int i = 0; i < 100; i++) {
+      keys.add("k" + i);
+      Boolean b = client.set(keys.get(i), 0, "value" + i).get();
+      Assertions.assertEquals(true, b);
+    }
+  }
+
+  @Test
+  void testParallelGet() throws Throwable {
+    List<Future<Object>> results = new ArrayList<>(10000);
+    for (int i = 0; i < 100; i++) {
+      results.add(client.asyncGet(keys.get(i)));
+    }
+
+    for (int i = 0; i < 100; i++) {
+      Object o = results.get(i).get();
+      Assertions.assertEquals("value" + i, o);
+    }
+  }
+
+  @Test
+  void testOptimizedOneOperation() throws Throwable {
+    List<Future<Object>> results = new ArrayList<>(10000);
+    for (int i = 0; i < 2; i++) {
+      results.add(client.asyncGet(keys.get(i)));
+    }
+    client.set(keys.get(0), 0, "value0");
+
+    for (int i = 0; i < 2; i++) {
+      Object o = results.get(i).get();
+      Assertions.assertEquals("value" + i, o);
+    }
+  }
+}


### PR DESCRIPTION
### 🔗 Related Issue

<!-- Please link related issue. ex) https://github.com/naver/arcus-java-client/issues/{issue_number} -->
- https://github.com/jam2in/arcus-works/issues/648

### ⌨️ What I did

<!-- Please describe this PR and what you've been working on. -->
- `asyncGetBulk`의 연산의 키 제한 개수와 같게 200개의 제한을 두었습니다.
- 초기에 getOperation에서 key의 개수를 세어 limit을 넘지 않는 경우 limit을 넘지 않을때 까지 operation을 모아 get <keys>로 optimize 시킵니다.
- 과거 optimize는 getOperation이 두개 이상 연속되어야만 유효했습니다.
이를 하나만 있어도 되도록 변경했습니다.(optimized 를 사용하기 위해 get이 두개 이상 연속 되었는지 판단 할 필요 사라짐)