### PR TITLE
INTERNAL: Handle SaslClient on AuthThread

### DIFF
--- a/src/main/java/net/spy/memcached/OperationFactory.java
+++ b/src/main/java/net/spy/memcached/OperationFactory.java
@@ -18,9 +18,8 @@ package net.spy.memcached;
 
 import java.util.Collection;
 import java.util.List;
-import java.util.Map;
 
-import javax.security.auth.callback.CallbackHandler;
+import javax.security.sasl.SaslClient;
 
 import net.spy.memcached.collection.Attributes;
 import net.spy.memcached.collection.BTreeFindPosition;
@@ -230,15 +229,12 @@ public interface OperationFactory {
   /**
    * Create a new sasl auth operation.
    */
-  SASLAuthOperation saslAuth(String[] mech, String serverName,
-                             Map<String, ?> props, CallbackHandler cbh, OperationCallback cb);
+  SASLAuthOperation saslAuth(SaslClient sc, OperationCallback cb);
 
   /**
    * Create a new sasl step operation.
    */
-  SASLStepOperation saslStep(String[] mech, byte[] challenge,
-                             String serverName, Map<String, ?> props, CallbackHandler cbh,
-                             OperationCallback cb);
+  SASLStepOperation saslStep(SaslClient sc, byte[] challenge, OperationCallback cb);
 
   /**
    * Set item attributes

--- a/src/main/java/net/spy/memcached/protocol/ascii/AsciiOperationFactory.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/AsciiOperationFactory.java
@@ -17,9 +17,8 @@
 package net.spy.memcached.protocol.ascii;
 
 import java.util.Collection;
-import java.util.Map;
 
-import javax.security.auth.callback.CallbackHandler;
+import javax.security.sasl.SaslClient;
 
 import net.spy.memcached.collection.Attributes;
 import net.spy.memcached.collection.BTreeFindPosition;
@@ -147,15 +146,11 @@ public class AsciiOperationFactory extends BaseOperationFactory {
     throw new UnsupportedOperationException();
   }
 
-  public SASLStepOperation saslStep(String[] mech, byte[] challenge,
-                                    String serverName, Map<String, ?> props, CallbackHandler cbh,
-                                    OperationCallback cb) {
+  public SASLStepOperation saslStep(SaslClient sc, byte[] challenge, OperationCallback cb) {
     throw new UnsupportedOperationException();
   }
 
-  public SASLAuthOperation saslAuth(String[] mech, String serverName,
-                                    Map<String, ?> props, CallbackHandler cbh,
-                                    OperationCallback cb) {
+  public SASLAuthOperation saslAuth(SaslClient sc, OperationCallback cb) {
     throw new UnsupportedOperationException();
   }
 

--- a/src/main/java/net/spy/memcached/protocol/binary/BinaryOperationFactory.java
+++ b/src/main/java/net/spy/memcached/protocol/binary/BinaryOperationFactory.java
@@ -17,9 +17,8 @@
 package net.spy.memcached.protocol.binary;
 
 import java.util.Collection;
-import java.util.Map;
 
-import javax.security.auth.callback.CallbackHandler;
+import javax.security.sasl.SaslClient;
 
 import net.spy.memcached.collection.Attributes;
 import net.spy.memcached.collection.BTreeFindPosition;
@@ -147,21 +146,16 @@ public class BinaryOperationFactory extends BaseOperationFactory {
     return new ConcatenationOperationImpl(catType, key, data, casId, cb);
   }
 
-  public SASLAuthOperation saslAuth(String[] mech, String serverName,
-                                    Map<String, ?> props, CallbackHandler cbh,
-                                    OperationCallback cb) {
-    return new SASLAuthOperationImpl(mech, serverName, props, cbh, cb);
+  public SASLAuthOperation saslAuth(SaslClient sc, OperationCallback cb) {
+    return new SASLAuthOperationImpl(sc, cb);
   }
 
   public SASLMechsOperation saslMechs(OperationCallback cb) {
     return new SASLMechsOperationImpl(cb);
   }
 
-  public SASLStepOperation saslStep(String[] mech, byte[] challenge,
-                                    String serverName, Map<String, ?> props, CallbackHandler cbh,
-                                    OperationCallback cb) {
-    return new SASLStepOperationImpl(mech, challenge, serverName,
-            props, cbh, cb);
+  public SASLStepOperation saslStep(SaslClient sc, byte[] challenge, OperationCallback cb) {
+    return new SASLStepOperationImpl(sc, challenge, cb);
   }
 
   //// UNSUPPORTED ////

--- a/src/main/java/net/spy/memcached/protocol/binary/SASLAuthOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/binary/SASLAuthOperationImpl.java
@@ -17,9 +17,6 @@
  */
 package net.spy.memcached.protocol.binary;
 
-import java.util.Map;
-
-import javax.security.auth.callback.CallbackHandler;
 import javax.security.sasl.SaslClient;
 import javax.security.sasl.SaslException;
 
@@ -31,9 +28,8 @@ public class SASLAuthOperationImpl extends SASLBaseOperationImpl
 
   private final static int CMD = 0x21;
 
-  public SASLAuthOperationImpl(String[] m, String s,
-                               Map<String, ?> p, CallbackHandler h, OperationCallback c) {
-    super(CMD, m, EMPTY_BYTES, s, p, h, c);
+  public SASLAuthOperationImpl(SaslClient sc, OperationCallback cb) {
+    super(CMD, sc, EMPTY_BYTES, cb);
   }
 
   @Override

--- a/src/main/java/net/spy/memcached/protocol/binary/SASLBaseOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/binary/SASLBaseOperationImpl.java
@@ -1,10 +1,6 @@
 package net.spy.memcached.protocol.binary;
 
 import java.io.IOException;
-import java.util.Map;
-
-import javax.security.auth.callback.CallbackHandler;
-import javax.security.sasl.Sasl;
 import javax.security.sasl.SaslClient;
 import javax.security.sasl.SaslException;
 
@@ -17,29 +13,19 @@ public abstract class SASLBaseOperationImpl extends OperationImpl {
 
   private static final int SASL_CONTINUE = 0x21;
 
-  protected final String[] mech;
+  protected final SaslClient sc;
   protected final byte[] challenge;
-  protected final String serverName;
-  protected final Map<String, ?> props;
-  protected final CallbackHandler cbh;
 
-  public SASLBaseOperationImpl(int c, String[] m, byte[] ch,
-                               String s, Map<String, ?> p, CallbackHandler h,
+  public SASLBaseOperationImpl(int c, SaslClient sc, byte[] challenge,
                                OperationCallback cb) {
     super(c, generateOpaque(), cb);
-    mech = m;
-    challenge = ch;
-    serverName = s;
-    props = p;
-    cbh = h;
+    this.sc = sc;
+    this.challenge = challenge;
   }
 
   @Override
   public void initialize() {
     try {
-      SaslClient sc = Sasl.createSaslClient(mech, null,
-              "memcached", serverName, props, cbh);
-
       byte[] response = buildResponse(sc);
       String mechanism = sc.getMechanismName();
 

--- a/src/main/java/net/spy/memcached/protocol/binary/SASLStepOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/binary/SASLStepOperationImpl.java
@@ -17,9 +17,6 @@
  */
 package net.spy.memcached.protocol.binary;
 
-import java.util.Map;
-
-import javax.security.auth.callback.CallbackHandler;
 import javax.security.sasl.SaslClient;
 import javax.security.sasl.SaslException;
 
@@ -31,9 +28,8 @@ public class SASLStepOperationImpl extends SASLBaseOperationImpl
 
   private final static int CMD = 0x22;
 
-  public SASLStepOperationImpl(String[] m, byte[] ch, String s,
-                               Map<String, ?> p, CallbackHandler h, OperationCallback c) {
-    super(CMD, m, ch, s, p, h, c);
+  public SASLStepOperationImpl(SaslClient sc, byte[] challenge, OperationCallback cb) {
+    super(CMD, sc, challenge, cb);
   }
 
   @Override


### PR DESCRIPTION
### 🔗 Related Issue
- jam2in/arcus-works#672

### ⌨️ What I did
1. Operation의 `initialize()`에서 `SaslClient`를 생성하는 대신,
AuthThread가 SaslClient를 생성하여 명령 인자로 전달하도록 합니다.

2. 각 연결에 대한 인증 과정에서 하나의 SaslClient 객체를 사용함으로써 multi-step auth mechanism에서 상태 정보를 유지할 수 있습니다.