### PR TITLE
INTERNAL: Remove duplicated operation method overrides

### DIFF
--- a/src/main/java/net/spy/memcached/protocol/BaseOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/BaseOperationImpl.java
@@ -291,7 +291,15 @@ public abstract class BaseOperationImpl extends SpyObject implements Operation {
     this.apiType = type;
   }
 
-  public abstract boolean isBulkOperation();
+  public boolean isBulkOperation() {
+    return false;
+  }
 
-  public abstract boolean isPipeOperation();
+  public boolean isPipeOperation() {
+    return false;
+  }
+
+  public boolean isIdempotentOperation() {
+    return true;
+  }
 }

--- a/src/main/java/net/spy/memcached/protocol/ascii/BTreeFindPositionOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/BTreeFindPositionOperationImpl.java
@@ -129,19 +129,4 @@ public final class BTreeFindPositionOperationImpl extends OperationImpl implemen
     return Collections.singleton(key);
   }
 
-  @Override
-  public boolean isBulkOperation() {
-    return false;
-  }
-
-  @Override
-  public boolean isPipeOperation() {
-    return false;
-  }
-
-  @Override
-  public boolean isIdempotentOperation() {
-    return true;
-  }
-
 }

--- a/src/main/java/net/spy/memcached/protocol/ascii/BTreeFindPositionWithGetOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/BTreeFindPositionWithGetOperationImpl.java
@@ -259,19 +259,4 @@ public final class BTreeFindPositionWithGetOperationImpl extends OperationImpl i
     return Collections.singleton(key);
   }
 
-  @Override
-  public boolean isBulkOperation() {
-    return false;
-  }
-
-  @Override
-  public boolean isPipeOperation() {
-    return false;
-  }
-
-  @Override
-  public boolean isIdempotentOperation() {
-    return true;
-  }
-
 }

--- a/src/main/java/net/spy/memcached/protocol/ascii/BTreeGetBulkOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/BTreeGetBulkOperationImpl.java
@@ -269,14 +269,4 @@ public final class BTreeGetBulkOperationImpl extends OperationImpl implements
     return true;
   }
 
-  @Override
-  public boolean isPipeOperation() {
-    return false;
-  }
-
-  @Override
-  public boolean isIdempotentOperation() {
-    return true;
-  }
-
 }

--- a/src/main/java/net/spy/memcached/protocol/ascii/BTreeGetByPositionOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/BTreeGetByPositionOperationImpl.java
@@ -262,19 +262,4 @@ public final class BTreeGetByPositionOperationImpl extends OperationImpl impleme
     return Collections.singleton(key);
   }
 
-  @Override
-  public boolean isBulkOperation() {
-    return false;
-  }
-
-  @Override
-  public boolean isPipeOperation() {
-    return false;
-  }
-
-  @Override
-  public boolean isIdempotentOperation() {
-    return true;
-  }
-
 }

--- a/src/main/java/net/spy/memcached/protocol/ascii/BTreeInsertAndGetOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/BTreeInsertAndGetOperationImpl.java
@@ -293,19 +293,4 @@ public final class BTreeInsertAndGetOperationImpl extends OperationImpl implemen
     return Collections.singleton(key);
   }
 
-  @Override
-  public boolean isBulkOperation() {
-    return false;
-  }
-
-  @Override
-  public boolean isPipeOperation() {
-    return false;
-  }
-
-  @Override
-  public boolean isIdempotentOperation() {
-    return true;
-  }
-
 }

--- a/src/main/java/net/spy/memcached/protocol/ascii/BTreeSortMergeGetOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/BTreeSortMergeGetOperationImpl.java
@@ -464,14 +464,4 @@ public final class BTreeSortMergeGetOperationImpl extends OperationImpl implemen
     return true;
   }
 
-  @Override
-  public boolean isPipeOperation() {
-    return false;
-  }
-
-  @Override
-  public boolean isIdempotentOperation() {
-    return true;
-  }
-
 }

--- a/src/main/java/net/spy/memcached/protocol/ascii/BTreeSortMergeGetOperationOldImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/BTreeSortMergeGetOperationOldImpl.java
@@ -317,14 +317,4 @@ public final class BTreeSortMergeGetOperationOldImpl extends OperationImpl imple
     return true;
   }
 
