### PR TITLE
FIX: Do not cancel when command is completing in handleLine()

### DIFF
--- a/src/main/java/net/spy/memcached/protocol/ascii/BTreeFindPositionOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/BTreeFindPositionOperationImpl.java
@@ -78,6 +78,7 @@ public final class BTreeFindPositionOperationImpl extends OperationImpl implemen
     }
     /* ENABLE_MIGRATION end */
 
+    OperationStatus status;
     if (line.startsWith("POSITION=")) {
       String[] stuff = line.split("=");
       assert stuff.length == 2;
@@ -88,15 +89,13 @@ public final class BTreeFindPositionOperationImpl extends OperationImpl implemen
       BTreeFindPositionOperation.Callback cb =
               (BTreeFindPositionOperation.Callback) getCallback();
       cb.gotData(position);
-      getCallback().receivedStatus(POSITION);
+      status = POSITION;
     } else {
-      OperationStatus status = matchStatus(line, NOT_FOUND, UNREADABLE,
+      status = matchStatus(line, NOT_FOUND, UNREADABLE,
               BKEY_MISMATCH, TYPE_MISMATCH, NOT_FOUND_ELEMENT);
       getLogger().debug(status);
-      getCallback().receivedStatus(status);
     }
-
-    transitionState(OperationState.COMPLETE);
+    complete(status);
   }
 
   @Override

--- a/src/main/java/net/spy/memcached/protocol/ascii/BTreeFindPositionWithGetOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/BTreeFindPositionWithGetOperationImpl.java
@@ -123,8 +123,7 @@ public final class BTreeFindPositionWithGetOperationImpl extends OperationImpl i
       OperationStatus status = matchStatus(line, END, NOT_FOUND, NOT_FOUND_ELEMENT,
               UNREADABLE, TYPE_MISMATCH, BKEY_MISMATCH);
       getLogger().debug(status);
-      getCallback().receivedStatus(status);
-      transitionState(OperationState.COMPLETE);
+      complete(status);
     }
   }
 
@@ -161,8 +160,7 @@ public final class BTreeFindPositionWithGetOperationImpl extends OperationImpl i
                   NOT_FOUND, NOT_FOUND_ELEMENT, UNREADABLE, TYPE_MISMATCH, BKEY_MISMATCH);
 
           getLogger().debug("Get complete!");
-          getCallback().receivedStatus(status);
-          transitionState(OperationState.COMPLETE);
+          complete(status);
           data = null;
           break;
         }

--- a/src/main/java/net/spy/memcached/protocol/ascii/BTreeGetBulkOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/BTreeGetBulkOperationImpl.java
@@ -122,9 +122,7 @@ public final class BTreeGetBulkOperationImpl extends OperationImpl implements
     } else {
       OperationStatus status = matchStatus(line, END);
       getLogger().debug(status);
-
-      getCallback().receivedStatus(status);
-      transitionState(OperationState.COMPLETE);
+      complete(status);
     }
   }
 

--- a/src/main/java/net/spy/memcached/protocol/ascii/BTreeGetByPositionOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/BTreeGetByPositionOperationImpl.java
@@ -120,8 +120,7 @@ public final class BTreeGetByPositionOperationImpl extends OperationImpl impleme
       OperationStatus status = matchStatus(line, END, NOT_FOUND,
               UNREADABLE, TYPE_MISMATCH, NOT_FOUND_ELEMENT);
       getLogger().debug(status);
-      getCallback().receivedStatus(status);
-      transitionState(OperationState.COMPLETE);
+      complete(status);
     }
   }
 
@@ -164,8 +163,7 @@ public final class BTreeGetByPositionOperationImpl extends OperationImpl impleme
                   NOT_FOUND_ELEMENT);
 
           getLogger().debug("Get complete!");
-          getCallback().receivedStatus(status);
-          transitionState(OperationState.COMPLETE);
+          complete(status);
           data = null;
           break;
         }

--- a/src/main/java/net/spy/memcached/protocol/ascii/BTreeInsertAndGetOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/BTreeInsertAndGetOperationImpl.java
@@ -153,8 +153,7 @@ public final class BTreeInsertAndGetOperationImpl extends OperationImpl implemen
         status = matchStatus(line, INSERT_AND_GET_STATUS_ON_LINE);
       }
       getLogger().debug(status);
