### PR TITLE
INTERNAL: remove unused CollectionResponse type

### DIFF
--- a/src/main/java/net/spy/memcached/collection/CollectionResponse.java
+++ b/src/main/java/net/spy/memcached/collection/CollectionResponse.java
@@ -45,9 +45,6 @@ public enum CollectionResponse {
   UNDEFINED,
   CANCELED,
 
-  INTERRUPT_EXCEPTION,
-  EXECUTION_EXCEPTION,
-  TIMEOUT_EXCEPTION,
   EXCEPTION,
 
   UPDATED,
@@ -56,12 +53,6 @@ public enum CollectionResponse {
 
   CREATED,
   EXISTS,
-  SERVER_ERROR,
-
-  /**
-   * Command pipelining result
-   */
-  RESPONSE,
 
   /**
    * read only collection


### PR DESCRIPTION
### 🔗 Related Issue

<!-- Please link related issue. ex) https://github.com/naver/arcus-java-client/issues/{issue_number} -->
- 

### ⌨️ What I did

<!-- Please describe this PR and what you've been working on. -->
- 사용되지 않는 CollectionResponse의 일부 타입을 제거합니다.