### PR TITLE
INTERNAL: Refactoring updateReplConnections.

### DIFF
--- a/src/main/java/net/spy/memcached/ArcusReplNodeAddress.java
+++ b/src/main/java/net/spy/memcached/ArcusReplNodeAddress.java
@@ -109,8 +109,7 @@ public final class ArcusReplNodeAddress extends InetSocketAddress {
     return list;
   }
 
-  static Map<String, List<ArcusReplNodeAddress>> makeGroupAddrsList(
-          List<InetSocketAddress> addrs) {
+  static Map<String, List<ArcusReplNodeAddress>> makeGroupAddrs(List<InetSocketAddress> addrs) {
 
     Map<String, List<ArcusReplNodeAddress>> newAllGroups =
             new HashMap<>();

--- a/src/main/java/net/spy/memcached/CacheManager.java
+++ b/src/main/java/net/spy/memcached/CacheManager.java
@@ -656,7 +656,7 @@ public final class CacheManager extends SpyThread implements Watcher,
   /* ENABLE_REPLICATION if */
   private List<InetSocketAddress> validateReplicaGroup(List<InetSocketAddress> socketList) {
     Map<String, List<ArcusReplNodeAddress>> newAllGroups =
-            ArcusReplNodeAddress.makeGroupAddrsList(socketList);
+            ArcusReplNodeAddress.makeGroupAddrs(socketList);
 
     // recreate socket list
     socketList.clear();


### PR DESCRIPTION
### 🔗 Related Issue

https://github.com/jam2in/arcus-works/issues/620#issuecomment-2505369614

### ⌨️ What I did

기존 로직의 경우 findChangedGroups을 통해
해시링의 형상과 zk로부터의 형상을 먼저 비교합니다.
그 후에 변경이 있는 Group에 대해서만 루프를 돌며 update를 수행합니다.

변경된 로직은 해시링의 형상(old)을 순회를 돌며
해당 해시링 기준, zk로부터의 형상(new)을 곧바로 비교하면서
update를 수행합니다.

리뷰를 위해 이슈 관련 히스토리도 아래에 정리합니다.

1. findChangedGroups가 알고보니, M / S 정보를 비교해서 변경을 감지하는것을 발견
2. 1번 문제는 특정 상황에서 switchover가 원복하는 문제가 그대로 남아 있음
3. 2번 상황 해결을 위해 masterCandidate를 사용하는 방안 사용
4. 3번 상황의 엣지 케이스 발견 및 해결

결론적으로 기존의 findChangedGroups가 가진 문제는 해결된 상태에서의 PR인점을 참고해주세요.

추가적으로 아래 코멘트 사항에서 언급된 경우도 처리합니다.
https://github.com/naver/arcus-java-client/pull/874#issuecomment-2673876201

기존에는 for 루프 내에서 group 별로 처리하는 경우를
for 루프 앞단에서 일괄적으로 이전 delayed switchover를 처리하도록 변경했습니다.


