### PR TITLE
CLEANUP: remove wasCancelled() method

### DIFF
--- a/src/main/java/net/spy/memcached/ArcusClient.java
+++ b/src/main/java/net/spy/memcached/ArcusClient.java
@@ -146,8 +146,10 @@ import net.spy.memcached.ops.Operation;
 import net.spy.memcached.ops.OperationCallback;
 import net.spy.memcached.ops.OperationStatus;
 import net.spy.memcached.ops.PipedOperationCallback;
+import net.spy.memcached.ops.StatusCode;
 import net.spy.memcached.ops.StoreType;
 import net.spy.memcached.plugin.FrontCacheMemcachedClient;
+import net.spy.memcached.protocol.BaseOperationImpl;
 import net.spy.memcached.transcoders.CollectionTranscoder;
 import net.spy.memcached.transcoders.Transcoder;
 import net.spy.memcached.util.BTreeUtil;
@@ -3429,6 +3431,8 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
   private CollectionOperationStatus toCollectionOperationStatus(OperationStatus status) {
     if (status instanceof CollectionOperationStatus) {
       return (CollectionOperationStatus) status;
+    } else if (status.getStatusCode() == StatusCode.CANCELLED) {
+      return BaseOperationImpl.COLLECTION_CANCELLED;
     } else {
       // This case is occurred when undefined status is returned from the ARCUS
       // or there's no master node while processing switchover.

--- a/src/main/java/net/spy/memcached/protocol/BaseOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/BaseOperationImpl.java
@@ -25,9 +25,11 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import net.spy.memcached.MemcachedNode;
 import net.spy.memcached.MemcachedReplicaGroup;
 import net.spy.memcached.RedirectHandler;
+import net.spy.memcached.collection.CollectionResponse;
 import net.spy.memcached.compat.SpyObject;
 import net.spy.memcached.ops.APIType;
 import net.spy.memcached.ops.CancelledOperationStatus;
+import net.spy.memcached.ops.CollectionOperationStatus;
 import net.spy.memcached.ops.Operation;
 import net.spy.memcached.ops.OperationCallback;
 import net.spy.memcached.ops.OperationErrorType;
@@ -47,6 +49,11 @@ public abstract class BaseOperationImpl extends SpyObject implements Operation {
    */
   public static final OperationStatus CANCELLED =
           new CancelledOperationStatus();
+
+  public static final CollectionOperationStatus COLLECTION_CANCELLED =
+          new CollectionOperationStatus(false, "collection canceled",
+                  CollectionResponse.CANCELED);
+
   private OperationState state = OperationState.WRITE_QUEUED;
   private ByteBuffer cmd = null;
   private boolean cancelled = false;
@@ -100,7 +107,7 @@ public abstract class BaseOperationImpl extends SpyObject implements Operation {
         cause += " @ " + handlingNode.getNodeName();
       }
       cancelCause = "Cancelled (" + cause + ")";
-      wasCancelled();
+      callback.receivedStatus(CANCELLED);
       callback.complete();
       return true;
     }
@@ -109,13 +116,6 @@ public abstract class BaseOperationImpl extends SpyObject implements Operation {
 
   public final String getCancelCause() {
     return cancelCause;
-  }
-
-  /**
-   * This is called on each subclass whenever an operation was cancelled.
-   */
-  protected void wasCancelled() {
-    getLogger().debug("was cancelled.");
   }
 
   public final OperationState getState() {

--- a/src/main/java/net/spy/memcached/protocol/ascii/BTreeFindPositionOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/BTreeFindPositionOperationImpl.java
@@ -36,9 +36,6 @@ import net.spy.memcached.ops.OperationType;
 public final class BTreeFindPositionOperationImpl extends OperationImpl implements
         BTreeFindPositionOperation {
 
-  private static final OperationStatus GET_CANCELED = new CollectionOperationStatus(
-          false, "collection canceled", CollectionResponse.CANCELED);
-
   private static final OperationStatus POSITION = new CollectionOperationStatus(
           true, "POSITION", CollectionResponse.OK); // OK is arbitrary response
   private static final OperationStatus NOT_FOUND = new CollectionOperationStatus(
@@ -118,11 +115,6 @@ public final class BTreeFindPositionOperationImpl extends OperationImpl implemen
       getLogger().debug("Request in ascii protocol: %s",
               (new String(bb.array())).replace("\r\n", "\\r\\n"));
     }
-  }
-
-  @Override
-  protected void wasCancelled() {
-    getCallback().receivedStatus(GET_CANCELED);
   }
 
   public Collection<String> getKeys() {

--- a/src/main/java/net/spy/memcached/protocol/ascii/BTreeFindPositionWithGetOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/BTreeFindPositionWithGetOperationImpl.java
@@ -40,9 +40,6 @@ public final class BTreeFindPositionWithGetOperationImpl extends OperationImpl i
 
   private final ByteArrayOutputStream byteBuffer = new ByteArrayOutputStream();
 
-  private static final OperationStatus GET_CANCELED = new CollectionOperationStatus(
-          false, "collection canceled", CollectionResponse.CANCELED);
-
   private static final OperationStatus END = new CollectionOperationStatus(
           true, "END", CollectionResponse.END);
   private static final OperationStatus NOT_FOUND = new CollectionOperationStatus(
@@ -248,11 +245,6 @@ public final class BTreeFindPositionWithGetOperationImpl extends OperationImpl i
       getLogger().debug("Request in ascii protocol: %s",
           (new String(bb.array())).replace("\r\n", "\\r\\n"));
     }
-  }
-
-  @Override
-  protected void wasCancelled() {
-    getCallback().receivedStatus(GET_CANCELED);
   }
 
   public Collection<String> getKeys() {

--- a/src/main/java/net/spy/memcached/protocol/ascii/BTreeGetBulkOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/BTreeGetBulkOperationImpl.java
@@ -41,9 +41,6 @@ public final class BTreeGetBulkOperationImpl extends OperationImpl implements
 
   private final ByteArrayOutputStream byteBuffer = new ByteArrayOutputStream();
 
-  private static final OperationStatus GET_CANCELED = new CollectionOperationStatus(
-          false, "collection canceled", CollectionResponse.CANCELED);
-
   private static final OperationStatus END = new CollectionOperationStatus(
           true, "END", CollectionResponse.END);
 
@@ -247,11 +244,6 @@ public final class BTreeGetBulkOperationImpl extends OperationImpl implements
       getLogger().debug("Request in ascii protocol: %s",
               (new String(bb.array())).replace("\r\n", "\\r\\n"));
     }
-  }
-
-  @Override
-  protected void wasCancelled() {
-    getCallback().receivedStatus(GET_CANCELED);
   }
 
   @Override

--- a/src/main/java/net/spy/memcached/protocol/ascii/BTreeGetByPositionOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/BTreeGetByPositionOperationImpl.java
@@ -41,9 +41,6 @@ public final class BTreeGetByPositionOperationImpl extends OperationImpl impleme
 
   private final ByteArrayOutputStream byteBuffer = new ByteArrayOutputStream();
 
-  private static final OperationStatus GET_CANCELED = new CollectionOperationStatus(
-          false, "collection canceled", CollectionResponse.CANCELED);
-
   private static final OperationStatus END = new CollectionOperationStatus(
           true, "END", CollectionResponse.END);
   private static final OperationStatus NOT_FOUND = new CollectionOperationStatus(
@@ -251,11 +248,6 @@ public final class BTreeGetByPositionOperationImpl extends OperationImpl impleme
       getLogger().debug("Request in ascii protocol: %s",
               (new String(bb.array())).replace("\r\n", "\\r\\n"));
     }
-  }
-
-  @Override
-  protected void wasCancelled() {
-    getCallback().receivedStatus(GET_CANCELED);
   }
 
   public Collection<String> getKeys() {

--- a/src/main/java/net/spy/memcached/protocol/ascii/BTreeInsertAndGetOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/BTreeInsertAndGetOperationImpl.java
@@ -43,9 +43,6 @@ public final class BTreeInsertAndGetOperationImpl extends OperationImpl implemen
 
   private final ByteArrayOutputStream byteBuffer = new ByteArrayOutputStream();
 
-  private static final OperationStatus GET_CANCELED = new CollectionOperationStatus(
-          false, "collection canceled", CollectionResponse.CANCELED);
-
   private static final OperationStatus CREATED_STORED = new CollectionOperationStatus(
           true, "CREATED_STORED", CollectionResponse.CREATED_STORED);
   private static final OperationStatus STORED = new CollectionOperationStatus(
@@ -279,11 +276,6 @@ public final class BTreeInsertAndGetOperationImpl extends OperationImpl implemen
       getLogger().debug("Request in ascii protocol: %s",
               (new String(bb.array())).replace("\r\n", "\\r\\n"));
     }
-  }
-
-  @Override
-  protected void wasCancelled() {
-    getCallback().receivedStatus(GET_CANCELED);
   }
 
   @Override

--- a/src/main/java/net/spy/memcached/protocol/ascii/BTreeSortMergeGetOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/BTreeSortMergeGetOperationImpl.java
@@ -44,9 +44,6 @@ public final class BTreeSortMergeGetOperationImpl extends OperationImpl implemen
 
   private final ByteArrayOutputStream byteBuffer = new ByteArrayOutputStream();
 
-  private static final OperationStatus GET_CANCELED = new CollectionOperationStatus(
-          false, "collection canceled", CollectionResponse.CANCELED);
-
   private static final OperationStatus END = new CollectionOperationStatus(
           true, "END", CollectionResponse.END);
   private static final OperationStatus DUPLICATED = new CollectionOperationStatus(
@@ -437,11 +434,6 @@ public final class BTreeSortMergeGetOperationImpl extends OperationImpl implemen
       getLogger().debug("Request in ascii protocol: %s",
               (new String(bb.array())).replace("\r\n", "\\r\\n"));
     }
-  }
-
-  @Override
-  protected void wasCancelled() {
-    getCallback().receivedStatus(GET_CANCELED);
   }
 
   public Collection<String> getKeys() {

--- a/src/main/java/net/spy/memcached/protocol/ascii/BTreeSortMergeGetOperationOldImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/BTreeSortMergeGetOperationOldImpl.java
@@ -41,9 +41,6 @@ public final class BTreeSortMergeGetOperationOldImpl extends OperationImpl imple
 
   private final ByteArrayOutputStream byteBuffer = new ByteArrayOutputStream();
 
-  private static final OperationStatus GET_CANCELED = new CollectionOperationStatus(
-          false, "collection canceled", CollectionResponse.CANCELED);
-
   private static final OperationStatus END = new CollectionOperationStatus(
           true, "END", CollectionResponse.END);
   private static final OperationStatus DUPLICATED = new CollectionOperationStatus(
@@ -301,11 +298,6 @@ public final class BTreeSortMergeGetOperationOldImpl extends OperationImpl imple
       getLogger().debug("Request in ascii protocol: %s",
               (new String(bb.array())).replace("\r\n", "\\r\\n"));
     }
-  }
-
-  @Override
-  protected void wasCancelled() {
-    getCallback().receivedStatus(GET_CANCELED);
   }
 
   public Collection<String> getKeys() {

--- a/src/main/java/net/spy/memcached/protocol/ascii/BaseGetOpImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/BaseGetOpImpl.java
@@ -229,11 +229,6 @@ abstract class BaseGetOpImpl extends OperationImpl {
   }
 
   @Override
-  protected final void wasCancelled() {
-    getCallback().receivedStatus(CANCELLED);
-  }
-
-  @Override
   public boolean isBulkOperation() {
     return keys.size() > 1;
   }

--- a/src/main/java/net/spy/memcached/protocol/ascii/BaseStoreOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/BaseStoreOperationImpl.java
@@ -100,12 +100,6 @@ abstract class BaseStoreOperationImpl extends OperationImpl {
     }
   }
 
-  @Override
-  protected void wasCancelled() {
-    // XXX:  Replace this comment with why I did this
-    getCallback().receivedStatus(CANCELLED);
-  }
-
   public Collection<String> getKeys() {
     return Collections.singleton(key);
   }

--- a/src/main/java/net/spy/memcached/protocol/ascii/CASOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/CASOperationImpl.java
@@ -104,12 +104,6 @@ class CASOperationImpl extends OperationImpl implements CASOperation {
     setBuffer(bb);
   }
 
-  @Override
-  protected void wasCancelled() {
-    // XXX:  Replace this comment with why I did this
-    getCallback().receivedStatus(CANCELLED);
-  }
-
   public Collection<String> getKeys() {
     return Collections.singleton(key);
   }

--- a/src/main/java/net/spy/memcached/protocol/ascii/CollectionCountOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/CollectionCountOperationImpl.java
@@ -40,9 +40,6 @@ import net.spy.memcached.ops.OperationType;
 public final class CollectionCountOperationImpl extends OperationImpl implements
         CollectionCountOperation {
 
-  private static final OperationStatus GET_CANCELED = new CollectionOperationStatus(
-          false, "collection canceled", CollectionResponse.CANCELED);
-
   private static final OperationStatus NOT_FOUND = new CollectionOperationStatus(
           false, "NOT_FOUND", CollectionResponse.NOT_FOUND);
   private static final OperationStatus TYPE_MISMATCH = new CollectionOperationStatus(
@@ -110,11 +107,6 @@ public final class CollectionCountOperationImpl extends OperationImpl implements
       getLogger().debug("Request in ascii protocol: %s",
               (new String(bb.array())).replace("\r\n", "\\r\\n"));
     }
-  }
-
-  @Override
-  protected void wasCancelled() {
-    getCallback().receivedStatus(GET_CANCELED);
   }
 
   public Collection<String> getKeys() {

--- a/src/main/java/net/spy/memcached/protocol/ascii/CollectionCreateOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/CollectionCreateOperationImpl.java
@@ -45,9 +45,6 @@ public final class CollectionCreateOperationImpl extends OperationImpl
 
   private static final int OVERHEAD = 32;
 
-  private static final OperationStatus STORE_CANCELED = new CollectionOperationStatus(
-          false, "collection canceled", CollectionResponse.CANCELED);
-
   private static final OperationStatus CREATED = new CollectionOperationStatus(
           true, "CREATED", CollectionResponse.CREATED);
   private static final OperationStatus EXISTS = new CollectionOperationStatus(
@@ -108,11 +105,6 @@ public final class CollectionCreateOperationImpl extends OperationImpl
       getLogger().debug("Request in ascii protocol: %s",
               (new String(bb.array())).replace("\r\n", "\\r\\n"));
     }
-  }
-
-  @Override
-  protected void wasCancelled() {
-    getCallback().receivedStatus(STORE_CANCELED);
   }
 
   @Override

--- a/src/main/java/net/spy/memcached/protocol/ascii/CollectionDeleteOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/CollectionDeleteOperationImpl.java
@@ -43,9 +43,6 @@ import net.spy.memcached.ops.OperationType;
 public final class CollectionDeleteOperationImpl extends OperationImpl
         implements CollectionDeleteOperation {
 
-  private static final OperationStatus DELETE_CANCELED = new CollectionOperationStatus(
-          false, "collection canceled", CollectionResponse.CANCELED);
-
   private static final OperationStatus DELETED = new CollectionOperationStatus(
           true, "DELETED", CollectionResponse.DELETED);
   private static final OperationStatus DELETED_DROPPED = new CollectionOperationStatus(
@@ -137,11 +134,6 @@ public final class CollectionDeleteOperationImpl extends OperationImpl
       getLogger().debug("Request in ascii protocol: %s",
               (new String(bb.array())).replace("\r\n", "\\r\\n"));
     }
-  }
-
-  @Override
-  protected void wasCancelled() {
-    getCallback().receivedStatus(DELETE_CANCELED);
   }
 
   public Collection<String> getKeys() {

--- a/src/main/java/net/spy/memcached/protocol/ascii/CollectionExistOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/CollectionExistOperationImpl.java
@@ -42,9 +42,6 @@ public final class CollectionExistOperationImpl extends OperationImpl
 
   private static final int OVERHEAD = 32;
 
-  private static final OperationStatus EXIST_CANCELED = new CollectionOperationStatus(
-          false, "collection canceled", CollectionResponse.CANCELED);
-
   private static final OperationStatus EXIST = new CollectionOperationStatus(
           true, "EXIST", CollectionResponse.EXIST);
   private static final OperationStatus NOT_EXIST = new CollectionOperationStatus(
@@ -112,11 +109,6 @@ public final class CollectionExistOperationImpl extends OperationImpl
       getLogger().debug("Request in ascii protocol: %s",
               (new String(bb.array())).replace("\r\n", "\\r\\n"));
     }
-  }
-
-  @Override
-  protected void wasCancelled() {
-    getCallback().receivedStatus(EXIST_CANCELED);
   }
 
   public Collection<String> getKeys() {

--- a/src/main/java/net/spy/memcached/protocol/ascii/CollectionGetOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/CollectionGetOperationImpl.java
@@ -48,9 +48,6 @@ public final class CollectionGetOperationImpl extends OperationImpl
 
   private final ByteArrayOutputStream byteBuffer = new ByteArrayOutputStream();
 
-  private static final OperationStatus GET_CANCELED = new CollectionOperationStatus(
-          false, "collection canceled", CollectionResponse.CANCELED);
-
   private static final OperationStatus END = new CollectionOperationStatus(
           true, "END", CollectionResponse.END);
   private static final OperationStatus DELETED = new CollectionOperationStatus(
@@ -286,11 +283,6 @@ public final class CollectionGetOperationImpl extends OperationImpl
       getLogger().debug("Request in ascii protocol: %s",
               (new String(bb.array())).replace("\r\n", "\\r\\n"));
     }
-  }
-
-  @Override
-  protected void wasCancelled() {
-    getCallback().receivedStatus(GET_CANCELED);
   }
 
   public Collection<String> getKeys() {

--- a/src/main/java/net/spy/memcached/protocol/ascii/CollectionInsertOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/CollectionInsertOperationImpl.java
@@ -47,9 +47,6 @@ public final class CollectionInsertOperationImpl extends OperationImpl
 
   private static final int OVERHEAD = 32;
 
-  private static final OperationStatus STORE_CANCELED = new CollectionOperationStatus(
-          false, "collection canceled", CollectionResponse.CANCELED);
-
   private static final OperationStatus CREATED_STORED = new CollectionOperationStatus(
           true, "CREATED_STORED", CollectionResponse.CREATED_STORED);
   private static final OperationStatus STORED = new CollectionOperationStatus(
@@ -143,11 +140,6 @@ public final class CollectionInsertOperationImpl extends OperationImpl
       getLogger().debug("Request in ascii protocol: %s",
               (new String(bb.array())).replace("\r\n", "\\r\\n"));
     }
-  }
-
-  @Override
-  protected void wasCancelled() {
-    getCallback().receivedStatus(STORE_CANCELED);
   }
 
   public Collection<String> getKeys() {

--- a/src/main/java/net/spy/memcached/protocol/ascii/CollectionMutateOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/CollectionMutateOperationImpl.java
@@ -41,8 +41,6 @@ import net.spy.memcached.ops.OperationType;
 public final class CollectionMutateOperationImpl extends OperationImpl implements
         CollectionMutateOperation {
 
-  private static final OperationStatus GET_CANCELED = new CollectionOperationStatus(
-          false, "collection canceled", CollectionResponse.CANCELED);
   private static final OperationStatus NOT_FOUND = new CollectionOperationStatus(
           false, "NOT_FOUND", CollectionResponse.NOT_FOUND);
   private static final OperationStatus NOT_FOUND_ELEMENT = new CollectionOperationStatus(
@@ -126,11 +124,6 @@ public final class CollectionMutateOperationImpl extends OperationImpl implement
       getLogger().debug("Request in ascii protocol: %s",
               (new String(bb.array())).replace("\r\n", "\\r\\n"));
     }
-  }
-
-  @Override
-  protected void wasCancelled() {
-    getCallback().receivedStatus(GET_CANCELED);
   }
 
   public Collection<String> getKeys() {

--- a/src/main/java/net/spy/memcached/protocol/ascii/CollectionUpdateOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/CollectionUpdateOperationImpl.java
@@ -44,9 +44,6 @@ public final class CollectionUpdateOperationImpl extends OperationImpl implement
 
   private static final int OVERHEAD = 32;
 
-  private static final OperationStatus STORE_CANCELED = new CollectionOperationStatus(
-          false, "collection canceled", CollectionResponse.CANCELED);
-
   private static final OperationStatus UPDATED = new CollectionOperationStatus(
           true, "UPDATED", CollectionResponse.UPDATED);
   private static final OperationStatus NOT_FOUND = new CollectionOperationStatus(
@@ -144,11 +141,6 @@ public final class CollectionUpdateOperationImpl extends OperationImpl implement
               "Request in ascii protocol: '%s'",
               (new String(bb.array())).replace("\r\n", "\\r\\n"));
     }
-  }
-
-  @Override
-  protected void wasCancelled() {
-    getCallback().receivedStatus(STORE_CANCELED);
   }
 
   public Collection<String> getKeys() {

--- a/src/main/java/net/spy/memcached/protocol/ascii/GetAttrOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/GetAttrOperationImpl.java
@@ -38,9 +38,6 @@ class GetAttrOperationImpl extends OperationImpl implements GetAttrOperation {
 
   private static final String CMD = "getattr";
 
-  private static final OperationStatus ATTR_CANCELED = new CollectionOperationStatus(
-          false, "collection canceled", CollectionResponse.CANCELED);
-
   private static final OperationStatus END = new CollectionOperationStatus(
           true, "END", CollectionResponse.END);
   private static final OperationStatus NOT_FOUND = new CollectionOperationStatus(
@@ -105,11 +102,6 @@ class GetAttrOperationImpl extends OperationImpl implements GetAttrOperation {
       getLogger().debug("Request in ascii protocol: %s",
               (new String(bb.array())).replace("\r\n", "\\r\\n"));
     }
-  }
-
-  @Override
-  protected void wasCancelled() {
-    getCallback().receivedStatus(ATTR_CANCELED);
   }
 
   @Override

--- a/src/main/java/net/spy/memcached/protocol/ascii/MutatorOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/MutatorOperationImpl.java
@@ -111,12 +111,6 @@ final class MutatorOperationImpl extends OperationImpl
     setBuffer(bb);
   }
 
-  @Override
-  protected void wasCancelled() {
-    // XXX:  Replace this comment with why the hell I did this.
-    getCallback().receivedStatus(CANCELLED);
-  }
-
   public Collection<String> getKeys() {
     return Collections.singleton(key);
   }

--- a/src/main/java/net/spy/memcached/protocol/ascii/PipeOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/PipeOperationImpl.java
@@ -20,9 +20,6 @@ import net.spy.memcached.ops.PipedOperationCallback;
 
 abstract class PipeOperationImpl extends OperationImpl {
 
-  protected static final OperationStatus CANCELED = new CollectionOperationStatus(
-          false, "collection canceled", CollectionResponse.CANCELED);
-
   protected static final OperationStatus END = new CollectionOperationStatus(
           true, "END", CollectionResponse.END);
   protected static final OperationStatus FAILED_END = new CollectionOperationStatus(
@@ -200,11 +197,6 @@ abstract class PipeOperationImpl extends OperationImpl {
       getLogger().debug("Request in ascii protocol: %s",
               (new String(buffer.array())).replace("\r\n", "\\r\\n"));
     }
-  }
-
-  @Override
-  protected void wasCancelled() {
-    getCallback().receivedStatus(CANCELED);
   }
 
   public Collection<String> getKeys() {

--- a/src/main/java/net/spy/memcached/protocol/ascii/SetAttrOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/SetAttrOperationImpl.java
@@ -39,9 +39,6 @@ class SetAttrOperationImpl extends OperationImpl
 
   private static final int OVERHEAD = 64;
 
-  private static final OperationStatus ATTR_CANCELED = new CollectionOperationStatus(
-          false, "collection canceled", CollectionResponse.CANCELED);
-
   private static final OperationStatus OK =
           new CollectionOperationStatus(true, "OK", CollectionResponse.OK);
   private static final OperationStatus NOT_FOUND =
@@ -104,11 +101,6 @@ class SetAttrOperationImpl extends OperationImpl
       getLogger().debug("Request in ascii protocol: %s",
               (new String(bb.array())).replace("\r\n", "\\r\\n"));
     }
-  }
-
-  @Override
-  protected void wasCancelled() {
-    getCallback().receivedStatus(ATTR_CANCELED);
   }
 
   public Collection<String> getKeys() {

--- a/src/main/java/net/spy/memcached/protocol/ascii/StatsOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/StatsOperationImpl.java
@@ -74,9 +74,4 @@ final class StatsOperationImpl extends OperationImpl
     setBuffer(ByteBuffer.wrap(msg));
   }
 
-  @Override
-  protected void wasCancelled() {
-    cb.receivedStatus(CANCELLED);
-  }
-
 }


### PR DESCRIPTION
### 🔗 Related Issue

<!-- Please link related issue. ex) https://github.com/naver/arcus-java-client/issues/{issue_number} -->
- https://github.com/jam2in/arcus-works/issues/698

### ⌨️ What I did

<!-- Please describe this PR and what you've been working on. -->
- 복잡하게 각 Operation마다 정의되어 있던 wasCancelled 메서드의 구현들을 없애고, Collection API여서 receivedStatus() 콜백에서 CollectionOperationStatus를 사용하는 경우에만 BaseOperationImpl에 존재하는 COLLECTION_CANCELLED 상수를 사용하도록 수정합니다.