### PR TITLE
INTERNAL: add PipeOperationImpl to reduce duplicate code

### DIFF
--- a/src/main/java/net/spy/memcached/protocol/ascii/CollectionBulkInsertOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/CollectionBulkInsertOperationImpl.java
@@ -17,187 +17,48 @@
  */
 package net.spy.memcached.protocol.ascii;
 
-import java.nio.ByteBuffer;
-import java.util.Collection;
-
 import net.spy.memcached.collection.CollectionBulkInsert;
-import net.spy.memcached.collection.CollectionResponse;
 import net.spy.memcached.ops.APIType;
 import net.spy.memcached.ops.CollectionBulkInsertOperation;
-import net.spy.memcached.ops.CollectionOperationStatus;
 import net.spy.memcached.ops.OperationCallback;
-import net.spy.memcached.ops.OperationState;
 import net.spy.memcached.ops.OperationStatus;
 import net.spy.memcached.ops.OperationType;
-import net.spy.memcached.ops.PipedOperationCallback;
 
 /**
  * Operation to store collection data in a memcached server.
  */
-public final class CollectionBulkInsertOperationImpl extends OperationImpl
+public final class CollectionBulkInsertOperationImpl extends PipeOperationImpl
         implements CollectionBulkInsertOperation {
 
-  private static final OperationStatus STORE_CANCELED = new CollectionOperationStatus(
-          false, "collection canceled", CollectionResponse.CANCELED);
-
-  private static final OperationStatus END = new CollectionOperationStatus(
-          true, "END", CollectionResponse.END);
-  private static final OperationStatus FAILED_END = new CollectionOperationStatus(
-          false, "END", CollectionResponse.END);
-
-  private static final OperationStatus CREATED_STORED = new CollectionOperationStatus(
-          true, "CREATED_STORED", CollectionResponse.CREATED_STORED);
-  private static final OperationStatus STORED = new CollectionOperationStatus(
-          true, "STORED", CollectionResponse.STORED);
-  private static final OperationStatus NOT_FOUND = new CollectionOperationStatus(
-          false, "NOT_FOUND", CollectionResponse.NOT_FOUND);
-  private static final OperationStatus ELEMENT_EXISTS = new CollectionOperationStatus(
-          false, "ELEMENT_EXISTS", CollectionResponse.ELEMENT_EXISTS);
-  private static final OperationStatus OVERFLOWED = new CollectionOperationStatus(
-          false, "OVERFLOWED", CollectionResponse.OVERFLOWED);
-  private static final OperationStatus OUT_OF_RANGE = new CollectionOperationStatus(
-          false, "OUT_OF_RANGE", CollectionResponse.OUT_OF_RANGE);
-  private static final OperationStatus TYPE_MISMATCH = new CollectionOperationStatus(
-          false, "TYPE_MISMATCH", CollectionResponse.TYPE_MISMATCH);
-  private static final OperationStatus BKEY_MISMATCH = new CollectionOperationStatus(
-          false, "BKEY_MISMATCH", CollectionResponse.BKEY_MISMATCH);
-
-  private final CollectionBulkInsert<?> insert;
-  private final PipedOperationCallback cb;
-
-  private int count;
-  private int index = 0;
-  private boolean successAll = true;
-
   public CollectionBulkInsertOperationImpl(CollectionBulkInsert<?> insert, OperationCallback cb) {
-    super(cb);
-    this.insert = insert;
-    this.cb = (PipedOperationCallback) cb;
-    if (this.insert instanceof CollectionBulkInsert.ListBulkInsert) {
+    super(insert.getKeyList(), insert, cb);
+    if (insert instanceof CollectionBulkInsert.ListBulkInsert) {
       setAPIType(APIType.LOP_INSERT);
-    } else if (this.insert instanceof CollectionBulkInsert.SetBulkInsert) {
+    } else if (insert instanceof CollectionBulkInsert.SetBulkInsert) {
       setAPIType(APIType.SOP_INSERT);
-    } else if (this.insert instanceof CollectionBulkInsert.MapBulkInsert) {
+    } else if (insert instanceof CollectionBulkInsert.MapBulkInsert) {
       setAPIType(APIType.MOP_INSERT);
-    } else if (this.insert instanceof CollectionBulkInsert.BTreeBulkInsert) {
+    } else if (insert instanceof CollectionBulkInsert.BTreeBulkInsert) {
       setAPIType(APIType.BOP_INSERT);
     }
     setOperationType(OperationType.WRITE);
   }
 
   @Override
-  public void handleLine(String line) {
-    assert getState() == OperationState.READING
-            : "Read ``" + line + "'' when in " + getState() + " state";
-    /* ENABLE_REPLICATION if */
-    if (hasSwitchedOver(line)) {
-      this.insert.setNextOpIndex(index);
-      prepareSwitchover(line);
-      return;
-    }
-    /* ENABLE_REPLICATION end */
-    /* ENABLE_MIGRATION if */
-    if (hasNotMyKey(line)) {
-      addRedirectMultiKeyOperation(line, insert.getKey(index));
-      if (insert.isNotPiped()) {
-        transitionState(OperationState.REDIRECT);
-      } else {
-        index++;
-      }
-      return;
-    }
-    /* ENABLE_MIGRATION end */
-    if (insert.isNotPiped()) {
-      OperationStatus status = matchStatus(line, STORED, CREATED_STORED,
-              NOT_FOUND, ELEMENT_EXISTS, OVERFLOWED, OUT_OF_RANGE,
-              TYPE_MISMATCH, BKEY_MISMATCH);
-      if (!status.isSuccess()) {
-        successAll = false;
-      }
-
-      cb.gotStatus(index, status);
-      cb.receivedStatus((successAll) ? END : FAILED_END);
-      transitionState(OperationState.COMPLETE);
-      return;
-    }
-
-    /*
-      RESPONSE <count>\r\n
-      <status of the 1st pipelined command>\r\n
-      [ ... ]
-      <status of the last pipelined command>\r\n
-      END|PIPE_ERROR <error_string>\r\n
-    */
-    if (line.startsWith("END") || line.startsWith("PIPE_ERROR ")) {
-      /* ENABLE_MIGRATION if */
-      if (needRedirect()) {
-        transitionState(OperationState.REDIRECT);
-        return;
-      }
-      /* ENABLE_MIGRATION end */
-      cb.receivedStatus((successAll) ? END : FAILED_END);
-      transitionState(OperationState.COMPLETE);
-    } else if (line.startsWith("RESPONSE ")) {
-      getLogger().debug("Got line %s", line);
-
-      // TODO server should be fixed
-      line = line.replace("   ", " ");
-      line = line.replace("  ", " ");
-
-      String[] stuff = line.split(" ");
-      assert "RESPONSE".equals(stuff[0]);
-      count = Integer.parseInt(stuff[1]);
-    } else {
-      OperationStatus status = matchStatus(line, STORED, CREATED_STORED,
-              NOT_FOUND, ELEMENT_EXISTS, OVERFLOWED, OUT_OF_RANGE,
-              TYPE_MISMATCH, BKEY_MISMATCH);
-
-      if (!status.isSuccess()) {
-        successAll = false;
-      }
-
-      cb.gotStatus(index, status);
-      index++;
-    }
+  protected OperationStatus checkStatus(String line) {
+    return matchStatus(line, STORED, CREATED_STORED,
+            NOT_FOUND, ELEMENT_EXISTS, OVERFLOWED, OUT_OF_RANGE,
+            TYPE_MISMATCH, BKEY_MISMATCH);
   }
 
   @Override
-  public void initialize() {
-    ByteBuffer buffer = insert.getAsciiCommand();
-    setBuffer(buffer);
-
-    if (getLogger().isDebugEnabled()) {
-      getLogger().debug("Request in ascii protocol: %s",
-              (new String(buffer.array())).replace("\r\n", "\\r\\n"));
-    }
-  }
-
-  @Override
-  protected void wasCancelled() {
-    getCallback().receivedStatus(STORE_CANCELED);
-  }
-
-  public Collection<String> getKeys() {
-    return insert.getKeyList();
-  }
-
   public CollectionBulkInsert<?> getInsert() {
-    return insert;
+    return (CollectionBulkInsert<?>) getCollectionPipe();
   }
 
   @Override
   public boolean isBulkOperation() {
     return true;
-  }
-
-  @Override
-  public boolean isPipeOperation() {
-    return true;
-  }
-
-  @Override
-  public boolean isIdempotentOperation() {
-    return !(insert instanceof CollectionBulkInsert.ListBulkInsert);
   }
 
 }

--- a/src/main/java/net/spy/memcached/protocol/ascii/CollectionPipedExistOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/CollectionPipedExistOperationImpl.java
@@ -17,172 +17,34 @@
  */
 package net.spy.memcached.protocol.ascii;
 
-import java.nio.ByteBuffer;
-import java.util.Collection;
 import java.util.Collections;
 
-import net.spy.memcached.collection.CollectionResponse;
 import net.spy.memcached.collection.SetPipedExist;
 import net.spy.memcached.ops.APIType;
-import net.spy.memcached.ops.CollectionOperationStatus;
 import net.spy.memcached.ops.CollectionPipedExistOperation;
 import net.spy.memcached.ops.OperationCallback;
-import net.spy.memcached.ops.OperationState;
 import net.spy.memcached.ops.OperationStatus;
 import net.spy.memcached.ops.OperationType;
-import net.spy.memcached.ops.PipedOperationCallback;
 
-public final class CollectionPipedExistOperationImpl extends OperationImpl implements
+public final class CollectionPipedExistOperationImpl extends PipeOperationImpl implements
         CollectionPipedExistOperation {
 
-  private static final OperationStatus EXIST_CANCELED = new CollectionOperationStatus(
-          false, "collection canceled", CollectionResponse.CANCELED);
-
-  private static final OperationStatus EXIST = new CollectionOperationStatus(
-          true, "EXIST", CollectionResponse.EXIST);
-  private static final OperationStatus NOT_EXIST = new CollectionOperationStatus(
-          true, "NOT_EXIST", CollectionResponse.NOT_EXIST);
-
-  private static final OperationStatus END = new CollectionOperationStatus(
-          true, "END", CollectionResponse.END);
-  private static final OperationStatus FAILED_END = new CollectionOperationStatus(
-          false, "END", CollectionResponse.END);
-
-  private static final OperationStatus NOT_FOUND = new CollectionOperationStatus(
-          false, "NOT_FOUND", CollectionResponse.NOT_FOUND);
-  private static final OperationStatus TYPE_MISMATCH = new CollectionOperationStatus(
-          false, "TYPE_MISMATCH", CollectionResponse.TYPE_MISMATCH);
-  private static final OperationStatus UNREADABLE = new CollectionOperationStatus(
-          false, "UNREADABLE", CollectionResponse.UNREADABLE);
-
-  private final String key;
-  private final SetPipedExist<?> setPipedExist;
-  private final PipedOperationCallback cb;
-
-  private int count;
-  private int index = 0;
-  private boolean successAll = true;
-
   public CollectionPipedExistOperationImpl(String key,
-                                           SetPipedExist<?> collectionExist,
-                                           OperationCallback cb) {
-    super(cb);
-    this.key = key;
-    this.setPipedExist = collectionExist;
-    this.cb = (PipedOperationCallback) cb;
-    if (this.setPipedExist instanceof SetPipedExist) {
-      setAPIType(APIType.SOP_EXIST);
-    }
+                                           SetPipedExist<?> collectionExist, OperationCallback cb) {
+    super(Collections.singletonList(key), collectionExist, cb);
+    setAPIType(APIType.SOP_EXIST);
     setOperationType(OperationType.READ);
   }
 
   @Override
-  public void handleLine(String line) {
-    assert getState() == OperationState.READING : "Read ``" + line
-            + "'' when in " + getState() + " state";
-
-    /* ENABLE_MIGRATION if */
-    if (hasNotMyKey(line)) {
-      // Only one NOT_MY_KEY is provided in response of single key piped operation when redirection.
-      addRedirectSingleKeyOperation(line, key);
-      if (setPipedExist.isNotPiped()) {
-        transitionState(OperationState.REDIRECT);
-      } else {
-        setPipedExist.setNextOpIndex(index);
-      }
-      return;
-    }
-    /* ENABLE_MIGRATION end */
-
-    if (setPipedExist.isNotPiped()) {
-      OperationStatus status = matchStatus(line, EXIST, NOT_EXIST,
-              NOT_FOUND, TYPE_MISMATCH, UNREADABLE);
-      if (!status.isSuccess()) {
-        successAll = false;
-      }
-
-      cb.gotStatus(index, status);
-      cb.receivedStatus(successAll ? END : FAILED_END);
-      transitionState(OperationState.COMPLETE);
-      return;
-    }
-
-    /*
-      RESPONSE <count>\r\n
-      <status of the 1st pipelined command>\r\n
-      [ ... ]
-      <status of the last pipelined command>\r\n
-      END|PIPE_ERROR <error_string>\r\n
-    */
-    if (line.startsWith("END") || line.startsWith("PIPE_ERROR ")) {
-      /* ENABLE_MIGRATION if */
-      if (needRedirect()) {
-        transitionState(OperationState.REDIRECT);
-        return;
-      }
-      /* ENABLE_MIGRATION end */
-      cb.receivedStatus((successAll) ? END : FAILED_END);
-      transitionState(OperationState.COMPLETE);
-    } else if (line.startsWith("RESPONSE ")) {
-      getLogger().debug("Got line %s", line);
-
-      // TODO server should be fixed
-      line = line.replace("   ", " ");
-      line = line.replace("  ", " ");
-
-      String[] stuff = line.split(" ");
-      assert "RESPONSE".equals(stuff[0]);
-      count = Integer.parseInt(stuff[1]);
-    } else {
-      OperationStatus status = matchStatus(line, EXIST, NOT_EXIST,
-              NOT_FOUND, TYPE_MISMATCH, UNREADABLE);
-
-      if (!status.isSuccess()) {
-        successAll = false;
-      }
-
-      cb.gotStatus(index, status);
-      index++;
-    }
+  protected OperationStatus checkStatus(String line) {
+    return matchStatus(line, EXIST, NOT_EXIST,
+            NOT_FOUND, TYPE_MISMATCH, UNREADABLE);
   }
 
   @Override
-  public void initialize() {
-    ByteBuffer buffer = setPipedExist.getAsciiCommand();
-    setBuffer(buffer);
-
-    if (getLogger().isDebugEnabled()) {
-      getLogger().debug("Request in ascii protocol: %s",
-              (new String(buffer.array())).replace("\r\n", "\\r\\n"));
-    }
-  }
-
-  @Override
-  protected void wasCancelled() {
-    getCallback().receivedStatus(EXIST_CANCELED);
-  }
-
-  public Collection<String> getKeys() {
-    return Collections.singleton(key);
-  }
-
   public SetPipedExist<?> getExist() {
-    return setPipedExist;
-  }
-
-  @Override
-  public boolean isBulkOperation() {
-    return false;
-  }
-
-  @Override
-  public boolean isPipeOperation() {
-    return true;
-  }
-
-  @Override
-  public boolean isIdempotentOperation() {
-    return true;
+    return (SetPipedExist<?>) getCollectionPipe();
   }
 
 }

--- a/src/main/java/net/spy/memcached/protocol/ascii/PipeOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/PipeOperationImpl.java
@@ -1,0 +1,232 @@
+package net.spy.memcached.protocol.ascii;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+import net.spy.memcached.collection.CollectionBulkInsert;
+import net.spy.memcached.collection.CollectionPipe;
+import net.spy.memcached.collection.CollectionPipedInsert;
+import net.spy.memcached.collection.CollectionResponse;
+import net.spy.memcached.ops.CollectionOperationStatus;
+import net.spy.memcached.ops.OperationCallback;
+import net.spy.memcached.ops.OperationErrorType;
+import net.spy.memcached.ops.OperationException;
+import net.spy.memcached.ops.OperationState;
+import net.spy.memcached.ops.OperationStatus;
+import net.spy.memcached.ops.PipedOperationCallback;
+
+abstract class PipeOperationImpl extends OperationImpl {
+
+  protected static final OperationStatus CANCELED = new CollectionOperationStatus(
+          false, "collection canceled", CollectionResponse.CANCELED);
+
+  protected static final OperationStatus END = new CollectionOperationStatus(
+          true, "END", CollectionResponse.END);
+  protected static final OperationStatus FAILED_END = new CollectionOperationStatus(
+          false, "END", CollectionResponse.END);
+
+  protected static final OperationStatus CREATED_STORED = new CollectionOperationStatus(
+          true, "CREATED_STORED", CollectionResponse.CREATED_STORED);
+  protected static final OperationStatus STORED = new CollectionOperationStatus(
+          true, "STORED", CollectionResponse.STORED);
+  protected static final OperationStatus UPDATED = new CollectionOperationStatus(
+          true, "UPDATED", CollectionResponse.UPDATED);
+  protected static final OperationStatus NOT_FOUND = new CollectionOperationStatus(
+          false, "NOT_FOUND", CollectionResponse.NOT_FOUND);
+  protected static final OperationStatus NOT_FOUND_ELEMENT = new CollectionOperationStatus(
+          false, "NOT_FOUND_ELEMENT", CollectionResponse.NOT_FOUND_ELEMENT);
+  protected static final OperationStatus NOTHING_TO_UPDATE = new CollectionOperationStatus(
+          false, "NOTHING_TO_UPDATE", CollectionResponse.NOTHING_TO_UPDATE);
+  protected static final OperationStatus ELEMENT_EXISTS = new CollectionOperationStatus(
+          false, "ELEMENT_EXISTS", CollectionResponse.ELEMENT_EXISTS);
+  protected static final OperationStatus OVERFLOWED = new CollectionOperationStatus(
+          false, "OVERFLOWED", CollectionResponse.OVERFLOWED);
+  protected static final OperationStatus OUT_OF_RANGE = new CollectionOperationStatus(
+          false, "OUT_OF_RANGE", CollectionResponse.OUT_OF_RANGE);
+  protected static final OperationStatus TYPE_MISMATCH = new CollectionOperationStatus(
+          false, "TYPE_MISMATCH", CollectionResponse.TYPE_MISMATCH);
+  protected static final OperationStatus BKEY_MISMATCH = new CollectionOperationStatus(
+          false, "BKEY_MISMATCH", CollectionResponse.BKEY_MISMATCH);
+  protected static final OperationStatus EFLAG_MISMATCH = new CollectionOperationStatus(
+          false, "EFLAG_MISMATCH", CollectionResponse.EFLAG_MISMATCH);
+
+  protected static final OperationStatus EXIST = new CollectionOperationStatus(
+          true, "EXIST", CollectionResponse.EXIST);
+  protected static final OperationStatus NOT_EXIST = new CollectionOperationStatus(
+          true, "NOT_EXIST", CollectionResponse.NOT_EXIST);
+  protected static final OperationStatus UNREADABLE = new CollectionOperationStatus(
+          false, "UNREADABLE", CollectionResponse.UNREADABLE);
+
+  protected boolean successAll = true;
+
+  private final CollectionPipe collectionPipe;
+  private final PipedOperationCallback cb;
+  private final List<String> keys;
+  private final boolean isIdempotent;
+
+  private int index = 0;
+  private boolean readUntilLastLine = false;
+
+  protected PipeOperationImpl(List<String> keys, CollectionPipe collectionPipe,
+                              OperationCallback cb) {
+    super(cb);
+    this.cb = (PipedOperationCallback) cb;
+    if (keys == null || keys.isEmpty()) {
+      throw new IllegalArgumentException("No keys provided");
+    }
+    this.keys = keys;
+    this.collectionPipe = collectionPipe;
+    this.isIdempotent = !(collectionPipe instanceof CollectionPipedInsert.ListPipedInsert ||
+            collectionPipe instanceof CollectionBulkInsert.ListBulkInsert);
+  }
+
+  @Override
+  public void handleLine(String line) {
+    assert getState() == OperationState.READING
+            : "Read ``" + line + "'' when in " + getState() + " state";
+
+    /* ENABLE_REPLICATION if */
+    if (isWriteOperation() && hasSwitchedOver(line)) {
+      this.collectionPipe.setNextOpIndex(index);
+      prepareSwitchover(line);
+      return;
+    }
+    /* ENABLE_REPLICATION end */
+
+    /* ENABLE_MIGRATION if */
+    if (hasNotMyKey(line)) {
+      if (isBulkOperation()) {
+        addRedirectMultiKeyOperation(line, keys.get(index));
+        if (collectionPipe.isNotPiped()) {
+          transitionState(OperationState.REDIRECT);
+        } else {
+          index++;
+        }
+      } else {
+        // Only one NOT_MY_KEY is provided in response of
+        // single key piped operation when redirection.
+        addRedirectSingleKeyOperation(line, keys.get(0));
+        if (collectionPipe.isNotPiped()) {
+          transitionState(OperationState.REDIRECT);
+        } else {
+          collectionPipe.setNextOpIndex(index);
+        }
+      }
+      return;
+    }
+    /* ENABLE_MIGRATION end */
+
+    if (collectionPipe.isNotPiped()) {
+      OperationStatus status = checkStatus(line);
+      if (!status.isSuccess()) {
+        successAll = false;
+      }
+      cb.gotStatus(index, status);
+
+      cb.receivedStatus((successAll) ? END : FAILED_END);
+      transitionState(OperationState.COMPLETE);
+      return;
+    }
+
+    /*
+      RESPONSE <count>\r\n
+      <status of the 1st pipelined command>\r\n
+      [ ... ]
+      <status of the last pipelined command>\r\n
+      END|PIPE_ERROR <error_string>\r\n
+    */
+    if (line.startsWith("END") || line.startsWith("PIPE_ERROR ")) {
+      /* ENABLE_MIGRATION if */
+      if (needRedirect()) {
+        transitionState(OperationState.REDIRECT);
+        return;
+      }
+      /* ENABLE_MIGRATION end */
+      cb.receivedStatus((successAll) ? END : FAILED_END);
+      transitionState(OperationState.COMPLETE);
+    } else if (line.startsWith("RESPONSE ")) {
+      getLogger().debug("Got line %s", line);
+
+      // TODO server should be fixed
+      line = line.replace("   ", " ");
+      line = line.replace("  ", " ");
+
+      String[] stuff = line.split(" ");
+      assert "RESPONSE".equals(stuff[0]);
+      readUntilLastLine = true;
+    } else {
+      OperationStatus status = checkStatus(line);
+      if (!status.isSuccess()) {
+        successAll = false;
+      }
+      cb.gotStatus(index, status);
+
+      index++;
+    }
+  }
+
+  @Override
+  protected void handleError(OperationErrorType eType, String line) throws IOException {
+    if (!readUntilLastLine) {
+      // this case means that error message came without 'RESPONSE <count>'.
+      // so it doesn't need to read 'PIPE_ERROR'.
+      super.handleError(eType, line);
+    } else {
+      // this case means that error message came after 'RESPONSE <count>'.
+      // so it needs to read 'PIPE_ERROR'.
+      getLogger().error("Error:  %s by %s", line, this);
+      exception = new OperationException(eType, line + " @ " + getHandlingNode().getNodeName());
+    }
+  }
+
+  /**
+   * call matchStatus() method with proper statuses in the child class
+   *
+   * @param line line that is read from the server
+   * @return status that is matched with the line
+   */
+  protected abstract OperationStatus checkStatus(String line);
+
+  @Override
+  public void initialize() {
+    ByteBuffer buffer = collectionPipe.getAsciiCommand();
+    setBuffer(buffer);
+    readUntilLastLine = false;
+
+    if (getLogger().isDebugEnabled()) {
+      getLogger().debug("Request in ascii protocol: %s",
+              (new String(buffer.array())).replace("\r\n", "\\r\\n"));
+    }
+  }
+
+  @Override
+  protected void wasCancelled() {
+    getCallback().receivedStatus(CANCELED);
+  }
+
+  public Collection<String> getKeys() {
+    return Collections.unmodifiableList(keys);
+  }
+
+  public CollectionPipe getCollectionPipe() {
+    return collectionPipe;
+  }
+
+  @Override
+  public boolean isBulkOperation() {
+    return false;
+  }
+
+  @Override
+  public final boolean isPipeOperation() {
+    return true;
+  }
+
+  @Override
+  public boolean isIdempotentOperation() {
+    return isIdempotent;
+  }
+}


### PR DESCRIPTION
### 🔗 Related Issue

<!-- Please link related issue. ex) https://github.com/naver/arcus-java-client/issues/{issue_number} -->
- 앞으로 pipe operation implementation 변경 지점이 많아질 것을 고려하여 PipeOperationImpl 클래스를 추가하여 이를 각각의 클래스가 상속받도록 합니다.
- 또한, 이전에 pipe_error까지 읽는 로직을 CollectionPipedInsertOperationImpl에만 적용했었기 때문에, 하나의 추상 클래스를 상속받도록 하여 CollectionPipedUpdateOperationImpl, CollectionPipedExistOperationImpl, CollectionBulkInsertOperationImpl에도 적용하고자 합니다.

### ⌨️ What I did

<!-- Please describe this PR and what you've been working on. -->
- handleLine, initialize 등의 메서드 중복과 static 필드 중복을 제거하였습니다.
- handleLine에서 각 연산(insert/exist/update/bulk insert)마다 다르게 처리해야 하는 부분은 추상 메서드로 빼 각 클래스에서 구현하도록 하였습니다.
- wasCancelled 메서드는 연산마다 다룰 CANCELLED 상태가 달라 각 클래스에서 구현하도록 하였습니다.
- getInsert/ getExist / getUpdate 메서드는 형변환이 필요하기 때문에 각 클래스에서 구현하도록 하였습니다.