### PR TITLE
CLEANUP: tidy TCPMemcachedNodeImpl

### DIFF
--- a/src/main/java/net/spy/memcached/MemcachedNode.java
+++ b/src/main/java/net/spy/memcached/MemcachedNode.java
@@ -73,11 +73,6 @@ public interface MemcachedNode {
   void fillWriteBuffer(boolean optimizeGets);
 
   /**
-   * Transition the current write item into a read state.
-   */
-  void transitionWriteItem();
-
-  /**
    * Get the operation at the top of the queue that is requiring input.
    */
   Operation getCurrentReadOp();

--- a/src/main/java/net/spy/memcached/MemcachedNodeROImpl.java
+++ b/src/main/java/net/spy/memcached/MemcachedNodeROImpl.java
@@ -177,10 +177,6 @@ public final class MemcachedNodeROImpl implements MemcachedNode {
     throw new UnsupportedOperationException();
   }
 
-  public void transitionWriteItem() {
-    throw new UnsupportedOperationException();
-  }
-
   public int writeSome() throws IOException {
     throw new UnsupportedOperationException();
   }

--- a/src/test/java/net/spy/memcached/MockMemcachedNode.java
+++ b/src/test/java/net/spy/memcached/MockMemcachedNode.java
@@ -75,10 +75,6 @@ public class MockMemcachedNode implements MemcachedNode {
     // noop
   }
 
-  public void transitionWriteItem() {
-    // noop
-  }
-
   public Operation getCurrentReadOp() {
     return null;
   }


### PR DESCRIPTION
### 🔗 Related Issue

<!-- Please link related issue. ex) https://github.com/naver/arcus-java-client/issues/{issue_number} -->
- https://github.com/jam2in/arcus-works/issues/678

### ⌨️ What I did

<!-- Please describe this PR and what you've been working on. -->
- TCPMemcachedNodeImpl 클래스를 정리했습니다.
  - transitionWriteItem 메서드를 제거합니다.
  - getBuffer 메서드를 한번만 호출하도록 합니다.