-      getCallback().receivedStatus(status);
-      transitionState(OperationState.COMPLETE);
+      complete(status);
     }
   }
 
@@ -191,8 +190,7 @@ public final class BTreeInsertAndGetOperationImpl extends OperationImpl implemen
         if (b == '\n') { // Finish the operation.
           OperationStatus status = matchStatus(byteBuffer.toString(), STORE_AND_GET_ON_DATA);
           getLogger().debug("Get complete!");
-          getCallback().receivedStatus(status);
-          transitionState(OperationState.COMPLETE);
+          complete(status);
           data = null;
           break;
         }

--- a/src/main/java/net/spy/memcached/protocol/ascii/BTreeSortMergeGetOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/BTreeSortMergeGetOperationImpl.java
@@ -135,8 +135,7 @@ public final class BTreeSortMergeGetOperationImpl extends OperationImpl implemen
               DUPLICATED, DUPLICATED_TRIMMED, OUT_OF_RANGE,
               ATTR_MISMATCH, TYPE_MISMATCH, BKEY_MISMATCH);
       getLogger().debug(status);
-      getCallback().receivedStatus(status);
-      transitionState(OperationState.COMPLETE);
+      complete(status);
     }
   }
 
@@ -311,8 +310,7 @@ public final class BTreeSortMergeGetOperationImpl extends OperationImpl implemen
               return;
             }
             /* ENABLE_MIGRATION end */
-            getCallback().receivedStatus(status);
-            transitionState(OperationState.COMPLETE);
+            complete(status);
             return;
           } else if (count < lineCount) {
             // <key> [<cause>]\r\n
@@ -340,8 +338,7 @@ public final class BTreeSortMergeGetOperationImpl extends OperationImpl implemen
               return;
             }
             /* ENABLE_MIGRATION end */
-            getCallback().receivedStatus(status);
-            transitionState(OperationState.COMPLETE);
+            complete(status);
             return;
           }
           byteBuffer.reset();
@@ -376,8 +373,7 @@ public final class BTreeSortMergeGetOperationImpl extends OperationImpl implemen
               return;
             }
             /* ENABLE_MIGRATION end */
-            getCallback().receivedStatus(status);
-            transitionState(OperationState.COMPLETE);
+            complete(status);
             return;
           } else if (count < lineCount) {
             // <key> <bkey>\r\n
@@ -399,8 +395,7 @@ public final class BTreeSortMergeGetOperationImpl extends OperationImpl implemen
               return;
             }
             /* ENABLE_MIGRATION end */
-            getCallback().receivedStatus(status);
-            transitionState(OperationState.COMPLETE);
+            complete(status);
             return;
           }
           byteBuffer.reset();

--- a/src/main/java/net/spy/memcached/protocol/ascii/BTreeSortMergeGetOperationOldImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/BTreeSortMergeGetOperationOldImpl.java
@@ -29,7 +29,6 @@ import net.spy.memcached.ops.APIType;
 import net.spy.memcached.ops.BTreeSortMergeGetOperationOld;
 import net.spy.memcached.ops.CollectionOperationStatus;
 import net.spy.memcached.ops.OperationCallback;
-import net.spy.memcached.ops.OperationState;
 import net.spy.memcached.ops.OperationStatus;
 import net.spy.memcached.ops.OperationType;
 
@@ -113,9 +112,7 @@ public final class BTreeSortMergeGetOperationOldImpl extends OperationImpl imple
               DUPLICATED, DUPLICATED_TRIMMED, OUT_OF_RANGE,
               ATTR_MISMATCH, TYPE_MISMATCH, BKEY_MISMATCH);
       getLogger().debug(status);
-      getCallback().receivedStatus(status);
-      transitionState(OperationState.COMPLETE);
-      return;
+      complete(status);
     }
   }
 
