### PR TITLE
FIX: Prevent concurrent modification by cloning shared `List<InetSocketAddress>` object per thread

### DIFF
--- a/src/main/java/net/spy/memcached/MemcachedConnection.java
+++ b/src/main/java/net/spy/memcached/MemcachedConnection.java
@@ -684,6 +684,7 @@ public final class MemcachedConnection extends SpyObject {
     /* ENABLE_MIGRATION end */
     List<InetSocketAddress> cacheList = cacheNodesChange.getAndSet(null);
     if (cacheList != null) {
+      cacheList = new ArrayList<>(cacheList);
       // Update the memcached server group.
       /* ENABLE_REPLICATION if */
       if (arcusReplEnabled) {
@@ -695,6 +696,7 @@ public final class MemcachedConnection extends SpyObject {
     }
     /* ENABLE_MIGRATION if */
     if (arcusMigrEnabled && alterList != null) {
+      alterList = new ArrayList<>(alterList);
       if (mgState == MigrationState.PREPARED) {
         if (!mgInProgress) {
           // prepare connections of alter nodes
@@ -714,7 +716,8 @@ public final class MemcachedConnection extends SpyObject {
 
   // Called by CacheManger to add the memcached server group.
   public void setCacheNodesChange(List<InetSocketAddress> addrs) {
-    List<InetSocketAddress> old = cacheNodesChange.getAndSet(addrs);
+    List<InetSocketAddress> old = cacheNodesChange.getAndSet(
+            Collections.unmodifiableList(addrs));
     if (old != null) {
       getLogger().info("Ignored previous cache nodes change.");
     }
@@ -731,12 +734,14 @@ public final class MemcachedConnection extends SpyObject {
   /* Called by CacheManger to add the alter memcached server group. */
   public void setAlterNodesChange(List<InetSocketAddress> addrs, boolean readingCacheList) {
     if (readingCacheList) {
-      List<InetSocketAddress> old = delayedAlterNodesChange.getAndSet(addrs);
+      List<InetSocketAddress> old = delayedAlterNodesChange.getAndSet(
+              Collections.unmodifiableList(addrs));
       if (old != null) {
         getLogger().info("Ignored previous delayed alter nodes change.");
       }
     } else {
-      List<InetSocketAddress> old = alterNodesChange.getAndSet(addrs);
+      List<InetSocketAddress> old = alterNodesChange.getAndSet(
+              Collections.unmodifiableList(addrs));
       if (old != null) {
         getLogger().info("Ignored previous alter nodes change.");
       }


### PR DESCRIPTION
### 🔗 Related Issue

<!-- Please link related issue. ex) https://github.com/naver/arcus-java-client/issues/{issue_number} -->
- https://github.com/jam2in/arcus-works/issues/723
- cache_list의 변경 사항과 alter_list의 변경 사항을 모든 IO Thread가 공유하는 형태이면서도 각각의 IO Thread가 거기에 Write 연산을 수행하여 문제가 발생한다.

### ⌨️ What I did

<!-- Please describe this PR and what you've been working on. -->
- 각각의 IO Thread가 cache_list의 변경 사항과 alter_list의 변경 사항을 복제한 다음 Write 연산을 수행하도록 합니다.