### PR TITLE
INTERNAL: choose get/mget when optimize get commands

### DIFF
--- a/src/main/java/net/spy/memcached/protocol/ascii/AsciiMemcachedNodeImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/AsciiMemcachedNodeImpl.java
@@ -49,7 +49,7 @@ public final class AsciiMemcachedNodeImpl extends TCPMemcachedNodeImpl {
       nxtOp = writeQ.peek();
       if (nxtOp instanceof GetOperation) {
         OptimizedGetImpl og = new OptimizedGetImpl(
-                (GetOperation) optimizedOp);
+                (GetOperation) optimizedOp, enabledMGetOp());
         optimizedOp = og;
 
         do {

--- a/src/main/java/net/spy/memcached/protocol/ascii/GetOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/GetOperationImpl.java
@@ -22,11 +22,6 @@ class GetOperationImpl extends BaseGetOpImpl implements GetOperation {
     setAPIType(APIType.GET);
   }
 
-  public GetOperationImpl(Collection<String> k, GetOperation.Callback c) {
-    super(CMD, c, new HashSet<>(k));
-    setAPIType(APIType.GET);
-  }
-
   public GetOperationImpl(Collection<String> keys, GetOperation.Callback cb, boolean isMGet) {
     super(isMGet ? CMD_MGET : CMD, cb, new HashSet<>(keys));
     setAPIType(APIType.GET);

--- a/src/main/java/net/spy/memcached/protocol/ascii/OptimizedGetImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/OptimizedGetImpl.java
@@ -15,8 +15,8 @@ final class OptimizedGetImpl extends GetOperationImpl {
   /**
    * Construct an optimized get starting with the given get operation.
    */
-  public OptimizedGetImpl(GetOperation firstGet) {
-    super(new HashSet<>(), new ProxyCallback());
+  public OptimizedGetImpl(GetOperation firstGet, boolean isMGet) {
+    super(new HashSet<>(), new ProxyCallback(), isMGet);
     pcb = (ProxyCallback) getCallback();
     addOperation(firstGet);
   }

--- a/src/test/java/net/spy/memcached/protocol/ascii/OptimizeOperationTest.java
+++ b/src/test/java/net/spy/memcached/protocol/ascii/OptimizeOperationTest.java
@@ -1,0 +1,56 @@
+package net.spy.memcached.protocol.ascii;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+
+import net.spy.memcached.ops.GetOperation;
+import net.spy.memcached.ops.OperationStatus;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class OptimizeOperationTest {
+
+  @Test
+  void chooseGetOrMGet() {
+    GetOperation.Callback cb = new GetOperation.Callback() {
+      @Override
+      public void gotData(String key, int flags, byte[] data) {
+        // do nothing
+      }
+
+      @Override
+      public void receivedStatus(OperationStatus status) {
+        // do nothing
+      }
+
+      @Override
+      public void complete() {
+        // do nothing
+      }
+    };
+    GetOperationImpl op1 = new GetOperationImpl("key", cb);
+    GetOperationImpl op2 = new GetOperationImpl("key2", cb);
+    OptimizedGetImpl optimizedOpWithMGet = new OptimizedGetImpl(op1, true);
+    optimizedOpWithMGet.addOperation(op2);
+    optimizedOpWithMGet.initialize();
+
+    OptimizedGetImpl optimizedOpWithGet = new OptimizedGetImpl(op1, false);
+    optimizedOpWithGet.addOperation(op2);
+    optimizedOpWithGet.initialize();
+
+    ByteBuffer bbWithMGet = optimizedOpWithMGet.getBuffer();
+    byte[] bytesWithMGet = new byte[bbWithMGet.remaining()];
+    bbWithMGet.get(bytesWithMGet);
+    String commandWithMGet = new String(bytesWithMGet, StandardCharsets.UTF_8);
+    assertTrue(commandWithMGet.contains("mget"));
+
+    ByteBuffer bbWithGet = optimizedOpWithGet.getBuffer();
+    byte[] bytesWithGet = new byte[bbWithGet.remaining()];
+    bbWithGet.get(bytesWithGet);
+    String commandWithGet = new String(bytesWithGet, StandardCharsets.UTF_8);
+    assertFalse(commandWithGet.contains("mget"));
+  }
+}


### PR DESCRIPTION
### 🔗 Related Issue

<!-- Please link related issue. ex) https://github.com/naver/arcus-java-client/issues/{issue_number} -->
- https://github.com/jam2in/arcus-works/issues/649

### ⌨️ What I did

<!-- Please describe this PR and what you've been working on. -->
- optimize 시 캐시 서버의 mget 지원 여부에 따라 get or mget 명령을 선택할 수 있도록 수정합니다.