### PR TITLE
INTERNAL: Extract compression logic from BaseSerializingTranscoder

### DIFF
--- a/src/main/java/net/spy/memcached/transcoders/CompressionUtils.java
+++ b/src/main/java/net/spy/memcached/transcoders/CompressionUtils.java
@@ -1,0 +1,84 @@
+package net.spy.memcached.transcoders;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.zip.GZIPInputStream;
+import java.util.zip.GZIPOutputStream;
+
+import net.spy.memcached.compat.CloseUtil;
+import net.spy.memcached.compat.SpyObject;
+
+/**
+ * Utility class for compression and decompression operations.
+ */
+public class CompressionUtils extends SpyObject {
+
+  public static final int DEFAULT_COMPRESSION_THRESHOLD = 16384;
+
+  private int compressionThreshold;
+
+  public CompressionUtils() {
+    this(DEFAULT_COMPRESSION_THRESHOLD);
+  }
+
+  public CompressionUtils(int compressionThreshold) {
+    this.compressionThreshold = compressionThreshold;
+  }
+
+  public void setCompressionThreshold(int compressionThreshold) {
+    this.compressionThreshold = compressionThreshold;
+  }
+
+  public boolean isCompressionCandidate(byte[] data) {
+    return data != null && data.length > compressionThreshold;
+  }
+
+  /**
+   * Compress the given array of bytes.
+   */
+  public byte[] compress(byte[] in) {
+    if (in == null) {
+      throw new NullPointerException("Can't compress null");
+    }
+    ByteArrayOutputStream bos = new ByteArrayOutputStream();
+    GZIPOutputStream gz = null;
+    try {
+      gz = new GZIPOutputStream(bos);
+      gz.write(in);
+    } catch (IOException e) {
+      throw new RuntimeException("IO exception compressing data", e);
+    } finally {
+      CloseUtil.close(gz);
+      CloseUtil.close(bos);
+    }
+    byte[] rv = bos.toByteArray();
+    getLogger().debug("Compressed %d bytes to %d", in.length, rv.length);
+    return rv;
+  }
+
+  /**
+   * Decompress the given array of bytes.
+   */
+  public byte[] decompress(byte[] in) {
+    ByteArrayOutputStream bos = null;
+    if (in != null) {
+      ByteArrayInputStream bis = new ByteArrayInputStream(in);
+      bos = new ByteArrayOutputStream();
+      GZIPInputStream gis;
+      try {
+        gis = new GZIPInputStream(bis);
+
+        byte[] buf = new byte[8192];
+        int r;
+        while ((r = gis.read(buf)) > 0) {
+          bos.write(buf, 0, r);
+        }
+      } catch (IOException e) {
+        getLogger().warn("Failed to decompress data", e);
+        bos = null;
+      }
+    }
+    return bos == null ? null : bos.toByteArray();
+  }
+}

--- a/src/main/java/net/spy/memcached/transcoders/SerializingTranscoder.java
+++ b/src/main/java/net/spy/memcached/transcoders/SerializingTranscoder.java
@@ -153,7 +153,7 @@ public class SerializingTranscoder extends BaseSerializingTranscoder
       flags |= SERIALIZED;
     }
     assert b != null;
-    if (b.length > compressionThreshold) {
+    if (isCompressionCandidate(b)) {
       byte[] compressed = compress(b);
       if (compressed.length < b.length) {
         getLogger().debug("Compressed %s from %d to %d",

--- a/src/main/java/net/spy/memcached/transcoders/WhalinTranscoder.java
+++ b/src/main/java/net/spy/memcached/transcoders/WhalinTranscoder.java
@@ -152,7 +152,7 @@ public class WhalinTranscoder extends BaseSerializingTranscoder
       flags |= SERIALIZED;
     }
     assert b != null;
-    if (b.length > compressionThreshold) {
+    if (isCompressionCandidate(b)) {
       byte[] compressed = compress(b);
       if (compressed.length < b.length) {
         getLogger().debug("Compressed %s from %d to %d",

--- a/src/main/java/net/spy/memcached/transcoders/WhalinV1Transcoder.java
+++ b/src/main/java/net/spy/memcached/transcoders/WhalinV1Transcoder.java
@@ -66,7 +66,7 @@ public class WhalinV1Transcoder extends BaseSerializingTranscoder
       flags |= SERIALIZED;
     }
     assert b != null;
-    if (b.length > compressionThreshold) {
+    if (isCompressionCandidate(b)) {
       byte[] compressed = compress(b);
       if (compressed.length < b.length) {
         getLogger().info("Compressed %s from %d to %d",


### PR DESCRIPTION
### 🔗 Related Issue

<!--Please link related issue. ex) https://github.com/naver/arcus-java-client/issues/{issue_number} -->
- https://github.com/jam2in/arcus-works/issues/453

### ⌨️ What I did

<!-- Please describe this PR and what you've been working on. -->
- `BaseSerializingTranscoder` 클래스에서 압축 관련 로직을 분리하여 별도의 `CompressionUtils` 클래스로 추출했습니다. 
- 추후 생성할 `BaseSerializingTranscoder`클래스를 상속하지 않는 Json Transcoder 클래스를 위한 작업입니다.