### PR TITLE
 CLEANUP: use replace method instead of replaceAll

### DIFF
--- a/src/main/java/net/spy/memcached/protocol/ascii/CollectionBulkInsertOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/CollectionBulkInsertOperationImpl.java
@@ -166,7 +166,7 @@ public final class CollectionBulkInsertOperationImpl extends OperationImpl
 
     if (getLogger().isDebugEnabled()) {
       getLogger().debug("Request in ascii protocol: %s",
-              (new String(buffer.array())).replaceAll("\\r\\n", "\n"));
+              (new String(buffer.array())).replace("\r\n", "\\r\\n"));
     }
   }
 

--- a/src/main/java/net/spy/memcached/protocol/ascii/CollectionCreateOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/CollectionCreateOperationImpl.java
@@ -106,7 +106,7 @@ public final class CollectionCreateOperationImpl extends OperationImpl
 
     if (getLogger().isDebugEnabled()) {
       getLogger().debug("Request in ascii protocol: %s",
-              (new String(bb.array())).replaceAll("\\r\\n", ""));
+              (new String(bb.array())).replace("\r\n", "\\r\\n"));
     }
   }
 

--- a/src/main/java/net/spy/memcached/protocol/ascii/CollectionExistOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/CollectionExistOperationImpl.java
@@ -110,7 +110,7 @@ public final class CollectionExistOperationImpl extends OperationImpl
 
     if (getLogger().isDebugEnabled()) {
       getLogger().debug("Request in ascii protocol: %s",
-              (new String(bb.array())).replaceAll("\\r\\n", ""));
+              (new String(bb.array())).replace("\r\n", "\\r\\n"));
     }
   }
 

--- a/src/main/java/net/spy/memcached/protocol/ascii/CollectionPipedExistOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/CollectionPipedExistOperationImpl.java
@@ -146,7 +146,7 @@ public final class CollectionPipedExistOperationImpl extends OperationImpl imple
 
     if (getLogger().isDebugEnabled()) {
       getLogger().debug("Request in ascii protocol: %s",
-              (new String(buffer.array())).replaceAll("\\r\\n", "\n"));
+              (new String(buffer.array())).replace("\r\n", "\\r\\n"));
     }
   }
 

--- a/src/main/java/net/spy/memcached/protocol/ascii/CollectionPipedInsertOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/CollectionPipedInsertOperationImpl.java
@@ -175,7 +175,7 @@ public final class CollectionPipedInsertOperationImpl extends OperationImpl
 
     if (getLogger().isDebugEnabled()) {
       getLogger().debug("Request in ascii protocol: %s",
-              (new String(buffer.array())).replaceAll("\\r\\n", "\n"));
+              (new String(buffer.array())).replace("\r\n", "\\r\\n"));
     }
   }
 

--- a/src/main/java/net/spy/memcached/protocol/ascii/CollectionPipedUpdateOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/CollectionPipedUpdateOperationImpl.java
@@ -170,7 +170,7 @@ public final class CollectionPipedUpdateOperationImpl extends OperationImpl impl
     if (getLogger().isDebugEnabled()) {
       getLogger().debug(
               "Request in ascii protocol: %s",
-                      (new String(buffer.array())).replaceAll("\\r\\n", "\n"));
+                      (new String(buffer.array())).replace("\r\n", "\\r\\n"));
     }
   }
 

--- a/src/main/java/net/spy/memcached/protocol/ascii/CollectionUpdateOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/CollectionUpdateOperationImpl.java
@@ -142,7 +142,7 @@ public final class CollectionUpdateOperationImpl extends OperationImpl implement
     if (getLogger().isDebugEnabled()) {
       getLogger().debug(
               "Request in ascii protocol: '%s'",
-              (new String(bb.array())).replaceAll("\\r\\n", "\r\n"));
+              (new String(bb.array())).replace("\r\n", "\\r\\n"));
     }
   }
 


### PR DESCRIPTION
### 🔗 Related Issue

<!-- Please link related issue. ex) https://github.com/naver/arcus-java-client/issues/{issue_number} -->
- https://github.com/jam2in/arcus-works/issues/623

### ⌨️ What I did

<!-- Please describe this PR and what you've been working on. -->
- Operation 클래스들의 initialize 메서드에서 디버깅목적으로 사용되는 replaceAll 메서드를 replace 메서드로 교체합니다.
- 이를 통해 로그에 `\r\n`이 정상적으로 보여지도록 합니다.