### PR TITLE
INTERNAL: Remove duplicated OpType in Operation instance.

### DIFF
--- a/src/main/java/net/spy/memcached/protocol/BaseOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/BaseOperationImpl.java
@@ -54,8 +54,6 @@ public abstract class BaseOperationImpl extends SpyObject {
   protected OperationException exception = null;
   private OperationCallback callback = null;
   private volatile MemcachedNode handlingNode = null;
-
-  private OperationType opType = OperationType.UNDEFINED;
   private APIType apiType = APIType.UNDEFINED;
 
   /* ENABLE_MIGRATION if */
@@ -267,19 +265,19 @@ public abstract class BaseOperationImpl extends SpyObject {
   }
 
   public OperationType getOperationType() {
-    return opType;
+    return apiType.getAPIOpType();
   }
 
   public void setOperationType(OperationType opType) {
-    this.opType = opType;
+    apiType.setAPIOpType(opType);
   }
 
   public boolean isWriteOperation() {
-    return this.opType == OperationType.WRITE;
+    return apiType.getAPIOpType() == OperationType.WRITE;
   }
 
   public boolean isReadOperation() {
-    return this.opType == OperationType.READ;
+    return apiType.getAPIOpType() == OperationType.READ;
   }
 
   public APIType getAPIType() {

--- a/src/main/java/net/spy/memcached/protocol/ascii/BTreeFindPositionOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/BTreeFindPositionOperationImpl.java
@@ -31,7 +31,6 @@ import net.spy.memcached.ops.CollectionOperationStatus;
 import net.spy.memcached.ops.OperationCallback;
 import net.spy.memcached.ops.OperationState;
 import net.spy.memcached.ops.OperationStatus;
-import net.spy.memcached.ops.OperationType;
 
 public final class BTreeFindPositionOperationImpl extends OperationImpl implements
         BTreeFindPositionOperation {
@@ -61,7 +60,6 @@ public final class BTreeFindPositionOperationImpl extends OperationImpl implemen
     this.key = key;
     this.get = get;
     setAPIType(APIType.BOP_POSITION);
-    setOperationType(OperationType.READ);
   }
 
   @Override

--- a/src/main/java/net/spy/memcached/protocol/ascii/BTreeFindPositionWithGetOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/BTreeFindPositionWithGetOperationImpl.java
@@ -33,7 +33,6 @@ import net.spy.memcached.ops.CollectionOperationStatus;
 import net.spy.memcached.ops.OperationCallback;
 import net.spy.memcached.ops.OperationState;
 import net.spy.memcached.ops.OperationStatus;
-import net.spy.memcached.ops.OperationType;
 
 public final class BTreeFindPositionWithGetOperationImpl extends OperationImpl implements
         BTreeFindPositionWithGetOperation {
@@ -80,7 +79,6 @@ public final class BTreeFindPositionWithGetOperationImpl extends OperationImpl i
     this.eHeadCount = get.getEHeadCount();
     this.eFlagIndex = get.getEFlagIndex();
     setAPIType(APIType.BOP_PWG);
-    setOperationType(OperationType.READ);
   }
 
   @Override

--- a/src/main/java/net/spy/memcached/protocol/ascii/BTreeGetBulkOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/BTreeGetBulkOperationImpl.java
@@ -31,7 +31,6 @@ import net.spy.memcached.ops.CollectionOperationStatus;
 import net.spy.memcached.ops.OperationCallback;
 import net.spy.memcached.ops.OperationState;
 import net.spy.memcached.ops.OperationStatus;
-import net.spy.memcached.ops.OperationType;
 
 /**
  * Operation to retrieve b+tree data with multiple keys
@@ -80,7 +79,6 @@ public final class BTreeGetBulkOperationImpl extends OperationImpl implements
     super(cb);
     this.getBulk = getBulk;
     setAPIType(APIType.BOP_GET);
-    setOperationType(OperationType.READ);
   }
 
   public void handleLine(String line) {

--- a/src/main/java/net/spy/memcached/protocol/ascii/BTreeGetByPositionOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/BTreeGetByPositionOperationImpl.java
@@ -34,7 +34,6 @@ import net.spy.memcached.ops.CollectionOperationStatus;
 import net.spy.memcached.ops.OperationCallback;
 import net.spy.memcached.ops.OperationState;
 import net.spy.memcached.ops.OperationStatus;
-import net.spy.memcached.ops.OperationType;
 
 public final class BTreeGetByPositionOperationImpl extends OperationImpl implements
         BTreeGetByPositionOperation {
@@ -77,7 +76,6 @@ public final class BTreeGetByPositionOperationImpl extends OperationImpl impleme
     this.eHeadCount = get.getEHeadCount();
     this.eFlagIndex = get.getEFlagIndex();
     setAPIType(APIType.BOP_GBP);
-    setOperationType(OperationType.READ);
   }
 
   @Override

--- a/src/main/java/net/spy/memcached/protocol/ascii/BTreeInsertAndGetOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/BTreeInsertAndGetOperationImpl.java
@@ -34,7 +34,6 @@ import net.spy.memcached.ops.CollectionOperationStatus;
 import net.spy.memcached.ops.OperationCallback;
 import net.spy.memcached.ops.OperationState;
 import net.spy.memcached.ops.OperationStatus;
-import net.spy.memcached.ops.OperationType;
 
 public final class BTreeInsertAndGetOperationImpl extends OperationImpl implements
         BTreeInsertAndGetOperation {
@@ -107,7 +106,6 @@ public final class BTreeInsertAndGetOperationImpl extends OperationImpl implemen
     } else {
       setAPIType(APIType.BOP_INSERT);
     }
-    setOperationType(OperationType.WRITE);
   }
 
   @Override

--- a/src/main/java/net/spy/memcached/protocol/ascii/BTreeSortMergeGetOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/BTreeSortMergeGetOperationImpl.java
@@ -33,7 +33,6 @@ import net.spy.memcached.ops.CollectionOperationStatus;
 import net.spy.memcached.ops.OperationCallback;
 import net.spy.memcached.ops.OperationState;
 import net.spy.memcached.ops.OperationStatus;
-import net.spy.memcached.ops.OperationType;
 import net.spy.memcached.util.BTreeUtil;
 
 /**
@@ -84,7 +83,6 @@ public final class BTreeSortMergeGetOperationImpl extends OperationImpl implemen
     super(cb);
     this.smGet = smGet;
     setAPIType(APIType.BOP_SMGET);
-    setOperationType(OperationType.READ);
   }
 
   public void handleLine(String line) {

--- a/src/main/java/net/spy/memcached/protocol/ascii/BTreeSortMergeGetOperationOldImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/BTreeSortMergeGetOperationOldImpl.java
@@ -31,7 +31,6 @@ import net.spy.memcached.ops.CollectionOperationStatus;
 import net.spy.memcached.ops.OperationCallback;
 import net.spy.memcached.ops.OperationState;
 import net.spy.memcached.ops.OperationStatus;
-import net.spy.memcached.ops.OperationType;
 
 /**
  * Operation to retrieve b+tree data with multiple keys
@@ -77,7 +76,6 @@ public final class BTreeSortMergeGetOperationOldImpl extends OperationImpl imple
     super(cb);
     this.smGet = smGet;
     setAPIType(APIType.BOP_SMGET);
-    setOperationType(OperationType.READ);
   }
 
   /**

--- a/src/main/java/net/spy/memcached/protocol/ascii/BaseGetOpImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/BaseGetOpImpl.java
@@ -27,7 +27,6 @@ import net.spy.memcached.ops.GetsOperation;
 import net.spy.memcached.ops.OperationCallback;
 import net.spy.memcached.ops.OperationState;
 import net.spy.memcached.ops.OperationStatus;
-import net.spy.memcached.ops.OperationType;
 import net.spy.memcached.ops.StatusCode;
 
 /**
@@ -55,7 +54,6 @@ abstract class BaseGetOpImpl extends OperationImpl {
     super(cb);
     cmd = c;
     keys = k;
-    setOperationType(OperationType.READ);
   }
 
   /**

--- a/src/main/java/net/spy/memcached/protocol/ascii/BaseStoreOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/BaseStoreOperationImpl.java
@@ -26,7 +26,6 @@ import net.spy.memcached.KeyUtil;
 import net.spy.memcached.ops.OperationCallback;
 import net.spy.memcached.ops.OperationState;
 import net.spy.memcached.ops.OperationStatus;
-import net.spy.memcached.ops.OperationType;
 import net.spy.memcached.ops.StatusCode;
 
 /**
@@ -57,7 +56,6 @@ abstract class BaseStoreOperationImpl extends OperationImpl {
     flags = f;
     exp = e;
     data = d;
-    setOperationType(OperationType.WRITE);
   }
 
   @Override

--- a/src/main/java/net/spy/memcached/protocol/ascii/CASOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/CASOperationImpl.java
@@ -30,7 +30,6 @@ import net.spy.memcached.ops.CASOperationStatus;
 import net.spy.memcached.ops.OperationCallback;
 import net.spy.memcached.ops.OperationState;
 import net.spy.memcached.ops.OperationStatus;
-import net.spy.memcached.ops.OperationType;
 import net.spy.memcached.ops.StatusCode;
 import net.spy.memcached.ops.StoreType;
 
@@ -66,7 +65,6 @@ class CASOperationImpl extends OperationImpl implements CASOperation {
     exp = e;
     data = d;
     setAPIType(APIType.CAS);
-    setOperationType(OperationType.WRITE);
   }
 
   @Override

--- a/src/main/java/net/spy/memcached/protocol/ascii/CollectionBulkInsertOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/CollectionBulkInsertOperationImpl.java
@@ -22,7 +22,6 @@ import net.spy.memcached.ops.APIType;
 import net.spy.memcached.ops.CollectionBulkInsertOperation;
 import net.spy.memcached.ops.OperationCallback;
 import net.spy.memcached.ops.OperationStatus;
-import net.spy.memcached.ops.OperationType;
 
 /**
  * Operation to store collection data in a memcached server.
@@ -41,7 +40,6 @@ public final class CollectionBulkInsertOperationImpl extends PipeOperationImpl
     } else if (insert instanceof CollectionBulkInsert.BTreeBulkInsert) {
       setAPIType(APIType.BOP_INSERT);
     }
-    setOperationType(OperationType.WRITE);
   }
 
   @Override

--- a/src/main/java/net/spy/memcached/protocol/ascii/CollectionCountOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/CollectionCountOperationImpl.java
@@ -32,7 +32,6 @@ import net.spy.memcached.ops.CollectionOperationStatus;
 import net.spy.memcached.ops.OperationCallback;
 import net.spy.memcached.ops.OperationState;
 import net.spy.memcached.ops.OperationStatus;
-import net.spy.memcached.ops.OperationType;
 
 /**
  * Operation to get exists item count from collection in a memcached server.
@@ -65,7 +64,6 @@ public final class CollectionCountOperationImpl extends OperationImpl implements
     if (this.collectionCount instanceof BTreeCount) {
       setAPIType(APIType.BOP_COUNT);
     }
-    setOperationType(OperationType.READ);
   }
 
   public void handleLine(String line) {

--- a/src/main/java/net/spy/memcached/protocol/ascii/CollectionCreateOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/CollectionCreateOperationImpl.java
@@ -35,7 +35,6 @@ import net.spy.memcached.ops.CollectionOperationStatus;
 import net.spy.memcached.ops.OperationCallback;
 import net.spy.memcached.ops.OperationState;
 import net.spy.memcached.ops.OperationStatus;
-import net.spy.memcached.ops.OperationType;
 
 /**
  * Operation to create empty collection in a memcached server.
@@ -70,7 +69,6 @@ public final class CollectionCreateOperationImpl extends OperationImpl
     } else if (this.collectionCreate instanceof MapCreate) {
       setAPIType(APIType.MOP_CREATE);
     }
-    setOperationType(OperationType.WRITE);
   }
 
   @Override

--- a/src/main/java/net/spy/memcached/protocol/ascii/CollectionDeleteOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/CollectionDeleteOperationImpl.java
@@ -35,7 +35,6 @@ import net.spy.memcached.ops.CollectionOperationStatus;
 import net.spy.memcached.ops.OperationCallback;
 import net.spy.memcached.ops.OperationState;
 import net.spy.memcached.ops.OperationStatus;
-import net.spy.memcached.ops.OperationType;
 
 /**
  * Operation to delete collection data in a memcached server.
@@ -78,7 +77,6 @@ public final class CollectionDeleteOperationImpl extends OperationImpl
     } else if (this.collectionDelete instanceof BTreeDelete) {
       setAPIType(APIType.BOP_DELETE);
     }
-    setOperationType(OperationType.WRITE);
   }
 
   @Override

--- a/src/main/java/net/spy/memcached/protocol/ascii/CollectionExistOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/CollectionExistOperationImpl.java
@@ -32,7 +32,6 @@ import net.spy.memcached.ops.CollectionOperationStatus;
 import net.spy.memcached.ops.OperationCallback;
 import net.spy.memcached.ops.OperationState;
 import net.spy.memcached.ops.OperationStatus;
-import net.spy.memcached.ops.OperationType;
 
 /**
  * Operation to check membership of an item in collection in a memcached server.
@@ -69,7 +68,6 @@ public final class CollectionExistOperationImpl extends OperationImpl
     if (this.collectionExist instanceof SetExist) {
       setAPIType(APIType.SOP_EXIST);
     }
-    setOperationType(OperationType.READ);
   }
 
   @Override

--- a/src/main/java/net/spy/memcached/protocol/ascii/CollectionInsertOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/CollectionInsertOperationImpl.java
@@ -37,7 +37,6 @@ import net.spy.memcached.ops.CollectionOperationStatus;
 import net.spy.memcached.ops.OperationCallback;
 import net.spy.memcached.ops.OperationState;
 import net.spy.memcached.ops.OperationStatus;
-import net.spy.memcached.ops.OperationType;
 
 /**
  * Operation to store collection data in a memcached server.
@@ -95,7 +94,6 @@ public final class CollectionInsertOperationImpl extends OperationImpl
     } else if (this.collectionInsert instanceof BTreeUpsert) {
       setAPIType(APIType.BOP_UPSERT);
     }
-    setOperationType(OperationType.WRITE);
   }
 
   @Override

--- a/src/main/java/net/spy/memcached/protocol/ascii/CollectionMutateOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/CollectionMutateOperationImpl.java
@@ -33,7 +33,6 @@ import net.spy.memcached.ops.Mutator;
 import net.spy.memcached.ops.OperationCallback;
 import net.spy.memcached.ops.OperationState;
 import net.spy.memcached.ops.OperationStatus;
-import net.spy.memcached.ops.OperationType;
 
 /**
  * Operation to incr/decr item value from collection in a memcached server.
@@ -75,7 +74,6 @@ public final class CollectionMutateOperationImpl extends OperationImpl implement
         setAPIType(APIType.BOP_DECR);
       }
     }
-    setOperationType(OperationType.WRITE);
   }
 
   public void handleLine(String line) {

--- a/src/main/java/net/spy/memcached/protocol/ascii/CollectionPipedExistOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/CollectionPipedExistOperationImpl.java
@@ -24,7 +24,6 @@ import net.spy.memcached.ops.APIType;
 import net.spy.memcached.ops.CollectionPipedExistOperation;
 import net.spy.memcached.ops.OperationCallback;
 import net.spy.memcached.ops.OperationStatus;
-import net.spy.memcached.ops.OperationType;
 
 public final class CollectionPipedExistOperationImpl extends PipeOperationImpl implements
         CollectionPipedExistOperation {
@@ -33,7 +32,6 @@ public final class CollectionPipedExistOperationImpl extends PipeOperationImpl i
                                            SetPipedExist<?> collectionExist, OperationCallback cb) {
     super(Collections.singletonList(key), collectionExist, cb);
     setAPIType(APIType.SOP_EXIST);
-    setOperationType(OperationType.READ);
   }
 
   @Override

--- a/src/main/java/net/spy/memcached/protocol/ascii/CollectionPipedInsertOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/CollectionPipedInsertOperationImpl.java
@@ -24,7 +24,6 @@ import net.spy.memcached.ops.APIType;
 import net.spy.memcached.ops.CollectionPipedInsertOperation;
 import net.spy.memcached.ops.OperationCallback;
 import net.spy.memcached.ops.OperationStatus;
-import net.spy.memcached.ops.OperationType;
 
 /**
  * Operation to store collection data in a memcached server.
@@ -46,7 +45,6 @@ public final class CollectionPipedInsertOperationImpl extends PipeOperationImpl
     } else if (insert instanceof CollectionPipedInsert.ByteArraysBTreePipedInsert) {
       setAPIType(APIType.BOP_INSERT);
     }
-    setOperationType(OperationType.WRITE);
   }
 
   @Override

--- a/src/main/java/net/spy/memcached/protocol/ascii/CollectionPipedUpdateOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/CollectionPipedUpdateOperationImpl.java
@@ -26,7 +26,6 @@ import net.spy.memcached.ops.APIType;
 import net.spy.memcached.ops.CollectionPipedUpdateOperation;
 import net.spy.memcached.ops.OperationCallback;
 import net.spy.memcached.ops.OperationStatus;
-import net.spy.memcached.ops.OperationType;
 
 /**
  * Operation to update collection data in a memcached server.
@@ -42,7 +41,6 @@ public final class CollectionPipedUpdateOperationImpl extends PipeOperationImpl 
     } else if (update instanceof MapPipedUpdate) {
       setAPIType(APIType.MOP_UPDATE);
     }
-    setOperationType(OperationType.WRITE);
   }
 
   @Override

--- a/src/main/java/net/spy/memcached/protocol/ascii/CollectionUpdateOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/CollectionUpdateOperationImpl.java
@@ -34,7 +34,6 @@ import net.spy.memcached.ops.CollectionUpdateOperation;
 import net.spy.memcached.ops.OperationCallback;
 import net.spy.memcached.ops.OperationState;
 import net.spy.memcached.ops.OperationStatus;
-import net.spy.memcached.ops.OperationType;
 
 /**
  * Operation to update collection data in a memcached server.
@@ -80,7 +79,6 @@ public final class CollectionUpdateOperationImpl extends OperationImpl implement
     } else if (this.collectionUpdate instanceof MapUpdate) {
       setAPIType(APIType.MOP_UPDATE);
     }
-    setOperationType(OperationType.WRITE);
   }
 
   @Override

--- a/src/main/java/net/spy/memcached/protocol/ascii/DeleteOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/DeleteOperationImpl.java
@@ -30,7 +30,6 @@ import net.spy.memcached.ops.DeleteOperation;
 import net.spy.memcached.ops.OperationCallback;
 import net.spy.memcached.ops.OperationState;
 import net.spy.memcached.ops.OperationStatus;
-import net.spy.memcached.ops.OperationType;
 import net.spy.memcached.ops.StatusCode;
 
 /**
@@ -52,7 +51,6 @@ final class DeleteOperationImpl extends OperationImpl
     super(cb);
     key = k;
     setAPIType(APIType.DELETE);
-    setOperationType(OperationType.WRITE);
   }
 
   @Override

--- a/src/main/java/net/spy/memcached/protocol/ascii/FlushByPrefixOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/FlushByPrefixOperationImpl.java
@@ -25,7 +25,6 @@ import net.spy.memcached.ops.FlushOperation;
 import net.spy.memcached.ops.OperationCallback;
 import net.spy.memcached.ops.OperationState;
 import net.spy.memcached.ops.OperationStatus;
-import net.spy.memcached.ops.OperationType;
 import net.spy.memcached.ops.StatusCode;
 
 /**
@@ -50,7 +49,6 @@ final class FlushByPrefixOperationImpl extends OperationImpl implements
     this.delay = delay;
     this.noreply = noreply;
     setAPIType(APIType.FLUSH);
-    setOperationType(OperationType.WRITE);
   }
 
   @Override

--- a/src/main/java/net/spy/memcached/protocol/ascii/FlushOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/FlushOperationImpl.java
@@ -27,7 +27,6 @@ import net.spy.memcached.ops.FlushOperation;
 import net.spy.memcached.ops.OperationCallback;
 import net.spy.memcached.ops.OperationState;
 import net.spy.memcached.ops.OperationStatus;
-import net.spy.memcached.ops.OperationType;
 import net.spy.memcached.ops.StatusCode;
 
 /**
@@ -47,7 +46,6 @@ final class FlushOperationImpl extends OperationImpl
     super(cb);
     delay = d;
     setAPIType(APIType.FLUSH);
-    setOperationType(OperationType.WRITE);
   }
 
   @Override

--- a/src/main/java/net/spy/memcached/protocol/ascii/GetAttrOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/GetAttrOperationImpl.java
@@ -29,7 +29,6 @@ import net.spy.memcached.ops.CollectionOperationStatus;
 import net.spy.memcached.ops.GetAttrOperation;
 import net.spy.memcached.ops.OperationState;
 import net.spy.memcached.ops.OperationStatus;
-import net.spy.memcached.ops.OperationType;
 
 /**
  * Implementation of the gets operation.
@@ -57,7 +56,6 @@ class GetAttrOperationImpl extends OperationImpl implements GetAttrOperation {
     this.key = key;
     this.cb = cb;
     setAPIType(APIType.GETATTR);
-    setOperationType(OperationType.READ);
   }
 
   @Override

--- a/src/main/java/net/spy/memcached/protocol/ascii/MutatorOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/MutatorOperationImpl.java
@@ -31,7 +31,6 @@ import net.spy.memcached.ops.MutatorOperation;
 import net.spy.memcached.ops.OperationCallback;
 import net.spy.memcached.ops.OperationState;
 import net.spy.memcached.ops.OperationStatus;
-import net.spy.memcached.ops.OperationType;
 import net.spy.memcached.ops.StatusCode;
 
 /**
@@ -66,7 +65,6 @@ final class MutatorOperationImpl extends OperationImpl
     } else if (m == Mutator.decr) {
       setAPIType(APIType.DECR);
     }
-    setOperationType(OperationType.WRITE);
   }
 
   @Override

--- a/src/main/java/net/spy/memcached/protocol/ascii/SetAttrOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/SetAttrOperationImpl.java
@@ -31,7 +31,6 @@ import net.spy.memcached.ops.CollectionOperationStatus;
 import net.spy.memcached.ops.OperationCallback;
 import net.spy.memcached.ops.OperationState;
 import net.spy.memcached.ops.OperationStatus;
-import net.spy.memcached.ops.OperationType;
 import net.spy.memcached.ops.SetAttrOperation;
 
 class SetAttrOperationImpl extends OperationImpl
@@ -64,7 +63,6 @@ class SetAttrOperationImpl extends OperationImpl
     // If no attributes given, set to default values
     this.attrs = (attrs == null) ? new CollectionAttributes() : attrs;
     setAPIType(APIType.SETATTR);
-    setOperationType(OperationType.WRITE);
   }
 
   @Override

--- a/src/main/java/net/spy/memcached/protocol/ascii/StatsOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/StatsOperationImpl.java
@@ -24,7 +24,6 @@ import java.nio.ByteBuffer;
 import net.spy.memcached.ops.APIType;
 import net.spy.memcached.ops.OperationState;
 import net.spy.memcached.ops.OperationStatus;
-import net.spy.memcached.ops.OperationType;
 import net.spy.memcached.ops.StatsOperation;
 import net.spy.memcached.ops.StatusCode;
 
@@ -51,7 +50,6 @@ final class StatsOperationImpl extends OperationImpl
       msg = ("stats " + arg + "\r\n").getBytes();
     }
     setAPIType(APIType.STATS);
-    setOperationType(OperationType.ETC);
   }
 
   @Override

--- a/src/main/java/net/spy/memcached/protocol/ascii/VersionOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/VersionOperationImpl.java
@@ -26,7 +26,6 @@ import net.spy.memcached.ops.NoopOperation;
 import net.spy.memcached.ops.OperationCallback;
 import net.spy.memcached.ops.OperationState;
 import net.spy.memcached.ops.OperationStatus;
-import net.spy.memcached.ops.OperationType;
 import net.spy.memcached.ops.StatusCode;
 import net.spy.memcached.ops.VersionOperation;
 
@@ -41,7 +40,6 @@ final class VersionOperationImpl extends OperationImpl
   public VersionOperationImpl(OperationCallback c) {
     super(c);
     setAPIType(APIType.VERSION);
-    setOperationType(OperationType.ETC);
   }
 
   @Override


### PR DESCRIPTION
### 🔗 Related Issue

https://github.com/jam2in/arcus-works/issues/696

### ⌨️ What I did

중복되는 opType 필드를 Operation 인스턴스에서 제거한다.