-  @Override
-  public boolean isPipeOperation() {
-    return false;
-  }
-
-  @Override
-  public boolean isIdempotentOperation() {
-    return true;
-  }
-
 }

--- a/src/main/java/net/spy/memcached/protocol/ascii/BaseGetOpImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/BaseGetOpImpl.java
@@ -237,14 +237,4 @@ abstract class BaseGetOpImpl extends OperationImpl {
     return keys.size() > 1;
   }
 
-  @Override
-  public boolean isPipeOperation() {
-    return false;
-  }
-
-  @Override
-  public boolean isIdempotentOperation() {
-    return true;
-  }
-
 }

--- a/src/main/java/net/spy/memcached/protocol/ascii/BaseStoreOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/BaseStoreOperationImpl.java
@@ -121,14 +121,4 @@ abstract class BaseStoreOperationImpl extends OperationImpl {
   public byte[] getData() {
     return data;
   }
-
-  @Override
-  public boolean isBulkOperation() {
-    return false;
-  }
-
-  @Override
-  public boolean isPipeOperation() {
-    return false;
-  }
 }

--- a/src/main/java/net/spy/memcached/protocol/ascii/CASOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/CASOperationImpl.java
@@ -134,19 +134,4 @@ class CASOperationImpl extends OperationImpl implements CASOperation {
     return StoreType.set;
   }
 
-  @Override
-  public boolean isBulkOperation() {
-    return false;
-  }
-
-  @Override
-  public boolean isPipeOperation() {
-    return false;
-  }
-
-  @Override
-  public boolean isIdempotentOperation() {
-    return true;
-  }
-
 }

--- a/src/main/java/net/spy/memcached/protocol/ascii/CollectionCountOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/CollectionCountOperationImpl.java
@@ -122,19 +122,4 @@ public final class CollectionCountOperationImpl extends OperationImpl implements
     return Collections.singleton(key);
   }
 
-  @Override
-  public boolean isBulkOperation() {
-    return false;
-  }
-
-  @Override
-  public boolean isPipeOperation() {
-    return false;
-  }
-
-  @Override
-  public boolean isIdempotentOperation() {
-    return true;
-  }
-
 }

--- a/src/main/java/net/spy/memcached/protocol/ascii/CollectionCreateOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/CollectionCreateOperationImpl.java
@@ -125,19 +125,4 @@ public final class CollectionCreateOperationImpl extends OperationImpl
     return collectionCreate;
   }
 
-  @Override
-  public boolean isBulkOperation() {
-    return false;
-  }
-
-  @Override
-  public boolean isPipeOperation() {
-    return false;
-  }
-
-  @Override
-  public boolean isIdempotentOperation() {
-    return true;
-  }
-
 }

--- a/src/main/java/net/spy/memcached/protocol/ascii/CollectionDeleteOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/CollectionDeleteOperationImpl.java
@@ -153,16 +153,6 @@ public final class CollectionDeleteOperationImpl extends OperationImpl
   }
 
   @Override
-  public boolean isBulkOperation() {
-    return false;
-  }
-
-  @Override
-  public boolean isPipeOperation() {
-    return false;
-  }
-
-  @Override
   public boolean isIdempotentOperation() {
     return !(collectionDelete instanceof ListDelete);
   }

--- a/src/main/java/net/spy/memcached/protocol/ascii/CollectionExistOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/CollectionExistOperationImpl.java
@@ -131,19 +131,4 @@ public final class CollectionExistOperationImpl extends OperationImpl
     return collectionExist;
   }
 
-  @Override
-  public boolean isBulkOperation() {
-    return false;
-  }
-
-  @Override
-  public boolean isPipeOperation() {
-    return false;
-  }
-
-  @Override
-  public boolean isIdempotentOperation() {
-    return true;
-  }
-
 }

--- a/src/main/java/net/spy/memcached/protocol/ascii/CollectionGetOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/CollectionGetOperationImpl.java
@@ -302,16 +302,6 @@ public final class CollectionGetOperationImpl extends OperationImpl
   }
 
   @Override
