### PR TITLE
INTERNAL: Encode elements starting from nextOpIndex

### DIFF
--- a/src/main/java/net/spy/memcached/collection/SetPipedExist.java
+++ b/src/main/java/net/spy/memcached/collection/SetPipedExist.java
@@ -49,18 +49,20 @@ public class SetPipedExist<T> extends CollectionPipe {
     int capacity = 0;
 
     // encode values
-    List<byte[]> encodedList = new ArrayList<>(values.size());
-    CachedData cd = null;
+    List<byte[]> encodedList = new ArrayList<>(values.size() - nextOpIndex);
+    CachedData cd;
+    int i = 0;
     for (T each : values) {
-      cd = tc.encode(each);
-      encodedList.add(cd.getData());
+      if (i++ >= nextOpIndex) {
+        cd = tc.encode(each);
+        encodedList.add(cd.getData());
+      }
     }
 
     // estimate the buffer capacity
     for (byte[] each : encodedList) {
-      capacity += KeyUtil.getKeyBytes(key).length;
+      capacity += KeyUtil.getKeyBytes(key).length + 64;
       capacity += each.length;
-      capacity += 64;
     }
 
     // allocate the buffer
@@ -68,7 +70,7 @@ public class SetPipedExist<T> extends CollectionPipe {
 
     // create ascii operation string
     int eSize = encodedList.size();
-    for (int i = this.nextOpIndex; i < eSize; i++) {
+    for (i = 0; i < eSize; i++) {
       byte[] each = encodedList.get(i);
 
       setArguments(bb, COMMAND, key, each.length,


### PR DESCRIPTION
### 🔗 Related Issue

<!-- Please link related issue. ex) https://github.com/naver/arcus-java-client/issues/{issue_number} -->
- https://github.com/jam2in/arcus-works/issues/669

### ⌨️ What I did

<!-- Please describe this PR and what you've been working on. -->

- `getAsciiCommand()` 메서드에서 불필요한 encode 작업을 제거하고, 연산 대상 데이터에 따라 적절하게 처리되도록 전체 로직을 리팩토링 하였습니다.
- `nextOpIndex` 이후의 값들만 encode 하도록 로직을 수정했습니다.
- `encodedList`의 구성 방식이 달라짐에 따라, ascii operation string 생성 로직에서 접근하는 인덱스를 올바르게 보정했습니다.
#### Review applied
- 기존에는 ListPipedInsert와 SetPipedInsert에서 Collection 타입을 사용하여, 인덱스 기반 접근이 불가능해 Iterator를 통한 순회 방식을 사용했습니다. 
  - 코드 일관성 및 효율성 개선을 위해, ListPipedInsert와 SetPipedInsert에서 해당되는 필드와 생성자 인자의 자료형을 Collection에서 List로 변경하고, 하위 로직도 인덱스 기반 for문으로 수정했습니다.
- SetPipedInsert 관련 테스트 코드(MultibyteKeyTest)도 타입 불일치 문제를 해결하도록 수정했습니다. 
- 변수(eSize)를 활용하여 encodedList의 크기 계산을 한 번만 수행하도록 변경했습니다.