### PR TITLE
FIX: Input the operation to none master node.

### DIFF
--- a/src/main/java/net/spy/memcached/ArcusClient.java
+++ b/src/main/java/net/spy/memcached/ArcusClient.java
@@ -130,6 +130,7 @@ import net.spy.memcached.internal.result.MopGetResultImpl;
 import net.spy.memcached.internal.result.SMGetResultImpl;
 import net.spy.memcached.internal.result.SMGetResultOldImpl;
 import net.spy.memcached.internal.result.SopGetResultImpl;
+import net.spy.memcached.ops.APIType;
 import net.spy.memcached.ops.BTreeFindPositionOperation;
 import net.spy.memcached.ops.BTreeFindPositionWithGetOperation;
 import net.spy.memcached.ops.BTreeGetBulkOperation;
@@ -1934,7 +1935,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
     }
 
     Collection<Entry<MemcachedNode, List<String>>> arrangedKey =
-            groupingKeys(keyList, smgetKeyChunkSize);
+            groupingKeys(keyList, smgetKeyChunkSize, APIType.BOP_SMGET);
     List<BTreeSMGet<Object>> smGetList = new ArrayList<>(
             arrangedKey.size());
     for (Entry<MemcachedNode, List<String>> entry : arrangedKey) {
@@ -1964,7 +1965,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
     }
 
     Collection<Entry<MemcachedNode, List<String>>> arrangedKey =
-            groupingKeys(keyList, smgetKeyChunkSize);
+            groupingKeys(keyList, smgetKeyChunkSize, APIType.BOP_SMGET);
     List<BTreeSMGet<Object>> smGetList = new ArrayList<>(
             arrangedKey.size());
     for (Entry<MemcachedNode, List<String>> entry : arrangedKey) {
@@ -3012,7 +3013,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
     }
 
     Collection<Entry<MemcachedNode, List<String>>> arrangedKey =
-            groupingKeys(keyList, smgetKeyChunkSize);
+            groupingKeys(keyList, smgetKeyChunkSize, APIType.BOP_SMGET);
     List<BTreeSMGet<Object>> smGetList = new ArrayList<>(
             arrangedKey.size());
     for (Entry<MemcachedNode, List<String>> entry : arrangedKey) {
@@ -3045,7 +3046,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
     }
 
     Collection<Entry<MemcachedNode, List<String>>> arrangedKey =
-            groupingKeys(keyList, smgetKeyChunkSize);
+            groupingKeys(keyList, smgetKeyChunkSize, APIType.BOP_SMGET);
     List<BTreeSMGet<Object>> smGetList = new ArrayList<>(
             arrangedKey.size());
     for (Entry<MemcachedNode, List<String>> entry : arrangedKey) {
@@ -3132,7 +3133,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
     validateKeys(keyList);
     checkDupKey(keyList);
     Collection<Entry<MemcachedNode, List<String>>> arrangedKey =
-            groupingKeys(keyList, NON_PIPED_BULK_INSERT_CHUNK_SIZE);
+            groupingKeys(keyList, NON_PIPED_BULK_INSERT_CHUNK_SIZE, APIType.BOP_INSERT);
 
     List<CollectionBulkInsert<T>> insertList = new ArrayList<>(
             arrangedKey.size());
@@ -3166,7 +3167,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
     validateKeys(keyList);
     checkDupKey(keyList);
     Collection<Entry<MemcachedNode, List<String>>> arrangedKey =
-            groupingKeys(keyList, NON_PIPED_BULK_INSERT_CHUNK_SIZE);
+            groupingKeys(keyList, NON_PIPED_BULK_INSERT_CHUNK_SIZE, APIType.BOP_INSERT);
     List<CollectionBulkInsert<T>> insertList = new ArrayList<>(
             arrangedKey.size());
 
@@ -3199,7 +3200,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
     validateKeys(keyList);
     checkDupKey(keyList);
     Collection<Entry<MemcachedNode, List<String>>> arrangedKey =
-            groupingKeys(keyList, NON_PIPED_BULK_INSERT_CHUNK_SIZE);
+            groupingKeys(keyList, NON_PIPED_BULK_INSERT_CHUNK_SIZE, APIType.MOP_INSERT);
 
     List<CollectionBulkInsert<T>> insertList = new ArrayList<>(
             arrangedKey.size());
@@ -3231,7 +3232,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
     checkDupKey(keyList);
 
     Collection<Entry<MemcachedNode, List<String>>> arrangedKey =
-            groupingKeys(keyList, NON_PIPED_BULK_INSERT_CHUNK_SIZE);
+            groupingKeys(keyList, NON_PIPED_BULK_INSERT_CHUNK_SIZE, APIType.SOP_INSERT);
     List<CollectionBulkInsert<T>> insertList = new ArrayList<>(
             arrangedKey.size());
 
@@ -3262,7 +3263,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
     checkDupKey(keyList);
 
     Collection<Entry<MemcachedNode, List<String>>> arrangedKey =
-            groupingKeys(keyList, NON_PIPED_BULK_INSERT_CHUNK_SIZE);
+            groupingKeys(keyList, NON_PIPED_BULK_INSERT_CHUNK_SIZE, APIType.LOP_INSERT);
     List<CollectionBulkInsert<T>> insertList = new ArrayList<>(
             arrangedKey.size());
 
@@ -3343,7 +3344,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
     }
 
     Collection<Entry<MemcachedNode, List<String>>> rearrangedKeys =
