### PR TITLE
INTERNAL: Limit bulk get keys size

### DIFF
--- a/src/test/java/net/spy/memcached/protocol/ascii/OptimizeOperationTest.java
+++ b/src/test/java/net/spy/memcached/protocol/ascii/OptimizeOperationTest.java
@@ -1,10 +1,16 @@
 package net.spy.memcached.protocol.ascii;
 
+import java.net.InetSocketAddress;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
 
+import net.spy.memcached.ConnectionFactory;
+import net.spy.memcached.ConnectionFactoryBuilder;
 import net.spy.memcached.ops.GetOperation;
 import net.spy.memcached.ops.OperationStatus;
+import net.spy.memcached.protocol.TCPMemcachedNodeImpl;
 
 import org.junit.jupiter.api.Test;
 
@@ -13,24 +19,25 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class OptimizeOperationTest {
 
+  private final GetOperation.Callback cb = new GetOperation.Callback() {
+    @Override
+    public void gotData(String key, int flags, byte[] data) {
+      // do nothing
+    }
+
+    @Override
+    public void receivedStatus(OperationStatus status) {
+      // do nothing
+    }
+
+    @Override
+    public void complete() {
+      // do nothing
+    }
+  };
+
   @Test
   void chooseGetOrMGet() {
-    GetOperation.Callback cb = new GetOperation.Callback() {
-      @Override
-      public void gotData(String key, int flags, byte[] data) {
-        // do nothing
-      }
-
-      @Override
-      public void receivedStatus(OperationStatus status) {
-        // do nothing
-      }
-
-      @Override
-      public void complete() {
-        // do nothing
-      }
-    };
     GetOperationImpl op1 = new GetOperationImpl("key", cb);
     GetOperationImpl op2 = new GetOperationImpl("key2", cb);
     OptimizedGetImpl optimizedOpWithMGet = new OptimizedGetImpl(op1, true);
@@ -52,5 +59,36 @@ class OptimizeOperationTest {
     bbWithGet.get(bytesWithGet);
     String commandWithGet = new String(bytesWithGet, StandardCharsets.UTF_8);
     assertFalse(commandWithGet.contains("mget"));
+  }
+
+
+  @Test
+  void doNotMergeTwoOperations() {
+    ConnectionFactoryBuilder builder = new ConnectionFactoryBuilder();
+    builder.setShouldOptimize(true);
+    ConnectionFactory cf = builder.build();
+    TCPMemcachedNodeImpl node = (TCPMemcachedNodeImpl) cf.createMemcachedNode("node1",
+            new InetSocketAddress("localhost", 11211), 4096);
+    node.setVersion("1.11.0");
+
+    List<String> keyList = new ArrayList<>();
+    for (int i = 0; i < 250; i++) {
+      keyList.add("k" + i);
+    }
+
+    GetOperationImpl op = new GetOperationImpl(keyList.get(0), cb);
+    GetOperationImpl op1 = new GetOperationImpl(keyList.subList(0, 190), cb, true);
+    GetOperationImpl op2 = new GetOperationImpl(keyList.subList(191, 205), cb, true);
+    node.addOpToWriteQ(op);
+    node.addOpToWriteQ(op1);
+    node.addOpToWriteQ(op2);
+    node.fillWriteBuffer(true);
+
+    ByteBuffer buffer = node.getWbuf();
+    byte[] bytesWithMGet = new byte[buffer.remaining()];
+    buffer.get(bytesWithMGet);
+    String commandWithMGet = new String(bytesWithMGet, StandardCharsets.UTF_8);
+    assertTrue(commandWithMGet.contains("mget 839 190"));
+    assertTrue(commandWithMGet.contains("mget 69 14"));
   }
 }


### PR DESCRIPTION
### 🔗 Related Issue

<!-- Please link related issue. ex) https://github.com/naver/arcus-java-client/issues/{issue_number} -->
- https://github.com/jam2in/arcus-works/issues/649

### ⌨️ What I did

<!-- Please describe this PR and what you've been working on. -->
- optimize 시 key limit을 두어 long query를 방지합니다.
- 두 operation이 있을 때 merge되는지 확인하는 테스트를 추가했습니다. 현재 fillWriteBuffer 호출 시 writeQ의 가장 첫 Operation은 optimize 대상에서 제외되기 때문에 테스트 코드에 get을 한번 호출해준 후 두번째 get부터 optimize가 되도록 해두었습니다.