### PR TITLE
 CLEANUP: remove useless type cast

### DIFF
--- a/src/main/java/net/spy/memcached/MemcachedConnection.java
+++ b/src/main/java/net/spy/memcached/MemcachedConnection.java
@@ -24,7 +24,6 @@ import java.net.ConnectException;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.net.SocketException;
-import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.nio.channels.ClosedChannelException;
 import java.nio.channels.SelectionKey;
@@ -984,7 +983,7 @@ public final class MemcachedConnection extends SpyObject {
     int read = channel.read(rbuf);
     while (read > 0) {
       getLogger().debug("Read %d bytes", read);
-      ((Buffer) rbuf).flip();
+      rbuf.flip();
       while (rbuf.remaining() > 0) {
         if (currentOp == null) {
           throw new IllegalStateException("No read operation.");
@@ -1014,13 +1013,13 @@ public final class MemcachedConnection extends SpyObject {
       }
       /* ENABLE_REPLICATION if */
       if (currentOp != null && currentOp.getState() == OperationState.MOVING) {
-        ((Buffer) rbuf).clear();
+        rbuf.clear();
         delayedSwitchoverGroups.remove(qa.getReplicaGroup());
         switchoverMemcachedReplGroup(qa, false);
         break;
       }
       /* ENABLE_REPLICATION end */
-      ((Buffer) rbuf).clear();
+      rbuf.clear();
       read = channel.read(rbuf);
     }
     if (read < 0) {

--- a/src/main/java/net/spy/memcached/collection/CollectionBulkInsert.java
+++ b/src/main/java/net/spy/memcached/collection/CollectionBulkInsert.java
@@ -17,7 +17,6 @@
  */
 package net.spy.memcached.collection;
 
-import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.util.List;
 
@@ -105,7 +104,7 @@ public abstract class CollectionBulkInsert<T> extends CollectionPipe {
       }
 
       // flip the buffer
-      ((Buffer) bb).flip();
+      bb.flip();
 
       return bb;
     }
@@ -159,7 +158,7 @@ public abstract class CollectionBulkInsert<T> extends CollectionPipe {
       }
 
       // flip the buffer
-      ((Buffer) bb).flip();
+      bb.flip();
 
       return bb;
     }
@@ -209,7 +208,7 @@ public abstract class CollectionBulkInsert<T> extends CollectionPipe {
         bb.put(CRLF);
       }
       // flip the buffer
-      ((Buffer) bb).flip();
+      bb.flip();
 
       return bb;
     }
@@ -263,7 +262,7 @@ public abstract class CollectionBulkInsert<T> extends CollectionPipe {
       }
 
       // flip the buffer
-      ((Buffer) bb).flip();
+      bb.flip();
 
       return bb;
     }

--- a/src/main/java/net/spy/memcached/collection/CollectionPipedInsert.java
+++ b/src/main/java/net/spy/memcached/collection/CollectionPipedInsert.java
@@ -17,7 +17,6 @@
  */
 package net.spy.memcached.collection;
 
-import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -101,7 +100,7 @@ public abstract class CollectionPipedInsert<T> extends CollectionPipe {
       }
 
       // flip the buffer
-      ((Buffer) bb).flip();
+      bb.flip();
 
       return bb;
     }
@@ -158,7 +157,7 @@ public abstract class CollectionPipedInsert<T> extends CollectionPipe {
       }
 
       // flip the buffer
-      ((Buffer) bb).flip();
+      bb.flip();
 
       return bb;
     }
@@ -219,7 +218,7 @@ public abstract class CollectionPipedInsert<T> extends CollectionPipe {
       }
 
       // flip the buffer
-      ((Buffer) bb).flip();
+      bb.flip();
 
       return bb;
     }
@@ -282,7 +281,7 @@ public abstract class CollectionPipedInsert<T> extends CollectionPipe {
       }
 
       // flip the buffer
-      ((Buffer) bb).flip();
+      bb.flip();
 
       return bb;
     }
@@ -343,7 +342,7 @@ public abstract class CollectionPipedInsert<T> extends CollectionPipe {
       }
 
       // flip the buffer
-      ((Buffer) bb).flip();
+      bb.flip();
 
       return bb;
     }

--- a/src/main/java/net/spy/memcached/collection/CollectionPipedUpdate.java
+++ b/src/main/java/net/spy/memcached/collection/CollectionPipedUpdate.java
@@ -17,7 +17,6 @@
  */
 package net.spy.memcached.collection;
 
