### PR TITLE
FIX: Return CANCELED status when getStatus called

### DIFF
--- a/src/main/java/net/spy/memcached/internal/CollectionFuture.java
+++ b/src/main/java/net/spy/memcached/internal/CollectionFuture.java
@@ -41,7 +41,7 @@ public class CollectionFuture<T> extends OperationFuture<T> {
   }
 
   public void set(T o, CollectionOperationStatus status) {
-    objRef.set(o);
+    super.set(o, status);
     collectionOpStatus = status;
   }
 

--- a/src/main/java/net/spy/memcached/internal/PipedCollectionFuture.java
+++ b/src/main/java/net/spy/memcached/internal/PipedCollectionFuture.java
@@ -104,11 +104,13 @@ public class PipedCollectionFuture<K, V>
   public void setOperationStatus(CollectionOperationStatus status) {
     if (operationStatus.get() == null) {
       operationStatus.set(status);
+      super.set(null, status);
       return;
     }
 
     if (!status.isSuccess() && operationStatus.get().isSuccess()) {
       operationStatus.set(status);
+      super.set(null, status);
     }
   }
 

--- a/src/test/manual/net/spy/memcached/collection/internal/CancelFutureTest.java
+++ b/src/test/manual/net/spy/memcached/collection/internal/CancelFutureTest.java
@@ -18,6 +18,7 @@ import net.spy.memcached.internal.CollectionGetBulkFuture;
 import net.spy.memcached.internal.CollectionGetFuture;
 import net.spy.memcached.internal.GetFuture;
 import net.spy.memcached.internal.OperationFuture;
+import net.spy.memcached.internal.PipedCollectionFuture;
 import net.spy.memcached.internal.SMGetFuture;
 import net.spy.memcached.ops.CollectionOperationStatus;
 import net.spy.memcached.ops.OperationStatus;
@@ -28,7 +29,6 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
-import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
@@ -118,7 +118,9 @@ class CancelFutureTest extends BaseIntegrationTest {
 
     // then
     OperationStatus status = future.getStatus();
-    assertNull(status);
+    assertInstanceOf(OperationStatus.class, status);
+    assertFalse(status.isSuccess());
+    assertEquals(StatusCode.CANCELLED, status.getStatusCode());
 
     CollectionOperationStatus operationStatus = future.getOperationStatus();
     assertInstanceOf(CollectionOperationStatus.class, operationStatus);
@@ -133,8 +135,9 @@ class CancelFutureTest extends BaseIntegrationTest {
   @Test
   void cancelWithPipedCollectionFuture() {
     // given
-    CollectionFuture<Map<Integer, CollectionOperationStatus>> future =
-            mc.asyncLopPipedInsertBulk("list", 0, Arrays.asList("value1", "value2"), null);
+    PipedCollectionFuture<Integer, CollectionOperationStatus> future =
+            (PipedCollectionFuture<Integer, CollectionOperationStatus>)
+                    mc.asyncLopPipedInsertBulk("list", 0, Arrays.asList("value1", "value2"), null);
 
     // when
     try {
@@ -145,7 +148,9 @@ class CancelFutureTest extends BaseIntegrationTest {
 
     // then
     OperationStatus status = future.getStatus();
-    assertNull(status);
+    assertInstanceOf(OperationStatus.class, status);
+    assertFalse(status.isSuccess());
+    assertEquals(StatusCode.CANCELLED, status.getStatusCode());
 
     CollectionOperationStatus operationStatus = future.getOperationStatus();
     assertInstanceOf(CollectionOperationStatus.class, operationStatus);
@@ -172,7 +177,9 @@ class CancelFutureTest extends BaseIntegrationTest {
 
     // then
     OperationStatus status = future.getStatus();
-    assertNull(status);
+    assertInstanceOf(OperationStatus.class, status);
+    assertFalse(status.isSuccess());
+    assertEquals(StatusCode.CANCELLED, status.getStatusCode());
 
     CollectionOperationStatus operationStatus = future.getOperationStatus();
     assertInstanceOf(CollectionOperationStatus.class, operationStatus);
@@ -199,7 +206,9 @@ class CancelFutureTest extends BaseIntegrationTest {
 
     // then
     OperationStatus status = future.getStatus();
-    assertNull(status);
+    assertInstanceOf(OperationStatus.class, status);
+    assertFalse(status.isSuccess());
+    assertEquals(StatusCode.CANCELLED, status.getStatusCode());
 
     CollectionOperationStatus operationStatus = future.getOperationStatus();
     assertInstanceOf(CollectionOperationStatus.class, operationStatus);


### PR DESCRIPTION
### 🔗 Related Issue

<!-- Please link related issue. ex) https://github.com/naver/arcus-java-client/issues/{issue_number} -->
- 

### ⌨️ What I did

<!-- Please describe this PR and what you've been working on. -->
- CollectionFuture를 상속받아 getStatus() 메서드가 존재하는 Future들에서 cancel 처리가 되었을 때, CANCELED status를 반환하도록 수정합니다.