### PR TITLE
FIX: use ubuntu latest version to prevent error

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       matrix:
         jdk: [ 8, 21 ]
-        os: [ ubuntu-20.04 ]
+        os: [ ubuntu-latest ]
       fail-fast: true
     if: |
       (github.event_name == 'pull_request' && github.event.pull_request.draft == false) ||


### PR DESCRIPTION
### 🔗 Related Issue

<!-- Please link related issue. ex) https://github.com/naver/arcus-java-client/issues/{issue_number} -->
- ubuntu 20.04 버전이 CI에서 사라져, 캐시 서버의 CI와 동일하게 ubuntu latest 버전을 사용하도록 합니다.

![image](https://github.com/user-attachments/assets/8287d4f5-04f3-4b83-994d-b194ffe784d3)

### ⌨️ What I did

<!-- Please describe this PR and what you've been working on. -->
-