### PR TITLE
INTERNAL: Implement Operation interface in BaseOperationImpl

### DIFF
--- a/src/main/java/net/spy/memcached/protocol/BaseOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/BaseOperationImpl.java
@@ -28,6 +28,7 @@ import net.spy.memcached.RedirectHandler;
 import net.spy.memcached.compat.SpyObject;
 import net.spy.memcached.ops.APIType;
 import net.spy.memcached.ops.CancelledOperationStatus;
+import net.spy.memcached.ops.Operation;
 import net.spy.memcached.ops.OperationCallback;
 import net.spy.memcached.ops.OperationErrorType;
 import net.spy.memcached.ops.OperationException;
@@ -39,7 +40,7 @@ import net.spy.memcached.ops.StatusCode;
 /**
  * Base class for protocol-specific operation implementations.
  */
-public abstract class BaseOperationImpl extends SpyObject {
+public abstract class BaseOperationImpl extends SpyObject implements Operation {
 
   /**
    * Status object for canceled operations.

--- a/src/main/java/net/spy/memcached/protocol/ascii/OperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/OperationImpl.java
@@ -24,7 +24,6 @@ import java.io.UnsupportedEncodingException;
 import java.nio.ByteBuffer;
 
 import net.spy.memcached.KeyUtil;
-import net.spy.memcached.ops.Operation;
 import net.spy.memcached.ops.OperationCallback;
 import net.spy.memcached.ops.OperationErrorType;
 import net.spy.memcached.ops.OperationState;
@@ -35,7 +34,7 @@ import net.spy.memcached.protocol.BaseOperationImpl;
 /**
  * Operations on a memcached connection.
  */
-abstract class OperationImpl extends BaseOperationImpl implements Operation {
+abstract class OperationImpl extends BaseOperationImpl {
 
   protected static final byte[] CRLF = {'\r', '\n'};
   private static final String CHARSET = "UTF-8";

--- a/src/main/java/net/spy/memcached/protocol/binary/OptimizedSetImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/binary/OptimizedSetImpl.java
@@ -28,13 +28,12 @@ import java.util.Map;
 
 import net.spy.memcached.KeyUtil;
 import net.spy.memcached.ops.CASOperation;
-import net.spy.memcached.ops.Operation;
 import net.spy.memcached.ops.OperationCallback;
 import net.spy.memcached.ops.OperationState;
 import net.spy.memcached.ops.OperationStatus;
 import net.spy.memcached.ops.StoreType;
 
-public final class OptimizedSetImpl extends OperationImpl implements Operation {
+public final class OptimizedSetImpl extends OperationImpl {
 
   private static final OperationCallback NOOP_CALLBACK = new NoopCallback();
 

--- a/src/test/java/net/spy/memcached/internal/CheckedOperationTimeoutExceptionTest.java
+++ b/src/test/java/net/spy/memcached/internal/CheckedOperationTimeoutExceptionTest.java
@@ -95,7 +95,7 @@ class CheckedOperationTimeoutExceptionTest {
     return op;
   }
 
-  static class TestOperation extends BaseOperationImpl implements Operation {
+  static class TestOperation extends BaseOperationImpl {
 
     @Override
     public void initialize() {


### PR DESCRIPTION
### 🔗 Related Issue

<!-- Please link related issue. ex) https://github.com/naver/arcus-java-client/issues/{issue_number} -->
- https://github.com/naver/arcus-java-client/pull/885#discussion_r2002328855 
위 코멘트의 요구사항에 대한 PR 입니다.

### ⌨️ What I did

<!-- Please describe this PR and what you've been working on. -->
- `BaseOperationImpl`이 `Operation`을 구현하도록 변경하고, 기존 하위 클래스에서 `implements Operation`을 제거하였습니다.