### PR TITLE
INTERNAL: use CollectionOperationStatus in collection API

### DIFF
--- a/src/main/java/net/spy/memcached/ArcusClient.java
+++ b/src/main/java/net/spy/memcached/ArcusClient.java
@@ -1606,7 +1606,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
             }
             if (cstatus.isSuccess()) {
               rv.set(Integer.valueOf(cstatus.getMessage()),
-                      new CollectionOperationStatus(new OperationStatus(true, "END")));
+                      new CollectionOperationStatus(true, "END", CollectionResponse.END));
               return;
             }
             rv.set(null, cstatus);
@@ -3520,10 +3520,9 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
             if (status.isSuccess()) {
               try {
                 rv.set(Long.valueOf(status.getMessage()),
-                        new CollectionOperationStatus(new OperationStatus(true, "END")));
+                        new CollectionOperationStatus(true, "END", CollectionResponse.END));
               } catch (NumberFormatException e) {
-                rv.set(null, new CollectionOperationStatus(
-                        new OperationStatus(false, status.getMessage())));
+                rv.set(null, new CollectionOperationStatus(false, status.getMessage(), CollectionResponse.EXCEPTION));
 
                 getLogger().debug("Key(%s), Bkey(%s) Unknown response : %s", k, subkey, status);
               }

--- a/src/main/java/net/spy/memcached/internal/CollectionGetBulkFuture.java
+++ b/src/main/java/net/spy/memcached/internal/CollectionGetBulkFuture.java
@@ -26,11 +26,11 @@ import java.util.concurrent.TimeoutException;
 
 import net.spy.memcached.MemcachedConnection;
 import net.spy.memcached.OperationTimeoutException;
+import net.spy.memcached.collection.CollectionResponse;
 import net.spy.memcached.internal.result.GetResult;
 import net.spy.memcached.ops.CollectionOperationStatus;
 import net.spy.memcached.ops.Operation;
 import net.spy.memcached.ops.OperationState;
-import net.spy.memcached.ops.OperationStatus;
 
 public class CollectionGetBulkFuture<T> implements Future<T> {
 
@@ -124,9 +124,9 @@ public class CollectionGetBulkFuture<T> implements Future<T> {
 
   public CollectionOperationStatus getOperationStatus() {
     if (isCancelled()) {
-      return new CollectionOperationStatus(new OperationStatus(false, "CANCELED"));
+      return new CollectionOperationStatus(false, "CANCELED", CollectionResponse.CANCELED);
     }
 
-    return new CollectionOperationStatus(new OperationStatus(true, "END"));
+    return new CollectionOperationStatus(true, "END", CollectionResponse.END);
   }
 }

--- a/src/main/java/net/spy/memcached/internal/result/SMGetResultImpl.java
+++ b/src/main/java/net/spy/memcached/internal/result/SMGetResultImpl.java
@@ -6,6 +6,7 @@ import java.util.List;
 import java.util.Map;
 
 import net.spy.memcached.collection.BKeyObject;
+import net.spy.memcached.collection.CollectionResponse;
 import net.spy.memcached.collection.SMGetElement;
 import net.spy.memcached.ops.CollectionOperationStatus;
 import net.spy.memcached.ops.OperationStatus;
@@ -153,13 +154,12 @@ public final class SMGetResultImpl<T> extends SMGetResult<T> {
   public void makeResultOperationStatus() {
     refineTrimmedKeys();
 
-    final OperationStatus status;
     if (!unique && hasDuplicatedBKeyResult()) {
-      status = new OperationStatus(true, "DUPLICATED");
+      resultOperationStatus = new CollectionOperationStatus(true, "DUPLICATED",
+              CollectionResponse.DUPLICATED);
     } else {
-      status = new OperationStatus(true, "END");
+      resultOperationStatus = new CollectionOperationStatus(true, "END", CollectionResponse.END);
     }
-    resultOperationStatus = new CollectionOperationStatus(status);
   }
 
   /**

--- a/src/main/java/net/spy/memcached/protocol/ascii/CollectionCountOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/CollectionCountOperationImpl.java
@@ -86,8 +86,7 @@ public final class CollectionCountOperationImpl extends OperationImpl implements
       assert "COUNT".equals(stuff[0]);
       count = Integer.parseInt(stuff[1]);
 
-      status = new CollectionOperationStatus(new OperationStatus(true,
-              String.valueOf(count)));
+      status = new CollectionOperationStatus(true, String.valueOf(count), CollectionResponse.END);
     } else {
       status = matchStatus(line, NOT_FOUND, TYPE_MISMATCH, BKEY_MISMATCH, UNREADABLE);
       getLogger().debug(status);

--- a/src/main/java/net/spy/memcached/protocol/ascii/CollectionMutateOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/CollectionMutateOperationImpl.java
@@ -98,7 +98,7 @@ public final class CollectionMutateOperationImpl extends OperationImpl implement
     boolean allDigit = line.chars().allMatch(Character::isDigit);
     OperationStatus status;
     if (allDigit) {
-      status = new OperationStatus(true, line);
+      status = new CollectionOperationStatus(true, line, CollectionResponse.END);
     } else {
       status = matchStatus(line, NOT_FOUND, NOT_FOUND_ELEMENT,
               UNREADABLE, OVERFLOWED, OUT_OF_RANGE,


### PR DESCRIPTION
### 🔗 Related Issue

<!-- Please link related issue. ex) https://github.com/naver/arcus-java-client/issues/{issue_number} -->
- https://github.com/jam2in/arcus-works/issues/715
> new CollectionOperationStatus(new OperationStatus(...)) 로 생성하는 부분은 비효율적으로 객체를 두번 생성하는 것이므로 new CollectionOperationStatus(true, "XX", CollectionResponse.XX)로 수정한다.

### ⌨️ What I did

<!-- Please describe this PR and what you've been working on. -->
- `new CollectionOperationStatus(new OperationStatus(...))` 형태로 사용하는 부분을 `new CollectioOperationStatus(.. , .., )` 형태로 수정했습니다.
- Collection 연산에서 OperationStatus를 생성해 사용하던 부분을 CollectionOperationStatus를 생성하도록 수정했습니다.