-  public boolean isBulkOperation() {
-    return false;
-  }
-
-  @Override
-  public boolean isPipeOperation() {
-    return false;
-  }
-
-  @Override
   public boolean isIdempotentOperation() {
     return !collectionGet.isDelete() && !collectionGet.isDropIfEmpty();
   }

--- a/src/main/java/net/spy/memcached/protocol/ascii/CollectionInsertOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/CollectionInsertOperationImpl.java
@@ -167,16 +167,6 @@ public final class CollectionInsertOperationImpl extends OperationImpl
   }
 
   @Override
-  public boolean isBulkOperation() {
-    return false;
-  }
-
-  @Override
-  public boolean isPipeOperation() {
-    return false;
-  }
-
-  @Override
   public boolean isIdempotentOperation() {
     return !(collectionInsert instanceof ListInsert);
   }

--- a/src/main/java/net/spy/memcached/protocol/ascii/CollectionMutateOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/CollectionMutateOperationImpl.java
@@ -142,16 +142,6 @@ public final class CollectionMutateOperationImpl extends OperationImpl implement
   }
 
   @Override
-  public boolean isBulkOperation() {
-    return false;
-  }
-
-  @Override
-  public boolean isPipeOperation() {
-    return false;
-  }
-
-  @Override
   public boolean isIdempotentOperation() {
     return false;
   }

--- a/src/main/java/net/spy/memcached/protocol/ascii/CollectionUpdateOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/CollectionUpdateOperationImpl.java
@@ -167,19 +167,4 @@ public final class CollectionUpdateOperationImpl extends OperationImpl implement
     return data;
   }
 
-  @Override
-  public boolean isBulkOperation() {
-    return false;
-  }
-
-  @Override
-  public boolean isPipeOperation() {
-    return false;
-  }
-
-  @Override
-  public boolean isIdempotentOperation() {
-    return true;
-  }
-
 }

--- a/src/main/java/net/spy/memcached/protocol/ascii/DeleteOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/DeleteOperationImpl.java
@@ -88,19 +88,4 @@ final class DeleteOperationImpl extends OperationImpl
     return Collections.singleton(key);
   }
 
-  @Override
-  public boolean isBulkOperation() {
-    return false;
-  }
-
-  @Override
-  public boolean isPipeOperation() {
-    return false;
-  }
-
-  @Override
-  public boolean isIdempotentOperation() {
-    return true;
-  }
-
 }

--- a/src/main/java/net/spy/memcached/protocol/ascii/FlushByPrefixOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/FlushByPrefixOperationImpl.java
@@ -86,16 +86,6 @@ final class FlushByPrefixOperationImpl extends OperationImpl implements
   }
 
   @Override
-  public boolean isBulkOperation() {
-    return false;
-  }
-
-  @Override
-  public boolean isPipeOperation() {
-    return false;
-  }
-
-  @Override
   public boolean isIdempotentOperation() {
     return false;
   }

--- a/src/main/java/net/spy/memcached/protocol/ascii/FlushOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/FlushOperationImpl.java
@@ -77,16 +77,6 @@ final class FlushOperationImpl extends OperationImpl
   }
 
   @Override
-  public boolean isBulkOperation() {
-    return false;
-  }
-
-  @Override
-  public boolean isPipeOperation() {
-    return false;
-  }
-
-  @Override
   public boolean isIdempotentOperation() {
     return false;
   }

--- a/src/main/java/net/spy/memcached/protocol/ascii/GetAttrOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/GetAttrOperationImpl.java
@@ -117,19 +117,4 @@ class GetAttrOperationImpl extends OperationImpl implements GetAttrOperation {
     return Collections.singleton(key);
   }
 
-  @Override
-  public boolean isBulkOperation() {
-    return false;
-  }
-
-  @Override
-  public boolean isPipeOperation() {
-    return false;
-  }
-
-  @Override
-  public boolean isIdempotentOperation() {
-    return true;
-  }
-
 }

--- a/src/main/java/net/spy/memcached/protocol/ascii/MutatorOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/MutatorOperationImpl.java
@@ -138,16 +138,6 @@ final class MutatorOperationImpl extends OperationImpl
   }
 
   @Override
