### PR TITLE
INTERNAL: Add ScramSaslClient

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -118,6 +118,11 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        <dependency>
+            <groupId>com.bolyartech.scram_sasl</groupId>
+            <artifactId>scram_sasl</artifactId>
+            <version>2.0.2</version>
+        </dependency>
 
         <!-- TEST -->
         <dependency>

--- a/src/main/java/net/spy/memcached/auth/ScramMechanism.java
+++ b/src/main/java/net/spy/memcached/auth/ScramMechanism.java
@@ -1,0 +1,49 @@
+package net.spy.memcached.auth;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+public enum ScramMechanism {
+  SCRAM_SHA_256("SHA-256", "HmacSHA256");
+
+  private static final Map<String, ScramMechanism> MECHANISMS_MAP;
+
+  private final String mechanismName;
+  private final String hashAlgorithm;
+  private final String macAlgorithm;
+
+  static {
+    Map<String, ScramMechanism> map = new HashMap<>();
+    for (ScramMechanism mech : values()) {
+      map.put(mech.mechanismName, mech);
+    }
+    MECHANISMS_MAP = Collections.unmodifiableMap(map);
+  }
+
+  private ScramMechanism(String hashAlgorithm, String macAlgorithm) {
+    this.mechanismName = "SCRAM-" + hashAlgorithm;
+    this.hashAlgorithm = hashAlgorithm;
+    this.macAlgorithm = macAlgorithm;
+  }
+
+  public final String mechanismName() {
+    return this.mechanismName;
+  }
+  public String hashAlgorithm() {
+    return hashAlgorithm;
+  }
+  
+  public String macAlgorithm() {
+    return macAlgorithm;
+  }
+
+  public static ScramMechanism forMechanismName(String mechanismName) {
+    return MECHANISMS_MAP.get(mechanismName);
+  }
+
+  public static Collection<String> mechanismNames() {
+    return MECHANISMS_MAP.keySet();
+  }
+}