@@ -259,8 +256,7 @@ public final class BTreeSortMergeGetOperationOldImpl extends OperationImpl imple
                   BKEY_MISMATCH);
 
           if (status.isSuccess()) {
-            getCallback().receivedStatus(status);
-            transitionState(OperationState.COMPLETE);
+            complete(status);
             return;
           } else {
             ((BTreeSortMergeGetOperationOld.Callback) getCallback())

--- a/src/main/java/net/spy/memcached/protocol/ascii/BaseGetOpImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/BaseGetOpImpl.java
@@ -82,8 +82,7 @@ abstract class BaseGetOpImpl extends OperationImpl {
         return;
       }
       /* ENABLE_MIGRATION end */
-      getCallback().receivedStatus(END);
-      transitionState(OperationState.COMPLETE);
+      complete(END);
       data = null;
     } else if (line.startsWith("VALUE ")) {
       getLogger().debug("Got line %s", line);
@@ -105,8 +104,7 @@ abstract class BaseGetOpImpl extends OperationImpl {
       addRedirectMultiKeyOperation(notMyKeyLine, line.trim());
     /* ENABLE_MIGRATION end */
     } else {
-      getCallback().receivedStatus(matchStatus(line));
-      transitionState(OperationState.COMPLETE);
+      complete(matchStatus(line));
     }
   }
 

--- a/src/main/java/net/spy/memcached/protocol/ascii/BaseStoreOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/BaseStoreOperationImpl.java
@@ -77,8 +77,7 @@ abstract class BaseStoreOperationImpl extends OperationImpl {
       return;
     }
     /* ENABLE_MIGRATION end */
-    getCallback().receivedStatus(matchStatus(line, STORED, NOT_FOUND, EXISTS));
-    transitionState(OperationState.COMPLETE);
+    complete(matchStatus(line, STORED, NOT_FOUND, EXISTS));
   }
 
   @Override

--- a/src/main/java/net/spy/memcached/protocol/ascii/CASOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/CASOperationImpl.java
@@ -86,8 +86,7 @@ class CASOperationImpl extends OperationImpl implements CASOperation {
       return;
     }
     /* ENABLE_MIGRATION end */
-    getCallback().receivedStatus(matchStatus(line, STORED, NOT_FOUND, EXISTS));
-    transitionState(OperationState.COMPLETE);
+    complete(matchStatus(line, STORED, NOT_FOUND, EXISTS));
   }
 
   @Override

--- a/src/main/java/net/spy/memcached/protocol/ascii/CollectionCountOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/CollectionCountOperationImpl.java
@@ -88,9 +88,7 @@ public final class CollectionCountOperationImpl extends OperationImpl implements
       status = matchStatus(line, NOT_FOUND, TYPE_MISMATCH, BKEY_MISMATCH, UNREADABLE);
       getLogger().debug(status);
     }
-
-    getCallback().receivedStatus(status);
-    transitionState(OperationState.COMPLETE);
+    complete(status);
   }
 
   public void initialize() {

--- a/src/main/java/net/spy/memcached/protocol/ascii/CollectionCreateOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/CollectionCreateOperationImpl.java
@@ -87,8 +87,7 @@ public final class CollectionCreateOperationImpl extends OperationImpl
       return;
     }
     /* ENABLE_MIGRATION end */
-    getCallback().receivedStatus(matchStatus(line, CREATED, EXISTS));
-    transitionState(OperationState.COMPLETE);
+    complete(matchStatus(line, CREATED, EXISTS));
   }
 
   @Override

--- a/src/main/java/net/spy/memcached/protocol/ascii/CollectionDeleteOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/CollectionDeleteOperationImpl.java
@@ -98,8 +98,7 @@ public final class CollectionDeleteOperationImpl extends OperationImpl
     OperationStatus status = matchStatus(line, DELETED, DELETED_DROPPED,
             NOT_FOUND, NOT_FOUND_ELEMENT, OUT_OF_RANGE, TYPE_MISMATCH,
             BKEY_MISMATCH);
-    getCallback().receivedStatus(status);
-    transitionState(OperationState.COMPLETE);
+    complete(status);
   }
 
   @Override

--- a/src/main/java/net/spy/memcached/protocol/ascii/CollectionExistOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/CollectionExistOperationImpl.java
@@ -82,8 +82,7 @@ public final class CollectionExistOperationImpl extends OperationImpl
     /* ENABLE_MIGRATION end */
     OperationStatus status = matchStatus(line, EXIST, NOT_EXIST,
             NOT_FOUND, TYPE_MISMATCH, UNREADABLE);
-    getCallback().receivedStatus(status);
-    transitionState(OperationState.COMPLETE);
+    complete(status);
   }
 
   @Override

--- a/src/main/java/net/spy/memcached/protocol/ascii/CollectionGetOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/CollectionGetOperationImpl.java
@@ -140,8 +140,7 @@ public final class CollectionGetOperationImpl extends OperationImpl
               DELETED_DROPPED, NOT_FOUND, NOT_FOUND_ELEMENT,
               OUT_OF_RANGE, TYPE_MISMATCH, BKEY_MISMATCH, UNREADABLE);
       getLogger().debug(status);