-  public boolean isBulkOperation() {
-    return false;
-  }
-
-  @Override
-  public boolean isPipeOperation() {
-    return false;
-  }
-
-  @Override
   public boolean isIdempotentOperation() {
     return false;
   }

--- a/src/main/java/net/spy/memcached/protocol/ascii/PipeOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/PipeOperationImpl.java
@@ -216,11 +216,6 @@ abstract class PipeOperationImpl extends OperationImpl {
   }
 
   @Override
-  public boolean isBulkOperation() {
-    return false;
-  }
-
-  @Override
   public final boolean isPipeOperation() {
     return true;
   }

--- a/src/main/java/net/spy/memcached/protocol/ascii/SetAttrOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/SetAttrOperationImpl.java
@@ -119,19 +119,4 @@ class SetAttrOperationImpl extends OperationImpl
     return attrs;
   }
 
-  @Override
-  public boolean isBulkOperation() {
-    return false;
-  }
-
-  @Override
-  public boolean isPipeOperation() {
-    return false;
-  }
-
-  @Override
-  public boolean isIdempotentOperation() {
-    return true;
-  }
-
 }

--- a/src/main/java/net/spy/memcached/protocol/ascii/StatsOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/StatsOperationImpl.java
@@ -76,19 +76,4 @@ final class StatsOperationImpl extends OperationImpl
     cb.receivedStatus(CANCELLED);
   }
 
-  @Override
-  public boolean isBulkOperation() {
-    return false;
-  }
-
-  @Override
-  public boolean isPipeOperation() {
-    return false;
-  }
-
-  @Override
-  public boolean isIdempotentOperation() {
-    return true;
-  }
-
 }

--- a/src/main/java/net/spy/memcached/protocol/ascii/StoreOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/StoreOperationImpl.java
@@ -49,9 +49,4 @@ final class StoreOperationImpl extends BaseStoreOperationImpl
     return storeType;
   }
 
-  @Override
-  public boolean isIdempotentOperation() {
-    return true;
-  }
-
 }

--- a/src/main/java/net/spy/memcached/protocol/ascii/VersionOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/VersionOperationImpl.java
@@ -62,19 +62,4 @@ final class VersionOperationImpl extends OperationImpl
     setBuffer(ByteBuffer.wrap(REQUEST));
   }
 
-  @Override
-  public boolean isBulkOperation() {
-    return false;
-  }
-
-  @Override
-  public boolean isPipeOperation() {
-    return false;
-  }
-
-  @Override
-  public boolean isIdempotentOperation() {
-    return true;
-  }
-
 }

--- a/src/main/java/net/spy/memcached/protocol/binary/ConcatenationOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/binary/ConcatenationOperationImpl.java
@@ -99,16 +99,6 @@ class ConcatenationOperationImpl extends OperationImpl
   }
 
   @Override
-  public boolean isBulkOperation() {
-    return false;
-  }
-
-  @Override
-  public boolean isPipeOperation() {
-    return false;
-  }
-
-  @Override
   public boolean isIdempotentOperation() {
     return false;
   }

--- a/src/main/java/net/spy/memcached/protocol/binary/DeleteOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/binary/DeleteOperationImpl.java
@@ -56,19 +56,4 @@ class DeleteOperationImpl extends OperationImpl implements
     return Collections.singleton(key);
   }
 
-  @Override
-  public boolean isBulkOperation() {
-    return false;
-  }
-
-  @Override
-  public boolean isPipeOperation() {
-    return false;
-  }
-
-  @Override
-  public boolean isIdempotentOperation() {
-    return true;
-  }
-
 }

--- a/src/main/java/net/spy/memcached/protocol/binary/FlushOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/binary/FlushOperationImpl.java
@@ -40,16 +40,6 @@ class FlushOperationImpl extends OperationImpl implements FlushOperation {
   }
 
   @Override
-  public boolean isBulkOperation() {
-    return false;
-  }
-
-  @Override
-  public boolean isPipeOperation() {
-    return false;
-  }
-
-  @Override
   public boolean isIdempotentOperation() {
     return false;
   }

