### PR TITLE
CLEANUP: remove useless constructor and change parameter order in btree command class

### DIFF
--- a/src/main/java/net/spy/memcached/ArcusClient.java
+++ b/src/main/java/net/spy/memcached/ArcusClient.java
@@ -1267,7 +1267,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
                                                                   boolean withDelete,
                                                                   boolean dropIfEmpty) {
     BTreeUtil.validateBkey(bkey);
-    BTreeGet get = new BTreeGet(bkey, withDelete, dropIfEmpty, eFlagFilter);
+    BTreeGet get = new BTreeGet(bkey, eFlagFilter, withDelete, dropIfEmpty);
     return asyncBopGet(key, get, collectionTranscoder);
   }
 
@@ -1287,7 +1287,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
                                                                   boolean withDelete,
                                                                   boolean dropIfEmpty) {
     BTreeUtil.validateBkey(from, to);
-    BTreeGet get = new BTreeGet(from, to, offset, count, withDelete, dropIfEmpty, eFlagFilter);
+    BTreeGet get = new BTreeGet(from, to, eFlagFilter, offset, count, withDelete, dropIfEmpty);
     return asyncBopGet(key, get, collectionTranscoder);
   }
 
@@ -1307,7 +1307,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
                                                                  boolean dropIfEmpty,
                                                                  Transcoder<T> tc) {
     BTreeUtil.validateBkey(bkey);
-    BTreeGet get = new BTreeGet(bkey, withDelete, dropIfEmpty, eFlagFilter);
+    BTreeGet get = new BTreeGet(bkey, eFlagFilter, withDelete, dropIfEmpty);
     return asyncBopGet(key, get, tc);
   }
 
@@ -1329,7 +1329,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
                                                                  boolean dropIfEmpty,
                                                                  Transcoder<T> tc) {
     BTreeUtil.validateBkey(from, to);
-    BTreeGet get = new BTreeGet(from, to, offset, count, withDelete, dropIfEmpty, eFlagFilter);
+    BTreeGet get = new BTreeGet(from, to, eFlagFilter, offset, count, withDelete, dropIfEmpty);
     return asyncBopGet(key, get, tc);
   }
 
@@ -2387,7 +2387,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
           String key, byte[] bkey, ElementFlagFilter eFlagFilter,
           boolean withDelete, boolean dropIfEmpty) {
     BTreeUtil.validateBkey(bkey);
-    BTreeGet get = new BTreeGet(bkey, withDelete, dropIfEmpty, eFlagFilter);
+    BTreeGet get = new BTreeGet(bkey, eFlagFilter, withDelete, dropIfEmpty);
     return asyncBopExtendedGet(key, get, collectionTranscoder);
   }
 
@@ -2402,7 +2402,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
           String key, byte[] bkey, ElementFlagFilter eFlagFilter,
           boolean withDelete, boolean dropIfEmpty, Transcoder<T> tc) {
     BTreeUtil.validateBkey(bkey);
-    BTreeGet get = new BTreeGet(bkey, withDelete, dropIfEmpty, eFlagFilter);
+    BTreeGet get = new BTreeGet(bkey, eFlagFilter, withDelete, dropIfEmpty);
     return asyncBopExtendedGet(key, get, tc);
   }
 
@@ -2418,7 +2418,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
           String key, byte[] from, byte[] to, ElementFlagFilter eFlagFilter,
           int offset, int count, boolean withDelete, boolean dropIfEmpty) {
     BTreeUtil.validateBkey(from, to);
-    BTreeGet get = new BTreeGet(from, to, offset, count, withDelete, dropIfEmpty, eFlagFilter);
+    BTreeGet get = new BTreeGet(from, to, eFlagFilter, offset, count, withDelete, dropIfEmpty);
     return asyncBopExtendedGet(key, get, collectionTranscoder);
   }
 
@@ -2436,7 +2436,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
           int count, boolean withDelete, boolean dropIfEmpty,
           Transcoder<T> tc) {
     BTreeUtil.validateBkey(from, to);
-    BTreeGet get = new BTreeGet(from, to, offset, count, withDelete, dropIfEmpty, eFlagFilter);
+    BTreeGet get = new BTreeGet(from, to, eFlagFilter, offset, count, withDelete, dropIfEmpty);
     return asyncBopExtendedGet(key, get, tc);
   }
 

