### PR TITLE
INTERNAL: use default collection transcoder

### DIFF
--- a/src/main/java/net/spy/memcached/ArcusClient.java
+++ b/src/main/java/net/spy/memcached/ArcusClient.java
@@ -357,7 +357,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
               ". Invoke ConnectionFactoryBuilder.setDnsCacheTtlCheck(false) to avoid this constraint.");
       throw new IllegalStateException("DNS cache TTL is out of range from 0 to " + MAX_DNS_CACHE_TTL);
     }
-    collectionTranscoder = new CollectionTranscoder();
+    collectionTranscoder = cf.getDefaultCollectionTranscoder();
     smgetKeyChunkSize = cf.getDefaultMaxSMGetKeyChunkSize();
     registerMbean(name);
   }

--- a/src/test/java/net/spy/memcached/ConnectionFactoryBuilderTest.java
+++ b/src/test/java/net/spy/memcached/ConnectionFactoryBuilderTest.java
@@ -33,6 +33,7 @@ import net.spy.memcached.protocol.ascii.AsciiMemcachedNodeImpl;
 import net.spy.memcached.protocol.ascii.AsciiOperationFactory;
 import net.spy.memcached.protocol.binary.BinaryMemcachedNodeImpl;
 import net.spy.memcached.protocol.binary.BinaryOperationFactory;
+import net.spy.memcached.transcoders.CollectionTranscoder;
 import net.spy.memcached.transcoders.SerializingTranscoder;
 import net.spy.memcached.transcoders.WhalinTranscoder;
 
@@ -41,6 +42,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -66,6 +68,7 @@ class ConnectionFactoryBuilderTest {
     //assertSame(DefaultConnectionFactory.DEFAULT_HASH, f.getHashAlg());
     assertSame(HashAlgorithm.KETAMA_HASH, f.getHashAlg());
     assertTrue(f.getDefaultTranscoder() instanceof SerializingTranscoder);
+    assertInstanceOf(CollectionTranscoder.class, f.getDefaultCollectionTranscoder());
     //assertSame(DefaultConnectionFactory.DEFAULT_FAILURE_MODE,
     // f.getFailureMode());
     assertSame(FailureMode.Cancel, f.getFailureMode());
@@ -139,6 +142,8 @@ class ConnectionFactoryBuilderTest {
             .setWriteOpQueueFactory(wQueueFactory)
             .setReadBufferSize(19)
             .setTranscoder(new WhalinTranscoder())
+            .setCollectionTranscoder(
+                    new CollectionTranscoder(CollectionTranscoder.MAX_ELEMENT_BYTES - 1))
             .setUseNagleAlgorithm(true)
             .setKeepAlive(true)
             .setDnsCacheTtlCheck(false)
@@ -151,6 +156,8 @@ class ConnectionFactoryBuilderTest {
     assertEquals(19, f.getReadBufSize());
     assertSame(HashAlgorithm.KETAMA_HASH, f.getHashAlg());
     assertTrue(f.getDefaultTranscoder() instanceof WhalinTranscoder);
+    assertEquals(CollectionTranscoder.MAX_ELEMENT_BYTES - 1,
+            f.getDefaultCollectionTranscoder().getMaxSize());
     assertSame(FailureMode.Redistribute, f.getFailureMode());
     assertEquals(1, f.getInitialObservers().size());
     assertSame(testObserver, f.getInitialObservers().iterator().next());


### PR DESCRIPTION
### 🔗 Related Issue

<!-- Please link related issue. ex) https://github.com/naver/arcus-java-client/issues/{issue_number} -->
- 현재 ConnectionFactoryBuilder에 setDefaultCollectionTranscoder, getDefaultCollectionTranscoder라는 메서드가 존재하지만 실제로 ArcusClient 객체 생성 시에 사용되지 않습니다.
- ArcusClient 생성 시 이 속성이 반영되도록 합니다.

### ⌨️ What I did

<!-- Please describe this PR and what you've been working on. -->
-