### PR TITLE
CLEANUP: remove useless constructor and change parameter order in delete command class

### DIFF
--- a/src/main/java/net/spy/memcached/ArcusClient.java
+++ b/src/main/java/net/spy/memcached/ArcusClient.java
@@ -1522,7 +1522,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
                                                   ElementFlagFilter eFlagFilter,
                                                   boolean dropIfEmpty) {
     BTreeUtil.validateBkey(bkey);
-    BTreeDelete delete = new BTreeDelete(bkey, false, dropIfEmpty, eFlagFilter);
+    BTreeDelete delete = new BTreeDelete(bkey, eFlagFilter, dropIfEmpty, false);
     return asyncCollectionDelete(key, delete);
   }
 
@@ -1532,7 +1532,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
                                                   ElementFlagFilter eFlagFilter, int count,
                                                   boolean dropIfEmpty) {
     BTreeUtil.validateBkey(from, to);
-    BTreeDelete delete = new BTreeDelete(from, to, count, false, dropIfEmpty, eFlagFilter);
+    BTreeDelete delete = new BTreeDelete(from, to, count, eFlagFilter, dropIfEmpty, false);
     return asyncCollectionDelete(key, delete);
   }
 
@@ -1540,7 +1540,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
   public CollectionFuture<Boolean> asyncMopDelete(String key,
                                                   boolean dropIfEmpty) {
     List<String> mkeyList = new ArrayList<>();
-    MapDelete delete = new MapDelete(mkeyList, false, dropIfEmpty);
+    MapDelete delete = new MapDelete(mkeyList, dropIfEmpty, false);
     return asyncCollectionDelete(key, delete);
   }
 
@@ -1553,7 +1553,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
     validateMKey(mkey);
     List<String> mkeyList = new ArrayList<>(1);
     mkeyList.add(mkey);
-    MapDelete delete = new MapDelete(mkeyList, false, dropIfEmpty);
+    MapDelete delete = new MapDelete(mkeyList, dropIfEmpty, false);
     return asyncCollectionDelete(key, delete);
   }
 
@@ -1574,21 +1574,21 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
   @Override
   public CollectionFuture<Boolean> asyncLopDelete(String key, int index,
                                                   boolean dropIfEmpty) {
-    ListDelete delete = new ListDelete(index, false, dropIfEmpty);
+    ListDelete delete = new ListDelete(index, dropIfEmpty, false);
     return asyncCollectionDelete(key, delete);
   }
 
   @Override
   public CollectionFuture<Boolean> asyncLopDelete(String key, int from,
                                                   int to, boolean dropIfEmpty) {
-    ListDelete delete = new ListDelete(from, to, false, dropIfEmpty);
+    ListDelete delete = new ListDelete(from, to, dropIfEmpty, false);
     return asyncCollectionDelete(key, delete);
   }
 
   @Override
   public CollectionFuture<Boolean> asyncSopDelete(String key, Object value,
                                                   boolean dropIfEmpty) {
-    SetDelete<Object> delete = new SetDelete<>(value, false, dropIfEmpty,
+    SetDelete<Object> delete = new SetDelete<>(value, dropIfEmpty, false,
             collectionTranscoder);
     return asyncCollectionDelete(key, delete);
   }
@@ -1596,7 +1596,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
   @Override
   public <T> CollectionFuture<Boolean> asyncSopDelete(String key, T value,
                                                       boolean dropIfEmpty, Transcoder<T> tc) {
-    SetDelete<T> delete = new SetDelete<>(value, false, dropIfEmpty, tc);
+    SetDelete<T> delete = new SetDelete<>(value, dropIfEmpty, false, tc);
     return asyncCollectionDelete(key, delete);
   }
 
@@ -2873,7 +2873,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
                                                   ElementFlagFilter eFlagFilter, int count,
                                                   boolean dropIfEmpty) {
     BTreeUtil.validateBkey(from, to);
-    BTreeDelete delete = new BTreeDelete(from, to, count, false, dropIfEmpty, eFlagFilter);
+    BTreeDelete delete = new BTreeDelete(from, to, count, eFlagFilter, dropIfEmpty, false);
     return asyncCollectionDelete(key, delete);
   }
 
@@ -2882,7 +2882,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
                                                   byte[] bkey, ElementFlagFilter eFlagFilter,
                                                   boolean dropIfEmpty) {
     BTreeUtil.validateBkey(bkey);
-    BTreeDelete delete = new BTreeDelete(bkey, false, dropIfEmpty, eFlagFilter);
+    BTreeDelete delete = new BTreeDelete(bkey, eFlagFilter, dropIfEmpty, false);
     return asyncCollectionDelete(key, delete);
   }
 

