### PR TITLE
INTERNAL: rename switchover method and state

### DIFF
--- a/src/main/java/net/spy/memcached/MemcachedConnection.java
+++ b/src/main/java/net/spy/memcached/MemcachedConnection.java
@@ -1000,7 +1000,7 @@ public final class MemcachedConnection extends SpyObject {
           assert op == currentOp : "Expected to pop " + currentOp + " got " + op;
           currentOp = qa.getCurrentReadOp();
         /* ENABLE_REPLICATION if */
-        } else if (currentOp.getState() == OperationState.MOVING) {
+        } else if (currentOp.getState() == OperationState.NEED_SWITCHOVER) {
           break;
         /* ENABLE_REPLICATION end */
         /* ENABLE_MIGRATION if */
@@ -1016,7 +1016,7 @@ public final class MemcachedConnection extends SpyObject {
         /* ENABLE_MIGRATION end */
       }
       /* ENABLE_REPLICATION if */
-      if (currentOp != null && currentOp.getState() == OperationState.MOVING) {
+      if (currentOp != null && currentOp.getState() == OperationState.NEED_SWITCHOVER) {
         ((Buffer) rbuf).clear();
         MemcachedReplicaGroup group = qa.getReplicaGroup();
         delayedSwitchoverGroups.remove(group);

--- a/src/main/java/net/spy/memcached/ops/OperationState.java
+++ b/src/main/java/net/spy/memcached/ops/OperationState.java
@@ -38,9 +38,10 @@ public enum OperationState {
   COMPLETE,
   /* ENABLE_REPLICATION if */
   /**
-   * State indicating this operation will be moved by switchover or failover
+   * State indicating this operation received SWITCHOVER | REPL_SLAVE
+   * and the node handling this operation need to switchover in the locator.
    */
-  MOVING,
+  NEED_SWITCHOVER,
   /* ENABLE_REPLICATION end */
 
   /* ENABLE_MIGRATION if */

--- a/src/main/java/net/spy/memcached/protocol/BaseOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/BaseOperationImpl.java
@@ -144,7 +144,7 @@ public abstract class BaseOperationImpl extends SpyObject {
     }
   }
 
-  protected final void receivedMoveOperations(String cause) {
+  protected final void prepareSwitchover(String cause) {
     // switchover message e.g.
     // one slave node case : "SWITCHOVER", "REPL_SLAVE",
     // two or more than slave nodes case : "SWITCHOVER <ip:port>", "REPL_SLAVE <ip:port>"
@@ -165,7 +165,7 @@ public abstract class BaseOperationImpl extends SpyObject {
     }
 
     getLogger().info("%s message received by %s operation from %s", cause, this, handlingNode);
-    transitionState(OperationState.MOVING);
+    transitionState(OperationState.NEED_SWITCHOVER);
   }
   /* ENABLE_REPLICATION end */
 

--- a/src/main/java/net/spy/memcached/protocol/ascii/BTreeInsertAndGetOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/BTreeInsertAndGetOperationImpl.java
@@ -121,7 +121,7 @@ public final class BTreeInsertAndGetOperationImpl extends OperationImpl implemen
 
     /* ENABLE_REPLICATION if */
     if (hasSwitchedOver(line)) {
-      receivedMoveOperations(line);
+      prepareSwitchover(line);
       return;
     }
     /* ENABLE_REPLICATION end */

--- a/src/main/java/net/spy/memcached/protocol/ascii/BaseStoreOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/BaseStoreOperationImpl.java
@@ -66,7 +66,7 @@ abstract class BaseStoreOperationImpl extends OperationImpl {
             : "Read ``" + line + "'' when in " + getState() + " state";
     /* ENABLE_REPLICATION if */
     if (hasSwitchedOver(line)) {
-      receivedMoveOperations(line);
+      prepareSwitchover(line);
       return;
     }
     /* ENABLE_REPLICATION end */

--- a/src/main/java/net/spy/memcached/protocol/ascii/CASOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/CASOperationImpl.java
@@ -75,7 +75,7 @@ class CASOperationImpl extends OperationImpl implements CASOperation {
             : "Read ``" + line + "'' when in " + getState() + " state";
     /* ENABLE_REPLICATION if */
     if (hasSwitchedOver(line)) {
-      receivedMoveOperations(line);
+      prepareSwitchover(line);
       return;
     }
     /* ENABLE_REPLICATION end */

--- a/src/main/java/net/spy/memcached/protocol/ascii/CollectionBulkInsertOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/CollectionBulkInsertOperationImpl.java
@@ -91,7 +91,7 @@ public final class CollectionBulkInsertOperationImpl extends OperationImpl
     /* ENABLE_REPLICATION if */
     if (hasSwitchedOver(line)) {
       this.insert.setNextOpIndex(index);
-      receivedMoveOperations(line);
+      prepareSwitchover(line);
       return;
     }
     /* ENABLE_REPLICATION end */

--- a/src/main/java/net/spy/memcached/protocol/ascii/CollectionCreateOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/CollectionCreateOperationImpl.java
@@ -79,7 +79,7 @@ public final class CollectionCreateOperationImpl extends OperationImpl
             : "Read ``" + line + "'' when in " + getState() + " state";
     /* ENABLE_REPLICATION if */
     if (hasSwitchedOver(line)) {
-      receivedMoveOperations(line);
+      prepareSwitchover(line);
       return;
     }
     /* ENABLE_REPLICATION end */

--- a/src/main/java/net/spy/memcached/protocol/ascii/CollectionDeleteOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/CollectionDeleteOperationImpl.java
@@ -87,7 +87,7 @@ public final class CollectionDeleteOperationImpl extends OperationImpl
             : "Read ``" + line + "'' when in " + getState() + " state";
     /* ENABLE_REPLICATION if */
     if (hasSwitchedOver(line)) {
-      receivedMoveOperations(line);
+      prepareSwitchover(line);
       return;
     }
     /* ENABLE_REPLICATION end */

--- a/src/main/java/net/spy/memcached/protocol/ascii/CollectionGetOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/CollectionGetOperationImpl.java
@@ -110,7 +110,7 @@ public final class CollectionGetOperationImpl extends OperationImpl
   public void handleLine(String line) {
     /* ENABLE_REPLICATION if */
     if (hasSwitchedOver(line)) {
-      receivedMoveOperations(line);
+      prepareSwitchover(line);
       return;
     }
     /* ENABLE_REPLICATION end */

--- a/src/main/java/net/spy/memcached/protocol/ascii/CollectionInsertOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/CollectionInsertOperationImpl.java
@@ -104,7 +104,7 @@ public final class CollectionInsertOperationImpl extends OperationImpl
             : "Read ``" + line + "'' when in " + getState() + " state";
     /* ENABLE_REPLICATION if */
     if (hasSwitchedOver(line)) {
-      receivedMoveOperations(line);
+      prepareSwitchover(line);
       return;
     }
     /* ENABLE_REPLICATION end */

--- a/src/main/java/net/spy/memcached/protocol/ascii/CollectionMutateOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/CollectionMutateOperationImpl.java
@@ -82,7 +82,7 @@ public final class CollectionMutateOperationImpl extends OperationImpl implement
 
     /* ENABLE_REPLICATION if */
     if (hasSwitchedOver(line)) {
-      receivedMoveOperations(line);
+      prepareSwitchover(line);
       return;
     }
     /* ENABLE_REPLICATION end */

--- a/src/main/java/net/spy/memcached/protocol/ascii/CollectionPipedInsertOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/CollectionPipedInsertOperationImpl.java
@@ -98,7 +98,7 @@ public final class CollectionPipedInsertOperationImpl extends OperationImpl
     /* ENABLE_REPLICATION if */
     if (hasSwitchedOver(line)) {
       this.insert.setNextOpIndex(index);
-      receivedMoveOperations(line);
+      prepareSwitchover(line);
       return;
     }
     /* ENABLE_REPLICATION end */

--- a/src/main/java/net/spy/memcached/protocol/ascii/CollectionPipedUpdateOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/CollectionPipedUpdateOperationImpl.java
@@ -92,7 +92,7 @@ public final class CollectionPipedUpdateOperationImpl extends OperationImpl impl
     /* ENABLE_REPLICATION if */
     if (hasSwitchedOver(line)) {
       this.update.setNextOpIndex(index);
-      receivedMoveOperations(line);
+      prepareSwitchover(line);
       return;
     }
     /* ENABLE_REPLICATION end */

--- a/src/main/java/net/spy/memcached/protocol/ascii/CollectionUpdateOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/CollectionUpdateOperationImpl.java
@@ -89,7 +89,7 @@ public final class CollectionUpdateOperationImpl extends OperationImpl implement
             + "'' when in " + getState() + " state";
     /* ENABLE_REPLICATION if */
     if (hasSwitchedOver(line)) {
-      receivedMoveOperations(line);
+      prepareSwitchover(line);
       return;
     }
     /* ENABLE_REPLICATION end */

--- a/src/main/java/net/spy/memcached/protocol/ascii/DeleteOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/DeleteOperationImpl.java
@@ -60,7 +60,7 @@ final class DeleteOperationImpl extends OperationImpl
     getLogger().debug("Delete of %s returned %s", key, line);
     /* ENABLE_REPLICATION if */
     if (hasSwitchedOver(line)) {
-      receivedMoveOperations(line);
+      prepareSwitchover(line);
       return;
     }
     /* ENABLE_REPLICATION end */

--- a/src/main/java/net/spy/memcached/protocol/ascii/FlushByPrefixOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/FlushByPrefixOperationImpl.java
@@ -58,7 +58,7 @@ final class FlushByPrefixOperationImpl extends OperationImpl implements
     getLogger().debug("Flush completed successfully");
     /* ENABLE_REPLICATION if */
     if (hasSwitchedOver(line)) {
-      receivedMoveOperations(line);
+      prepareSwitchover(line);
       return;
     }
     /* ENABLE_REPLICATION end */

--- a/src/main/java/net/spy/memcached/protocol/ascii/FlushOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/FlushOperationImpl.java
@@ -55,7 +55,7 @@ final class FlushOperationImpl extends OperationImpl
     getLogger().debug("Flush completed successfully");
     /* ENABLE_REPLICATION if */
     if (hasSwitchedOver(line)) {
-      receivedMoveOperations(line);
+      prepareSwitchover(line);
       return;
     }
     /* ENABLE_REPLICATION end */

--- a/src/main/java/net/spy/memcached/protocol/ascii/MutatorOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/MutatorOperationImpl.java
@@ -73,7 +73,7 @@ final class MutatorOperationImpl extends OperationImpl
   public void handleLine(String line) {
     /* ENABLE_REPLICATION if */
     if (hasSwitchedOver(line)) {
-      receivedMoveOperations(line);
+      prepareSwitchover(line);
       return;
     }
     /* ENABLE_REPLICATION end */

--- a/src/main/java/net/spy/memcached/protocol/ascii/OperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/OperationImpl.java
@@ -145,7 +145,7 @@ abstract class OperationImpl extends BaseOperationImpl implements Operation {
     // Loop while there's data remaining to get it all drained.
     while (data.remaining() > 0) {
       if (getState() == OperationState.COMPLETE ||
-          getState() == OperationState.MOVING || // ENABLE_REPLICATION
+          getState() == OperationState.NEED_SWITCHOVER || // ENABLE_REPLICATION
           getState() == OperationState.REDIRECT) { // ENABLE_MIGRATION
         return;
       }

--- a/src/main/java/net/spy/memcached/protocol/ascii/SetAttrOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/SetAttrOperationImpl.java
@@ -73,7 +73,7 @@ class SetAttrOperationImpl extends OperationImpl
             : "Read ``" + line + "'' when in " + getState() + " state";
     /* ENABLE_REPLICATION if */
     if (hasSwitchedOver(line)) {
-      receivedMoveOperations(line);
+      prepareSwitchover(line);
       return;
     }
     /* ENABLE_REPLICATION end */


### PR DESCRIPTION
### 🔗 Related Issue

<!-- Please link related issue. ex) https://github.com/naver/arcus-java-client/issues/{issue_number} -->
- https://github.com/jam2in/arcus-works/issues/662

### ⌨️ What I did

<!-- Please describe this PR and what you've been working on. -->
- switchover 용어 변경합니다.
  - OperationState.MOVING -> OperationState.NEED_SWITCHOVER
  - receivedMoveOperations -> prepareSwitchover