### PR TITLE
FIX: Return CANCELED status when getOperationStatus called

### DIFF
--- a/src/main/java/net/spy/memcached/ArcusClient.java
+++ b/src/main/java/net/spy/memcached/ArcusClient.java
@@ -1524,12 +1524,12 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
 
           @Override
           public void receivedStatus(OperationStatus status) {
-            CollectionOperationStatus cstatus = toCollectionOperationStatus(status);
-            if (cstatus.isSuccess()) {
-              rv.set(Integer.valueOf(cstatus.getMessage()),
+            if (status.isSuccess()) {
+              rv.set(Integer.valueOf(status.getMessage()),
                       new CollectionOperationStatus(true, "END", CollectionResponse.END));
               return;
             }
+            CollectionOperationStatus cstatus = toCollectionOperationStatus(status);
             rv.set(null, cstatus);
           }
 
@@ -1909,8 +1909,9 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
             }
           } else {
             stopCollect.set(true);
-            result.setFailedOperationStatus(status);
-            getLogger().warn("SMGetFailed. status=%s", status);
+            CollectionOperationStatus cstatus = toCollectionOperationStatus(status);
+            result.setFailedOperationStatus(cstatus);
+            getLogger().warn("SMGetFailed. status=%s", cstatus);
           }
         }
 
@@ -1974,8 +1975,9 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
             }
           } else {
             stopCollect.set(true);
-            result.setFailedOperationStatus(status);
-            getLogger().warn("SMGetFailed. status=%s", status);
+            CollectionOperationStatus cstatus = toCollectionOperationStatus(status);
+            result.setFailedOperationStatus(cstatus);
+            getLogger().warn("SMGetFailed. status=%s", cstatus);
           }
         }
 

--- a/src/main/java/net/spy/memcached/internal/CollectionFuture.java
+++ b/src/main/java/net/spy/memcached/internal/CollectionFuture.java
@@ -20,7 +20,6 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicReference;
 
 import net.spy.memcached.ops.CollectionOperationStatus;
