### PR TITLE
INTERNAL: integrate piped operation callbacks

### DIFF
--- a/src/main/java/net/spy/memcached/ops/CollectionBulkInsertOperation.java
+++ b/src/main/java/net/spy/memcached/ops/CollectionBulkInsertOperation.java
@@ -25,8 +25,4 @@ public interface CollectionBulkInsertOperation extends KeyedOperation {
 
   CollectionBulkInsert<?> getInsert();
 
-  interface Callback extends OperationCallback {
-    void gotStatus(String key, OperationStatus status);
-  }
-
 }

--- a/src/main/java/net/spy/memcached/ops/CollectionPipedExistOperation.java
+++ b/src/main/java/net/spy/memcached/ops/CollectionPipedExistOperation.java
@@ -25,8 +25,4 @@ public interface CollectionPipedExistOperation extends KeyedOperation {
 
   SetPipedExist<?> getExist();
 
-  interface Callback extends OperationCallback {
-    void gotStatus(Integer index, OperationStatus status);
-  }
-
 }

--- a/src/main/java/net/spy/memcached/ops/CollectionPipedInsertOperation.java
+++ b/src/main/java/net/spy/memcached/ops/CollectionPipedInsertOperation.java
@@ -25,8 +25,4 @@ public interface CollectionPipedInsertOperation extends KeyedOperation {
 
   CollectionPipedInsert<?> getInsert();
 
-  interface Callback extends OperationCallback {
-    void gotStatus(Integer index, OperationStatus status);
-  }
-
 }

--- a/src/main/java/net/spy/memcached/ops/CollectionPipedUpdateOperation.java
+++ b/src/main/java/net/spy/memcached/ops/CollectionPipedUpdateOperation.java
@@ -25,8 +25,4 @@ public interface CollectionPipedUpdateOperation extends KeyedOperation {
 
   CollectionPipedUpdate<?> getUpdate();
 
-  interface Callback extends OperationCallback {
-    void gotStatus(Integer index, OperationStatus status);
-  }
-
 }

--- a/src/main/java/net/spy/memcached/ops/MultiCollectionBulkInsertOperationCallback.java
+++ b/src/main/java/net/spy/memcached/ops/MultiCollectionBulkInsertOperationCallback.java
@@ -18,14 +18,14 @@
 package net.spy.memcached.ops;
 
 public class MultiCollectionBulkInsertOperationCallback extends MultiOperationCallback
