### PR TITLE
FIX: Duplicated switchover event.

### DIFF
--- a/src/main/java/net/spy/memcached/MemcachedReplicaGroup.java
+++ b/src/main/java/net/spy/memcached/MemcachedReplicaGroup.java
@@ -32,6 +32,7 @@ public abstract class MemcachedReplicaGroup extends SpyObject {
   protected MemcachedNode masterCandidate;
   private final StringBuilder sb = new StringBuilder();
   private boolean delayedSwitchover = false;
+  private boolean alreadySwitched = false;
 
   public static final int MAX_REPL_SLAVE_SIZE = 2;
   public static final int MAX_REPL_GROUP_SIZE = MAX_REPL_SLAVE_SIZE + 1;
@@ -41,6 +42,17 @@ public abstract class MemcachedReplicaGroup extends SpyObject {
       throw new IllegalArgumentException("Memcached in Replica Group must have group name");
     }
     this.group = groupName;
+  }
+
+  public List<ArcusReplNodeAddress> getArcusReplNodeAddressList() {
+    List<ArcusReplNodeAddress> arcusReplNodeAddressList = new ArrayList<>();
+    if (masterNode != null) {
+      arcusReplNodeAddressList.add((ArcusReplNodeAddress) masterNode.getSocketAddress());
+    }
+    for (MemcachedNode slaveNode : slaveNodes) {
+      arcusReplNodeAddressList.add((ArcusReplNodeAddress) slaveNode.getSocketAddress());
+    }
+    return arcusReplNodeAddressList;
   }
 
   @Override
@@ -54,6 +66,14 @@ public abstract class MemcachedReplicaGroup extends SpyObject {
     }
     sb.append("]");
     return sb.toString();
+  }
+
+  public boolean isAlreadySwitched() {
+    return alreadySwitched;
+  }
+
+  public void setAlreadySwitched(boolean alreadySwitched) {
+    this.alreadySwitched = alreadySwitched;
   }
 
   public boolean isEmptyGroup() {

--- a/src/main/java/net/spy/memcached/protocol/BaseOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/BaseOperationImpl.java
@@ -166,6 +166,7 @@ public abstract class BaseOperationImpl extends SpyObject {
 
     getLogger().info("%s message received by %s operation from %s", cause, this, handlingNode);
     transitionState(OperationState.MOVING);
+    group.setAlreadySwitched(true);
   }
   /* ENABLE_REPLICATION end */
 


### PR DESCRIPTION
### 🔗 Related Issue

- https://github.com/jam2in/arcus-works/issues/638

### ⌨️ What I did

findChangedGroups 로직에서 swichover의 old 형상으로 되돌리는 문제를 해결했습니다.
로직은 대략 아래와 같이 구현되어있습니다.

1. 검사하려는 node의 그룹이 alreadySwitched인지 확인
2. master / slave 여부를 제외한 groupname, ip, port 정보들 중 변경 있는지 확인
3. master / slave 여부가 old 형상으로 되돌려졌는지 확인
4. flag 원복

우선 리뷰를 위해 한글로 주석을 달아두었습니다.
추후 리뷰 완료되면 제거 또는 영어로 변경할 예정입니다.