### PR TITLE
INTERNAL: set StatusCode in CollectionOperationStatus

### DIFF
--- a/src/main/java/net/spy/memcached/ops/CollectionOperationStatus.java
+++ b/src/main/java/net/spy/memcached/ops/CollectionOperationStatus.java
@@ -28,7 +28,7 @@ public class CollectionOperationStatus extends OperationStatus {
   private final CollectionResponse collectionResponse;
 
   public CollectionOperationStatus(boolean success, String msg, CollectionResponse res) {
-    super(success, msg);
+    super(success, msg, StatusCode.fromAsciiLine(res.name()));
     this.collectionResponse = res;
   }
 

--- a/src/main/java/net/spy/memcached/ops/StatusCode.java
+++ b/src/main/java/net/spy/memcached/ops/StatusCode.java
@@ -19,57 +19,113 @@
 
 package net.spy.memcached.ops;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import net.spy.memcached.compat.log.Logger;
 import net.spy.memcached.compat.log.LoggerFactory;
 
 public enum StatusCode {
 
-  SUCCESS,
-  ERR_NOT_FOUND,
-  ERR_EXISTS,
-  ERR_2BIG,
-  ERR_INVAL,
-  ERR_NOT_STORED,
-  ERR_DELTA_BADVAL,
-  ERR_TYPE_MISMATCH,
-  ERR_UNKNOWN_COMMAND,
-  ERR_NO_MEM,
-  ERR_NOT_SUPPORTED,
-  ERR_ERROR,
-  ERR_SERVER,
-  ERR_CLIENT,
-  CANCELLED,
-  INTERRUPTED,
-  TIMEDOUT,
-  UNDEFINED;
+  /*
+   Key-Value Statuses
+   */
+  SUCCESS("SUCCESS"),
+
+  ERR_NOT_FOUND("NOT_FOUND"),
+  ERR_EXISTS("EXISTS"),
+  ERR_INVAL("INVALID"),
+  ERR_NOT_STORED("NOT_STORED"),
+  ERR_NOT_SUPPORTED("NOT_SUPPORTED"),
+
+  // error from server (These replace ERR_INTERNAL.),
+  ERR_ERROR("ERROR"),
+  ERR_SERVER("SERVER_ERROR"),
+  ERR_CLIENT("CLIENT_ERROR"),
+
+  // error from client
+  CANCELLED("CANCELED"),
+  INTERRUPTED("INTERRUPTED"),
+  TIMEDOUT("TIMEDOUT"),
+  UNDEFINED("UNDEFINED"),
+  EXCEPTION("EXCEPTION"),
+
+  // for backward-compatibility with spymemcached.
+  // in Arcus ASCII Commands, these are given with SERVER_ERROR / ERROR prefix.
+  ERR_2BIG("2BIG"),
+  ERR_DELTA_BADVAL("DELTA_BADVAL"),
+  ERR_UNKNOWN_COMMAND("UNKNOWN_COMMAND"),
+  ERR_NO_MEM("NO_MEM"),
+
+  /*
+  Collection & Attribute Statuses
+   */
+  ERR_TYPE_MISMATCH("TYPE_MISMATCH"),
+  ERR_NOT_FOUND_ELEMENT("NOT_FOUND_ELEMENT"),
+  ERR_ELEMENT_EXISTS("ELEMENT_EXISTS"),
+  ERR_UNREADABLE("UNREADABLE"),
+  ERR_OVERFLOWED("OVERFLOWED"),
+  ERR_OUT_OF_RANGE("OUT_OF_RANGE"),
+  ERR_NOTHING_TO_UPDATE("NOTHING_TO_UPDATE"),
+  ERR_ATTR_NOT_FOUND("ATTR_ERROR_NOT_FOUND"),
+  ERR_ATTR_BAD_VALUE("ATTR_ERROR_BAD_VALUE"),
+
+  // Set specific
+  EXIST("EXIST"),
+  NOT_EXIST("NOT_EXIST"),
+
+  // B+TREE specific
+  DUPLICATED("DUPLICATED"),
+  TRIMMED("TRIMMED"),
+  DUPLICATED_TRIMMED("DUPLICATED_TRIMMED"),
+  ERR_BKEY_MISMATCH("BKEY_MISMATCH"),
+  ERR_EFLAG_MISMATCH("EFLAG_MISMATCH"),
+  ERR_ATTR_MISMATCH("ATTR_MISMATCH");
+
+  private final String message;
 
   private static final Logger logger =
           LoggerFactory.getLogger(StatusCode.class);
 
-  public static StatusCode fromAsciiLine(String line) {
-    if (line.equals("OK") || line.equals("END") ||
-        line.equals("STORED") || line.equals("DELETED")) {
-      return SUCCESS;
-    } else if (line.equals("NOT_STORED")) {
-      return ERR_NOT_STORED;
-    } else if (line.equals("EXISTS")) {
-      return ERR_EXISTS;
-    } else if (line.equals("NOT_FOUND")) {
-      return ERR_NOT_FOUND;
-    } else if (line.equals("TYPE_MISMATCH")) {
-      return ERR_TYPE_MISMATCH;
-    } else if (line.equals("ERROR")) {
-      return ERR_ERROR;
-    } else if (line.equals("SERVER_ERROR")) {
-      return ERR_SERVER;
-    } else if (line.equals("CLIENT_ERROR")) {
-      return ERR_CLIENT;
-    } else if (line.startsWith("INVALID")) {
-      return ERR_INVAL;
-    } else {
-      logger.warn("Undefined response message: %s", line);
-      return UNDEFINED;
+  StatusCode(String message) {
+    this.message = message;
+  }
+
+  private static final Map<String, StatusCode> ENUM_STRINGS;
+
+  static {
+    StatusCode[] values = StatusCode.values();
+    ENUM_STRINGS = new HashMap<>(values.length);
+    for (StatusCode code : values) {
+      ENUM_STRINGS.put(code.message, code);
     }
+
+    ENUM_STRINGS.put("OK", SUCCESS);
+    ENUM_STRINGS.put("END", SUCCESS);
+    ENUM_STRINGS.put("STORED", SUCCESS);
+    ENUM_STRINGS.put("DELETED", SUCCESS);
+
+    ENUM_STRINGS.put("DELETED_DROPPED", SUCCESS);
+    ENUM_STRINGS.put("CREATED", SUCCESS);
+    ENUM_STRINGS.put("CREATED_STORED", SUCCESS);
+    ENUM_STRINGS.put("REPLACED", SUCCESS);
+    ENUM_STRINGS.put("UPDATED", SUCCESS);
+  }
+
+  public static StatusCode fromAsciiLine(String line) {
+    StatusCode statusCode = ENUM_STRINGS.get(line);
+
+    // This case is rarely occurred.
+    if (statusCode == null) {
+      if (line.startsWith("INVALID")) {
+        return ERR_INVAL;
+      } else {
+        logger.warn("Undefined response message: %s", line);
+        return UNDEFINED;
+      }
+    }
+
+    return statusCode;
   }
 
 }

--- a/src/main/java/net/spy/memcached/protocol/ascii/BTreeInsertAndGetOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/BTreeInsertAndGetOperationImpl.java
@@ -66,8 +66,6 @@ public final class BTreeInsertAndGetOperationImpl extends OperationImpl implemen
           false, "TYPE_MISMATCH", CollectionResponse.TYPE_MISMATCH);
   private static final OperationStatus BKEY_MISMATCH = new CollectionOperationStatus(
           false, "BKEY_MISMATCH", CollectionResponse.BKEY_MISMATCH);
-  private static final OperationStatus UNDEFINED_OPERATION = new CollectionOperationStatus(
-          false, "UNDEFINED_OPERATION", CollectionResponse.UNDEFINED);
 
   private static final OperationStatus[] INSERT_AND_GET_STATUS_ON_LINE = {
       STORED, CREATED_STORED, NOT_FOUND, ELEMENT_EXISTS, OVERFLOWED,


### PR DESCRIPTION
### 🔗 Related Issue

<!-- Please link related issue. ex) https://github.com/naver/arcus-java-client/issues/{issue_number} -->
- https://github.com/jam2in/arcus-works/issues/715

### ⌨️ What I did

<!-- Please describe this PR and what you've been working on. -->
- CollectionOperationStatus에 항상 StatusCode가 들어갈 수 있도록 수정합니다.
- 성공 응답인 `DELETED_DROPPED`, `CREATED`, `CREATED_STORED`, `REPLACED`, `UPDATED`의 경우 SUCCESS 코드를 가지도록 통합했습니다. 사용자가 어떤 작업을 요청해 성공했든 상관 없이, 성공했다는 의미만 반환해도 문제 없다고 생각합니다.
- 실패 응답에는 기본적으로 `ERR_` 로 시작하도록 했습니다.

- fromAsciiLine 메서드에서 String 타입을 StatusCode 타입으로 변환하기 위해 구동 시 Map에 캐싱해두도록 하고, 변환 시 Map에서 get()하도록 합니다.