### PR TITLE
INTERNAL: add limit to setMaxSMGetKeyChunkSize method

### DIFF
--- a/src/main/java/net/spy/memcached/ConnectionFactoryBuilder.java
+++ b/src/main/java/net/spy/memcached/ConnectionFactoryBuilder.java
@@ -368,6 +368,10 @@ public class ConnectionFactoryBuilder {
    * Set max smget key chunk size
    */
   public ConnectionFactoryBuilder setMaxSMGetKeyChunkSize(int size) {
+    if (size <= 0 || size > 10000) {
+      throw new IllegalArgumentException(
+              "Max smget key chunk size must be a positive number and less than 10000");
+    }
     maxSMGetChunkSize = size;
     return this;
   }


### PR DESCRIPTION
### 🔗 Related Issue

<!-- Please link related issue. ex) https://github.com/naver/arcus-java-client/issues/{issue_number} -->
- 

### ⌨️ What I did

<!-- Please describe this PR and what you've been working on. -->
- CFB 문서 작성 도중 setMaxSMGetKeyChunkSize에 대한 최대 크기가 지정되지 않음을 확인했습니다.
- 서버에서 받아들이는 최대 크기까지만 지정할 수 있도록 하여 서버 에러가 발생하지 않도록 합니다.