-      getCallback().receivedStatus(status);
-      transitionState(OperationState.COMPLETE);
+      complete(status);
     }
   }
 
@@ -190,8 +189,7 @@ public final class CollectionGetOperationImpl extends OperationImpl
                   BKEY_MISMATCH, UNREADABLE);
 
           getLogger().debug("Get complete!");
-          getCallback().receivedStatus(status);
-          transitionState(OperationState.COMPLETE);
+          complete(status);
           data = null;
           break;
         }

--- a/src/main/java/net/spy/memcached/protocol/ascii/CollectionInsertOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/CollectionInsertOperationImpl.java
@@ -116,8 +116,7 @@ public final class CollectionInsertOperationImpl extends OperationImpl
     OperationStatus status = matchStatus(line, STORED, REPLACED, CREATED_STORED,
             NOT_FOUND, ELEMENT_EXISTS, OVERFLOWED, OUT_OF_RANGE,
             TYPE_MISMATCH, BKEY_MISMATCH);
-    getCallback().receivedStatus(status);
-    transitionState(OperationState.COMPLETE);
+    complete(status);
   }
 
   @Override

--- a/src/main/java/net/spy/memcached/protocol/ascii/CollectionMutateOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/CollectionMutateOperationImpl.java
@@ -104,9 +104,7 @@ public final class CollectionMutateOperationImpl extends OperationImpl implement
 
       getLogger().debug(status);
     }
-
-    getCallback().receivedStatus(status);
-    transitionState(OperationState.COMPLETE);
+    complete(status);
   }
 
   public void initialize() {

--- a/src/main/java/net/spy/memcached/protocol/ascii/CollectionUpdateOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/CollectionUpdateOperationImpl.java
@@ -100,8 +100,7 @@ public final class CollectionUpdateOperationImpl extends OperationImpl implement
     OperationStatus status = matchStatus(line, UPDATED, NOT_FOUND, NOT_FOUND_ELEMENT,
             NOTHING_TO_UPDATE, TYPE_MISMATCH, BKEY_MISMATCH,
             EFLAG_MISMATCH);
-    getCallback().receivedStatus(status);
-    transitionState(OperationState.COMPLETE);
+    complete(status);
   }
 
   @Override

--- a/src/main/java/net/spy/memcached/protocol/ascii/DeleteOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/DeleteOperationImpl.java
@@ -71,8 +71,7 @@ final class DeleteOperationImpl extends OperationImpl
       return;
     }
     /* ENABLE_MIGRATION end */
-    getCallback().receivedStatus(matchStatus(line, DELETED, NOT_FOUND));
-    transitionState(OperationState.COMPLETE);
+    complete(matchStatus(line, DELETED, NOT_FOUND));
   }
 
   @Override

--- a/src/main/java/net/spy/memcached/protocol/ascii/FlushByPrefixOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/FlushByPrefixOperationImpl.java
@@ -23,7 +23,6 @@ import java.nio.ByteBuffer;
 import net.spy.memcached.ops.APIType;
 import net.spy.memcached.ops.FlushOperation;
 import net.spy.memcached.ops.OperationCallback;
-import net.spy.memcached.ops.OperationState;
 import net.spy.memcached.ops.OperationStatus;
 import net.spy.memcached.ops.OperationType;
 import net.spy.memcached.ops.StatusCode;
@@ -62,8 +61,7 @@ final class FlushByPrefixOperationImpl extends OperationImpl implements
       return;
     }
     /* ENABLE_REPLICATION end */
-    getCallback().receivedStatus(matchStatus(line, OK, NOT_FOUND));
-    transitionState(OperationState.COMPLETE);
+    complete(matchStatus(line, OK, NOT_FOUND));
   }
 
   @Override

--- a/src/main/java/net/spy/memcached/protocol/ascii/FlushOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/FlushOperationImpl.java
@@ -25,7 +25,6 @@ import java.nio.ByteBuffer;
 import net.spy.memcached.ops.APIType;
 import net.spy.memcached.ops.FlushOperation;
 import net.spy.memcached.ops.OperationCallback;
-import net.spy.memcached.ops.OperationState;
 import net.spy.memcached.ops.OperationStatus;
 import net.spy.memcached.ops.OperationType;
 import net.spy.memcached.ops.StatusCode;