--- a/src/main/java/net/spy/memcached/collection/BTreeDelete.java
+++ b/src/main/java/net/spy/memcached/collection/BTreeDelete.java
@@ -25,83 +25,38 @@ public class BTreeDelete extends CollectionDelete {
 
   protected ElementFlagFilter elementFlagFilter;
 
-  public BTreeDelete(long bkey, boolean noreply) {
+  public BTreeDelete(long bkey, ElementFlagFilter elementFlagFilter,
+                     boolean dropIfEmpty, boolean noreply) {
     this.range = String.valueOf(bkey);
-    this.noreply = noreply;
-  }
-
-  public BTreeDelete(long bkey, boolean noreply, boolean dropIfEmpty,
-                     ElementFlagFilter elementFlagFilter) {
-    this(bkey, noreply);
-    this.dropIfEmpty = dropIfEmpty;
     this.elementFlagFilter = elementFlagFilter;
-  }
-
-  public BTreeDelete(long from, long to, boolean noreply) {
-    this.range = from + ".." + to;
+    this.dropIfEmpty = dropIfEmpty;
     this.noreply = noreply;
   }
 
-  public BTreeDelete(long from, long to, int count, boolean noreply) {
+  public BTreeDelete(long from, long to, int count, ElementFlagFilter elementFlagFilter,
+                     boolean dropIfEmpty, boolean noreply) {
     this.range = from + ".." + to;
     this.count = count;
-    this.noreply = noreply;
-  }
-
-  public BTreeDelete(long from, long to, int count, boolean noreply, boolean dropIfEmpty,
-                     ElementFlagFilter elementFlagFilter) {
-    this(from, to, count, noreply);
     this.dropIfEmpty = dropIfEmpty;
     this.noreply = noreply;
     this.elementFlagFilter = elementFlagFilter;
   }
 
-  public BTreeDelete(byte[] bkey, boolean noreply, boolean dropIfEmpty,
-                     ElementFlagFilter elementFlagFilter) {
+  public BTreeDelete(byte[] bkey, ElementFlagFilter elementFlagFilter,
+                     boolean dropIfEmpty, boolean noreply) {
     this.range = BTreeUtil.toHex(bkey);
     this.noreply = noreply;
     this.dropIfEmpty = dropIfEmpty;
     this.elementFlagFilter = elementFlagFilter;
   }
 
-  public BTreeDelete(byte[] from, byte[] to, int count, boolean noreply, boolean dropIfEmpty,
-                     ElementFlagFilter elementFlagFilter) {
+  public BTreeDelete(byte[] from, byte[] to, int count, ElementFlagFilter elementFlagFilter,
+                     boolean dropIfEmpty, boolean noreply) {
     this.range = BTreeUtil.toHex(from) + ".." + BTreeUtil.toHex(to);
     this.count = count;
     this.noreply = noreply;
     this.dropIfEmpty = dropIfEmpty;
     this.elementFlagFilter = elementFlagFilter;
-  }
-
-  public BTreeDelete(long bkey, boolean noreply, boolean dropIfEmpty,
-                     ElementMultiFlagsFilter elementMultiFlagsFilter) {
-    this(bkey, noreply);
-    this.dropIfEmpty = dropIfEmpty;
-    this.elementFlagFilter = elementMultiFlagsFilter;
-  }
-
-  public BTreeDelete(long from, long to, int count, boolean noreply, boolean dropIfEmpty,
-                     ElementMultiFlagsFilter elementMultiFlagsFilter) {
-    this(from, to, count, noreply);
-    this.dropIfEmpty = dropIfEmpty;
-    this.elementFlagFilter = elementMultiFlagsFilter;
-  }
-
-  public BTreeDelete(byte[] bkey, boolean noreply, boolean dropIfEmpty,
-                     ElementMultiFlagsFilter elementMultiFlagsFilter) {
-    this.range = BTreeUtil.toHex(bkey);
-    this.noreply = noreply;
-    this.dropIfEmpty = dropIfEmpty;
-    this.elementFlagFilter = elementMultiFlagsFilter;
-  }
-
-  public BTreeDelete(byte[] from, byte[] to, int count, boolean noreply, boolean dropIfEmpty,
-                     ElementMultiFlagsFilter elementMultiFlagsFilter) {
-    this.range = BTreeUtil.toHex(from) + ".." + BTreeUtil.toHex(to);
-    this.count = count;
-    this.noreply = noreply;
-    this.dropIfEmpty = dropIfEmpty;
-    this.elementFlagFilter = elementMultiFlagsFilter;
   }
 
   @Override

--- a/src/main/java/net/spy/memcached/collection/ListDelete.java
+++ b/src/main/java/net/spy/memcached/collection/ListDelete.java
@@ -20,24 +20,16 @@ public class ListDelete extends CollectionDelete {
 
   private static final String command = "lop delete";
 
-  public ListDelete(int index, boolean noreply) {
+  public ListDelete(int index, boolean dropIfEmpty, boolean noreply) {
     this.range = String.valueOf(index);
+    this.dropIfEmpty = dropIfEmpty;
     this.noreply = noreply;
   }
 
-  public ListDelete(int index, boolean noreply, boolean dropIfEmpty) {
-    this(index, noreply);
+  public ListDelete(int from, int to, boolean dropIfEmpty, boolean noreply) {
+    this.range = from + ".." + to;
     this.dropIfEmpty = dropIfEmpty;
-  }
-
-  public ListDelete(int from, int to, boolean noreply) {
-    this.range = String.valueOf(from) + ".." + String.valueOf(to);
     this.noreply = noreply;
-  }
-
-  public ListDelete(int from, int to, boolean noreply, boolean dropIfEmpty) {
-    this(from, to, noreply);
-    this.dropIfEmpty = dropIfEmpty;
   }
 
   @Override

--- a/src/main/java/net/spy/memcached/collection/MapDelete.java
+++ b/src/main/java/net/spy/memcached/collection/MapDelete.java
@@ -26,14 +26,10 @@ public class MapDelete extends CollectionDelete {
   private String spaceSeparatedKeys;
   protected byte[] additionalArgs;
 
-  public MapDelete(List<String> mkeyList, boolean noreply) {
+  public MapDelete(List<String> mkeyList, boolean dropIfEmpty, boolean noreply) {
     this.mkeyList = mkeyList;
-    this.noreply = noreply;
-  }
-
-  public MapDelete(List<String> mkeyList, boolean noreply, boolean dropIfEmpty) {
-    this(mkeyList, noreply);
     this.dropIfEmpty = dropIfEmpty;
+    this.noreply = noreply;
   }
 
   public void setKeySeparator(String keySeparator) {

--- a/src/main/java/net/spy/memcached/collection/SetDelete.java
+++ b/src/main/java/net/spy/memcached/collection/SetDelete.java
@@ -26,16 +26,12 @@ public class SetDelete<T> extends CollectionDelete {
   protected byte[] additionalArgs;
   protected Transcoder<T> tc;
 
-  public SetDelete(T value, boolean noreply, Transcoder<T> tc) {
+  public SetDelete(T value, boolean dropIfEmpty, boolean noreply, Transcoder<T> tc) {
     this.value = value;
+    this.dropIfEmpty = dropIfEmpty;
     this.noreply = noreply;
     this.tc = tc;
     this.additionalArgs = tc.encode(value).getData();
-  }
-
-  public SetDelete(T value, boolean noreply, boolean dropIfEmpty, Transcoder<T> tc) {
-    this(value, noreply, tc);
-    this.dropIfEmpty = dropIfEmpty;
   }
 
   public T getValue() {

--- a/src/test/manual/net/spy/memcached/MultibyteKeyTest.java
+++ b/src/test/manual/net/spy/memcached/MultibyteKeyTest.java
@@ -446,7 +446,7 @@ class MultibyteKeyTest {
   void CollectionDeleteOperationImplTest() {
     try {
       opFact.collectionDelete(MULTIBYTE_KEY,
-          new BTreeDelete(1L, false),
+          new BTreeDelete(1L, ElementFlagFilter.DO_NOT_FILTER, true, false),
           new OperationCallback() {
             @Override
             public void receivedStatus(OperationStatus status) {

--- a/src/test/manual/net/spy/memcached/emptycollection/ProtocolBTreeDeleteTest.java
+++ b/src/test/manual/net/spy/memcached/emptycollection/ProtocolBTreeDeleteTest.java
@@ -27,34 +27,32 @@ class ProtocolBTreeDeleteTest {
 
   @Test
   void testStringify() {
-    // default setting : dropIfEmpty = true
-
     assertEquals("10 drop",
-            (new BTreeDelete(10, false)).stringify());
+            (new BTreeDelete(10, ElementFlagFilter.DO_NOT_FILTER, true, false)).stringify());
 
-    assertEquals("10", (new BTreeDelete(10, false, false,
-            ElementFlagFilter.DO_NOT_FILTER)).stringify());
-    assertEquals("10 drop", (new BTreeDelete(10, false,
-            true, ElementFlagFilter.DO_NOT_FILTER)).stringify());
+    assertEquals("10", (new BTreeDelete(10, ElementFlagFilter.DO_NOT_FILTER, false,
+            false)).stringify());
+    assertEquals("10 drop", (new BTreeDelete(10, ElementFlagFilter.DO_NOT_FILTER,
+            true, false)).stringify());
 
     assertEquals("10..20 1", (new BTreeDelete(10, 20, 1,
-            false, false, ElementFlagFilter.DO_NOT_FILTER)).stringify());
+            ElementFlagFilter.DO_NOT_FILTER, false, false)).stringify());
     assertEquals("10..20 1 drop", (new BTreeDelete(10, 20,
-            1, false, true, ElementFlagFilter.DO_NOT_FILTER)).stringify());
+            1, ElementFlagFilter.DO_NOT_FILTER, true, false)).stringify());
 
-    assertEquals("10 drop noreply", (new BTreeDelete(10,
-            true)).stringify());
+    assertEquals("10 drop noreply", (new BTreeDelete(10, ElementFlagFilter.DO_NOT_FILTER,
+            true, true)).stringify());
 
-    assertEquals("10 noreply", (new BTreeDelete(10, true,
-            false, ElementFlagFilter.DO_NOT_FILTER)).stringify());
+    assertEquals("10 noreply", (new BTreeDelete(10, ElementFlagFilter.DO_NOT_FILTER,
+            false, true)).stringify());
     assertEquals("10 drop noreply", (new BTreeDelete(10,
-            true, true, ElementFlagFilter.DO_NOT_FILTER)).stringify());
+            ElementFlagFilter.DO_NOT_FILTER, true, true)).stringify());
 
     assertEquals("10..20 1 noreply", (new BTreeDelete(10,
-            20, 1, true, false, ElementFlagFilter.DO_NOT_FILTER))
+            20, 1, ElementFlagFilter.DO_NOT_FILTER, false, true))
             .stringify());
     assertEquals("10..20 1 drop noreply", (new BTreeDelete(
-            10, 20, 1, true, true, ElementFlagFilter.DO_NOT_FILTER))
+            10, 20, 1, ElementFlagFilter.DO_NOT_FILTER, true, true))
             .stringify());
   }
 }

--- a/src/test/manual/net/spy/memcached/emptycollection/ProtocolListDeleteTest.java
+++ b/src/test/manual/net/spy/memcached/emptycollection/ProtocolListDeleteTest.java
@@ -26,31 +26,23 @@ class ProtocolListDeleteTest {
 
   @Test
   void testStringify() {
-    // default setting : dropIfEmpty = true
-
-    assertEquals("10 drop",
-            (new ListDelete(10, false)).stringify());
-
     assertEquals("10",
             (new ListDelete(10, false, false)).stringify());
     assertEquals("10 drop",
-            (new ListDelete(10, false, true)).stringify());
+            (new ListDelete(10, true, false)).stringify());
 
     assertEquals("10..20", (new ListDelete(10, 20, false,
             false)).stringify());
     assertEquals("10..20 drop", (new ListDelete(10, 20,
-            false, true)).stringify());
+            true, false)).stringify());
 
-    assertEquals("10 drop noreply",
-            (new ListDelete(10, true)).stringify());
-
-    assertEquals("10 noreply", (new ListDelete(10, true,
-            false)).stringify());
+    assertEquals("10 noreply", (new ListDelete(10, false,
+            true)).stringify());
     assertEquals("10 drop noreply", (new ListDelete(10,
             true, true)).stringify());
 
     assertEquals("10..20 noreply", (new ListDelete(10, 20,
-            true, false)).stringify());
+            false, true)).stringify());
     assertEquals("10..20 drop noreply", (new ListDelete(10,
             20, true, true)).stringify());
   }