-    implements CollectionBulkInsertOperation.Callback {
+    implements PipedOperationCallback {
 
   public MultiCollectionBulkInsertOperationCallback(OperationCallback original, int todo) {
     super(original, todo);
   }
 
   @Override
-  public void gotStatus(String key, OperationStatus status) {
-    ((CollectionBulkInsertOperation.Callback) originalCallback).gotStatus(key, status);
+  public void gotStatus(Integer index, OperationStatus status) {
+    ((PipedOperationCallback) originalCallback).gotStatus(index, status);
   }
 }

--- a/src/main/java/net/spy/memcached/ops/PipedOperationCallback.java
+++ b/src/main/java/net/spy/memcached/ops/PipedOperationCallback.java
@@ -1,0 +1,5 @@
+package net.spy.memcached.ops;
+
+public interface PipedOperationCallback extends OperationCallback {
+  void gotStatus(Integer index, OperationStatus status);
+}

--- a/src/test/java/net/spy/memcached/protocol/ascii/BaseOpTest.java
+++ b/src/test/java/net/spy/memcached/protocol/ascii/BaseOpTest.java
@@ -28,11 +28,11 @@ import java.util.List;
 import java.util.concurrent.LinkedBlockingQueue;
 
 import net.spy.memcached.collection.CollectionPipedInsert;
-import net.spy.memcached.ops.CollectionPipedInsertOperation;
 import net.spy.memcached.ops.Operation;
 import net.spy.memcached.ops.OperationCallback;
 import net.spy.memcached.ops.OperationException;
 import net.spy.memcached.ops.OperationStatus;
+import net.spy.memcached.ops.PipedOperationCallback;
 
 import org.junit.jupiter.api.Test;
 
@@ -115,7 +115,7 @@ class BaseOpTest {
     CollectionPipedInsert.ListPipedInsert<String> insert =
             new CollectionPipedInsert.ListPipedInsert<>(key, 0,
                     Arrays.asList("a", "b"), null, null);
-    OperationCallback cb = new CollectionPipedInsertOperation.Callback() {
+    OperationCallback cb = new PipedOperationCallback() {
       @Override
       public void receivedStatus(OperationStatus status) {
       }

--- a/src/test/manual/net/spy/memcached/MultibyteKeyTest.java
+++ b/src/test/manual/net/spy/memcached/MultibyteKeyTest.java
@@ -59,17 +59,14 @@ import net.spy.memcached.ops.BTreeGetByPositionOperation;
 import net.spy.memcached.ops.BTreeInsertAndGetOperation;
 import net.spy.memcached.ops.BTreeSortMergeGetOperation;
 import net.spy.memcached.ops.BTreeSortMergeGetOperationOld;
-import net.spy.memcached.ops.CollectionBulkInsertOperation;
 import net.spy.memcached.ops.CollectionGetOperation;
-import net.spy.memcached.ops.CollectionPipedExistOperation;
-import net.spy.memcached.ops.CollectionPipedInsertOperation;
-import net.spy.memcached.ops.CollectionPipedUpdateOperation;
 import net.spy.memcached.ops.ConcatenationType;
 import net.spy.memcached.ops.GetAttrOperation;
 import net.spy.memcached.ops.GetsOperation;
 import net.spy.memcached.ops.Mutator;
 import net.spy.memcached.ops.OperationCallback;
 import net.spy.memcached.ops.OperationStatus;
+import net.spy.memcached.ops.PipedOperationCallback;
 import net.spy.memcached.ops.StoreType;
 import net.spy.memcached.protocol.ascii.AsciiOperationFactory;
 import net.spy.memcached.transcoders.CollectionTranscoder;
@@ -342,8 +339,8 @@ class MultibyteKeyTest {
 
   @Test
   void CollectionPipedInsertOperationImplTest() {
-    CollectionPipedInsertOperation.Callback cpsCallback =
-        new CollectionPipedInsertOperation.Callback() {
+    PipedOperationCallback cpsCallback =
+        new PipedOperationCallback() {
           @Override
           public void gotStatus(Integer index, OperationStatus status) {
           }
@@ -464,10 +461,10 @@ class MultibyteKeyTest {
   @Test
   void CollectionBulkInsertOperationImplTest() {
     CollectionBulkInsert<Integer> insert = null;
-    CollectionBulkInsertOperation.Callback cbsCallback =
-        new CollectionBulkInsertOperation.Callback() {
+    PipedOperationCallback cbsCallback =
+        new PipedOperationCallback() {
           @Override
-          public void gotStatus(String key, OperationStatus status) {
+          public void gotStatus(Integer index, OperationStatus status) {
           }
 
           @Override
@@ -585,7 +582,7 @@ class MultibyteKeyTest {
       opFact.collectionPipedUpdate(MULTIBYTE_KEY,
               new CollectionPipedUpdate.BTreePipedUpdate<>(
                       MULTIBYTE_KEY, elementsList, new IntegerTranscoder()),
-          new CollectionPipedUpdateOperation.Callback() {
+          new PipedOperationCallback() {
             @Override
             public void gotStatus(Integer index, OperationStatus status) {
             }
@@ -634,7 +631,7 @@ class MultibyteKeyTest {
     try {
       opFact.collectionPipedExist(MULTIBYTE_KEY,
               new SetPipedExist<>(MULTIBYTE_KEY, objectList, new IntegerTranscoder()),
-          new CollectionPipedExistOperation.Callback() {
+          new PipedOperationCallback() {
             @Override
             public void gotStatus(Integer index, OperationStatus status) {
             }


### PR DESCRIPTION
### 🔗 Related Issue

<!-- Please link related issue. ex) https://github.com/naver/arcus-java-client/issues/{issue_number} -->
- https://github.com/naver/arcus-java-client/pull/872#discussion_r1924920050

### ⌨️ What I did

<!-- Please describe this PR and what you've been working on. -->
  - pipe 연산 callback을 PipedOperationCallback으로 통합합니다.
    - bulk insert 연산의 callback에서 주어진 index에 해당하는 key를 찾을 수 있으므로 인터페이스 통합이 가능합니다.
  - 콜백 객체의 gotStatus() 메서드 내부에서 status의 성공 여부를 판단해 처리하도록 수정했습니다.
  - piped exist 연산의 경우 not my key로 인해 redirect될 수 있고 이 과정에서 일부 서버에 단일 연산이 보내지고 응답받을 수 있습니다. 하지만 단일 연산 처리 시 successAll를 고려하지 않고 있어 이를 고려하도록 수정했습니다.