-import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.List;
@@ -127,7 +126,7 @@ public abstract class CollectionPipedUpdate<T> extends CollectionPipe {
       }
 
       // flip the buffer
-      ((Buffer) bb).flip();
+      bb.flip();
 
       return bb;
     }
@@ -191,7 +190,7 @@ public abstract class CollectionPipedUpdate<T> extends CollectionPipe {
       }
 
       // flip the buffer
-      ((Buffer) bb).flip();
+      bb.flip();
 
       return bb;
     }

--- a/src/main/java/net/spy/memcached/collection/SetPipedExist.java
+++ b/src/main/java/net/spy/memcached/collection/SetPipedExist.java
@@ -17,7 +17,6 @@
  */
 package net.spy.memcached.collection;
 
-import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.List;
@@ -79,7 +78,7 @@ public class SetPipedExist<T> extends CollectionPipe {
       bb.put(CRLF);
     }
     // flip the buffer
-    ((Buffer) bb).flip();
+    bb.flip();
 
     return bb;
   }

--- a/src/main/java/net/spy/memcached/protocol/BaseOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/BaseOperationImpl.java
@@ -18,7 +18,6 @@
 package net.spy.memcached.protocol;
 
 import java.io.IOException;
-import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -133,7 +132,7 @@ public abstract class BaseOperationImpl extends SpyObject {
         // fallthrough
       case WRITE_QUEUED:
         if (getBuffer() != null) {
-          ((Buffer) getBuffer()).reset(); // buffer offset reset
+          getBuffer().reset(); // buffer offset reset
         } else {
           initialize(); // this case cannot happen.
         }
@@ -206,7 +205,7 @@ public abstract class BaseOperationImpl extends SpyObject {
   protected final void setBuffer(ByteBuffer to) {
     assert to != null : "Trying to set buffer to null";
     cmd = to;
-    ((Buffer) cmd).mark();
+    cmd.mark();
   }
 
   /**

--- a/src/main/java/net/spy/memcached/protocol/TCPMemcachedNodeImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/TCPMemcachedNodeImpl.java
@@ -19,7 +19,6 @@ package net.spy.memcached.protocol;
 
 import java.io.IOException;
 import java.net.SocketAddress;
-import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.nio.channels.SelectionKey;
 import java.nio.channels.SocketChannel;
@@ -142,7 +141,7 @@ public abstract class TCPMemcachedNodeImpl extends SpyObject
     setSocketAddress(sa);
     rbuf = ByteBuffer.allocate(bufSize);
     wbuf = ByteBuffer.allocate(bufSize);
-    ((Buffer) getWbuf()).clear();
+    getWbuf().clear();
     readQ = rq;
     writeQ = wq;
     inputQueue = iq;
@@ -224,8 +223,8 @@ public abstract class TCPMemcachedNodeImpl extends SpyObject
       op.cancel(cause);
     }
 
-    ((Buffer) getWbuf()).clear();
-    ((Buffer) getRbuf()).clear();
+    getWbuf().clear();
+    getRbuf().clear();
     toWrite = 0;
   }
 
@@ -246,7 +245,7 @@ public abstract class TCPMemcachedNodeImpl extends SpyObject
 
   public final void fillWriteBuffer(boolean shouldOptimize) {
     if (toWrite == 0 && readQ.remainingCapacity() > 0) {
-      ((Buffer) getWbuf()).clear();
+      getWbuf().clear();
       Operation o = getNextWritableOp();
       while (o != null && toWrite < getWbuf().capacity()) {
         assert o.getState() == OperationState.WRITING;
@@ -277,7 +276,7 @@ public abstract class TCPMemcachedNodeImpl extends SpyObject
         }
         toWrite += bytesToCopy;
       }
-      ((Buffer) getWbuf()).flip();
+      getWbuf().flip();
       assert toWrite <= getWbuf().capacity()
               : "toWrite exceeded capacity: " + this;
       assert toWrite == getWbuf().remaining()

--- a/src/main/java/net/spy/memcached/protocol/ascii/BTreeFindPositionOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/BTreeFindPositionOperationImpl.java
@@ -17,7 +17,6 @@
  */
 package net.spy.memcached.protocol.ascii;
 
-import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.util.Collection;
 import java.util.Collections;
@@ -111,7 +110,7 @@ public final class BTreeFindPositionOperationImpl extends OperationImpl implemen
             + cmd.length() + args.length() + 16);
 
     setArguments(bb, cmd, key, args);
-    ((Buffer) bb).flip();
+    bb.flip();
     setBuffer(bb);
 
     if (getLogger().isDebugEnabled()) {

--- a/src/main/java/net/spy/memcached/protocol/ascii/BTreeFindPositionWithGetOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/BTreeFindPositionWithGetOperationImpl.java
@@ -17,7 +17,6 @@
 package net.spy.memcached.protocol.ascii;
 
 import java.io.ByteArrayOutputStream;
-import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -241,7 +240,7 @@ public final class BTreeFindPositionWithGetOperationImpl extends OperationImpl i
     ByteBuffer bb = ByteBuffer.allocate(KeyUtil.getKeyBytes(key).length
             + cmd.length() + args.length() + 16);
     setArguments(bb, cmd, key, args);
-    ((Buffer) bb).flip();
+    bb.flip();
     setBuffer(bb);
 
     if (getLogger().isDebugEnabled()) {

--- a/src/main/java/net/spy/memcached/protocol/ascii/BTreeGetBulkOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/BTreeGetBulkOperationImpl.java
@@ -18,7 +18,6 @@
 package net.spy.memcached.protocol.ascii;
 
 import java.io.ByteArrayOutputStream;
-import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.util.Collection;
 
@@ -240,7 +239,7 @@ public final class BTreeGetBulkOperationImpl extends OperationImpl implements
 
     setArguments(bb, getBulk.getSpaceSeparatedKeys());
 
-    ((Buffer) bb).flip();
+    bb.flip();
     setBuffer(bb);
 
     if (getLogger().isDebugEnabled()) {

--- a/src/main/java/net/spy/memcached/protocol/ascii/BTreeGetByPositionOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/BTreeGetByPositionOperationImpl.java
@@ -18,7 +18,6 @@
 package net.spy.memcached.protocol.ascii;
 
 import java.io.ByteArrayOutputStream;
-import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -244,7 +243,7 @@ public final class BTreeGetByPositionOperationImpl extends OperationImpl impleme
             + args.length() + 16);
 
     setArguments(bb, cmd, key, args);
-    ((Buffer) bb).flip();
+    bb.flip();
     setBuffer(bb);
 
     if (getLogger().isDebugEnabled()) {

--- a/src/main/java/net/spy/memcached/protocol/ascii/BTreeInsertAndGetOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/BTreeInsertAndGetOperationImpl.java
@@ -18,7 +18,6 @@
 package net.spy.memcached.protocol.ascii;
 
 import java.io.ByteArrayOutputStream;
-import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -274,7 +273,7 @@ public final class BTreeInsertAndGetOperationImpl extends OperationImpl implemen
             get.getElementFlagByHex(), dataToStore.length, args);
     bb.put(dataToStore);
     bb.put(CRLF);
-    ((Buffer) bb).flip();
+    bb.flip();
     setBuffer(bb);
 
     if (getLogger().isDebugEnabled()) {

--- a/src/main/java/net/spy/memcached/protocol/ascii/BTreeSortMergeGetOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/BTreeSortMergeGetOperationImpl.java
@@ -18,7 +18,6 @@
 package net.spy.memcached.protocol.ascii;
 
 import java.io.ByteArrayOutputStream;
-import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.util.Collection;
 
@@ -435,7 +434,7 @@ public final class BTreeSortMergeGetOperationImpl extends OperationImpl implemen
 
     setArguments(bb, smGet.getSpaceSeparatedKeys());
 
-    ((Buffer) bb).flip();
+    bb.flip();
     setBuffer(bb);
 
     if (getLogger().isDebugEnabled()) {

--- a/src/main/java/net/spy/memcached/protocol/ascii/BTreeSortMergeGetOperationOldImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/BTreeSortMergeGetOperationOldImpl.java
@@ -18,7 +18,6 @@
 package net.spy.memcached.protocol.ascii;
 
 import java.io.ByteArrayOutputStream;
-import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.util.Collection;
 
@@ -294,7 +293,7 @@ public final class BTreeSortMergeGetOperationOldImpl extends OperationImpl imple
 
     setArguments(bb, smGet.getSpaceSeparatedKeys());
 
-    ((Buffer) bb).flip();
+    bb.flip();
     setBuffer(bb);
 
     if (getLogger().isDebugEnabled()) {

--- a/src/main/java/net/spy/memcached/protocol/ascii/BaseGetOpImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/BaseGetOpImpl.java
@@ -17,7 +17,6 @@
  */
 package net.spy.memcached.protocol.ascii;
 
-import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.util.Collection;
 import java.util.Iterator;
@@ -206,7 +205,7 @@ abstract class BaseGetOpImpl extends OperationImpl {
 
     b = ByteBuffer.allocate(size);
     b.put(commandLine);
-    ((Buffer) b).flip();
+    b.flip();
     setBuffer(b);
   }
 

--- a/src/main/java/net/spy/memcached/protocol/ascii/BaseStoreOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/BaseStoreOperationImpl.java
@@ -17,7 +17,6 @@
  */
 package net.spy.memcached.protocol.ascii;
 
-import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.util.Collection;
 import java.util.Collections;
@@ -91,7 +90,7 @@ abstract class BaseStoreOperationImpl extends OperationImpl {
             + (2 + data.length - bb.remaining());
     bb.put(data);
     bb.put(CRLF);
-    ((Buffer) bb).flip();
+    bb.flip();
     setBuffer(bb);
 
     if (getLogger().isDebugEnabled()) {

--- a/src/main/java/net/spy/memcached/protocol/ascii/CASOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/CASOperationImpl.java
@@ -17,7 +17,6 @@
  */
 package net.spy.memcached.protocol.ascii;
 
-import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.util.Collection;
 import java.util.Collections;
@@ -100,7 +99,7 @@ class CASOperationImpl extends OperationImpl implements CASOperation {
             + (2 + data.length - bb.remaining());
     bb.put(data);
     bb.put(CRLF);
-    ((Buffer) bb).flip();
+    bb.flip();
     setBuffer(bb);
   }
 

--- a/src/main/java/net/spy/memcached/protocol/ascii/CollectionCountOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/CollectionCountOperationImpl.java
@@ -17,7 +17,6 @@
  */
 package net.spy.memcached.protocol.ascii;
 
-import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.util.Collection;
 import java.util.Collections;
@@ -104,7 +103,7 @@ public final class CollectionCountOperationImpl extends OperationImpl implements
             + cmd.length() + args.length() + 16);
 
     setArguments(bb, cmd, key, args);
-    ((Buffer) bb).flip();
+    bb.flip();
     setBuffer(bb);
 
     if (getLogger().isDebugEnabled()) {

--- a/src/main/java/net/spy/memcached/protocol/ascii/CollectionCreateOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/CollectionCreateOperationImpl.java
@@ -17,7 +17,6 @@
  */
 package net.spy.memcached.protocol.ascii;
 
-import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.util.Collection;
 import java.util.Collections;
@@ -101,7 +100,7 @@ public final class CollectionCreateOperationImpl extends OperationImpl
             + args.length()
             + OVERHEAD);
     setArguments(bb, collectionCreate.getCommand(), key, args);
-    ((Buffer) bb).flip();
+    bb.flip();
     setBuffer(bb);
 
     if (getLogger().isDebugEnabled()) {

--- a/src/main/java/net/spy/memcached/protocol/ascii/CollectionDeleteOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/CollectionDeleteOperationImpl.java
@@ -17,7 +17,6 @@
  */
 package net.spy.memcached.protocol.ascii;
 
-import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.util.Collection;
 import java.util.Collections;
@@ -130,7 +129,7 @@ public final class CollectionDeleteOperationImpl extends OperationImpl
       bb.put(CRLF);
     }
 
-    ((Buffer) bb).flip();
+    bb.flip();
     setBuffer(bb);
 
     if (getLogger().isDebugEnabled()) {

--- a/src/main/java/net/spy/memcached/protocol/ascii/CollectionExistOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/CollectionExistOperationImpl.java
@@ -17,7 +17,6 @@
  */
 package net.spy.memcached.protocol.ascii;
 
-import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.util.Collection;
 import java.util.Collections;
@@ -105,7 +104,7 @@ public final class CollectionExistOperationImpl extends OperationImpl
       bb.put(CRLF);
     }
 
-    ((Buffer) bb).flip();
+    bb.flip();
     setBuffer(bb);
 
     if (getLogger().isDebugEnabled()) {

--- a/src/main/java/net/spy/memcached/protocol/ascii/CollectionGetOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/CollectionGetOperationImpl.java
@@ -18,7 +18,6 @@
 package net.spy.memcached.protocol.ascii;
 
 import java.io.ByteArrayOutputStream;
-import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -279,7 +278,7 @@ public final class CollectionGetOperationImpl extends OperationImpl
       bb.put(CRLF);
     }
 
-    ((Buffer) bb).flip();
+    bb.flip();
     setBuffer(bb);
 
     if (getLogger().isDebugEnabled()) {

--- a/src/main/java/net/spy/memcached/protocol/ascii/CollectionInsertOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/CollectionInsertOperationImpl.java
@@ -17,7 +17,6 @@
  */
 package net.spy.memcached.protocol.ascii;
 
-import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.util.Collection;
 import java.util.Collections;
@@ -136,7 +135,7 @@ public final class CollectionInsertOperationImpl extends OperationImpl
             collectionInsert.getElementFlagByHex(), data.length, args);
     bb.put(data);
     bb.put(CRLF);
-    ((Buffer) bb).flip();
+    bb.flip();
     setBuffer(bb);
 
     if (getLogger().isDebugEnabled()) {

--- a/src/main/java/net/spy/memcached/protocol/ascii/CollectionMutateOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/CollectionMutateOperationImpl.java
@@ -17,7 +17,6 @@
  */
 package net.spy.memcached.protocol.ascii;
 
-import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.util.Collection;
 import java.util.Collections;
@@ -119,7 +118,7 @@ public final class CollectionMutateOperationImpl extends OperationImpl implement
             + cmd.length() + args.length() + 16);
 
     setArguments(bb, cmd, key, subkey, args);
-    ((Buffer) bb).flip();
+    bb.flip();
     setBuffer(bb);
 
     if (getLogger().isDebugEnabled()) {

--- a/src/main/java/net/spy/memcached/protocol/ascii/CollectionUpdateOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/CollectionUpdateOperationImpl.java
@@ -17,7 +17,6 @@
  */
 package net.spy.memcached.protocol.ascii;
 
-import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.util.Collection;
 import java.util.Collections;
@@ -136,7 +135,7 @@ public final class CollectionUpdateOperationImpl extends OperationImpl implement
       bb.put(data);
       bb.put(CRLF);
     }
-    ((Buffer) bb).flip();
+    bb.flip();
     setBuffer(bb);
 
     if (getLogger().isDebugEnabled()) {

--- a/src/main/java/net/spy/memcached/protocol/ascii/DeleteOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/DeleteOperationImpl.java
@@ -19,7 +19,6 @@
 
 package net.spy.memcached.protocol.ascii;
 
-import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.util.Collection;
 import java.util.Collections;
@@ -80,7 +79,7 @@ final class DeleteOperationImpl extends OperationImpl
     ByteBuffer b = ByteBuffer.allocate(
             KeyUtil.getKeyBytes(key).length + OVERHEAD);
     setArguments(b, "delete", key);
-    ((Buffer) b).flip();
+    b.flip();
     setBuffer(b);
   }
 

--- a/src/main/java/net/spy/memcached/protocol/ascii/FlushByPrefixOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/FlushByPrefixOperationImpl.java
@@ -17,7 +17,6 @@
  */
 package net.spy.memcached.protocol.ascii;
 
-import java.nio.Buffer;
 import java.nio.ByteBuffer;
 
 import net.spy.memcached.ops.APIType;
@@ -81,7 +80,7 @@ final class FlushByPrefixOperationImpl extends OperationImpl implements
 
     ByteBuffer bb = ByteBuffer.allocate(sb.length());
     bb.put(sb.toString().getBytes());
-    ((Buffer) bb).flip();
+    bb.flip();
     setBuffer(bb);
   }
 

--- a/src/main/java/net/spy/memcached/protocol/ascii/FlushOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/FlushOperationImpl.java
@@ -19,7 +19,6 @@
 
 package net.spy.memcached.protocol.ascii;
 
-import java.nio.Buffer;
 import java.nio.ByteBuffer;
 
 import net.spy.memcached.ops.APIType;
@@ -71,7 +70,7 @@ final class FlushOperationImpl extends OperationImpl
     } else {
       b = ByteBuffer.allocate(32);
       b.put(("flush_all " + delay + "\r\n").getBytes());
-      ((Buffer) b).flip();
+      b.flip();
     }
     setBuffer(b);
   }

--- a/src/main/java/net/spy/memcached/protocol/ascii/GetAttrOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/GetAttrOperationImpl.java
@@ -17,7 +17,6 @@
  */
 package net.spy.memcached.protocol.ascii;
 
-import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.util.Collection;
 import java.util.Collections;
@@ -98,7 +97,7 @@ class GetAttrOperationImpl extends OperationImpl implements GetAttrOperation {
     int size = CMD.length() + KeyUtil.getKeyBytes(key).length + 16;
     ByteBuffer bb = ByteBuffer.allocate(size);
     setArguments(bb, CMD, key);
-    ((Buffer) bb).flip();
+    bb.flip();
     setBuffer(bb);
 
     if (getLogger().isDebugEnabled()) {

--- a/src/main/java/net/spy/memcached/protocol/ascii/MutatorOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/MutatorOperationImpl.java
@@ -19,7 +19,6 @@
 
 package net.spy.memcached.protocol.ascii;
 
-import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.util.Collection;
 import java.util.Collections;
@@ -107,7 +106,7 @@ final class MutatorOperationImpl extends OperationImpl
     } else {
       setArguments(b, mutator.name(), key, amount);
     }
-    ((Buffer) b).flip();
+    b.flip();
     setBuffer(b);
   }
 

--- a/src/main/java/net/spy/memcached/protocol/ascii/SetAttrOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/SetAttrOperationImpl.java
@@ -17,7 +17,6 @@
  */
 package net.spy.memcached.protocol.ascii;
 
-import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.util.Collection;
 import java.util.Collections;
@@ -97,7 +96,7 @@ class SetAttrOperationImpl extends OperationImpl
 
     setArguments(bb, "setattr", key, attrs);
 
-    ((Buffer) bb).flip();
+    bb.flip();
     setBuffer(bb);
 
     if (getLogger().isDebugEnabled()) {

--- a/src/main/java/net/spy/memcached/protocol/binary/MultiGetOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/binary/MultiGetOperationImpl.java
@@ -18,7 +18,6 @@
 package net.spy.memcached.protocol.binary;
 
 import java.io.IOException;
-import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.util.Collection;
 import java.util.HashMap;
@@ -98,7 +97,7 @@ class MultiGetOperationImpl extends OperationImpl implements GetOperation {
     bb.putInt(terminalOpaque);
     bb.putLong(0); // cas
 
-    ((Buffer) bb).flip();
+    bb.flip();
     setBuffer(bb);
   }
 

--- a/src/main/java/net/spy/memcached/protocol/binary/OperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/binary/OperationImpl.java
@@ -18,7 +18,6 @@
 package net.spy.memcached.protocol.binary;
 
 import java.io.IOException;
-import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -300,7 +299,7 @@ abstract class OperationImpl extends BaseOperationImpl {
     bb.put(keyBytes);
     bb.put(val);
 
-    ((Buffer) bb).flip();
+    bb.flip();
     setBuffer(bb);
   }
 

--- a/src/main/java/net/spy/memcached/protocol/binary/OptimizedSetImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/binary/OptimizedSetImpl.java
@@ -18,7 +18,6 @@
 package net.spy.memcached.protocol.binary;
 
 import java.io.IOException;
-import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -118,7 +117,7 @@ public final class OptimizedSetImpl extends OperationImpl implements Operation {
     bb.putInt(terminalOpaque);
     bb.putLong(0); // cas
 
-    ((Buffer) bb).flip();
+    bb.flip();
     setBuffer(bb);
   }
 

--- a/src/test/java/net/spy/memcached/protocol/ascii/BaseOpTest.java
+++ b/src/test/java/net/spy/memcached/protocol/ascii/BaseOpTest.java
@@ -19,7 +19,6 @@
 
 package net.spy.memcached.protocol.ascii;
 
-import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
 import java.util.LinkedList;
@@ -89,12 +88,12 @@ class BaseOpTest {
     SimpleOp op = new SimpleOp(OperationReadType.LINE);
 
     b.put(input1.getBytes());
-    ((Buffer) b).flip();
+    b.flip();
     op.readFromBuffer(b);
     assertNull(op.getCurrentLine());
-    ((Buffer) b).clear();
+    b.clear();
     b.put(input2.getBytes());
-    ((Buffer) b).flip();
+    b.flip();
     op.readFromBuffer(b);
     assertEquals("this is a test", op.getCurrentLine());
   }


### PR DESCRIPTION
### 🔗 Related Issue

<!-- Please link related issue. ex) https://github.com/naver/arcus-java-client/issues/{issue_number} -->
- 

### ⌨️ What I did

<!-- Please describe this PR and what you've been working on. -->
- 필요없는 `(Buffer)` 타입 캐스팅을 제거합니다. 