--- a/src/main/java/net/spy/memcached/auth/ScramSaslClient.java
+++ b/src/main/java/net/spy/memcached/auth/ScramSaslClient.java
@@ -1,0 +1,179 @@
+package net.spy.memcached.auth;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Map;
+
+import javax.security.auth.callback.Callback;
+import javax.security.auth.callback.CallbackHandler;
+import javax.security.auth.callback.NameCallback;
+import javax.security.auth.callback.PasswordCallback;
+import javax.security.sasl.SaslClient;
+import javax.security.sasl.SaslClientFactory;
+import javax.security.sasl.SaslException;
+
+import com.bolyartech.scram_sasl.client.ScramClientFunctionality;
+import com.bolyartech.scram_sasl.client.ScramClientFunctionalityImpl;
+import com.bolyartech.scram_sasl.common.ScramException;
+
+public class ScramSaslClient implements SaslClient {
+
+  enum State {
+    SEND_CLIENT_FIRST_MESSAGE,
+    RECEIVE_SERVER_FIRST_MESSAGE,
+    RECEIVE_SERVER_FINAL_MESSAGE,
+    COMPLETE,
+    FAILED
+  }
+
+  private final ScramMechanism mechanism;
+  private final CallbackHandler callbackHandler;
+  private final ScramClientFunctionality scf;
+  private State state;
+
+  public ScramSaslClient(ScramMechanism mechanism, CallbackHandler cbh) {
+    this.callbackHandler = cbh;
+    this.mechanism = mechanism;
+    this.scf = new ScramClientFunctionalityImpl(
+            mechanism.hashAlgorithm(), mechanism.macAlgorithm());
+    this.state = State.SEND_CLIENT_FIRST_MESSAGE;
+  }
+
+  @Override
+  public String getMechanismName() {
+    return this.mechanism.mechanismName();
+  }
+
+  @Override
+  public boolean hasInitialResponse() {
+    return true;
+  }
+
+  @Override
+  public byte[] evaluateChallenge(byte[] challenge) throws SaslException {
+    try {
+      switch (this.state) {
+        case SEND_CLIENT_FIRST_MESSAGE:
+          if (challenge != null && challenge.length != 0) {
+            throw new SaslException("Expected empty challenge");
+          }
+
+          NameCallback nameCallback = new NameCallback("Name: ");
+
+          try {
+            callbackHandler.handle(new Callback[]{nameCallback});
+          } catch (Throwable e) {
+            throw new SaslException("User name could not be obtained", e);
+          }
+
+          String username = nameCallback.getName();
+          byte[] clientFirstMessage = this.scf.prepareFirstMessage(username).getBytes();
+          this.state = State.RECEIVE_SERVER_FIRST_MESSAGE;
+          return clientFirstMessage;
+        
+        case RECEIVE_SERVER_FIRST_MESSAGE:
+          String serverFirstMessage = new String(challenge, StandardCharsets.UTF_8);
+
+          PasswordCallback passwordCallback = new PasswordCallback("Password: ", false);
+          try {
+            callbackHandler.handle(new Callback[]{passwordCallback});
+          } catch (Throwable e) {
+            throw new SaslException("Password could not be obtained", e);
+          }
+
+          String password = String.valueOf(passwordCallback.getPassword());
+          byte[] clientFinalMessage = this.scf.prepareFinalMessage(
+                  password, serverFirstMessage).getBytes();
+          if (clientFinalMessage == null) {
+            throw new SaslException("clientFinalMessage should not be null");
+          }
+          this.state = State.RECEIVE_SERVER_FINAL_MESSAGE;
+          return clientFinalMessage;
+        
+        case RECEIVE_SERVER_FINAL_MESSAGE:
+          String serverFinalMessage = new String(challenge, StandardCharsets.UTF_8);
+          if (!this.scf.checkServerFinalMessage(serverFinalMessage)) {
+            throw new SaslException("Sasl authentication using " + this.mechanism +
+                    " failed with error: invalid server final message");
+          }
+          this.state = State.COMPLETE;
+          return new byte[]{};
+      
+        default:
+          throw new SaslException("Unexpected challenge in Sasl client state " + this.state);
+      }
+    } catch (ScramException e) {
+      this.state = State.FAILED;
+      throw new SaslException("ScramException", e);
+    } catch (SaslException e) {
+      this.state = State.FAILED;
+      throw e;
+    }
+  }
+
+  @Override
+  public boolean isComplete() {
+    return this.state == State.COMPLETE;
+  }
+
+  @Override
+  public byte[] unwrap(byte[] incoming, int offset, int len) throws SaslException {
+    if (!isComplete()) {
+      throw new IllegalStateException("Authentication exchange has not completed");
+    }
+    return Arrays.copyOfRange(incoming, offset, offset + len);
+  }
+
+  @Override
+  public byte[] wrap(byte[] outgoing, int offset, int len) throws SaslException {
+    if (!isComplete()) {
+      throw new IllegalStateException("Authentication exchange has not completed");
+    }
+    return Arrays.copyOfRange(outgoing, offset, offset + len);
+  }
+
+  @Override
+  public Object getNegotiatedProperty(String propName) {
+    if (!isComplete()) {
+      throw new IllegalStateException("Authentication exchange has not completed");
+    }
+    return null;
+  }
+
+  @Override
+  public void dispose() throws SaslException {
+  }
+
+  public static class ScramSaslClientFactory implements SaslClientFactory {
+    @Override
+    public SaslClient createSaslClient(String[] mechanisms,
+            String authorizationId,
+            String protocol,
+            String serverName,
+            Map<String, ?> props,
+            CallbackHandler cbh) throws SaslException {
+
+      ScramMechanism mechanism = null;
+      for (String mech : mechanisms) {
+        mechanism = ScramMechanism.forMechanismName(mech);
+        if (mechanism != null) {
+          break;
+        }
+      }
+      if (mechanism == null) {
+        throw new SaslException(String.format("Requested mechanisms '%s' not supported."
+                + " Supported mechanisms are '%s'.",
+                Arrays.asList(mechanisms), ScramMechanism.mechanismNames()));
+      }
+
+      return new ScramSaslClient(mechanism, cbh);
+    }
+
+    @Override
+    public String[] getMechanismNames(Map<String, ?> props) {
+      Collection<String> mechanisms = ScramMechanism.mechanismNames();
+      return mechanisms.toArray(new String[0]);
+    }
+  }
+}