--- a/src/main/java/net/spy/memcached/collection/BTreeCount.java
+++ b/src/main/java/net/spy/memcached/collection/BTreeCount.java
@@ -36,16 +36,6 @@ public class BTreeCount extends CollectionCount {
     this.elementFlagFilter = elementFlagFilter;
   }
 
-  public BTreeCount(long from, long to, ElementMultiFlagsFilter elementMultiFlagsFilter) {
-    this.range = from + ".." + to;
-    this.elementFlagFilter = elementMultiFlagsFilter;
-  }
-
-  public BTreeCount(byte[] from, byte[] to, ElementMultiFlagsFilter elementMultiFlagsFilter) {
-    this.range = BTreeUtil.toHex(from) + ".." + BTreeUtil.toHex(to);
-    this.elementFlagFilter = elementMultiFlagsFilter;
-  }
-
   public String stringify() {
     if (str != null) {
       return str;

--- a/src/main/java/net/spy/memcached/collection/BTreeGet.java
+++ b/src/main/java/net/spy/memcached/collection/BTreeGet.java
@@ -28,9 +28,8 @@ public class BTreeGet extends CollectionGet {
   protected ElementFlagFilter elementFlagFilter;
   private boolean reverse = false;
 
-  private BTreeGet(String range,
-                   boolean delete, boolean dropIfEmpty,
-                   ElementFlagFilter elementFlagFilter) {
+  private BTreeGet(String range, ElementFlagFilter elementFlagFilter,
+                   boolean delete, boolean dropIfEmpty) {
     this.range = range;
     this.delete = delete;
     this.dropIfEmpty = dropIfEmpty;
@@ -39,40 +38,37 @@ public class BTreeGet extends CollectionGet {
     this.eFlagIndex = 1;
   }
 
-  public BTreeGet(long bkey,
-                  boolean delete, boolean dropIfEmpty,
-                  ElementFlagFilter elementFlagFilter) {
-    this(String.valueOf(bkey), delete, dropIfEmpty, elementFlagFilter);
+  public BTreeGet(long bkey, ElementFlagFilter elementFlagFilter,
+                  boolean delete, boolean dropIfEmpty) {
+    this(String.valueOf(bkey), elementFlagFilter, delete, dropIfEmpty);
   }
 
-  public BTreeGet(byte[] bkey,
-                  boolean delete, boolean dropIfEmpty,
-                  ElementFlagFilter elementFlagFilter) {
-    this(BTreeUtil.toHex(bkey), delete, dropIfEmpty, elementFlagFilter);
+  public BTreeGet(byte[] bkey, ElementFlagFilter elementFlagFilter,
+                  boolean delete, boolean dropIfEmpty) {
+    this(BTreeUtil.toHex(bkey), elementFlagFilter, delete, dropIfEmpty);
   }
 
-  private BTreeGet(String range, boolean reverse, int offset,
-                   int count, boolean delete, boolean dropIfEmpty,
-                   ElementFlagFilter elementFlagFilter) {
-    this(range, delete, dropIfEmpty, elementFlagFilter);
+  private BTreeGet(String range, boolean reverse, ElementFlagFilter elementFlagFilter,
+                   int offset, int count, boolean delete, boolean dropIfEmpty) {
+    this(range, elementFlagFilter, delete, dropIfEmpty);
     this.offset = offset;
     this.count = count;
     this.reverse = reverse;
   }
 
-  public BTreeGet(long from, long to, int offset, int count,
-                  boolean delete, boolean dropIfEmpty,
-                  ElementFlagFilter elementFlagFilter) {
-    this(from + ".." + to, from > to,
-        offset, count, delete, dropIfEmpty, elementFlagFilter);
+  public BTreeGet(long from, long to, ElementFlagFilter elementFlagFilter,
+                  int offset, int count,
+                  boolean delete, boolean dropIfEmpty) {
+    this(from + ".." + to, from > to, elementFlagFilter,
+        offset, count, delete, dropIfEmpty);
   }
 
-  public BTreeGet(byte[] from, byte[] to, int offset, int count,
-                  boolean delete, boolean dropIfEmpty,
-                  ElementFlagFilter elementFlagFilter) {
+  public BTreeGet(byte[] from, byte[] to, ElementFlagFilter elementFlagFilter,
+                  int offset, int count,
+                  boolean delete, boolean dropIfEmpty) {
     this(BTreeUtil.toHex(from) + ".." + BTreeUtil.toHex(to),
             BTreeUtil.compareByteArraysInLexOrder(from, to) > 0,
-        offset, count, delete, dropIfEmpty, elementFlagFilter);
+            elementFlagFilter, offset, count, delete, dropIfEmpty);
   }
 
   public boolean isReversed() {

--- a/src/test/manual/net/spy/memcached/MultibyteKeyTest.java
+++ b/src/test/manual/net/spy/memcached/MultibyteKeyTest.java
@@ -423,7 +423,7 @@ class MultibyteKeyTest {
     byte[] to = new byte[]{10, 10};
     try {
       opFact.collectionGet(MULTIBYTE_KEY,
-          new BTreeGet(from, to, 0, 0, false, false, ElementFlagFilter.DO_NOT_FILTER),
+          new BTreeGet(from, to, ElementFlagFilter.DO_NOT_FILTER, 0, 0, false, false),
           new CollectionGetOperation.Callback() {
             @Override
             public void gotData(String bkey, int flags, byte[] data, byte[] eflag) {

--- a/src/test/manual/net/spy/memcached/emptycollection/ProtocolBTreeGetTest.java
+++ b/src/test/manual/net/spy/memcached/emptycollection/ProtocolBTreeGetTest.java
@@ -29,23 +29,25 @@ class ProtocolBTreeGetTest {
 
   @Test
   void testStringify() {
-    assertEquals("10 drop", (new BTreeGet(bkey, true, true,
-            ElementFlagFilter.DO_NOT_FILTER)).stringify());
-    assertEquals("10 delete", (new BTreeGet(bkey, true,
-            false, ElementFlagFilter.DO_NOT_FILTER)).stringify());
-    assertEquals("10", (new BTreeGet(bkey, false, true,
-            ElementFlagFilter.DO_NOT_FILTER)).stringify());
-    assertEquals("10", (new BTreeGet(bkey, false, false,
-            ElementFlagFilter.DO_NOT_FILTER)).stringify());
+    assertEquals("10 drop", (new BTreeGet(bkey, ElementFlagFilter.DO_NOT_FILTER,
+            true, true)).stringify());
+    assertEquals("10 delete", (new BTreeGet(bkey, ElementFlagFilter.DO_NOT_FILTER,
+            true, false)).stringify());
+    assertEquals("10", (new BTreeGet(bkey, ElementFlagFilter.DO_NOT_FILTER,
+            false, true)).stringify());
+    assertEquals("10", (new BTreeGet(bkey, ElementFlagFilter.DO_NOT_FILTER,
+            false, false)).stringify());
 
     assertEquals("10..20 1 1 delete", (new BTreeGet(10, 20,
-            1, 1, true, false, ElementFlagFilter.DO_NOT_FILTER))
+            ElementFlagFilter.DO_NOT_FILTER,
+            1, 1, true, false))
             .stringify());
-    assertEquals("10..20 1 1 drop", (new BTreeGet(10, 20, 1,
-            1, true, true, ElementFlagFilter.DO_NOT_FILTER)).stringify());
-    assertEquals("10..20 1 1", (new BTreeGet(10, 20, 1, 1,
-            false, true, ElementFlagFilter.DO_NOT_FILTER)).stringify());
-    assertEquals("10..20 1 1", (new BTreeGet(10, 20, 1, 1,
-            false, false, ElementFlagFilter.DO_NOT_FILTER)).stringify());
+    assertEquals("10..20 1 1 drop", (new BTreeGet(10, 20,
+            ElementFlagFilter.DO_NOT_FILTER, 1,
+            1, true, true)).stringify());
+    assertEquals("10..20 1 1", (new BTreeGet(10, 20, ElementFlagFilter.DO_NOT_FILTER,
+            1, 1, false, true)).stringify());
+    assertEquals("10..20 1 1", (new BTreeGet(10, 20, ElementFlagFilter.DO_NOT_FILTER,
+            1, 1, false, false)).stringify());
   }
 }


### PR DESCRIPTION
### 🔗 Related Issue

<!-- Please link related issue. ex) https://github.com/naver/arcus-java-client/issues/{issue_number} -->
- https://github.com/jam2in/arcus-works/issues/665

### ⌨️ What I did

<!-- Please describe this PR and what you've been working on. -->
- btree command class에서 불필요한 생성자를 제거하고 parameter 순서를 조정합니다.