### PR TITLE
INTERNAL: Add matchStatus() call to handle unknown response for mget and stats commands.

### DIFF
--- a/src/main/java/net/spy/memcached/protocol/ascii/BaseGetOpImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/BaseGetOpImpl.java
@@ -105,7 +105,8 @@ abstract class BaseGetOpImpl extends OperationImpl {
       addRedirectMultiKeyOperation(notMyKeyLine, line.trim());
     /* ENABLE_MIGRATION end */
     } else {
-      assert false : "Unknown line type: " + line;
+      getCallback().receivedStatus(matchStatus(line));
+      transitionState(OperationState.COMPLETE);
     }
   }
 

--- a/src/main/java/net/spy/memcached/protocol/ascii/StatsOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/StatsOperationImpl.java
@@ -56,13 +56,16 @@ final class StatsOperationImpl extends OperationImpl
 
   @Override
   public void handleLine(String line) {
-    if (line.startsWith("END")) {
-      cb.receivedStatus(END);
-      transitionState(OperationState.COMPLETE);
-    } else {
+    if (line.startsWith("STAT") || line.startsWith("PREFIX") || line.startsWith("ITEM")) {
       String[] parts = line.split(" ", 3);
       assert parts.length == 3;
       cb.gotStat(parts[1], parts[2]);
+    } else if (line.startsWith("END")) {
+      cb.receivedStatus(END);
+      transitionState(OperationState.COMPLETE);
+    } else {
+      cb.receivedStatus(matchStatus(line));
+      transitionState(OperationState.COMPLETE);
     }
   }
 


### PR DESCRIPTION
### 🔗 Related Issue

<!-- Please link related issue. ex) https://github.com/naver/arcus-java-client/issues/{issue_number} -->
- https://github.com/jam2in/arcus-works/issues/226

### ⌨️ What I did

<!-- Please describe this PR and what you've been working on. -->
- mget, stats 명령어에 대하여 INVALID 응답이 올 때의 처리를 추가합니다.