--- a/src/main/java/net/spy/memcached/protocol/binary/GetOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/binary/GetOperationImpl.java
@@ -76,19 +76,4 @@ class GetOperationImpl extends OperationImpl
     return Collections.singleton(key);
   }
 
-  @Override
-  public boolean isBulkOperation() {
-    return false;
-  }
-
-  @Override
-  public boolean isPipeOperation() {
-    return false;
-  }
-
-  @Override
-  public boolean isIdempotentOperation() {
-    return true;
-  }
-
 }

--- a/src/main/java/net/spy/memcached/protocol/binary/MultiGetOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/binary/MultiGetOperationImpl.java
@@ -136,14 +136,4 @@ class MultiGetOperationImpl extends OperationImpl implements GetOperation {
     return true;
   }
 
-  @Override
-  public boolean isPipeOperation() {
-    return false;
-  }
-
-  @Override
-  public boolean isIdempotentOperation() {
-    return true;
-  }
-
 }

--- a/src/main/java/net/spy/memcached/protocol/binary/MutatorOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/binary/MutatorOperationImpl.java
@@ -96,16 +96,6 @@ class MutatorOperationImpl extends OperationImpl implements
   }
 
   @Override
-  public boolean isBulkOperation() {
-    return false;
-  }
-
-  @Override
-  public boolean isPipeOperation() {
-    return false;
-  }
-
-  @Override
   public boolean isIdempotentOperation() {
     return false;
   }

--- a/src/main/java/net/spy/memcached/protocol/binary/NoopOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/binary/NoopOperationImpl.java
@@ -36,19 +36,4 @@ class NoopOperationImpl extends OperationImpl implements NoopOperation {
     prepareBuffer("", 0, EMPTY_BYTES);
   }
 
-  @Override
-  public boolean isBulkOperation() {
-    return false;
-  }
-
-  @Override
-  public boolean isPipeOperation() {
-    return false;
-  }
-
-  @Override
-  public boolean isIdempotentOperation() {
-    return true;
-  }
-
 }

--- a/src/main/java/net/spy/memcached/protocol/binary/OptimizedSetImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/binary/OptimizedSetImpl.java
@@ -191,19 +191,4 @@ public final class OptimizedSetImpl extends OperationImpl {
 
   }
 
-  @Override
-  public boolean isBulkOperation() {
-    return false;
-  }
-
-  @Override
-  public boolean isPipeOperation() {
-    return false;
-  }
-
-  @Override
-  public boolean isIdempotentOperation() {
-    return true;
-  }
-
 }

--- a/src/main/java/net/spy/memcached/protocol/binary/SASLAuthOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/binary/SASLAuthOperationImpl.java
@@ -40,9 +40,4 @@ public class SASLAuthOperationImpl extends SASLBaseOperationImpl
 
   }
 
-  @Override
-  public boolean isIdempotentOperation() {
-    return false;
-  }
-
 }

--- a/src/main/java/net/spy/memcached/protocol/binary/SASLBaseOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/binary/SASLBaseOperationImpl.java
@@ -59,12 +59,7 @@ public abstract class SASLBaseOperationImpl extends OperationImpl {
   }
 
   @Override
-  public boolean isBulkOperation() {
-    return false;
-  }
-
-  @Override
-  public boolean isPipeOperation() {
+  public boolean isIdempotentOperation() {
     return false;
   }
 

--- a/src/main/java/net/spy/memcached/protocol/binary/SASLMechsOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/binary/SASLMechsOperationImpl.java
@@ -42,15 +42,6 @@ class SASLMechsOperationImpl extends OperationImpl implements
             new OperationStatus(true, new String(pl), StatusCode.SUCCESS));
   }
 
-  @Override
-  public boolean isBulkOperation() {
-    return false;
-  }
-
-  @Override
-  public boolean isPipeOperation() {
-    return false;
-  }
 
   @Override
   public boolean isIdempotentOperation() {

--- a/src/main/java/net/spy/memcached/protocol/binary/SASLStepOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/binary/SASLStepOperationImpl.java
@@ -37,9 +37,4 @@ public class SASLStepOperationImpl extends SASLBaseOperationImpl
     return sc.evaluateChallenge(challenge);
   }
 
