### PR TITLE
FIX: Invalid opType in XopGet operation instance.

### DIFF
--- a/src/main/java/net/spy/memcached/MemcachedConnection.java
+++ b/src/main/java/net/spy/memcached/MemcachedConnection.java
@@ -1124,7 +1124,7 @@ public final class MemcachedConnection extends SpyObject {
   }
 
   private boolean redirectSingleKeyOperation(String key, Operation op) {
-    return redirectSingleKeyOperation(findNodeByKey(key, op.getAPIType()), op);
+    return redirectSingleKeyOperation(findNodeByKey(key, op), op);
   }
 
   private boolean redirectSingleKeyOperation(MemcachedNode node, Operation op) {
@@ -1146,7 +1146,7 @@ public final class MemcachedConnection extends SpyObject {
       Operation op) {
 
     Map<MemcachedNode, List<String>> keysByNode =
-            redirectHandler.groupRedirectKeys(this, op.getAPIType());
+            redirectHandler.groupRedirectKeys(this, op);
     return redirectMultiKeyOperation(keysByNode, op);
   }
 
@@ -1289,7 +1289,7 @@ public final class MemcachedConnection extends SpyObject {
           String key = keys.toArray()[0].toString();
           success = success || redirectSingleKeyOperation(key, op);
         } else {
-          Map<MemcachedNode, List<String>> nodeByKeys = groupKeysByNode(keys, op.getAPIType());
+          Map<MemcachedNode, List<String>> nodeByKeys = groupKeysByNode(keys, op);
           success = success || redirectMultiKeyOperation(nodeByKeys, op);
         }
       } else {
@@ -1303,10 +1303,10 @@ public final class MemcachedConnection extends SpyObject {
   }
 
   public Map<MemcachedNode, List<String>> groupKeysByNode(Collection<String> keys,
-                                                          APIType apiType) {
+                                                          Operation op) {
     Map<MemcachedNode, List<String>> keysByNode = new HashMap<>();
     for (String key : keys) {
-      MemcachedNode node = findNodeByKey(key, apiType);
+      MemcachedNode node = findNodeByKey(key, op);
       if (node == null) {
         return null;
       }
@@ -1404,6 +1404,22 @@ public final class MemcachedConnection extends SpyObject {
     }
     return pick;
   }
+
+  private ReplicaPick getReplicaPick(Operation op) {
+    ReplicaPick pick = ReplicaPick.MASTER;
+    if (op.isReadOperation()) {
+      ReadPriority readPriority = connFactory.getAPIReadPriority().get(op.getAPIType());
+      if (readPriority == null) {
+        readPriority = connFactory.getReadPriority();
+      }
+      if (readPriority == ReadPriority.SLAVE) {
+        pick = ReplicaPick.SLAVE;
+      } else if (readPriority == ReadPriority.RR) {
+        pick = ReplicaPick.RR;
+      }
+    }
+    return pick;
+  }
   /* ENABLE_REPLICATION end */
 
   /**
@@ -1416,6 +1432,15 @@ public final class MemcachedConnection extends SpyObject {
     /* ENABLE_REPLICATION if */
     if (this.arcusReplEnabled) {
       return ((ArcusReplKetamaNodeLocator) locator).getPrimary(key, getReplicaPick(apiType));
+    }
+    /* ENABLE_REPLICATION end */
+    return locator.getPrimary(key);
+  }
+
+  public MemcachedNode getPrimaryNode(final String key, final Operation op) {
+    /* ENABLE_REPLICATION if */
+    if (this.arcusReplEnabled) {
+      return ((ArcusReplKetamaNodeLocator) locator).getPrimary(key, getReplicaPick(op));
     }
     /* ENABLE_REPLICATION end */
     return locator.getPrimary(key);
@@ -1436,6 +1461,14 @@ public final class MemcachedConnection extends SpyObject {
     return locator.getSequence(key);
   }
 
+  public Iterator<MemcachedNode> getNodeSequence(final String key, final Operation op) {
+    /* ENABLE_REPLICATION if */
+    if (this.arcusReplEnabled) {
+      return ((ArcusReplKetamaNodeLocator) locator).getSequence(key, getReplicaPick(op));
+    }
+    /* ENABLE_REPLICATION end */
+    return locator.getSequence(key);
+  }
 
   /**
    * Add an operation to the given connection.
@@ -1444,7 +1477,7 @@ public final class MemcachedConnection extends SpyObject {
    * @param o   the operation
    */
   public void addOperation(final String key, final Operation o) {
-    addOperation(findNodeByKey(key, o.getAPIType()), o);
+    addOperation(findNodeByKey(key, o), o);
   }
 
   public void insertOperation(final MemcachedNode node, final Operation o) {
@@ -1592,8 +1625,9 @@ public final class MemcachedConnection extends SpyObject {
     }
   }
 
+
   /**
-   * find memcachednode for key
+   * find memcachednode for key before op instance created.
    *
    * @param key
    * @param apiType
@@ -1609,6 +1643,34 @@ public final class MemcachedConnection extends SpyObject {
     }
     if (failureMode == FailureMode.Redistribute) {
       Iterator<MemcachedNode> iter = getNodeSequence(key, apiType);
+      while (iter.hasNext()) {
+        MemcachedNode n = iter.next();
+        if (n != null && n.isActive()) {
+          node = n;
+          break;
+        }
+      }
+    }
+    return node;
+  }
+
+  /**
+   * find memcachednode for key
+   *
+   * @param key
+   * @param op
+   * @return a memcached node
+   */
+  public MemcachedNode findNodeByKey(String key, Operation op) {
+    MemcachedNode node = getPrimaryNode(key, op);
+    if (node == null) {
+      return null;
+    }
+    if (node.isActive() || node.isFirstConnecting()) {
+      return node;
+    }
+    if (failureMode == FailureMode.Redistribute) {
+      Iterator<MemcachedNode> iter = getNodeSequence(key, op);
       while (iter.hasNext()) {
         MemcachedNode n = iter.next();
         if (n != null && n.isActive()) {

--- a/src/main/java/net/spy/memcached/RedirectHandler.java
+++ b/src/main/java/net/spy/memcached/RedirectHandler.java
@@ -22,7 +22,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import net.spy.memcached.ops.APIType;
+import net.spy.memcached.ops.Operation;
 
 public abstract class RedirectHandler {
 
@@ -93,12 +93,12 @@ public abstract class RedirectHandler {
     }
 
     public Map<MemcachedNode, List<String>> groupRedirectKeys(
-            MemcachedConnection conn, APIType apiType) {
+            MemcachedConnection conn, Operation op) {
 
       Map<MemcachedNode, List<String>> keysByNode = null;
       List<String> keysWithoutOwner = keysByOwner.remove(UNKNOWN_OWNER);
       if (keysWithoutOwner != null) {
-        keysByNode = conn.groupKeysByNode(keysWithoutOwner, apiType);
+        keysByNode = conn.groupKeysByNode(keysWithoutOwner, op);
         if (keysByNode == null) {
           return null;
         }

--- a/src/main/java/net/spy/memcached/ops/APIType.java
+++ b/src/main/java/net/spy/memcached/ops/APIType.java
@@ -72,7 +72,7 @@ public enum APIType {
   // undefined API
   UNDEFINED(OperationType.UNDEFINED);
 
-  private OperationType apiOpType;
+  private final OperationType apiOpType;
 
   APIType(OperationType t) {
     this.apiOpType = t;
@@ -82,7 +82,4 @@ public enum APIType {
     return this.apiOpType;
   }
 
-  public void setAPIOpType(OperationType t) {
-    this.apiOpType = t;
-  }
 }

--- a/src/main/java/net/spy/memcached/protocol/ascii/CollectionGetOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/CollectionGetOperationImpl.java
@@ -101,9 +101,10 @@ public final class CollectionGetOperationImpl extends OperationImpl
       setAPIType(APIType.BOP_GET);
     }
     if (collectionGet.isDelete()) {
-      getAPIType().setAPIOpType(OperationType.WRITE);
+      setOperationType(OperationType.WRITE);
+    } else {
+      setOperationType(OperationType.READ);
     }
-    setOperationType(getAPIType().getAPIOpType());
   }
 
   public void handleLine(String line) {


### PR DESCRIPTION
### 🔗 Related Issue

enum 타입의 필드가 불변으로 바뀌지 않아서
부정확한 read / write OperatoinType이 발생하는 문제 
(아래 코멘트 참고)
https://github.com/naver/arcus-java-client/pull/879#issuecomment-2677460078
### ⌨️ What I did

다양한 구현들을 생각해보았는데, 앞서 언급된 의견들 전부 고려해서
현재 PR이 제일 깔끔하다고 생각들었습니다.

XopGet의 경우 기본적으로는 read opType을 가지고,
op 생성자 내에서 delete 옵션이 true인 경우
setter를 통해 op 타입을 write로 변경합니다.

기존 findNodeByKey의 경우는 APIType을 인자로 받고 해당 인자내의 OpType을 사용했었는데요,
이 대신 Op 자체를 넘겨서 setter를 통해 변경된 Op를 사용하도록 변경했습니다.

groupingKeys와 같은 Op 인스턴스가 생기기전에 노드를 찾아야 하는 경우에만
기존의 APIType을 인자로 받는 findNodeByKey를 호출하도록 변경했습니다.