@@ -59,8 +58,7 @@ final class FlushOperationImpl extends OperationImpl
       return;
     }
     /* ENABLE_REPLICATION end */
-    getCallback().receivedStatus(matchStatus(line, OK));
-    transitionState(OperationState.COMPLETE);
+    complete(matchStatus(line, OK));
   }
 
   @Override

--- a/src/main/java/net/spy/memcached/protocol/ascii/GetAttrOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/GetAttrOperationImpl.java
@@ -85,8 +85,7 @@ class GetAttrOperationImpl extends OperationImpl implements GetAttrOperation {
     } else {
       OperationStatus status = matchStatus(line, END, NOT_FOUND, ATTR_ERROR_NOT_FOUND);
       getLogger().debug(status);
-      getCallback().receivedStatus(status);
-      transitionState(OperationState.COMPLETE);
+      complete(status);
     }
   }
 

--- a/src/main/java/net/spy/memcached/protocol/ascii/MutatorOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/MutatorOperationImpl.java
@@ -93,9 +93,7 @@ final class MutatorOperationImpl extends OperationImpl
     } else {
       status = matchStatus(line, NOT_FOUND, TYPE_MISMATCH);
     }
-
-    getCallback().receivedStatus(status);
-    transitionState(OperationState.COMPLETE);
+    complete(status);
   }
 
   @Override

--- a/src/main/java/net/spy/memcached/protocol/ascii/PipeOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/PipeOperationImpl.java
@@ -123,8 +123,7 @@ abstract class PipeOperationImpl extends OperationImpl {
       }
       cb.gotStatus(index, status);
 
-      cb.receivedStatus((successAll) ? END : FAILED_END);
-      transitionState(OperationState.COMPLETE);
+      complete((successAll) ? END : FAILED_END);
       return;
     }
 
@@ -142,8 +141,7 @@ abstract class PipeOperationImpl extends OperationImpl {
         return;
       }
       /* ENABLE_MIGRATION end */
-      cb.receivedStatus((successAll) ? END : FAILED_END);
-      transitionState(OperationState.COMPLETE);
+      complete((successAll) ? END : FAILED_END);
     } else if (line.startsWith("RESPONSE ")) {
       getLogger().debug("Got line %s", line);
 

--- a/src/main/java/net/spy/memcached/protocol/ascii/SetAttrOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/SetAttrOperationImpl.java
@@ -83,8 +83,7 @@ class SetAttrOperationImpl extends OperationImpl
     /* ENABLE_MIGRATION end */
     OperationStatus status = matchStatus(line, OK, NOT_FOUND,
             ATTR_ERROR_NOT_FOUND, ATTR_ERROR_BAD_VALUE);
-    getCallback().receivedStatus(status);
-    transitionState(OperationState.COMPLETE);
+    complete(status);
   }
 
   @Override

--- a/src/main/java/net/spy/memcached/protocol/ascii/StatsOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/StatsOperationImpl.java
@@ -22,7 +22,6 @@ package net.spy.memcached.protocol.ascii;
 import java.nio.ByteBuffer;
 
 import net.spy.memcached.ops.APIType;
-import net.spy.memcached.ops.OperationState;
 import net.spy.memcached.ops.OperationStatus;
 import net.spy.memcached.ops.OperationType;
 import net.spy.memcached.ops.StatsOperation;
@@ -61,11 +60,9 @@ final class StatsOperationImpl extends OperationImpl
       assert parts.length == 3;
       cb.gotStat(parts[1], parts[2]);
     } else if (line.startsWith("END")) {
-      cb.receivedStatus(END);
-      transitionState(OperationState.COMPLETE);
+      complete(END);
     } else {
-      cb.receivedStatus(matchStatus(line));
-      transitionState(OperationState.COMPLETE);
+      complete(matchStatus(line));
     }
   }
 

--- a/src/main/java/net/spy/memcached/protocol/ascii/VersionOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/VersionOperationImpl.java
@@ -24,7 +24,6 @@ import java.nio.ByteBuffer;
 import net.spy.memcached.ops.APIType;
 import net.spy.memcached.ops.NoopOperation;
 import net.spy.memcached.ops.OperationCallback;
-import net.spy.memcached.ops.OperationState;
 import net.spy.memcached.ops.OperationStatus;
 import net.spy.memcached.ops.OperationType;
 import net.spy.memcached.ops.StatusCode;