-  @Override
-  public boolean isIdempotentOperation() {
-    return false;
-  }
-
 }

--- a/src/main/java/net/spy/memcached/protocol/binary/StatsOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/binary/StatsOperationImpl.java
@@ -55,19 +55,4 @@ public class StatsOperationImpl extends OperationImpl
     resetInput();
   }
 
-  @Override
-  public boolean isBulkOperation() {
-    return false;
-  }
-
-  @Override
-  public boolean isPipeOperation() {
-    return false;
-  }
-
-  @Override
-  public boolean isIdempotentOperation() {
-    return true;
-  }
-
 }

--- a/src/main/java/net/spy/memcached/protocol/binary/StoreOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/binary/StoreOperationImpl.java
@@ -123,19 +123,4 @@ class StoreOperationImpl extends OperationImpl
     return storeType;
   }
 
-  @Override
-  public boolean isBulkOperation() {
-    return false;
-  }
-
-  @Override
-  public boolean isPipeOperation() {
-    return false;
-  }
-
-  @Override
-  public boolean isIdempotentOperation() {
-    return true;
-  }
-
 }

--- a/src/main/java/net/spy/memcached/protocol/binary/VersionOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/binary/VersionOperationImpl.java
@@ -41,19 +41,4 @@ class VersionOperationImpl extends OperationImpl implements VersionOperation {
             new OperationStatus(true, new String(pl), StatusCode.SUCCESS));
   }
 
-  @Override
-  public boolean isBulkOperation() {
-    return false;
-  }
-
-  @Override
-  public boolean isPipeOperation() {
-    return false;
-  }
-
-  @Override
-  public boolean isIdempotentOperation() {
-    return true;
-  }
-
 }

--- a/src/test/java/net/spy/memcached/AsciiClientTest.java
+++ b/src/test/java/net/spy/memcached/AsciiClientTest.java
@@ -53,16 +53,6 @@ class AsciiClientTest extends ProtocolBaseCase {
       }
 
       @Override
-      public boolean isBulkOperation() {
-        return false;
-      }
-
-      @Override
-      public boolean isPipeOperation() {
-        return false;
-      }
-
-      @Override
       public boolean isIdempotentOperation() {
         return false;
       }

--- a/src/test/java/net/spy/memcached/internal/CheckedOperationTimeoutExceptionTest.java
+++ b/src/test/java/net/spy/memcached/internal/CheckedOperationTimeoutExceptionTest.java
@@ -108,16 +108,6 @@ class CheckedOperationTimeoutExceptionTest {
     }
 
     @Override
-    public boolean isBulkOperation() {
-      return false;
-    }
-
-    @Override
-    public boolean isPipeOperation() {
-      return false;
-    }
-
-    @Override
     public boolean isIdempotentOperation() {
       return false;
     }

--- a/src/test/java/net/spy/memcached/protocol/ascii/BaseOpTest.java
+++ b/src/test/java/net/spy/memcached/protocol/ascii/BaseOpTest.java
@@ -206,16 +206,6 @@ class BaseOpTest {
     }
 
     @Override
-    public boolean isBulkOperation() {
-      return false;
-    }
-
-    @Override
-    public boolean isPipeOperation() {
-      return false;
-    }
-
-    @Override
     public boolean isIdempotentOperation() {
       return false;
     }


### PR DESCRIPTION
### 🔗 Related Issue

<!-- Please link related issue. ex) https://github.com/naver/arcus-java-client/issues/{issue_number} -->
- https://github.com/jam2in/arcus-works/issues/697

### ⌨️ What I did

<!-- Please describe this PR and what you've been working on. -->
- `isIdempotentOperation()`, `isBulkOperation()`, `isPipeOperation()` 메서드의 구현체 대부분이 동일한 반환값을 가지므로 중복된 구현을 제거하고자 `BaseOperationImpl` 추상 클래스에 공통 구현으로 정리했습니다.
- 다수의 `OperationImpl` 구현체들에서 불필요한 메서드 오버라이드를 정리했습니다.