-            groupingKeys(keyList, BOPGET_BULK_CHUNK_SIZE);
+            groupingKeys(keyList, BOPGET_BULK_CHUNK_SIZE, APIType.BOP_GET);
 
     List<BTreeGetBulk<T>> getBulkList = new ArrayList<>(
             rearrangedKeys.size());
@@ -3384,7 +3385,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
     }
 
     Collection<Entry<MemcachedNode, List<String>>> rearrangedKeys =
-            groupingKeys(keyList, BOPGET_BULK_CHUNK_SIZE);
+            groupingKeys(keyList, BOPGET_BULK_CHUNK_SIZE, APIType.BOP_GET);
 
     List<BTreeGetBulk<T>> getBulkList = new ArrayList<>(
             rearrangedKeys.size());

--- a/src/main/java/net/spy/memcached/MemcachedClient.java
+++ b/src/main/java/net/spy/memcached/MemcachedClient.java
@@ -53,6 +53,7 @@ import net.spy.memcached.internal.SingleElementInfiniteIterator;
 import net.spy.memcached.internal.result.GetResult;
 import net.spy.memcached.internal.result.GetResultImpl;
 import net.spy.memcached.internal.result.GetsResultImpl;
+import net.spy.memcached.ops.APIType;
 import net.spy.memcached.ops.CASOperationStatus;
 import net.spy.memcached.ops.CancelledOperationStatus;
 import net.spy.memcached.ops.ConcatenationType;
@@ -1072,7 +1073,7 @@ public class MemcachedClient extends SpyThread
 
     // Grouping keys by memcached node
     Collection<Map.Entry<MemcachedNode, List<String>>> arrangedKey