@@ -52,9 +51,7 @@ final class VersionOperationImpl extends OperationImpl
     } else {
       status = new OperationStatus(false, line, StatusCode.fromAsciiLine(line));
     }
-
-    getCallback().receivedStatus(status);
-    transitionState(OperationState.COMPLETE);
+    complete(status);
   }
 
   @Override

--- a/src/main/java/net/spy/memcached/protocol/binary/GetOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/binary/GetOperationImpl.java
@@ -64,7 +64,7 @@ class GetOperationImpl extends OperationImpl
       GetsOperation.Callback cb = (GetsOperation.Callback) getCallback();
       cb.gotData(key, flags, responseCas, data);
     }
-    getCallback().receivedStatus(STATUS_OK);
+    complete(STATUS_OK);
   }
 
   @Override

--- a/src/main/java/net/spy/memcached/protocol/binary/MultiGetOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/binary/MultiGetOperationImpl.java
@@ -28,7 +28,6 @@ import java.util.Map;
 import net.spy.memcached.KeyUtil;
 import net.spy.memcached.ops.GetOperation;
 import net.spy.memcached.ops.OperationCallback;
-import net.spy.memcached.ops.OperationState;
 
 import static net.spy.memcached.protocol.binary.GetOperationImpl.EXTRA_HDR_LEN;
 