--- a/src/test/manual/net/spy/memcached/emptycollection/ProtocolMapDeleteTest.java
+++ b/src/test/manual/net/spy/memcached/emptycollection/ProtocolMapDeleteTest.java
@@ -35,39 +35,30 @@ class ProtocolMapDeleteTest {
     List<String> mkeyList2 = new ArrayList<>();
     mkeyList2.add("mkey1");
     mkeyList2.add("mkey2");
-    // default setting : dropIfEmpty = true
 
     MapDelete mapDelete;
-    mapDelete = new MapDelete(mkeyList, false);
-    mapDelete.setKeySeparator(" ");
-    assertEquals("4 1 drop", mapDelete.stringify());
-
     mapDelete = new MapDelete(mkeyList, false, false);
     mapDelete.setKeySeparator(" ");
     assertEquals("4 1", mapDelete.stringify());
-    mapDelete = new MapDelete(mkeyList, false, true);
+    mapDelete = new MapDelete(mkeyList, true, false);
     mapDelete.setKeySeparator(" ");
     assertEquals("4 1 drop", mapDelete.stringify());
 
     mapDelete = new MapDelete(mkeyList2, false, false);
     mapDelete.setKeySeparator(" ");
     assertEquals("11 2", mapDelete.stringify());
-    mapDelete = new MapDelete(mkeyList2, false, true);
+    mapDelete = new MapDelete(mkeyList2, true, false);
     mapDelete.setKeySeparator(" ");
     assertEquals("11 2 drop", mapDelete.stringify());
 
-    mapDelete = new MapDelete(mkeyList, true);
-    mapDelete.setKeySeparator(" ");
-    assertEquals("4 1 drop noreply", mapDelete.stringify());
-
-    mapDelete = new MapDelete(mkeyList, true, false);
+    mapDelete = new MapDelete(mkeyList, false, true);
     mapDelete.setKeySeparator(" ");
     assertEquals("4 1 noreply", mapDelete.stringify());
     mapDelete = new MapDelete(mkeyList, true, true);
     mapDelete.setKeySeparator(" ");
     assertEquals("4 1 drop noreply", mapDelete.stringify());
 
-    mapDelete = new MapDelete(mkeyList2, true, false);
+    mapDelete = new MapDelete(mkeyList2, false, true);
     mapDelete.setKeySeparator(" ");
     assertEquals("11 2 noreply", mapDelete.stringify());
     mapDelete = new MapDelete(mkeyList2, true, true);

--- a/src/test/manual/net/spy/memcached/emptycollection/ProtocolSetDeleteTest.java
+++ b/src/test/manual/net/spy/memcached/emptycollection/ProtocolSetDeleteTest.java
@@ -31,21 +31,13 @@ class ProtocolSetDeleteTest {
 
   @Test
   void testStringify() {
-    // default setting : dropIfEmpty = true
-
-    SetDelete<Object> del = new SetDelete<>(value, false, testTranscoder);
-    assertEquals("5 drop", del.stringify());
-
-    del = new SetDelete<>(value, false, false, testTranscoder);
+    SetDelete<Object> del = new SetDelete<>(value, false, false, testTranscoder);
     assertEquals("5", del.stringify());
 
-    del = new SetDelete<>(value, false, true, testTranscoder);
+    del = new SetDelete<>(value, true, false, testTranscoder);
     assertEquals("5 drop", del.stringify());
 
-    del = new SetDelete<>(value, true, testTranscoder);
-    assertEquals("5 drop noreply", del.stringify());
-
-    del = new SetDelete<>(value, true, false, testTranscoder);
+    del = new SetDelete<>(value, false, true, testTranscoder);
     assertEquals("5 noreply", del.stringify());
 
     del = new SetDelete<>(value, true, true, testTranscoder);
@@ -55,19 +47,13 @@ class ProtocolSetDeleteTest {
   @Test
   void testGetAdditionalArgs() {
     byte[] expected = new byte[]{'v', 'a', 'l', 'u', 'e'};
-    SetDelete<Object> del = new SetDelete<>(value, false, testTranscoder);
-    assertArrayEquals(expected, del.getAdditionalArgs());
-
-    del = new SetDelete<>(value, false, false, testTranscoder);
-    assertArrayEquals(expected, del.getAdditionalArgs());
-
-    del = new SetDelete<>(value, false, true, testTranscoder);
-    assertArrayEquals(expected, del.getAdditionalArgs());
-
-    del = new SetDelete<>(value, true, testTranscoder);
+    SetDelete<Object> del = new SetDelete<>(value, false, false, testTranscoder);
     assertArrayEquals(expected, del.getAdditionalArgs());
 
     del = new SetDelete<>(value, true, false, testTranscoder);
+    assertArrayEquals(expected, del.getAdditionalArgs());
+
+    del = new SetDelete<>(value, false, true, testTranscoder);
     assertArrayEquals(expected, del.getAdditionalArgs());
 
     del = new SetDelete<>(value, true, true, testTranscoder);


### PR DESCRIPTION
### 🔗 Related Issue

<!-- Please link related issue. ex) https://github.com/naver/arcus-java-client/issues/{issue_number} -->
- https://github.com/jam2in/arcus-works/issues/665
### ⌨️ What I did

<!-- Please describe this PR and what you've been working on. -->
- delete command 객체 (ListDelete, SetDelete, ..) 에서 안쓰는 생성자를 제거하고 생성자 인자 순서를 변경합니다.