### PR TITLE
FIX: use proper index when lop piped insert

### DIFF
--- a/src/main/java/net/spy/memcached/ArcusClient.java
+++ b/src/main/java/net/spy/memcached/ArcusClient.java
@@ -1854,6 +1854,9 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
       PartitionedList<T> list = new PartitionedList<>(valueList, MAX_PIPED_ITEM_COUNT);
       for (List<T> elementList : list) {
         insertList.add(new ListPipedInsert<>(key, index, elementList, attributesForCreate, tc));
+        if (index >= 0) {
+          index += elementList.size();
+        }
       }
     }
     return asyncCollectionPipedInsert(key, insertList);

--- a/src/test/manual/net/spy/memcached/bulkoperation/PipeInsertTest.java
+++ b/src/test/manual/net/spy/memcached/bulkoperation/PipeInsertTest.java
@@ -99,8 +99,6 @@ class PipeInsertTest extends BaseIntegrationTest {
     }
 
     try {
-      long start = System.currentTimeMillis();
-
       CollectionAttributes attr = new CollectionAttributes();
 
       CollectionFuture<Map<Integer, CollectionOperationStatus>> future = mc
@@ -108,8 +106,6 @@ class PipeInsertTest extends BaseIntegrationTest {
 
       Map<Integer, CollectionOperationStatus> map = future.get(5000L,
               TimeUnit.MILLISECONDS);
-
-      // System.out.println(System.currentTimeMillis() - start + "ms");
 
       assertTrue(map.isEmpty());
 
@@ -125,7 +121,7 @@ class PipeInsertTest extends BaseIntegrationTest {
   }
 
   @Test
-  void testLopPipeInsert() {
+  void testLopPipeInsertLast() {
     int elementCount = 5000;
 
     List<Object> elements = new ArrayList<>(elementCount);
@@ -135,8 +131,6 @@ class PipeInsertTest extends BaseIntegrationTest {
     }
 
     try {
-      long start = System.currentTimeMillis();
-
       CollectionAttributes attr = new CollectionAttributes();
 
       CollectionFuture<Map<Integer, CollectionOperationStatus>> future = mc
@@ -145,7 +139,38 @@ class PipeInsertTest extends BaseIntegrationTest {
       Map<Integer, CollectionOperationStatus> map = future.get(5000L,
               TimeUnit.MILLISECONDS);
 
-      // System.out.println(System.currentTimeMillis() - start + "ms");
+      assertTrue(map.isEmpty());
+
+      List<Object> list = mc.asyncLopGet(KEY, 0, 9999, false, false)
+              .get();
+
+      assertEquals(4000, list.size());
+      assertEquals("value1000", list.get(0));
+      assertEquals("value1501", list.get(501));
+    } catch (Exception e) {
+      e.printStackTrace();
+      fail(e.getMessage());
+    }
+  }
+
+  @Test
+  void testLopPipeInsertFirst() {
+    int elementCount = 4000;
+
+    List<Object> elements = new ArrayList<>(elementCount);
+
+    for (int i = 0; i < elementCount; i++) {
+      elements.add("value" + i);
+    }
+
+    try {
+      CollectionAttributes attr = new CollectionAttributes();
+
+      CollectionFuture<Map<Integer, CollectionOperationStatus>> future = mc
+              .asyncLopPipedInsertBulk(KEY, 0, elements, attr);
+
+      Map<Integer, CollectionOperationStatus> map = future.get(5000L,
+              TimeUnit.MILLISECONDS);
 
       assertTrue(map.isEmpty());
 
@@ -153,6 +178,8 @@ class PipeInsertTest extends BaseIntegrationTest {
               .get();
 
       assertEquals(4000, list.size());
+      assertEquals("value0", list.get(0));
+      assertEquals("value501", list.get(501));
     } catch (Exception e) {
       e.printStackTrace();
       fail(e.getMessage());
@@ -190,7 +217,7 @@ class PipeInsertTest extends BaseIntegrationTest {
               = future2.get(5000L, TimeUnit.MILLISECONDS);
       Map<Integer, CollectionOperationStatus> map3
               = future3.get(5000L, TimeUnit.MILLISECONDS);
-      assertEquals(map1.size() + map2.size() + map3.size(), 0);
+      assertEquals(0, map1.size() + map2.size() + map3.size());
 
       List<Object> list = mc.asyncLopGet(KEY, 0, 9999, false, false).get();
       assertEquals((elementCount * 3) + 2, list.size());


### PR DESCRIPTION
### 🔗 Related Issue

<!-- Please link related issue. ex) https://github.com/naver/arcus-java-client/issues/{issue_number} -->
- https://github.com/naver/arcus-java-client/pull/795/files#r1953855345

### ⌨️ What I did

<!-- Please describe this PR and what you've been working on. -->
- 기존에 500개 이상의 원소를 파이프를 이용해 리스트에 추가하고자 할 때 인덱스를 똑같은 값으로 주어 사용자가 입력한 원소 순서대로 리스트에 저장하지 않는 문제가 있었습니다.
- 원소 500개마다 생성하는 ListPipedInsert 객체의 index를 증가시키며 할당하여 이전 ListPipedInsert 객체 원소 뒤에 추가될 수 있도록 하였습니다.