@@ -105,8 +104,7 @@ class MultiGetOperationImpl extends OperationImpl implements GetOperation {
   @Override
   protected void finishedPayload(byte[] pl) throws IOException {
     if (responseOpaque == terminalOpaque) {
-      getCallback().receivedStatus(STATUS_OK);
-      transitionState(OperationState.COMPLETE);
+      complete(STATUS_OK);
     } else if (errorCode != 0) {
       getLogger().warn("Error on key %s:  %s (%d)",
               keys.get(responseOpaque), new String(pl), errorCode);

--- a/src/main/java/net/spy/memcached/protocol/binary/MutatorOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/binary/MutatorOperationImpl.java
@@ -71,7 +71,7 @@ class MutatorOperationImpl extends OperationImpl implements
 
   @Override
   protected void decodePayload(byte[] pl) {
-    getCallback().receivedStatus(new OperationStatus(true,
+    complete(new OperationStatus(true,
             String.valueOf(decodeLong(pl, 0)), StatusCode.SUCCESS));
   }
 

--- a/src/main/java/net/spy/memcached/protocol/binary/OperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/binary/OperationImpl.java
@@ -28,7 +28,6 @@ import net.spy.memcached.KeyUtil;
 import net.spy.memcached.ops.CASOperationStatus;
 import net.spy.memcached.ops.OperationCallback;
 import net.spy.memcached.ops.OperationErrorType;
-import net.spy.memcached.ops.OperationState;
 import net.spy.memcached.ops.OperationStatus;
 import net.spy.memcached.ops.StatusCode;
 import net.spy.memcached.protocol.BaseOperationImpl;
@@ -169,12 +168,10 @@ abstract class OperationImpl extends BaseOperationImpl {
       if (status == null) {
         handleError(OperationErrorType.SERVER, new String(pl));
       } else {
-        getCallback().receivedStatus(status);
-        transitionState(OperationState.COMPLETE);
+        complete(status);
       }
     } else {
       decodePayload(pl);
-      transitionState(OperationState.COMPLETE);
     }
   }
 
@@ -195,7 +192,7 @@ abstract class OperationImpl extends BaseOperationImpl {
    */
   protected void decodePayload(byte[] pl) {
     assert pl.length == 0 : "Payload has bytes, but decode isn't overridden";
-    getCallback().receivedStatus(STATUS_OK);
+    complete(STATUS_OK);
   }
 
   /**

--- a/src/main/java/net/spy/memcached/protocol/binary/OptimizedSetImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/binary/OptimizedSetImpl.java
@@ -29,7 +29,6 @@ import java.util.Map;
 import net.spy.memcached.KeyUtil;
 import net.spy.memcached.ops.CASOperation;
 import net.spy.memcached.ops.OperationCallback;
-import net.spy.memcached.ops.OperationState;
 import net.spy.memcached.ops.OperationStatus;
 import net.spy.memcached.ops.StoreType;
 
@@ -146,7 +145,7 @@ public final class OptimizedSetImpl extends OperationImpl {
         cb.receivedStatus(STATUS_OK);
         cb.complete();
       }
-      transitionState(OperationState.COMPLETE);
+      complete(STATUS_OK);
     } else {
       OperationCallback cb = callbacks.remove(responseOpaque);
       assert cb != null : "No callback for " + responseOpaque;

--- a/src/main/java/net/spy/memcached/protocol/binary/SASLBaseOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/binary/SASLBaseOperationImpl.java
@@ -5,7 +5,6 @@ import javax.security.sasl.SaslClient;
 import javax.security.sasl.SaslException;
 
 import net.spy.memcached.ops.OperationCallback;
-import net.spy.memcached.ops.OperationState;
 import net.spy.memcached.ops.OperationStatus;
 import net.spy.memcached.ops.StatusCode;
 
@@ -41,18 +40,17 @@ public abstract class SASLBaseOperationImpl extends OperationImpl {
   @Override
   protected void decodePayload(byte[] pl) {
     getLogger().debug("Auth response:  %s", new String(pl));
+    complete(new OperationStatus(true, new String(pl), StatusCode.SUCCESS));
   }
 
   @Override
   protected void finishedPayload(byte[] pl) throws IOException {
     if (errorCode == SASL_CONTINUE) {
-      getCallback().receivedStatus(new OperationStatus(true,
+      complete(new OperationStatus(true,
               new String(pl), StatusCode.SUCCESS));
-      transitionState(OperationState.COMPLETE);
     } else if (errorCode == 0) {
-      getCallback().receivedStatus(new OperationStatus(true,
+      complete(new OperationStatus(true,
               "", StatusCode.SUCCESS));
-      transitionState(OperationState.COMPLETE);
     } else {
       super.finishedPayload(pl);
     }

--- a/src/main/java/net/spy/memcached/protocol/binary/SASLMechsOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/binary/SASLMechsOperationImpl.java
@@ -38,8 +38,7 @@ class SASLMechsOperationImpl extends OperationImpl implements
 
   @Override
   protected void decodePayload(byte[] pl) {
-    getCallback().receivedStatus(
-            new OperationStatus(true, new String(pl), StatusCode.SUCCESS));
+    complete(new OperationStatus(true, new String(pl), StatusCode.SUCCESS));
   }
 
 

--- a/src/main/java/net/spy/memcached/protocol/binary/StatsOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/binary/StatsOperationImpl.java
@@ -19,7 +19,6 @@ package net.spy.memcached.protocol.binary;
 
 import java.io.IOException;
 
-import net.spy.memcached.ops.OperationState;
 import net.spy.memcached.ops.StatsOperation;
 
 public class StatsOperationImpl extends OperationImpl
@@ -49,8 +48,7 @@ public class StatsOperationImpl extends OperationImpl
       cb.gotStat(new String(keyBytes, "UTF-8"),
               new String(data, "UTF-8"));
     } else {
-      getCallback().receivedStatus(STATUS_OK);
-      transitionState(OperationState.COMPLETE);
+      complete(STATUS_OK);
     }
     resetInput();
   }

--- a/src/main/java/net/spy/memcached/protocol/binary/VersionOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/binary/VersionOperationImpl.java
@@ -37,8 +37,7 @@ class VersionOperationImpl extends OperationImpl implements VersionOperation {
 
   @Override
   protected void decodePayload(byte[] pl) {
-    getCallback().receivedStatus(
-            new OperationStatus(true, new String(pl), StatusCode.SUCCESS));
+    complete(new OperationStatus(true, new String(pl), StatusCode.SUCCESS));
   }
 
 }


### PR DESCRIPTION
### 🔗 Related Issue

<!-- Please link related issue. ex) https://github.com/naver/arcus-java-client/issues/{issue_number} -->
- https://github.com/jam2in/arcus-works/issues/714

### ⌨️ What I did

<!-- Please describe this PR and what you've been working on. -->
- status를 Future에 넘기고 OperationState를 complete로 바꾸는 도중에 들어오는 cancel 요청은 실패하도록 수정합니다.
- BaseOperationImpl 클래스에 `complete(OperationStatus status)` 메서드를 추가하여 complete 로직을 모아두었습니다.
- 이슈에서 이야기 나눴던 Future#setOperationStatus 동작 조건은 다음 PR에서 반영할 예정입니다.