### PR TITLE
INTERNAL: change getApiReadPriority args to APIType.

### DIFF
--- a/src/main/java/net/spy/memcached/ConnectionFactory.java
+++ b/src/main/java/net/spy/memcached/ConnectionFactory.java
@@ -22,7 +22,6 @@ import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.util.Collection;
 import java.util.List;
-import java.util.Map;
 import java.util.concurrent.BlockingQueue;
 
 import net.spy.memcached.auth.AuthDescriptor;
@@ -232,8 +231,7 @@ public interface ConnectionFactory {
   /**
    * get api read priority
    *
-   * @return
    */
-  Map<APIType, ReadPriority> getAPIReadPriority();
+  ReadPriority getAPIReadPriority(APIType apiType);
   /* ENABLE_REPLICATION end */
 }

--- a/src/main/java/net/spy/memcached/ConnectionFactoryBuilder.java
+++ b/src/main/java/net/spy/memcached/ConnectionFactoryBuilder.java
@@ -417,16 +417,6 @@ public class ConnectionFactoryBuilder {
 
     return this;
   }
-
-  public ReadPriority getAPIReadPriority(APIType apiType) {
-    ReadPriority priority = this.apiReadPriorityList.get(apiType);
-
-    return priority != null ? priority : ReadPriority.MASTER;
-  }
-
-  public Map<APIType, ReadPriority> getAPIReadPriority() {
-    return this.apiReadPriorityList;
-  }
   /* ENABLE_REPLICATION end */
 
   public ConnectionFactoryBuilder setKeepAlive(boolean on) {
@@ -653,8 +643,12 @@ public class ConnectionFactoryBuilder {
       }
 
       @Override
-      public Map<APIType, ReadPriority> getAPIReadPriority() {
-        return apiReadPriorityList;
+      public ReadPriority getAPIReadPriority(APIType apiType) {
+        ReadPriority readPriority = apiReadPriorityList.get(apiType);
+        if (readPriority == null) {
+          return this.getReadPriority();
+        }
+        return readPriority;
       }
       /* ENABLE_REPLICATION end */
     };

--- a/src/main/java/net/spy/memcached/DefaultConnectionFactory.java
+++ b/src/main/java/net/spy/memcached/DefaultConnectionFactory.java
@@ -377,8 +377,13 @@ public class DefaultConnectionFactory extends SpyObject
     return DEFAULT_READ_PRIORITY;
   }
 
-  public Map<APIType, ReadPriority> getAPIReadPriority() {
-    return DEFAULT_API_READ_PRIORITY_LIST;
+  @Override
+  public ReadPriority getAPIReadPriority(APIType apiType) {
+    ReadPriority readPriority = DEFAULT_API_READ_PRIORITY_LIST.get(apiType);
+    if (readPriority == null) {
+      return DEFAULT_READ_PRIORITY;
+    }
+    return readPriority;
   }
   /* ENABLE_REPLICATION end */
 }

--- a/src/main/java/net/spy/memcached/MemcachedConnection.java
+++ b/src/main/java/net/spy/memcached/MemcachedConnection.java
@@ -1349,10 +1349,7 @@ public final class MemcachedConnection extends SpyObject {
   private ReplicaPick getReplicaPick(APIType apiType) {
     ReplicaPick pick = ReplicaPick.MASTER;
     if (apiType.getAPIOpType() == OperationType.READ) {
-      ReadPriority readPriority = connFactory.getAPIReadPriority().get(apiType);
-      if (readPriority == null) {
-        readPriority = connFactory.getReadPriority();
-      }
+      ReadPriority readPriority = connFactory.getAPIReadPriority(apiType);
       if (readPriority == ReadPriority.SLAVE) {
         pick = ReplicaPick.SLAVE;
       } else if (readPriority == ReadPriority.RR) {
@@ -1365,10 +1362,7 @@ public final class MemcachedConnection extends SpyObject {
   private ReplicaPick getReplicaPick(Operation op) {
     ReplicaPick pick = ReplicaPick.MASTER;
     if (op.isReadOperation()) {
-      ReadPriority readPriority = connFactory.getAPIReadPriority().get(op.getAPIType());
-      if (readPriority == null) {
-        readPriority = connFactory.getReadPriority();
-      }
+      ReadPriority readPriority = connFactory.getAPIReadPriority(op.getAPIType());
       if (readPriority == ReadPriority.SLAVE) {
         pick = ReplicaPick.SLAVE;
       } else if (readPriority == ReadPriority.RR) {

--- a/src/test/java/net/spy/memcached/ClientBaseCase.java
+++ b/src/test/java/net/spy/memcached/ClientBaseCase.java
@@ -24,7 +24,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 import java.util.concurrent.BlockingQueue;
 
 import net.spy.memcached.auth.AuthDescriptor;
@@ -268,8 +267,8 @@ abstract class ClientBaseCase {
         }
 
         @Override
-        public Map<APIType, ReadPriority> getAPIReadPriority() {
-          return inner.getAPIReadPriority();
+        public ReadPriority getAPIReadPriority(APIType apiType) {
+          return inner.getAPIReadPriority(apiType);
         }
         /* ENABLE_REPLICATION end */
       };


### PR DESCRIPTION
### 🔗 Related Issue

https://github.com/jam2in/arcus-works/issues/694#issuecomment-2791501998

### ⌨️ What I did

<!-- Please describe this PR and what you've been working on. -->

- 기존에는 ApiType을 인자로 주지 않고, 결과를 Map을 리턴하고 리턴된 값의 Map.get(ApiType)을 통해  ReadPriority를 얻어왔다.
- 이를 getAPIReadPriority 메서드를 호출할때 인자로 ApiType을 사용하고 Map아닌 ReadPriority를 곧바로 리턴하는 구현으로 변경한다.