-import net.spy.memcached.ops.OperationState;
 
 /**
  * Managed future for collection operations.
@@ -47,7 +46,7 @@ public class CollectionFuture<T> extends OperationFuture<T> {
   }
 
   public CollectionOperationStatus getOperationStatus() {
-    return (op.getState() == OperationState.COMPLETE) ? collectionOpStatus : null;
+    return this.isDone() ? collectionOpStatus : null;
   }
 
 }

--- a/src/main/java/net/spy/memcached/internal/result/SMGetResultImpl.java
+++ b/src/main/java/net/spy/memcached/internal/result/SMGetResultImpl.java
@@ -6,7 +6,6 @@ import java.util.List;
 import net.spy.memcached.collection.CollectionResponse;
 import net.spy.memcached.collection.SMGetElement;
 import net.spy.memcached.ops.CollectionOperationStatus;
-import net.spy.memcached.ops.OperationStatus;
 
 public final class SMGetResultImpl<T> extends SMGetResult<T> {
   private final int count;
@@ -24,9 +23,9 @@ public final class SMGetResultImpl<T> extends SMGetResult<T> {
     return mergedResult;
   }
 
-  public void setFailedOperationStatus(OperationStatus status) {
+  public void setFailedOperationStatus(CollectionOperationStatus status) {
     if (failedOperationStatus == null) {
-      failedOperationStatus = new CollectionOperationStatus(status);
+      failedOperationStatus = status;
     }
     mergedResult.clear();
     trimmedKeyMap.clear();

--- a/src/main/java/net/spy/memcached/internal/result/SMGetResultOldImpl.java
+++ b/src/main/java/net/spy/memcached/internal/result/SMGetResultOldImpl.java
@@ -39,9 +39,9 @@ public final class SMGetResultOldImpl<T> extends SMGetResult<T> {
     return finalResult;
   }
 
-  public void setFailedOperationStatus(OperationStatus status) {
+  public void setFailedOperationStatus(CollectionOperationStatus status) {
     if (failedOperationStatus == null) {
-      failedOperationStatus = new CollectionOperationStatus(status);
+      failedOperationStatus = status;
     }
     mergedResult.clear();
   }

--- a/src/test/manual/net/spy/memcached/collection/internal/CancelFutureTest.java
+++ b/src/test/manual/net/spy/memcached/collection/internal/CancelFutureTest.java
@@ -1,0 +1,264 @@
+package net.spy.memcached.collection.internal;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ExecutionException;
+
+import net.spy.memcached.collection.BTreeGetResult;
+import net.spy.memcached.collection.BaseIntegrationTest;
+import net.spy.memcached.collection.CollectionResponse;
+import net.spy.memcached.collection.ElementFlagFilter;
+import net.spy.memcached.collection.SMGetElement;
+import net.spy.memcached.collection.SMGetMode;
+import net.spy.memcached.internal.BTreeStoreAndGetFuture;
+import net.spy.memcached.internal.BroadcastFuture;
+import net.spy.memcached.internal.CollectionFuture;
+import net.spy.memcached.internal.CollectionGetBulkFuture;
+import net.spy.memcached.internal.CollectionGetFuture;
+import net.spy.memcached.internal.GetFuture;
+import net.spy.memcached.internal.OperationFuture;
+import net.spy.memcached.internal.SMGetFuture;
+import net.spy.memcached.ops.CollectionOperationStatus;
+import net.spy.memcached.ops.OperationStatus;
+import net.spy.memcached.ops.StatusCode;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+class CancelFutureTest extends BaseIntegrationTest {
+
+  @Test
+  void cancelWithOperationFuture() {
+    // given
+    OperationFuture<Boolean> future = mc.set("key", 0, "value");
+
+    // when
+    try {
+      future.cancel(true);
+    } catch (Exception e) {
+      fail("Expected cancel to not throw an exception", e);
+    }
+
+    // then
+    OperationStatus status = future.getStatus();
+    assertInstanceOf(OperationStatus.class, status);
+    assertFalse(status instanceof CollectionOperationStatus);
+    assertFalse(status.isSuccess());
+    assertEquals("cancelled", status.getMessage());
+    assertEquals(StatusCode.CANCELLED, status.getStatusCode());
+
+    assertTrue(future.isCancelled());
+  }
+
+  @Test
+  void cancelWithGetFuture() {
+    // given
+    GetFuture<Object> future = mc.asyncGet("key");
+
+    // when
+    try {
+      future.cancel(true);
+    } catch (Exception e) {
+      fail("Expected cancel to not throw an exception", e);
+    }
+
+    // then
+    OperationStatus status = future.getStatus();
+    assertInstanceOf(OperationStatus.class, status);
+    assertFalse(status instanceof CollectionOperationStatus);
+    assertFalse(status.isSuccess());
+    assertEquals("cancelled", status.getMessage());
+    assertEquals(StatusCode.CANCELLED, status.getStatusCode());
+
+    assertTrue(future.isCancelled());
+  }
+
+  @Test
+  void cancelWithBroadcastFuture() throws ExecutionException, InterruptedException {
+    // given
+    mc.set("prefix:key1", 0, "value1").get();
+    BroadcastFuture<Boolean> future = (BroadcastFuture<Boolean>) mc.flush("prefix");
+
+    // when
+    try {
+      future.cancel(true);
+    } catch (Exception e) {
+      fail("Expected cancel to not throw an exception", e);
+    }
+
+    // then
+    OperationStatus status = future.getStatus();
+    assertInstanceOf(OperationStatus.class, status);
+    assertFalse(status instanceof CollectionOperationStatus);
+    assertFalse(status.isSuccess());
+    assertEquals("cancelled", status.getMessage());
+    assertEquals(StatusCode.CANCELLED, status.getStatusCode());
+
+    assertTrue(future.isCancelled());
+  }
+
+  @Test
+  void cancelWithCollectionFuture() {
+    // given
+    CollectionFuture<List<Object>> future = mc.asyncLopGet("list", 0, false, false);
+
+    // when
+    try {
+      future.cancel(true);
+    } catch (Exception e) {
+      fail("Expected cancel to not throw an exception", e);
+    }
+
+    // then
+    OperationStatus status = future.getStatus();
+    assertNull(status);
+
+    CollectionOperationStatus operationStatus = future.getOperationStatus();
+    assertInstanceOf(CollectionOperationStatus.class, operationStatus);
+    assertInstanceOf(OperationStatus.class, operationStatus);
+    assertFalse(operationStatus.isSuccess());
+    assertEquals(StatusCode.CANCELLED, operationStatus.getStatusCode());
+    assertEquals(CollectionResponse.CANCELED, operationStatus.getResponse());
+
+    assertTrue(future.isCancelled());
+  }
+
+  @Test
+  void cancelWithPipedCollectionFuture() {
+    // given
+    CollectionFuture<Map<Integer, CollectionOperationStatus>> future =
+            mc.asyncLopPipedInsertBulk("list", 0, Arrays.asList("value1", "value2"), null);
+
+    // when
+    try {
+      future.cancel(true);
+    } catch (Exception e) {
+      fail("Expected cancel to not throw an exception", e);
+    }
+
+    // then
+    OperationStatus status = future.getStatus();
+    assertNull(status);
+
+    CollectionOperationStatus operationStatus = future.getOperationStatus();
+    assertInstanceOf(CollectionOperationStatus.class, operationStatus);
+    assertInstanceOf(OperationStatus.class, operationStatus);
+    assertFalse(operationStatus.isSuccess());
+    assertEquals(StatusCode.CANCELLED, operationStatus.getStatusCode());
+    assertEquals(CollectionResponse.CANCELED, operationStatus.getResponse());
+
+    assertTrue(future.isCancelled());
+  }
+
+  @Test
+  void cancelWithBTreeStoreAndGetFuture() {
+    // given
+    BTreeStoreAndGetFuture<Boolean, Object> future =
+            mc.asyncBopInsertAndGetTrimmed("btree", 0, null, "value", null);
+
+    // when
+    try {
+      future.cancel(true);
+    } catch (Exception e) {
+      fail("Expected cancel to not throw an exception", e);
+    }
+
+    // then
+    OperationStatus status = future.getStatus();
+    assertNull(status);
+
+    CollectionOperationStatus operationStatus = future.getOperationStatus();
+    assertInstanceOf(CollectionOperationStatus.class, operationStatus);
+    assertInstanceOf(OperationStatus.class, operationStatus);
+    assertFalse(operationStatus.isSuccess());
+    assertEquals(StatusCode.CANCELLED, operationStatus.getStatusCode());
+    assertEquals(CollectionResponse.CANCELED, operationStatus.getResponse());
+
+    assertTrue(future.isCancelled());
+  }
+
+  @Test
+  void cancelWithCollectionGetFuture() {
+    // given
+    CollectionGetFuture<List<Object>> future =
+            (CollectionGetFuture<List<Object>>) mc.asyncLopGet("list", 0, false, false);
+
+    // when
+    try {
+      future.cancel(true);
+    } catch (Exception e) {
+      fail("Expected cancel to not throw an exception", e);
+    }
+
+    // then
+    OperationStatus status = future.getStatus();
+    assertNull(status);
+
+    CollectionOperationStatus operationStatus = future.getOperationStatus();
+    assertInstanceOf(CollectionOperationStatus.class, operationStatus);
+    assertInstanceOf(OperationStatus.class, operationStatus);
+    assertFalse(operationStatus.isSuccess());
+    assertEquals(StatusCode.CANCELLED, operationStatus.getStatusCode());
+    assertEquals(CollectionResponse.CANCELED, operationStatus.getResponse());
+
+    assertTrue(future.isCancelled());
+  }
+
+  @Test
+  void cancelWithCollectionGetBulkFuture() {
+    // given
+    CollectionGetBulkFuture<Map<String, BTreeGetResult<Long, Object>>> future =
+            mc.asyncBopGetBulk(Arrays.asList("btree1", "btree2"),
+                    0, 10, ElementFlagFilter.DO_NOT_FILTER, 0, 50);
+
+    // when
+    try {
+      future.cancel(true);
+    } catch (Exception e) {
+      fail("Expected cancel to not throw an exception", e);
+    }
+
+    // then
+    CollectionOperationStatus status = future.getOperationStatus();
+    assertInstanceOf(CollectionOperationStatus.class, status);
+    assertInstanceOf(OperationStatus.class, status);
+    assertFalse(status.isSuccess());
+    assertEquals(StatusCode.CANCELLED, status.getStatusCode());
+    assertEquals(CollectionResponse.CANCELED, status.getResponse());
+
+    assertTrue(future.isCancelled());
+  }
+
+  @Test
+  void cancelWithSMGetFuture() {
+    // given
+    SMGetFuture<List<SMGetElement<Object>>> future = mc.asyncBopSortMergeGet(
+            Arrays.asList("btree1", "btree2"),
+            0, 10, ElementFlagFilter.DO_NOT_FILTER, 100, SMGetMode.UNIQUE);
+
+    // when
+    try {
+      future.cancel(true);
+    } catch (Exception e) {
+      fail("Expected cancel to not throw an exception", e);
+    }
+
+    // then
+    CollectionOperationStatus status = future.getOperationStatus();
+    assertInstanceOf(CollectionOperationStatus.class, status);
+    assertInstanceOf(OperationStatus.class, status);
+    assertFalse(status.isSuccess());
+    assertEquals(StatusCode.CANCELLED, status.getStatusCode());
+    assertEquals(CollectionResponse.CANCELED, status.getResponse());
+
+    assertTrue(future.isCancelled());
+  }
+
+}

--- a/src/test/manual/net/spy/memcached/ops/OperationStatusTest.java
+++ b/src/test/manual/net/spy/memcached/ops/OperationStatusTest.java
@@ -5,14 +5,12 @@ import java.util.List;
 
 import net.spy.memcached.collection.BaseIntegrationTest;
 import net.spy.memcached.collection.CollectionResponse;
-import net.spy.memcached.internal.GetFuture;
 import net.spy.memcached.internal.OperationFuture;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 class OperationStatusTest extends BaseIntegrationTest {
@@ -151,21 +149,6 @@ class OperationStatusTest extends BaseIntegrationTest {
     assertNotEquals(status1, status3);
     assertEquals(status1.hashCode(), status2.hashCode());
     assertNotEquals(status1.hashCode(), status3.hashCode());
-  }
-
-  @Test
-  void cancelMakesOperationStatus() {
-    GetFuture<Object> future = mc.asyncGet("key");
-    try {
-      future.cancel(true);
-    } catch (Exception e) {
-      // expected
-    }
-    OperationStatus status = future.getStatus();
-    assertFalse(status instanceof CollectionOperationStatus);
-    assertFalse(status.isSuccess());
-    assertEquals("cancelled", status.getMessage());
-    assertEquals(StatusCode.CANCELLED, status.getStatusCode());
   }
 
   @Test


### PR DESCRIPTION
### 🔗 Related Issue

<!-- Please link related issue. ex) https://github.com/naver/arcus-java-client/issues/{issue_number} -->
- 

### ⌨️ What I did

<!-- Please describe this PR and what you've been working on. -->
- SMGet API 에서 toCollectionOperationStatus 사용하도록 수정합니다. 그리고 setFailedOperationStatus 인자를 CollectionOperationStatus 타입으로 변경했습니다. 이를 통해 #897 에서 추가적인 변경이 없도록 합니다.

- asyncCollectionCount API에서 실패했을 때에만 CollectionOperationStatus 변환하도록 수정했습니다.
- CancelFutureTest를 통해 모든 Future 타입에서 Future#cancel 호출되었을 때 동작을 검증합니다.