### PR TITLE
FEAT: Add INVALID response without reconnecting.

### DIFF
--- a/src/main/java/net/spy/memcached/collection/CollectionResponse.java
+++ b/src/main/java/net/spy/memcached/collection/CollectionResponse.java
@@ -49,6 +49,7 @@ public enum CollectionResponse {
   EXECUTION_EXCEPTION,
   TIMEOUT_EXCEPTION,
   EXCEPTION,
+  INVALID,
 
   UPDATED,
   BKEY_MISMATCH,
@@ -87,6 +88,8 @@ public enum CollectionResponse {
   public static CollectionResponse resolve(String s) {
     if (ENUM_STRINGS.contains(s)) {
       return CollectionResponse.valueOf(s);
+    } else if (s.startsWith(CollectionResponse.INVALID.name())) {
+      return CollectionResponse.INVALID;
     } else {
       return UNDEFINED;
     }

--- a/src/main/java/net/spy/memcached/ops/CollectionOperationStatus.java
+++ b/src/main/java/net/spy/memcached/ops/CollectionOperationStatus.java
@@ -33,7 +33,7 @@ public class CollectionOperationStatus extends OperationStatus {
   }
 
   public CollectionOperationStatus(OperationStatus status) {
-    super(status.isSuccess(), status.getMessage());
+    super(status.isSuccess(), status.getMessage(), status.getStatusCode());
     this.collectionResponse = CollectionResponse.resolve(status.getMessage());
   }
 

--- a/src/main/java/net/spy/memcached/ops/StatusCode.java
+++ b/src/main/java/net/spy/memcached/ops/StatusCode.java
@@ -64,6 +64,8 @@ public enum StatusCode {
       return ERR_SERVER;
     } else if (line.equals("CLIENT_ERROR")) {
       return ERR_CLIENT;
+    } else if (line.startsWith("INVALID")) {
+      return ERR_INVAL;
     } else {
       logger.warn("Undefined response message: %s", line);
       return UNDEFINED;


### PR DESCRIPTION
### 🔗 Related Issue

https://github.com/jam2in/arcus-works/issues/710#issuecomment-2820012306

### ⌨️ What I did

기존의 reconnect 하지 않는 실패 응답값들에 대한 처리는 아래와 같습니다.
미리 static으로 설정된 아래의 OperationStatus를 matchStatus의 인자로 넘겨줍니다. 
인자로 설정된 OperationStatus와 응답값과 일치할 경우 해당 OperationStatus를 
Future에 설정하게 되는 것입니다.

```java
private static final OperationStatus END = new CollectionOperationStatus(
          true, "END", CollectionResponse.END);

  private static final OperationStatus OK = new CollectionOperationStatus(
          true, "OK", CollectionResponse.OK);
```

INVALID가 응답으로 들어올 경우는 조금 다르게 구현했습니다.
동일하게 handleLine 에서 처리되어 내부의 matchStatus를 호출합니다.
다만, INVALID는 미리 static하게 설정해둔 OperationStatus가 없습니다.
이는 INVALID와 함께 오는 msg 값을 사용자에게 전달하기 위함입니다.
(ex - "INVALID too many count")
모든 INVALID 상황에 맞는 응답 메세지를 가지는 static 인스턴스를
Operation 클래스 내에 만드는것 이상한 것 같습니다.

matchStatus의 인자로 들어온 static 인스턴스와 line의 값("INVALID ...")이 
일치하지 않기에 fromAsciiLine이 호출된 후,
여기서 INVALID에 대한 에러 코드를 리턴한 후, INVALID OperationStatus를 생성합니다.
결론적으로 INVALID 상태와 메세지가 담긴 OperationStatus가
Future에 심기게 되고 사용자가 확인해볼 수 있습니다.

## 공통으로 발생 가능한 상황
- prefix : 이미 java-client단에서 invalid prefix는 예외처리 중

## 다른 상황들
### KV
- set : ok
- add : ok
- replace : ok
- append : ok
- prepend : ok
- cas : ok
- incr : ok
- decr : ok
- mget : 하나의 연산에 200개 씩 보내는 제약이 이미 존재해서 INVALID 발생 X
### LIST
- lop create : ok
- lop insert : ok
### SET
- sop create : ok
- sop insert : ok
- sop exist : ok
- sop delete : ok
- sop get : ok
### MAP
- mop create : ok
- mop insert : ok
- mop upsert : ok
- mop update : ok
- mop delete : ok
- mop get : ok
### BTREE
- bop create : ok
- bop insert : ok
- bop delete : ok
- bop upsert : ok
- bop update : ok
- bop pwg : ok
- bop mget : ok
- bop smget : ok

Future의 OperationStatus에 INVALID 상태와 이와 함께 넘어온 메세지를 담아줍니다.