### PR TITLE
INTERNAL: deprecate old smget API

### DIFF
--- a/src/main/java/net/spy/memcached/ArcusClient.java
+++ b/src/main/java/net/spy/memcached/ArcusClient.java
@@ -1888,6 +1888,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
     return rv;
   }
 
+  @Deprecated
   @Override
   public SMGetFuture<List<SMGetElement<Object>>> asyncBopSortMergeGet(
           List<String> keyList, long from, long to, ElementFlagFilter eFlagFilter,
@@ -2916,6 +2917,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
     return rv;
   }
 
+  @Deprecated
   @Override
   public SMGetFuture<List<SMGetElement<Object>>> asyncBopSortMergeGet(
           List<String> keyList, byte[] from, byte[] to,

--- a/src/main/java/net/spy/memcached/ArcusClientIF.java
+++ b/src/main/java/net/spy/memcached/ArcusClientIF.java
@@ -1399,7 +1399,10 @@ public interface ArcusClientIF {
    * @param count       number of returning values. must be larger than 0.
    *                    {@code offset + count} must not be more than 1000.
    * @return a future that will hold the return value list of the fetch.
+   * @deprecated use {@link #asyncBopSortMergeGet(List, long, long,
+   * ElementFlagFilter, int, SMGetMode)}
    */
+  @Deprecated
   SMGetFuture<List<SMGetElement<Object>>> asyncBopSortMergeGet(
           List<String> keyList, long from, long to, ElementFlagFilter eFlagFilter,
           int offset, int count);
@@ -1949,7 +1952,10 @@ public interface ArcusClientIF {
    * @param count       number of returning values. must be larger than 0.
    *                    {@code offset + count} must not be more than 1000.
    * @return a future that will hold the return value list of the fetch.
+   * @deprecated use {@link #asyncBopSortMergeGet(java.util.List, byte[], byte[],
+   * ElementFlagFilter, int, SMGetMode)}
    */
+  @Deprecated
   SMGetFuture<List<SMGetElement<Object>>> asyncBopSortMergeGet(
           List<String> keyList, byte[] from, byte[] to, ElementFlagFilter eFlagFilter,
           int offset, int count);

--- a/src/main/java/net/spy/memcached/ArcusClientPool.java
+++ b/src/main/java/net/spy/memcached/ArcusClientPool.java
@@ -1104,6 +1104,7 @@ public class ArcusClientPool implements MemcachedClientIF, ArcusClientIF {
     return this.getClient().flush(prefix, delay);
   }
 
+  @Deprecated
   @Override
   public SMGetFuture<List<SMGetElement<Object>>> asyncBopSortMergeGet(
           List<String> keyList, long from, long to,
@@ -1363,6 +1364,7 @@ public class ArcusClientPool implements MemcachedClientIF, ArcusClientIF {
             count, withDelete, dropIfEmpty, tc);
   }
 
+  @Deprecated
   @Override
   public SMGetFuture<List<SMGetElement<Object>>> asyncBopSortMergeGet(
           List<String> keyList, byte[] from, byte[] to,

--- a/src/test/java/net/spy/memcached/ArcusTimeoutTest.java
+++ b/src/test/java/net/spy/memcached/ArcusTimeoutTest.java
@@ -233,6 +233,7 @@ class ArcusTimeoutTest {
       keyList.add(KEY + i);
     }
 
+    @SuppressWarnings("deprecation")
     SMGetFuture<List<SMGetElement<Object>>> future = mc.asyncBopSortMergeGet(
             keyList, 0, 1000, ElementFlagFilter.DO_NOT_FILTER, 0, 500);
     assertThrows(TimeoutException.class, () -> future.get(1L, TimeUnit.MILLISECONDS));
@@ -263,6 +264,7 @@ class ArcusTimeoutTest {
     byte[] from = new byte[]{(byte) 0};
     byte[] to = new byte[]{(byte) 1000};
 
+    @SuppressWarnings("deprecation")
     SMGetFuture<List<SMGetElement<Object>>> future = mc.asyncBopSortMergeGet(
             keyList, from, to, ElementFlagFilter.DO_NOT_FILTER, 0, 500);
     assertThrows(TimeoutException.class, () -> future.get(1L, TimeUnit.MILLISECONDS));

--- a/src/test/manual/net/spy/memcached/LongKeyTest/BaseLongKeyTest.java
+++ b/src/test/manual/net/spy/memcached/LongKeyTest/BaseLongKeyTest.java
@@ -178,6 +178,7 @@ class BaseLongKeyTest extends BaseIntegrationTest {
     SMGetMode smgetMode = SMGetMode.UNIQUE;
 
     /* old SMGetTest */
+    @SuppressWarnings("deprecation")
     SMGetFuture<List<SMGetElement<Object>>> oldFuture = mc
             .asyncBopSortMergeGet(keys, 0, 10,
                     ElementFlagFilter.DO_NOT_FILTER, 0, 10);

--- a/src/test/manual/net/spy/memcached/btreesmget/ByteArrayBKeySMGetErrorTest.java
+++ b/src/test/manual/net/spy/memcached/btreesmget/ByteArrayBKeySMGetErrorTest.java
@@ -39,6 +39,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
+@SuppressWarnings("deprecation")
 class ByteArrayBKeySMGetErrorTest extends BaseIntegrationTest {
 
   private static final List<String> KEY_LIST = new ArrayList<>();

--- a/src/test/manual/net/spy/memcached/btreesmget/ByteArrayBKeySMGetIrregularEflagTest.java
+++ b/src/test/manual/net/spy/memcached/btreesmget/ByteArrayBKeySMGetIrregularEflagTest.java
@@ -66,6 +66,7 @@ class ByteArrayBKeySMGetIrregularEflagTest extends BaseIntegrationTest {
       mc.asyncBopInsert(key2, new byte[]{4}, eFlag, value + "2",
               new CollectionAttributes()).get();
 
+      @SuppressWarnings("deprecation")
       List<SMGetElement<Object>> list = mc.asyncBopSortMergeGet(
               testKeyList, new byte[]{0}, new byte[]{10},
               ElementFlagFilter.DO_NOT_FILTER, 0, 10).get();

--- a/src/test/manual/net/spy/memcached/btreesmget/ByteArrayBKeySMGetTest.java
+++ b/src/test/manual/net/spy/memcached/btreesmget/ByteArrayBKeySMGetTest.java
@@ -40,6 +40,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
+@SuppressWarnings("deprecation")
 class ByteArrayBKeySMGetTest extends BaseIntegrationTest {
 
   private final String KEY = this.getClass().getSimpleName();

--- a/src/test/manual/net/spy/memcached/btreesmget/SMGetErrorTest.java
+++ b/src/test/manual/net/spy/memcached/btreesmget/SMGetErrorTest.java
@@ -41,6 +41,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
+@SuppressWarnings("deprecation")
 class SMGetErrorTest extends BaseIntegrationTest {
 
   private static final List<String> KEY_LIST = new ArrayList<>();

--- a/src/test/manual/net/spy/memcached/btreesmget/SMGetTest.java
+++ b/src/test/manual/net/spy/memcached/btreesmget/SMGetTest.java
@@ -40,6 +40,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
+@SuppressWarnings("deprecation")
 class SMGetTest extends BaseIntegrationTest {
 
   private final String KEY = this.getClass().getSimpleName();

--- a/src/test/manual/net/spy/memcached/btreesmget/SMGetWithCombinationEflagTest.java
+++ b/src/test/manual/net/spy/memcached/btreesmget/SMGetWithCombinationEflagTest.java
@@ -39,6 +39,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
+@SuppressWarnings("deprecation")
 class SMGetWithCombinationEflagTest extends BaseIntegrationTest {
 
   private final String KEY = this.getClass().getSimpleName();

--- a/src/test/manual/net/spy/memcached/btreesmget/SMGetWithEflagTest.java
+++ b/src/test/manual/net/spy/memcached/btreesmget/SMGetWithEflagTest.java
@@ -39,6 +39,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
+@SuppressWarnings("deprecation")
 class SMGetWithEflagTest extends BaseIntegrationTest {
 
   private final String KEY = this.getClass().getSimpleName();

--- a/src/test/manual/net/spy/memcached/collection/btree/BopSortMergeOldTest.java
+++ b/src/test/manual/net/spy/memcached/collection/btree/BopSortMergeOldTest.java
@@ -37,6 +37,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
+@SuppressWarnings("deprecation")
 class BopSortMergeOldTest extends BaseIntegrationTest {
 
   private final List<String> keyList3 = new ArrayList<>();


### PR DESCRIPTION
### 🔗 Related Issue

<!-- Please link related issue. ex) https://github.com/naver/arcus-java-client/issues/{issue_number} -->
- 

### ⌨️ What I did

<!-- Please describe this PR and what you've been working on. -->
- 기존에 private old smget API만 deprecate되어 있어서, public old smget API를 deprecate시킵니다.
- 어떤 캐시 서버 버전부터 new smget을 사용할 수 있는지 javadoc에 명시하면 좋을 것 같은데, 어디에서 찾아야할 지 모르겠습니다.
- 테스트 코드에서 클래스 자체에 suppress한 것은 테스트코드 전역적으로 old smget을 사용하는 경우이고, 메서드 사용시에만 suppress한 것은 특정 테스트 케이스에서만 old smget을 사용하는 경우입니다.