### PR TITLE
INTERNAL: make piped insert operations process synchronously

### DIFF
--- a/src/test/manual/net/spy/memcached/bulkoperation/BopInsertBulkMultipleTest.java
+++ b/src/test/manual/net/spy/memcached/bulkoperation/BopInsertBulkMultipleTest.java
@@ -23,6 +23,7 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
+import net.spy.memcached.ArcusClient;
 import net.spy.memcached.collection.BaseIntegrationTest;
 import net.spy.memcached.collection.CollectionAttributes;
 import net.spy.memcached.collection.Element;
@@ -122,7 +123,7 @@ class BopInsertBulkMultipleTest extends BaseIntegrationTest {
 
       Map<Integer, CollectionOperationStatus> map = future.get(2000L,
               TimeUnit.MILLISECONDS);
-      assertEquals(bkeySize, map.size());
+      assertEquals(ArcusClient.MAX_PIPED_ITEM_COUNT, map.size());
 
     } catch (Exception e) {
       e.printStackTrace();

--- a/src/test/manual/net/spy/memcached/bulkoperation/BopPipeUpdateTest.java
+++ b/src/test/manual/net/spy/memcached/bulkoperation/BopPipeUpdateTest.java
@@ -21,6 +21,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
+import net.spy.memcached.ArcusClient;
 import net.spy.memcached.collection.BaseIntegrationTest;
 import net.spy.memcached.collection.CollectionAttributes;
 import net.spy.memcached.collection.CollectionResponse;
@@ -233,13 +234,13 @@ class BopPipeUpdateTest extends BaseIntegrationTest {
 
       // System.out.println(System.currentTimeMillis() - start + "ms");
 
-      assertEquals(600, map2.size());
+      assertEquals(ArcusClient.MAX_PIPED_ITEM_COUNT, map2.size());
       assertEquals(CollectionResponse.NOT_FOUND_ELEMENT, map2.get(0)
               .getResponse());
 
       for (long i = 600; i < elementCount; i++) {
         assertEquals(
-                "updated" + i,
+                "value" + i,
                 mc.asyncBopGet(KEY, i, ElementFlagFilter.DO_NOT_FILTER,
                         false, false).get(1000L, TimeUnit.MILLISECONDS)
                         .get(i).getValue());
@@ -274,7 +275,7 @@ class BopPipeUpdateTest extends BaseIntegrationTest {
 
       // System.out.println(System.currentTimeMillis() - start + "ms");
 
-      assertEquals(elementCount, map2.size());
+      assertEquals(ArcusClient.MAX_PIPED_ITEM_COUNT, map2.size());
       assertEquals(CollectionResponse.NOT_FOUND, map2.get(0)
               .getResponse());
 

--- a/src/test/manual/net/spy/memcached/bulkoperation/LopInsertBulkMultipleValueTest.java
+++ b/src/test/manual/net/spy/memcached/bulkoperation/LopInsertBulkMultipleValueTest.java
@@ -23,8 +23,10 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
+import net.spy.memcached.ArcusClient;
 import net.spy.memcached.collection.BaseIntegrationTest;
 import net.spy.memcached.collection.CollectionAttributes;
+import net.spy.memcached.collection.CollectionResponse;
 import net.spy.memcached.ops.CollectionOperationStatus;
 
 import org.junit.jupiter.api.AfterEach;
@@ -32,6 +34,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
@@ -111,9 +114,7 @@ class LopInsertBulkMultipleValueTest extends BaseIntegrationTest {
   void testErrorCount() {
     int valueCount = 1200;
     Object[] valueList = new Object[valueCount];
-    for (int i = 0; i < valueList.length; i++) {
-      valueList[i] = "MyValue";
-    }
+    Arrays.fill(valueList, "MyValue");
 
     try {
       // SET
@@ -123,8 +124,10 @@ class LopInsertBulkMultipleValueTest extends BaseIntegrationTest {
 
       Map<Integer, CollectionOperationStatus> map = future.get(1000L,
               TimeUnit.MILLISECONDS);
-      assertEquals(valueCount, map.size());
-
+      assertEquals(ArcusClient.MAX_PIPED_ITEM_COUNT, map.size());
+      assertEquals(CollectionResponse.NOT_FOUND,
+              map.get(ArcusClient.MAX_PIPED_ITEM_COUNT - 1).getResponse());
+      assertNull(map.get(ArcusClient.MAX_PIPED_ITEM_COUNT));
     } catch (Exception e) {
       e.printStackTrace();
       fail();

--- a/src/test/manual/net/spy/memcached/bulkoperation/MopInsertBulkMultipleTest.java
+++ b/src/test/manual/net/spy/memcached/bulkoperation/MopInsertBulkMultipleTest.java
@@ -23,6 +23,7 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
+import net.spy.memcached.ArcusClient;
 import net.spy.memcached.collection.BaseIntegrationTest;
 import net.spy.memcached.collection.CollectionAttributes;
 import net.spy.memcached.ops.CollectionOperationStatus;
@@ -116,7 +117,7 @@ class MopInsertBulkMultipleTest extends BaseIntegrationTest {
 
       Map<Integer, CollectionOperationStatus> map = future.get(2000L,
               TimeUnit.MILLISECONDS);
-      assertEquals(elementSize, map.size());
+      assertEquals(ArcusClient.MAX_PIPED_ITEM_COUNT, map.size());
 
     } catch (Exception e) {
       e.printStackTrace();

--- a/src/test/manual/net/spy/memcached/bulkoperation/SopInsertBulkMultipleValueTest.java
+++ b/src/test/manual/net/spy/memcached/bulkoperation/SopInsertBulkMultipleValueTest.java
@@ -122,7 +122,7 @@ class SopInsertBulkMultipleValueTest extends BaseIntegrationTest {
 
       Map<Integer, CollectionOperationStatus> map = future.get(2000L,
               TimeUnit.MILLISECONDS);
-      assertEquals(valueCount, map.size());
+      assertEquals(ArcusClient.MAX_PIPED_ITEM_COUNT, map.size());
     } catch (Exception e) {
       e.printStackTrace();
       fail();


### PR DESCRIPTION
### 🔗 Related Issue

<!-- Please link related issue. ex) https://github.com/naver/arcus-java-client/issues/{issue_number} -->
- https://github.com/jam2in/arcus-works/issues/540

### ⌨️ What I did

<!-- Please describe this PR and what you've been working on. -->
- ArcusClient 클래스
  - `syncCollectionPipedInsert() / syncCollectionPipedUpdate()` 메서드
      - 현재 수행중인 op 한 개가 complete된 후에 다음 op를 MemcachedNode가 처리할 수 있도록 등록한다.
- PipedCollectionFuture
  - 초기에 생성된 모든 operation들을 List 필드에 담아두도록 한다.
  - 사용자로부터 cancel 요청 시, 기존에 cancel 되지 않은 상태라면 op를 순회하며 cancel을 시도한다.
  - 내부적으로 혹은 사용자로부터 온 cancel 요청이 성공하지 않았거나, cancel 요청이 아직 진행중인 경우 isCancelled()는 false를 반환한다.
  - 사용자의 cancel 요청(worker thread)과 내부 동작 중 cancel 요청(IO thread)이 동시에 발생할 수 있다.
    - BaseOperationImpl의 callbacked 변수로 인해 해당 값을 먼저 점유한 요청이 먼저 cancel을 시도하게 된다.
    - 이미 cancel된 후에는 다른 요청이 cancel을 할 수 없게 된다.
      - 사용자 요청이 실패했다면 Future에서 다음 op에 대해 cancel 요청을 보낼 것이다.
      - 내부 요청이 실패했다면 별다른 처리를 하지 않는다.