### PR TITLE
CLEANUP: Remove unnecessary type conversion from `List<String>` to `String` when parsing cache list znodes

### DIFF
--- a/src/main/java/net/spy/memcached/ArcusReplNodeAddress.java
+++ b/src/main/java/net/spy/memcached/ArcusReplNodeAddress.java
@@ -20,6 +20,7 @@ package net.spy.memcached;
 
 import java.net.InetSocketAddress;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -69,11 +70,11 @@ public final class ArcusReplNodeAddress extends InetSocketAddress {
     return new ArcusReplNodeAddress(group, master, ip, port);
   }
 
-  private static List<InetSocketAddress> parseNodeNames(String s) {
+  private static List<InetSocketAddress> parseNodeNames(List<String> s) {
     List<InetSocketAddress> addrs = new ArrayList<>();
 
-    for (String node : s.split(",")) {
-      String[] temp = node.split("\\^");
+    for (String node : s) {
+      String[] temp = node.trim().split("\\^");
       String group = temp[0];
       boolean master = temp[1].equals("M");
       String ipport = temp[2];
@@ -87,9 +88,14 @@ public final class ArcusReplNodeAddress extends InetSocketAddress {
     return addrs;
   }
 
-  // Similar to AddrUtil.getAddresses.  This version parses replication znode names.
-  // Znode names are group^{M,S}^ip:port-hostname
-  static List<InetSocketAddress> getAddresses(String s) {
+  /***
+   * Similar to AddrUtil.getAddresses.  This version parses replication znode names.
+   * Znode names are group^{M,S}^ip:port-hostname
+   * @param s The {@link java.util.List} of {@link java.lang.String}
+   *    *          containing {@code group^{M,S}^ip:port}
+   * @return The {@link java.util.List} of {@link net.spy.memcached.ArcusReplNodeAddress}
+   */
+  static List<InetSocketAddress> getAddresses(List<String> s) {
     List<InetSocketAddress> list = null;
 
     if (s != null && !s.isEmpty()) {
@@ -106,7 +112,7 @@ public final class ArcusReplNodeAddress extends InetSocketAddress {
     if (list == null) {
       list = new ArrayList<>(0);
     }
-    return list;
+    return Collections.unmodifiableList(list);
   }
 
   static Map<String, List<ArcusReplNodeAddress>> makeGroupAddrs(List<InetSocketAddress> addrs) {

--- a/src/main/java/net/spy/memcached/CacheManager.java
+++ b/src/main/java/net/spy/memcached/CacheManager.java
@@ -23,6 +23,7 @@ import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.text.SimpleDateFormat;
 import java.util.AbstractMap;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
@@ -418,20 +419,17 @@ public final class CacheManager extends SpyThread implements Watcher,
     }
   }
 
+  /**
+   * @param children The {@link java.util.List} of {@link java.lang.String}
+   *                 containing {@code ip:port-hostname} or {@code group^{M,S}^ip:port-hostname}
+   * @return The {@link java.util.List} of {@link java.net.InetSocketAddress}
+   *         or {@link net.spy.memcached.ArcusReplNodeAddress}
+   */
   private List<InetSocketAddress> getSocketAddrList(List<String> children) {
-    StringBuilder addrs = new StringBuilder();
-    for (int i = 0; i < children.size(); i++) {
-      String[] temp = children.get(i).split("-");
-      if (i != 0) {
-        addrs.append(",").append(temp[0]);
-      } else {
-        addrs.append(temp[0]);
-      }
+    List<String> addrs = new ArrayList<>(children.size());
+    for (String child : children) {
+      addrs.add(child.split("-")[0]);
     }
-    return convertToSocketAddresses(addrs.toString());
-  }
-
-  private List<InetSocketAddress> convertToSocketAddresses(String addrs) {
     /* ENABLE_REPLICATION if */
     if (arcusReplEnabled) {
       return ArcusReplNodeAddress.getAddresses(addrs);

--- a/src/test/java/net/spy/memcached/AddrUtilTest.java
+++ b/src/test/java/net/spy/memcached/AddrUtilTest.java
@@ -17,6 +17,8 @@
 package net.spy.memcached;
 
 import java.net.InetSocketAddress;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -34,8 +36,8 @@ class AddrUtilTest {
 
   @Test
   void testSingle() throws Exception {
-    List<InetSocketAddress> addrs =
-            AddrUtil.getAddresses("www.google.com:80");
+    List<InetSocketAddress> addrs = AddrUtil.getAddresses(
+            Collections.singletonList("www.google.com:80"));
     assertEquals(1, addrs.size());
     assertEquals("www.google.com", addrs.get(0).getHostName());
     assertEquals(80, addrs.get(0).getPort());
@@ -43,8 +45,8 @@ class AddrUtilTest {
 
   @Test
   void testTwo() throws Exception {
-    List<InetSocketAddress> addrs =
-            AddrUtil.getAddresses("www.google.com:80 www.yahoo.com:81");
+    List<InetSocketAddress> addrs = AddrUtil.getAddresses(
+            Arrays.asList("www.google.com:80", " www.yahoo.com:81"));
     assertEquals(2, addrs.size());
     assertEquals("www.google.com", addrs.get(0).getHostName());
     assertEquals(80, addrs.get(0).getPort());
@@ -54,8 +56,8 @@ class AddrUtilTest {
 
   @Test
   void testThree() throws Exception {
-    List<InetSocketAddress> addrs =
-            AddrUtil.getAddresses(" ,  www.google.com:80 ,, ,, www.yahoo.com:81 , ,,");
+    List<InetSocketAddress> addrs = AddrUtil.getAddresses(Arrays.asList(
+            " ", "  www.google.com:80 ", "", " ", "", " www.yahoo.com:81 ", " ", "", ""));
     assertEquals(2, addrs.size());
     assertEquals("www.google.com", addrs.get(0).getHostName());
     assertEquals(80, addrs.get(0).getPort());
@@ -65,7 +67,7 @@ class AddrUtilTest {
 
   @Test
   void testBrokenHost() throws Exception {
-    String s = "www.google.com:80 www.yahoo.com:81:more";
+    List<String> s = Arrays.asList("www.google.com:80", " www.yahoo.com:81:more");
     try {
       List<InetSocketAddress> addrs = AddrUtil.getAddresses(s);
       fail("Expected failure, got " + addrs);
@@ -77,19 +79,18 @@ class AddrUtilTest {
 
   @Test
   void testBrokenHost2() throws Exception {
-    String s = "www.google.com:80 www.yahoo.com";
+    List<String> s = Arrays.asList("www.google.com:80", " www.yahoo.com");
     try {
       List<InetSocketAddress> addrs = AddrUtil.getAddresses(s);
       fail("Expected failure, got " + addrs);
     } catch (IllegalArgumentException e) {
-      assertEquals("Invalid server ``www.yahoo.com'' in list:  "
-              + s, e.getMessage());
+      assertEquals("Invalid server ``www.yahoo.com''", e.getMessage());
     }
   }
 
   @Test
   void testNullList() throws Exception {
-    String s = null;
+    List<String> s = null;
     try {
       List<InetSocketAddress> addrs = AddrUtil.getAddresses(s);
       fail("Expected failure, got " + addrs);
@@ -100,8 +101,8 @@ class AddrUtilTest {
 
   @Test
   void testIPv6Host() throws Exception {
-    List<InetSocketAddress> addrs =
-            AddrUtil.getAddresses("::1:80");
+    List<InetSocketAddress> addrs = AddrUtil.getAddresses(
+            Collections.singletonList("::1:80"));
     assertEquals(1, addrs.size());
 
     Set<String> validLocalhostNames = new HashSet<>();

--- a/src/test/java/net/spy/memcached/ArcusKetamaNodeLocatorTest.java
+++ b/src/test/java/net/spy/memcached/ArcusKetamaNodeLocatorTest.java
@@ -20,6 +20,7 @@ package net.spy.memcached;
 import java.net.InetSocketAddress;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
@@ -142,7 +143,7 @@ class ArcusKetamaNodeLocatorTest extends AbstractNodeLocationCase {
 
     for (int i = 0; i < nodes.length; i++) {
       final int idx = i;
-      List<InetSocketAddress> a = AddrUtil.getAddresses(servers[i]);
+      List<InetSocketAddress> a = AddrUtil.getAddresses(Collections.singletonList(servers[i]));
 
       nodes[i] = context.mock(MemcachedNode.class, "node##" + i);
       context.checking(buildExpectations(e -> {

--- a/src/test/java/net/spy/memcached/ArcusTimeoutTest.java
+++ b/src/test/java/net/spy/memcached/ArcusTimeoutTest.java
@@ -19,6 +19,7 @@ package net.spy.memcached;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
@@ -63,7 +64,7 @@ class ArcusTimeoutTest {
       public FailureMode getFailureMode() {
         return FailureMode.Retry;
       }
-    }, AddrUtil.getAddresses("0.0.0.0:23456"));
+    }, AddrUtil.getAddresses(Collections.singletonList("0.0.0.0:23456")));
   }
 
   @AfterEach

--- a/src/test/java/net/spy/memcached/AsciiIPV6ClientTest.java
+++ b/src/test/java/net/spy/memcached/AsciiIPV6ClientTest.java
@@ -1,5 +1,7 @@
 package net.spy.memcached;
 
+import java.util.Collections;
+
 /**
  * Test the test protocol over IPv6.
  */
@@ -7,8 +9,8 @@ class AsciiIPV6ClientTest extends AsciiClientTest {
 
   @Override
   protected void initClient(ConnectionFactory cf) throws Exception {
-    client = new MemcachedClient(cf,
-            AddrUtil.getAddresses("::1:11211"));
+    client = new MemcachedClient(cf, AddrUtil.getAddresses(
+            Collections.singletonList("::1:11211")));
   }
 
   @Override

--- a/src/test/java/net/spy/memcached/BinaryIPV6ClientTest.java
+++ b/src/test/java/net/spy/memcached/BinaryIPV6ClientTest.java
@@ -1,5 +1,7 @@
 package net.spy.memcached;
 
+import java.util.Collections;
+
 /**
  * Binary IPv6 client test.
  */
@@ -7,8 +9,8 @@ class BinaryIPV6ClientTest extends BinaryClientTest {
 
   @Override
   protected void initClient(ConnectionFactory cf) throws Exception {
-    client = new MemcachedClient(cf,
-            AddrUtil.getAddresses("::1:11211"));
+    client = new MemcachedClient(cf, AddrUtil.getAddresses(
+            Collections.singletonList("::1:11211")));
   }
 
   @Override

--- a/src/test/java/net/spy/memcached/CancelFailureModeTest.java
+++ b/src/test/java/net/spy/memcached/CancelFailureModeTest.java
@@ -1,5 +1,6 @@
 package net.spy.memcached;
 
+import java.util.Collections;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 
@@ -21,7 +22,7 @@ class CancelFailureModeTest {
       public FailureMode getFailureMode() {
         return FailureMode.Cancel;
       }
-    }, AddrUtil.getAddresses(serverList));
+    }, AddrUtil.getAddresses(Collections.singletonList(serverList)));
   }
 
   @AfterEach

--- a/src/test/java/net/spy/memcached/CancellationBaseCase.java
+++ b/src/test/java/net/spy/memcached/CancellationBaseCase.java
@@ -47,7 +47,7 @@ abstract class CancellationBaseCase {
   }
 
   protected void initClient(ConnectionFactory cf) throws Exception {
-    client = new MemcachedClient(cf, AddrUtil.getAddresses(serverList));
+    client = new MemcachedClient(cf, AddrUtil.getAddresses(Collections.singletonList(serverList)));
   }
 
   private void tryCancellation(Future<?> f) throws Exception {

--- a/src/test/java/net/spy/memcached/ClientBaseCase.java
+++ b/src/test/java/net/spy/memcached/ClientBaseCase.java
@@ -309,7 +309,7 @@ abstract class ClientBaseCase {
   }
 
   protected void openDirect(ConnectionFactory cf) throws Exception {
-    client = new ArcusClient(cf, AddrUtil.getAddresses(ARCUS_HOST));
+    client = new ArcusClient(cf, AddrUtil.getAddresses(Collections.singletonList(ARCUS_HOST)));
   }
 
   @BeforeEach

--- a/src/test/java/net/spy/memcached/ConsistentHashingTest.java
+++ b/src/test/java/net/spy/memcached/ConsistentHashingTest.java
@@ -37,7 +37,7 @@ class ConsistentHashingTest {
    * @param totalNodes totalNodes
    */
   private void runThisManyNodes(final int totalNodes) {
-    final String[] stringNodes = generateAddresses(totalNodes);
+    final List<String>[] stringNodes = generateAddresses(totalNodes);
 
     List<MemcachedNode> smaller = createNodes(
             AddrUtil.getAddresses(stringNodes[0]));
@@ -88,8 +88,11 @@ class ConsistentHashingTest {
 
   }
 
-  private String[] generateAddresses(final int maxSize) {
-    final String[] results = new String[2];
+  private List<String>[] generateAddresses(final int maxSize) {
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    final List<String>[] results = new List[2];
+    results[0] = new ArrayList<>(maxSize);
+    results[1] = new ArrayList<>(maxSize);
 
     // Generate a pseudo-random set of addresses.
     long now = new Date().getTime();
@@ -100,28 +103,16 @@ class ConsistentHashingTest {
     String port = ":11211 ";
     int last = (int) ((now % 100) + 3);
 
-    StringBuilder prefix = new StringBuilder();
-    prefix.append(first);
-    prefix.append(".");
-    prefix.append(second);
-    prefix.append(".1.");
+    String prefix = first + "." + second + ".1.";
 
     // Don't protect the possible range too much, as we are our own client.
-    StringBuilder buf = new StringBuilder();
     for (int ix = 0; ix < maxSize - 1; ix++) {
-      buf.append(prefix);
-      buf.append(last + ix);
-      buf.append(port);
+      String addr = prefix + (last + ix) + port;
+      results[0].add(addr);
+      results[1].add(addr);
     }
 
-    results[0] = buf.toString();
-
-    buf.append(prefix);
-    buf.append(last + maxSize - 1);
-    buf.append(port);
-
-    results[1] = buf.toString();
-
+    results[1].add(prefix + (last + maxSize - 1) + port);
     return results;
   }
 

--- a/src/test/java/net/spy/memcached/DoLotsOfSets.java
+++ b/src/test/java/net/spy/memcached/DoLotsOfSets.java
@@ -2,6 +2,7 @@ package net.spy.memcached;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Future;
@@ -23,7 +24,7 @@ final class DoLotsOfSets {
     // we're going to add.
     MemcachedClient client = new MemcachedClient(
             new DefaultConnectionFactory(350000, 32768),
-            AddrUtil.getAddresses("localhost:11211"));
+            AddrUtil.getAddresses(Collections.singletonList("localhost:11211")));
     int count = 300000;
     long start = System.currentTimeMillis();
     byte[] toStore = new byte[26];

--- a/src/test/java/net/spy/memcached/KetamaNodeLocatorTest.java
+++ b/src/test/java/net/spy/memcached/KetamaNodeLocatorTest.java
@@ -3,6 +3,7 @@ package net.spy.memcached;
 import java.net.InetSocketAddress;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
@@ -140,7 +141,8 @@ class KetamaNodeLocatorTest extends AbstractNodeLocationCase {
 
     for (int i = 0; i < nodes.length; i++) {
       final int idx = i;
-      List<InetSocketAddress> a = AddrUtil.getAddresses(servers[i]);
+      List<InetSocketAddress> a = AddrUtil.getAddresses(
+              Collections.singletonList(servers[i]));
 
       nodes[i] = context.mock(MemcachedNode.class, "node##" + i);
       context.checking(buildExpectations(e -> {

--- a/src/test/java/net/spy/memcached/MemcachedClientConstructorTest.java
+++ b/src/test/java/net/spy/memcached/MemcachedClientConstructorTest.java
@@ -94,8 +94,8 @@ class MemcachedClientConstructorTest {
   @Test
   void testNullFactoryConstructor() throws Exception {
     try {
-      client = new MemcachedClient(null,
-              AddrUtil.getAddresses(ARCUS_HOST));
+      client = new MemcachedClient(null, AddrUtil.getAddresses(
+              Collections.singletonList(ARCUS_HOST)));
       fail("Expected null pointer exception, got " + client);
     } catch (NullPointerException e) {
       assertEquals("Connection factory required", e.getMessage());
@@ -111,7 +111,7 @@ class MemcachedClientConstructorTest {
           return -1;
         }
       },
-              AddrUtil.getAddresses(ARCUS_HOST));
+              AddrUtil.getAddresses(Collections.singletonList(ARCUS_HOST)));
       fail("Expected null pointer exception, got " + client);
     } catch (IllegalArgumentException e) {
       assertEquals("Operation timeout must be positive.", e.getMessage());
@@ -127,7 +127,7 @@ class MemcachedClientConstructorTest {
           return 0;
         }
       },
-              AddrUtil.getAddresses(ARCUS_HOST));
+              AddrUtil.getAddresses(Collections.singletonList(ARCUS_HOST)));
       fail("Expected null pointer exception, got " + client);
     } catch (IllegalArgumentException e) {
       assertEquals("Operation timeout must be positive.", e.getMessage());
@@ -142,7 +142,7 @@ class MemcachedClientConstructorTest {
         public OperationFactory getOperationFactory() {
           return null;
         }
-      }, AddrUtil.getAddresses(ARCUS_HOST));
+      }, AddrUtil.getAddresses(Collections.singletonList(ARCUS_HOST)));
       fail("Expected AssertionError, got " + client);
     } catch (AssertionError e) {
       assertEquals("Connection factory failed to make op factory",
@@ -159,7 +159,7 @@ class MemcachedClientConstructorTest {
                 List<InetSocketAddress> addrs) throws IOException {
           return null;
         }
-      }, AddrUtil.getAddresses(ARCUS_HOST));
+      }, AddrUtil.getAddresses(Collections.singletonList(ARCUS_HOST)));
       fail("Expected AssertionError, got " + client);
     } catch (AssertionError e) {
       assertEquals("Connection factory failed to make a connection",
@@ -170,7 +170,8 @@ class MemcachedClientConstructorTest {
 
   @Test
   void testArraymodNodeLocatorAccessor() throws Exception {
-    client = new MemcachedClient(AddrUtil.getAddresses(ARCUS_HOST));
+    client = new MemcachedClient(AddrUtil.getAddresses(
+            Collections.singletonList(ARCUS_HOST)));
     assertTrue(client.getNodeLocator() instanceof ArrayModNodeLocator);
     assertTrue(client.getNodeLocator().getPrimary("x")
             instanceof MemcachedNodeROImpl);
@@ -178,8 +179,8 @@ class MemcachedClientConstructorTest {
 
   @Test
   void testKetamaNodeLocatorAccessor() throws Exception {
-    client = new MemcachedClient(new KetamaConnectionFactory(),
-            AddrUtil.getAddresses(ARCUS_HOST));
+    client = new MemcachedClient(new KetamaConnectionFactory(), AddrUtil.getAddresses(
+            Collections.singletonList(ARCUS_HOST)));
     assertTrue(client.getNodeLocator() instanceof KetamaNodeLocator);
     assertTrue(client.getNodeLocator().getPrimary("x")
             instanceof MemcachedNodeROImpl);

--- a/src/test/java/net/spy/memcached/MemcachedConnectionTest.java
+++ b/src/test/java/net/spy/memcached/MemcachedConnectionTest.java
@@ -21,6 +21,8 @@ import java.lang.reflect.Field;
 import java.net.InetSocketAddress;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.SortedMap;
@@ -71,7 +73,7 @@ class MemcachedConnectionTest {
   @Test
   void testNodesChangeQueue() throws Exception {
     // when
-    conn.setCacheNodesChange(AddrUtil.getAddresses("0.0.0.0:11211"));
+    conn.setCacheNodesChange(AddrUtil.getAddresses(Collections.singletonList("0.0.0.0:11211")));
 
     // 1st test (nodes=1)
     conn.handleCacheNodesChange();
@@ -80,7 +82,8 @@ class MemcachedConnectionTest {
     assertTrue(1 == locator.getAll().size());
 
     // when
-    conn.setCacheNodesChange(AddrUtil.getAddresses("0.0.0.0:11211,0.0.0.0:11212,0.0.0.0:11213"));
+    conn.setCacheNodesChange(AddrUtil.getAddresses(
+            Arrays.asList("0.0.0.0:11211", "0.0.0.0:11212", "0.0.0.0:11213")));
 
     // 2nd test (nodes=3)
     conn.handleCacheNodesChange();
@@ -89,7 +92,7 @@ class MemcachedConnectionTest {
     assertTrue(3 == locator.getAll().size());
 
     // when
-    conn.setCacheNodesChange(AddrUtil.getAddresses("0.0.0.0:11212"));
+    conn.setCacheNodesChange(AddrUtil.getAddresses(Collections.singletonList("0.0.0.0:11212")));
 
     // 3rd test (nodes=1)
     conn.handleCacheNodesChange();
@@ -114,7 +117,7 @@ class MemcachedConnectionTest {
   void testNodesChangeQueue_invalid_addr() {
     try {
       // when : putting an invalid address
-      conn.setCacheNodesChange(AddrUtil.getAddresses(""));
+      conn.setCacheNodesChange(Collections.emptyList());
 
       // test
       conn.handleCacheNodesChange();
@@ -130,7 +133,8 @@ class MemcachedConnectionTest {
   @Test
   void testNodesChangeQueue_redundant() throws Exception {
     // when
-    conn.setCacheNodesChange(AddrUtil.getAddresses("0.0.0.0:11211,0.0.0.0:11211"));
+    conn.setCacheNodesChange(AddrUtil.getAddresses(
+            Arrays.asList("0.0.0.0:11211", "0.0.0.0:11211")));
 
     // test
     conn.handleCacheNodesChange();
@@ -142,8 +146,8 @@ class MemcachedConnectionTest {
   @Test
   void testNodesChangeQueue_twice() throws Exception {
     // when
-    conn.setCacheNodesChange(AddrUtil.getAddresses("0.0.0.0:11211"));
-    conn.setCacheNodesChange(AddrUtil.getAddresses("0.0.0.0:11211"));
+    conn.setCacheNodesChange(AddrUtil.getAddresses(Collections.singletonList("0.0.0.0:11211")));
+    conn.setCacheNodesChange(AddrUtil.getAddresses(Collections.singletonList("0.0.0.0:11211")));
 
     // test
     conn.handleCacheNodesChange();

--- a/src/test/java/net/spy/memcached/RedistributeFailureModeTest.java
+++ b/src/test/java/net/spy/memcached/RedistributeFailureModeTest.java
@@ -1,6 +1,7 @@
 package net.spy.memcached;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Future;
@@ -34,7 +35,7 @@ class RedistributeFailureModeTest extends ClientBaseCase {
 
   @Override
   protected void initClient(ConnectionFactory cf) throws Exception {
-    client = new MemcachedClient(cf, AddrUtil.getAddresses(serverList));
+    client = new MemcachedClient(cf, AddrUtil.getAddresses(Collections.singletonList(serverList)));
   }
 
   @Override

--- a/src/test/java/net/spy/memcached/TimeoutTest.java
+++ b/src/test/java/net/spy/memcached/TimeoutTest.java
@@ -1,6 +1,7 @@
 package net.spy.memcached;
 
 import java.util.Arrays;
+import java.util.Collections;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -24,7 +25,7 @@ class TimeoutTest {
         return FailureMode.Retry;
       }
     },
-            AddrUtil.getAddresses("127.0.0.1:64213"));
+            AddrUtil.getAddresses(Collections.singletonList("127.0.0.1:64213")));
   }
 
   @AfterEach

--- a/src/test/manual/net/spy/memcached/MemcachedConnectionReplTest.java
+++ b/src/test/manual/net/spy/memcached/MemcachedConnectionReplTest.java
@@ -22,6 +22,8 @@ import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 import org.junit.jupiter.api.AfterEach;
@@ -56,8 +58,8 @@ class MemcachedConnectionReplTest {
 
   @Test
   void testHandleCacheNodesChange() throws IOException {
-    conn.setCacheNodesChange(ArcusReplNodeAddress.getAddresses(
-            "g0^M^127.0.0.1:11211,g0^S^127.0.0.2:11211"));
+    conn.setCacheNodesChange(ArcusReplNodeAddress.getAddresses(Arrays.asList(
+            "g0^M^127.0.0.1:11211", "g0^S^127.0.0.2:11211")));
     conn.handleCacheNodesChange();
     assertEquals(2, locator.getAll().size());
     assertEquals(1, locator.getAllGroups().size());
@@ -79,14 +81,14 @@ class MemcachedConnectionReplTest {
 
   @Test
   void testHandleCacheNodesChange_switchover() throws IOException {
-    conn.setCacheNodesChange(ArcusReplNodeAddress.getAddresses(
-            "g0^M^127.0.0.1:11211,g0^S^127.0.0.2:11211"));
+    conn.setCacheNodesChange(ArcusReplNodeAddress.getAddresses(Arrays.asList(
+            "g0^M^127.0.0.1:11211", "g0^S^127.0.0.2:11211")));
     conn.handleCacheNodesChange();
     assertEquals(2, locator.getAll().size());
     assertEquals(1, locator.getAllGroups().size());
 
-    conn.setCacheNodesChange(ArcusReplNodeAddress.getAddresses(
-            "g0^S^127.0.0.1:11211,g0^S^127.0.0.2:11211"));
+    conn.setCacheNodesChange(ArcusReplNodeAddress.getAddresses(Arrays.asList(
+            "g0^S^127.0.0.1:11211", "g0^S^127.0.0.2:11211")));
     conn.handleCacheNodesChange();
     assertEquals(2, locator.getAll().size());
     assertEquals(1, locator.getAllGroups().size());
@@ -105,8 +107,8 @@ class MemcachedConnectionReplTest {
     assertEquals("{g0 M 127.0.0.1:11211}", masterAddr.toString());
     assertEquals("{g0 S 127.0.0.2:11211}", slaveAddr.toString());
 
-    conn.setCacheNodesChange(ArcusReplNodeAddress.getAddresses(
-            "g0^S^127.0.0.1:11211,g0^M^127.0.0.2:11211"));
+    conn.setCacheNodesChange(ArcusReplNodeAddress.getAddresses(Arrays.asList(
+            "g0^S^127.0.0.1:11211", "g0^M^127.0.0.2:11211")));
     conn.handleCacheNodesChange();
     assertEquals(2, locator.getAll().size());
     assertEquals(1, locator.getAllGroups().size());
@@ -128,13 +130,14 @@ class MemcachedConnectionReplTest {
 
   @Test
   void testHandleCacheNodesChange_failover_master() throws IOException {
-    conn.setCacheNodesChange(ArcusReplNodeAddress.getAddresses(
-            "g0^M^127.0.0.1:11211,g0^S^127.0.0.2:11211"));
+    conn.setCacheNodesChange(ArcusReplNodeAddress.getAddresses(Arrays.asList(
+            "g0^M^127.0.0.1:11211", "g0^S^127.0.0.2:11211")));
     conn.handleCacheNodesChange();
     assertEquals(2, locator.getAll().size());
     assertEquals(1, locator.getAllGroups().size());
 
-    conn.setCacheNodesChange(ArcusReplNodeAddress.getAddresses("g0^S^127.0.0.2:11211"));
+    conn.setCacheNodesChange(ArcusReplNodeAddress.getAddresses(Collections.singletonList(
+            "g0^S^127.0.0.2:11211")));
     conn.handleCacheNodesChange();
     assertEquals(2, locator.getAll().size());
     assertEquals(1, locator.getAllGroups().size());
@@ -148,7 +151,8 @@ class MemcachedConnectionReplTest {
     assertNotNull(master);
     assertNotNull(slave);
 
-    conn.setCacheNodesChange(ArcusReplNodeAddress.getAddresses("g0^M^127.0.0.2:11211"));
+    conn.setCacheNodesChange(ArcusReplNodeAddress.getAddresses(Collections.singletonList(
+            "g0^M^127.0.0.2:11211")));
     conn.handleCacheNodesChange();
     assertEquals(1, locator.getAll().size());
     assertEquals(1, locator.getAllGroups().size());
@@ -166,13 +170,14 @@ class MemcachedConnectionReplTest {
 
   @Test
   void testHandleCacheNodesChange_failover_slave() throws IOException {
-    conn.setCacheNodesChange(ArcusReplNodeAddress.getAddresses(
-            "g0^M^127.0.0.1:11211,g0^S^127.0.0.2:11211"));
+    conn.setCacheNodesChange(ArcusReplNodeAddress.getAddresses(Arrays.asList(
+            "g0^M^127.0.0.1:11211", "g0^S^127.0.0.2:11211")));
     conn.handleCacheNodesChange();
     assertEquals(2, locator.getAll().size());
     assertEquals(1, locator.getAllGroups().size());
 
-    conn.setCacheNodesChange(ArcusReplNodeAddress.getAddresses("g0^M^127.0.0.1:11211"));
+    conn.setCacheNodesChange(ArcusReplNodeAddress.getAddresses(Collections.singletonList(
+            "g0^M^127.0.0.1:11211")));
     conn.handleCacheNodesChange();
 
     assertEquals(1, locator.getAll().size());
@@ -191,8 +196,8 @@ class MemcachedConnectionReplTest {
 
   @Test
   void testHandleCacheNodesChange_failover_all() throws IOException {
-    conn.setCacheNodesChange(ArcusReplNodeAddress.getAddresses(
-            "g0^M^127.0.0.1:11211,g0^S^127.0.0.2:11211"));
+    conn.setCacheNodesChange(ArcusReplNodeAddress.getAddresses(Arrays.asList(
+            "g0^M^127.0.0.1:11211", "g0^S^127.0.0.2:11211")));
     conn.handleCacheNodesChange();
     assertEquals(2, locator.getAll().size());
     assertEquals(1, locator.getAllGroups().size());
@@ -206,8 +211,9 @@ class MemcachedConnectionReplTest {
 
   @Test
   void testHandleCacheNodesChange_multiple_groups() throws IOException {
-    conn.setCacheNodesChange(ArcusReplNodeAddress.getAddresses(
-            "g0^M^127.0.0.1:11211,g0^S^127.0.0.2:11211,g1^M^127.0.0.3:11211,g1^S^127.0.0.4:11211"));
+    conn.setCacheNodesChange(ArcusReplNodeAddress.getAddresses(Arrays.asList(
+            "g0^M^127.0.0.1:11211", "g0^S^127.0.0.2:11211",
+            "g1^M^127.0.0.3:11211", "g1^S^127.0.0.4:11211")));
     conn.handleCacheNodesChange();
     assertEquals(4, locator.getAll().size());
     assertEquals(2, locator.getAllGroups().size());
@@ -243,14 +249,16 @@ class MemcachedConnectionReplTest {
 
   @Test
   void testHandleCacheNodesChange_edge_case_1() throws IOException {
-    conn.setCacheNodesChange(ArcusReplNodeAddress.getAddresses(
-            "g0^M^127.0.0.1:11211,g0^S^127.0.0.2:11211,g1^M^127.0.0.3:11211,g1^S^127.0.0.4:11211"));
+    conn.setCacheNodesChange(ArcusReplNodeAddress.getAddresses(Arrays.asList(
+            "g0^M^127.0.0.1:11211", "g0^S^127.0.0.2:11211",
+            "g1^M^127.0.0.3:11211", "g1^S^127.0.0.4:11211")));
     conn.handleCacheNodesChange();
     assertEquals(4, locator.getAll().size());
     assertEquals(2, locator.getAllGroups().size());
 
-    conn.setCacheNodesChange(ArcusReplNodeAddress.getAddresses(
-            "g1^M^127.0.0.1:11211,g1^S^127.0.0.2:11211,g0^M^127.0.0.3:11211,g0^S^127.0.0.4:11211"));
+    conn.setCacheNodesChange(ArcusReplNodeAddress.getAddresses(Arrays.asList(
+            "g1^M^127.0.0.1:11211", "g1^S^127.0.0.2:11211",
+            "g0^M^127.0.0.3:11211", "g0^S^127.0.0.4:11211")));
     conn.handleCacheNodesChange();
     assertEquals(4, locator.getAll().size());
     assertEquals(2, locator.getAllGroups().size());
@@ -286,14 +294,16 @@ class MemcachedConnectionReplTest {
 
   @Test
   void testHandleCacheNodesChange_edge_case_2() throws IOException {
-    conn.setCacheNodesChange(ArcusReplNodeAddress.getAddresses(
-            "g0^M^127.0.0.1:11211,g0^S^127.0.0.2:11211,g1^M^127.0.0.3:11211,g1^S^127.0.0.4:11211"));
+    conn.setCacheNodesChange(ArcusReplNodeAddress.getAddresses(Arrays.asList(
+            "g0^M^127.0.0.1:11211", "g0^S^127.0.0.2:11211",
+            "g1^M^127.0.0.3:11211", "g1^S^127.0.0.4:11211")));
     conn.handleCacheNodesChange();
     assertEquals(4, locator.getAll().size());
     assertEquals(2, locator.getAllGroups().size());
 
-    conn.setCacheNodesChange(ArcusReplNodeAddress.getAddresses(
-            "g1^S^127.0.0.1:11211,g1^M^127.0.0.2:11211,g0^S^127.0.0.3:11211,g0^M^127.0.0.4:11211"));
+    conn.setCacheNodesChange(ArcusReplNodeAddress.getAddresses(Arrays.asList(
+            "g1^S^127.0.0.1:11211", "g1^M^127.0.0.2:11211",
+            "g0^S^127.0.0.3:11211", "g0^M^127.0.0.4:11211")));
     conn.handleCacheNodesChange();
     assertEquals(4, locator.getAll().size());
     assertEquals(2, locator.getAllGroups().size());

--- a/src/test/manual/net/spy/memcached/collection/BaseIntegrationTest.java
+++ b/src/test/manual/net/spy/memcached/collection/BaseIntegrationTest.java
@@ -120,7 +120,7 @@ public class BaseIntegrationTest {
     };
     cfb.setInitialObservers(Collections.singleton(obs));
 
-    mc = new ArcusClient(cfb.build(), AddrUtil.getAddresses(ARCUS_HOST));
+    mc = new ArcusClient(cfb.build(), AddrUtil.getAddresses(Collections.singletonList(ARCUS_HOST)));
     latch.await();
   }
 

--- a/src/test/manual/net/spy/memcached/test/AuthTest.java
+++ b/src/test/manual/net/spy/memcached/test/AuthTest.java
@@ -1,5 +1,7 @@
 package net.spy.memcached.test;
 
+import java.util.Collections;
+
 import net.spy.memcached.AddrUtil;
 import net.spy.memcached.ConnectionFactoryBuilder;
 import net.spy.memcached.ConnectionFactoryBuilder.Protocol;
@@ -25,7 +27,7 @@ class AuthTest extends SpyObject implements Runnable {
     client = new MemcachedClient(new ConnectionFactoryBuilder()
             .setProtocol(Protocol.BINARY)
             .setAuthDescriptor(AuthDescriptor.typical(username, password))
-            .build(), AddrUtil.getAddresses("localhost:11212"));
+            .build(), AddrUtil.getAddresses(Collections.singletonList("localhost:11212")));
   }
 
   public void shutdown() throws Exception {

--- a/src/test/manual/net/spy/memcached/test/ExcessivelyLargeGetTest.java
+++ b/src/test/manual/net/spy/memcached/test/ExcessivelyLargeGetTest.java
@@ -3,6 +3,7 @@ package net.spy.memcached.test;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Map;
 import java.util.Random;
 
@@ -37,7 +38,7 @@ class ExcessivelyLargeGetTest extends SpyObject implements Runnable {
   public ExcessivelyLargeGetTest() throws Exception {
     client = new MemcachedClient(new ConnectionFactoryBuilder()
             .setProtocol(Protocol.BINARY).setOpTimeout(15000).build(),
-            AddrUtil.getAddresses(ARCUS_HOST));
+            AddrUtil.getAddresses(Collections.singletonList(ARCUS_HOST)));
     keys = new ArrayList<>(N);
     new Random().nextBytes(value);
   }

--- a/src/test/manual/net/spy/memcached/test/LoaderTest.java
+++ b/src/test/manual/net/spy/memcached/test/LoaderTest.java
@@ -1,5 +1,6 @@
 package net.spy.memcached.test;
 
+import java.util.Collections;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
@@ -25,7 +26,7 @@ class LoaderTest extends SpyObject implements Runnable {
   public void init() throws Exception {
     client = new MemcachedClient(new ConnectionFactoryBuilder()
             .setProtocol(Protocol.BINARY).setOpQueueMaxBlockTime(1000)
-            .build(), AddrUtil.getAddresses("localhost:11211"));
+            .build(), AddrUtil.getAddresses(Collections.singletonList("localhost:11211")));
   }
 
   public void shutdown() throws Exception {

--- a/src/test/manual/net/spy/memcached/test/MemcachedThreadBench.java
+++ b/src/test/manual/net/spy/memcached/test/MemcachedThreadBench.java
@@ -16,6 +16,8 @@
  */
 package net.spy.memcached.test;
 
+import java.util.Collections;
+
 import net.spy.memcached.AddrUtil;
 import net.spy.memcached.DefaultConnectionFactory;
 import net.spy.memcached.MemcachedClient;
@@ -63,7 +65,7 @@ class MemcachedThreadBench {
 
     MemcachedClient client = new MemcachedClient(
             new DefaultConnectionFactory(100000, 32768),
-            AddrUtil.getAddresses(serverlist));
+            AddrUtil.getAddresses(Collections.singletonList(serverlist)));
 
     WorkerStat[] statArray = new WorkerStat[threads];
     Thread[] threadArray = new Thread[threads];

--- a/src/test/manual/net/spy/memcached/test/MemoryFullTest.java
+++ b/src/test/manual/net/spy/memcached/test/MemoryFullTest.java
@@ -1,5 +1,6 @@
 package net.spy.memcached.test;
 
+import java.util.Collections;
 import java.util.Random;
 import java.util.concurrent.ExecutionException;
 
@@ -32,8 +33,8 @@ final class MemoryFullTest {
       // OK
     }
 
-    MemcachedClient c = new MemcachedClient(
-            AddrUtil.getAddresses("localhost:11200"));
+    MemcachedClient c = new MemcachedClient(AddrUtil.getAddresses(
+            Collections.singletonList("localhost:11200")));
     boolean success = false;
     Random r = new Random();
     byte[] somebytes = new byte[71849];

--- a/src/test/manual/net/spy/memcached/test/MultiNodeFailureTest.java
+++ b/src/test/manual/net/spy/memcached/test/MultiNodeFailureTest.java
@@ -15,8 +15,8 @@ final class MultiNodeFailureTest {
   }
 
   public static void main(String args[]) throws Exception {
-    MemcachedClient c = new MemcachedClient(
-            AddrUtil.getAddresses("localhost:11200 localhost:11201"));
+    MemcachedClient c = new MemcachedClient(AddrUtil.getAddresses(
+            Arrays.asList("localhost:11200", " localhost:11201")));
     while (true) {
       for (int i = 0; i < 1000; i++) {
         try {

--- a/src/test/manual/net/spy/memcached/test/ObserverToy.java
+++ b/src/test/manual/net/spy/memcached/test/ObserverToy.java
@@ -45,7 +45,7 @@ final class ObserverToy {
         return false;
       }
 
-    }, AddrUtil.getAddresses("localhost:11212"));
+    }, AddrUtil.getAddresses(Collections.singletonList("localhost:11212")));
 
     while (true) {
       try {

--- a/src/test/manual/net/spy/memcached/test/SASLConnectReconnect.java
+++ b/src/test/manual/net/spy/memcached/test/SASLConnectReconnect.java
@@ -2,6 +2,7 @@ package net.spy.memcached.test;
 
 import java.io.IOException;
 import java.net.InetSocketAddress;
+import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.ConsoleHandler;
@@ -36,7 +37,7 @@ class SASLConnectReconnect {
     AuthDescriptor ad = new AuthDescriptor(new String[]{"PLAIN"},
             new PlainCallbackHandler(username, password));
     try {
-      List<InetSocketAddress> addresses = AddrUtil.getAddresses(host);
+      List<InetSocketAddress> addresses = AddrUtil.getAddresses(Collections.singletonList(host));
       mc = new MemcachedClient(
               new ConnectionFactoryBuilder().setProtocol(Protocol.BINARY)
                       .setAuthDescriptor(ad).build(), addresses);


### PR DESCRIPTION
### 🔗 Related Issue

<!-- Please link related issue. ex) https://github.com/naver/arcus-java-client/issues/{issue_number} -->
- https://github.com/jam2in/arcus-works/issues/723
- https://github.com/jam2in/arcus-works/issues/406
- https://github.com/naver/arcus-java-client/pull/915

### ⌨️ What I did

<!-- Please describe this PR and what you've been working on. -->

ZK에서 Cache List 정보를 가져왔을 때의 흐름은 다음과 같습니다.

#### AS-IS
- CacheMonitor Thread에서 Cache List 정보를 `List<String>` 형태로 수신
- CacheMonitor Thread에서 `List<String>` 형태를 `String` 형태로 변환
- CacheMonitor Thread에서 `String` 형태를 `List<InetSocketAddress>` 형태로 변환
- CacheMonitor Thread에서 `List<InetSocketAddress>` 형태의 정보를 각각의 IO Thread에게 전달
- 각각의 IO Thread는 `List<InetSocketAddress>` 형태의 정보를 사용하기 전에 먼저 복제한 다음에 사용하고, 복제본에 Write 연산 수행

#### TO-BE
- CacheMonitor Thread에서 Cache List 정보를 `List<String>` 형태로 수신
- CacheMonitor Thread에서 `List<String>` 형태의 정보를 `List<InetSocketAddress>` 형태로 변환하여 IO Thread에게 전달
- 각각의 IO Thread는 `List<InetSocketAddress>` 형태의 정보를 복제하여 사용하고, 여기에 Write 연산 수행