--- a/src/main/java/net/spy/memcached/auth/ScramSaslClientProvider.java
+++ b/src/main/java/net/spy/memcached/auth/ScramSaslClientProvider.java
@@ -1,0 +1,21 @@
+package net.spy.memcached.auth;
+
+import java.security.Provider;
+import java.security.Security;
+
+import net.spy.memcached.auth.ScramSaslClient.ScramSaslClientFactory;
+
+public final class ScramSaslClientProvider extends Provider {
+
+  private static final long serialVersionUID = 1L;
+
+  @SuppressWarnings("deprecation")
+  private ScramSaslClientProvider() {
+    super("SASL/SCRAM Client Provider", 1.0, "SASL/SCRAM Client Provider for Arcus");
+    put("SaslClientFactory.SCRAM-SHA-256", ScramSaslClientFactory.class.getName());
+  }
+
+  public static void initialize() {
+    Security.addProvider(new ScramSaslClientProvider());
+  }
+}


### PR DESCRIPTION
### 🔗 Related Issue
- jam2in/arcus-works#672

### ⌨️ What I did
- Scram 인증을 위한 ScramSaslClient를 구현합니다.
- [com.bolyartech.scram_sasl](https://github.com/ogrebgr/scram-sasl) 의존성을 추가합니다.
- Kafka의 [ScramSaslClient](https://github.com/apache/kafka/tree/trunk/clients/src/main/java/org/apache/kafka/common/security/scram/internals) 구현을 참고하였습니다.
- 기존 java client의 코드 배치나 스타일과 차이가 있는지도 확인해 주시면 좋겠습니다.

---

- 대략 아래와 같은 구현으로 SCRAM 인증 사용하여 캐시 서버와 연결할 수 있습니다.
- `ScramSaslClientProvider.initialize();` 호출한 다음부터 SCRAM-SHA-256 mechanism 사용할 수 있게 되는데,
어느 위치에 두는 것이 좋은지 잘 모르겠어서, 우선은 라이브러리 외부에서 직접 호출하는 형태로 테스트했습니다.

```java
  private static final String[] mechanism = {"SCRAM-SHA-256"};
  private static final String username = "user01";
  private static final String password = "passwd01";

  private ArcusClient newClient(boolean useCluster, boolean useBinaryProtocol) throws IOException {
    ConnectionFactoryBuilder cfb = new ConnectionFactoryBuilder()
        .setAuthDescriptor(new AuthDescriptor(mechanism, 
        new PlainCallbackHandler(username, password)));
    
    if (useBinaryProtocol) {
      cfb.setProtocol(Protocol.BINARY);
    }

    if (useCluster) {
      return ArcusClient.createArcusClient("127.0.0.1:2181", "servicecode-01", cfb);
    } else {
      return new ArcusClient(cfb.build(), AddrUtil.getAddresses("127.0.0.1:11211"));
    }

  }

  @Test
  public void testSasl() throws Exception {
    ScramSaslClientProvider.initialize();

    ArcusClient mc = newClient(true, true);
    Thread.sleep(10000);

    assertTrue(mc.set("namsic:kv01", 30, "value01").get());
    assertEquals("value01", mc.get("namsic:kv01"));
  }
```

---

이 PR이 반영되는 시점부터 binary protocol 사용 시 `SCRAM-SHA-256` 사용할 수 있게 됩니다.
ascii protocol에서 SASL 인증 사용하려면 관련 operation을 구현해야 합니다.
https://github.com/naver/arcus-java-client/blob/5c135756197cdaf481d806425eef12cb83f89b66/src/main/java/net/spy/memcached/protocol/ascii/AsciiOperationFactory.java#L149-L155
