### PR TITLE
FIX: Handling abnormal swithover from zk.

### DIFF
--- a/src/main/java/net/spy/memcached/MemcachedReplicaGroup.java
+++ b/src/main/java/net/spy/memcached/MemcachedReplicaGroup.java
@@ -86,6 +86,10 @@ public abstract class MemcachedReplicaGroup extends SpyObject {
     }
   }
 
+  public void clearMasterCandidate() {
+    this.masterCandidate = null;
+  }
+
   public void setMasterCandidateByAddr(String address) {
     for (MemcachedNode node : this.getSlaveNodes()) {
       if (address.equals(((ArcusReplNodeAddress) node.getSocketAddress()).getIPPort())) {


### PR DESCRIPTION
### 🔗 Related Issue

캐시 서버로부터의 응답을 통해 master candidate를 설정하고 난 뒤,
zk로부터 비정상적인 switchover를 감지하는 경우에 대한 처리이다.

#### 이중화

|상태|ROLE1|ROLE2|처리로직
|:----:|:-----:|:-----:|:-----:|
|초기상태|M|S|
|SwitchOver 응답 후 상태|M|S(masterCandidate)|
|정상 상태 (1st ZK 변경)|S|S|Invalid Group 처리
|정상 상태 (2nd ZK 변경)|S|M|switch-over 로직이 처리
|비정상1|X|M|Fail-Over 로직이 처리
|비정상2|M|X| **처리필요**
|비정상3|X|X|그룹 제거(기존 로직이 처리)


#### 삼중화
|상태|ROLE1|ROLE2|ROLE3|처리로직
|:----:|:-----:|:-----:|:-----:|:-----:|
|초기상태|M|S1|S2
|SwitchOver 응답 후 상태|M|S1(masterCandidate)|S2
|정상 상태 (1st ZK 변경)|S3|S1|S2|Invalid Group 처리
|정상 상태 (2nd ZK 변경)|S3|M|S2|switch-over 로직이 처리
|비정상1|S3|M|X| Switch-Over 로직이 처리
|비정상2|X|M|S2| Fail-Over 로직이 처리
|비정상3|S3|X|M| **처리필요**
|비정상4|X|M|X| Fail-Over 로직이 처리
|비정상5|X|X|M| Fail-Over 로직이 처리
|비정상6|M|X|X| **처리필요**
|비정상7|X|X|X|그룹 제거(기존 로직이 처리)

참고로 아래와 같은 케이스들은 zk 시퀀스 넘버에 의한 
Repl Role 선정 방식에 의해 발생되지 않습니다.
|ROLE1|ROLE2|ROLE3
|:----:|:-----:|:-----:|
|M|X|S|

위 표를 참고하여 발생 가능한 비정상 경우들은 아래와 같다.



### 이중화
- M S : 초기 상태
- M S(master-candidate) : 서버로부터 응답을 받은 후 상태
- M X : new Master가 될 노드가 떨어지고 old Master가 newMaster인 상태 - 비정상
- S M : 정상적인 경우


### 삼중화
아래 케이스와 함께 이중화의 비정상 케이스처럼 
old Master가 newMaster이고 slave가 모두 떨어진 케이스
- M S1 S2: 초기 상태
- M S1(master-candidate) S2: 서버로부터 응답을 받은 후 상태
- S X M : new Master가 될 노드가 떨어지고 2번 Slave가 새로운 New master가 된 상태 - 비정상
- S M S : 정상적인 경우


### ⌨️ What I did

비정상 이중화인 경우는 oldMaster와 newMaster가 동일하기 때문에 아래 로직을 따른다.
https://github.com/naver/arcus-java-client/blob/f60ed483c1d9ad76f5bbcaa1d8f17e1a294d6643/src/main/java/net/spy/memcached/MemcachedConnection.java#L470


비정상 삼중화인 경우는 oldSlaves 내에 newMaster가 있고
newSlaves 내에 oldMaster가 존재하기에 기존의 Switchover 로직을 따른다.
https://github.com/naver/arcus-java-client/blob/daf63340a49b80796a37e3daa3ceaf116b72ede5/src/main/java/net/spy/memcached/MemcachedConnection.java#L490-L491

두 경우 모두 cache server 응답에 의해 설정된
master candidate에 쌓인 ops 객체들을 oldmaster로 옮겨줘야한다.

이중화의 경우 master candidate를 null로 설정해서 master로 op가 처리되도록 한다.

삼중화는 zk로부터 받은 master를 설정하여 
최신 master에 op가 처리되도록 한다.