-            = groupingKeys(keys, GET_BULK_CHUNK_SIZE);
+            = groupingKeys(keys, GET_BULK_CHUNK_SIZE, APIType.GET);
     final CountDownLatch latch = new CountDownLatch(arrangedKey.size());
 
     GetOperation.Callback cb = new GetOperation.Callback() {
@@ -1205,7 +1206,7 @@ public class MemcachedClient extends SpyThread
 
     // Grouping keys by memcached node
     Collection<Map.Entry<MemcachedNode, List<String>>> arrangedKey
-            = groupingKeys(keys, GET_BULK_CHUNK_SIZE);
+            = groupingKeys(keys, GET_BULK_CHUNK_SIZE, APIType.GETS);
 
     final CountDownLatch latch = new CountDownLatch(arrangedKey.size());
 
@@ -2169,11 +2170,11 @@ public class MemcachedClient extends SpyThread
    * @return list of grouped (memcached node + keys) in the group
    */
   protected Collection<Map.Entry<MemcachedNode, List<String>>> groupingKeys(
-          Collection<String> keyList, int maxKeyCountPerGroup) {
+          Collection<String> keyList, int maxKeyCountPerGroup, APIType apiType) {
     List<Map.Entry<MemcachedNode, List<String>>> resultList = new ArrayList<>();
     Map<MemcachedNode, List<String>> nodeMap = new HashMap<>();
     for (String key : keyList) {
-      MemcachedNode qa = conn.findNodeByKey(key);
+      MemcachedNode qa = conn.findNodeByKey(key, apiType);
       List<String> keyGroup = nodeMap.get(qa);
 
       if (keyGroup == null) {

--- a/src/main/java/net/spy/memcached/RedirectHandler.java
+++ b/src/main/java/net/spy/memcached/RedirectHandler.java
@@ -22,6 +22,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import net.spy.memcached.ops.APIType;
+
 public abstract class RedirectHandler {
 
   private Long spoint = null;
@@ -91,12 +93,12 @@ public abstract class RedirectHandler {
     }
 
     public Map<MemcachedNode, List<String>> groupRedirectKeys(
-        MemcachedConnection conn) {
+            MemcachedConnection conn, APIType apiType) {
 
       Map<MemcachedNode, List<String>> keysByNode = null;
       List<String> keysWithoutOwner = keysByOwner.remove(UNKNOWN_OWNER);
       if (keysWithoutOwner != null) {
-        keysByNode = conn.groupKeysByNode(keysWithoutOwner);
+        keysByNode = conn.groupKeysByNode(keysWithoutOwner, apiType);
         if (keysByNode == null) {
           return null;
         }

--- a/src/test/java/net/spy/memcached/protocol/ascii/OperationExceptionTest.java
+++ b/src/test/java/net/spy/memcached/protocol/ascii/OperationExceptionTest.java
@@ -1,6 +1,7 @@
 package net.spy.memcached.protocol.ascii;
 
 import net.spy.memcached.collection.BaseIntegrationTest;
+import net.spy.memcached.ops.APIType;
 import net.spy.memcached.ops.OperationErrorType;
 import net.spy.memcached.ops.OperationException;
 
@@ -14,11 +15,15 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  */
 class OperationExceptionTest extends BaseIntegrationTest {
 
+  private final APIType apiType = APIType.GET;
+
   @Test
   void testServer() {
     OperationException oe = new OperationException(OperationErrorType.SERVER,
             "SERVER_ERROR figures" + " @ "
-                    + mc.getMemcachedConnection().getPrimaryNode("test").getNodeName());
+                    + mc.getMemcachedConnection()
+                    .getPrimaryNode("test", apiType)
+                    .getNodeName());
     assertSame(OperationErrorType.SERVER, oe.getType());
     assertTrue(String.valueOf(oe).startsWith("OperationException: SERVER:" +
             " SERVER_ERROR figures @ ArcusClient-"));
@@ -28,7 +33,9 @@ class OperationExceptionTest extends BaseIntegrationTest {
   void testClient() {
     OperationException oe = new OperationException(OperationErrorType.CLIENT,
             "CLIENT_ERROR nope" + " @ "
-                    + mc.getMemcachedConnection().getPrimaryNode("test").getNodeName());
+                    + mc.getMemcachedConnection()
+                    .getPrimaryNode("test", apiType)
+                    .getNodeName());
     assertSame(OperationErrorType.CLIENT, oe.getType());
     assertTrue(String.valueOf(oe).startsWith("OperationException: CLIENT:" +
             " CLIENT_ERROR nope @ ArcusClient-"));
@@ -38,7 +45,9 @@ class OperationExceptionTest extends BaseIntegrationTest {
   void testGeneral() {
     OperationException oe = new OperationException(OperationErrorType.GENERAL,
             "ERROR no matching command" + " @ "
-                    + mc.getMemcachedConnection().getPrimaryNode("test").getNodeName());
+                    + mc.getMemcachedConnection()
+                    .getPrimaryNode("test", apiType)
+                    .getNodeName());
     assertSame(OperationErrorType.GENERAL, oe.getType());
     assertTrue(String.valueOf(oe).startsWith("OperationException: GENERAL:" +
             " ERROR no matching command @ ArcusClient-"));


### PR DESCRIPTION
### 🔗 Related Issue

https://github.com/jam2in/arcus-works/issues/686#issuecomment-2646933197
위 이슈에서 파생됨

기존 로직에서는 ReplicaPick.Slave 또는 ReplicaPick.RR 시,
Operation의 타입에 상관없이 선택된 노드에 연산을 처리한다.
즉, write 연산인 경우에도 Slave 노드에 연산이 처리될 수 있다.

대략 아래의 흐름에서 문제가 발생한다.

- Repl 사용하는 응용에서 api 호출로 인해 Operation 객체 생성
- addOp 호출
- addOperation 호출 
- 내부에서 cache key에 해당하는 node 찾기 위한 findNodeByKey 호출
- findNodeByKey에서 ReplicatkPick.Slave 설정 시 Slave 노드에 해당하는 node 리턴
- 해당 node에 op 객체를 inputQ에 삽입
- 해당 op가 write 연산일 경우 slave 노드에 write 연산을 삽입하는 문제가 발생

### ⌨️ What I did

1. addOperation 호출 시, 해당 op의 write / read 여부를 확인 후 ReplicaPick을 찾도록 변경
2. groupingKeys의 경우, op 객체가 생성되기 전에 수행되는 로직이다. 그래서 이를 호출하는 api의 타입을 직접 보고 read / write 여부를 인자로 넘겨서 확인 가능하도록 변경