### PR TITLE
INTERNAL: improve refineTrimmedKeys method using Java 8 removeIf

### DIFF
--- a/src/main/java/net/spy/memcached/internal/result/SMGetResultImpl.java
+++ b/src/main/java/net/spy/memcached/internal/result/SMGetResultImpl.java
@@ -1,11 +1,8 @@
 package net.spy.memcached.internal.result;
 
 import java.util.ArrayList;
-import java.util.Iterator;
 import java.util.List;
-import java.util.Map;
 
-import net.spy.memcached.collection.BKeyObject;
 import net.spy.memcached.collection.CollectionResponse;
 import net.spy.memcached.collection.SMGetElement;
 import net.spy.memcached.ops.CollectionOperationStatus;
@@ -172,15 +169,10 @@ public final class SMGetResultImpl<T> extends SMGetResult<T> {
     if (!trimmedKeyMap.isEmpty() && count <= mergedResult.size()) {
       SMGetElement<T> lastElement = mergedResult.get(mergedResult.size() - 1);
 
-      // FIXME: use removeIf with entrySet() when upgrading java version 8
-      Iterator<Map.Entry<String, BKeyObject>> iterator = trimmedKeyMap.entrySet().iterator();
-      while (iterator.hasNext()) {
-        Map.Entry<String, BKeyObject> entry = iterator.next();
+      trimmedKeyMap.entrySet().removeIf(entry -> {
         int comp = entry.getValue().compareTo(lastElement.getBkeyObject());
-        if ((reverse) ? (comp <= 0) : (comp >= 0)) {
-          iterator.remove();
-        }
-      }
+        return (reverse) ? (comp <= 0) : (comp >= 0);
+      });
     }
   }
 }


### PR DESCRIPTION
### 🔗 Related Issue

<!-- Please link related issue. ex) https://github.com/naver/arcus-java-client/issues/{issue_number} -->
- 이 PR은 SMGetResultImpl 클래스의 refineTrimmedKeys 메서드를 개선하여 Java 8의 removeIf 기능을 활용합니다.

### ⌨️ What I did

<!-- Please describe this PR and what you've been working on. -->
- 기존 코드의 Iterator를 사용한 방식에서 removeIf 메서드를 사용하는 방식으로 변경했습니다
- "FIXME: use removeIf with entrySet() when upgrading java version 8" 주석을 제거했습니다
- 코드의 가독성 및 유지보수성을 향상시켰습니다
- 사용하지 않는 import 문을 제거하였습니다. (Iterator, Map, BKeyObject)