### PR TITLE
FIX: Send ERR_INTERNAL status when pipe error occurred

### DIFF
--- a/src/main/java/net/spy/memcached/protocol/ascii/PipeOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/PipeOperationImpl.java
@@ -17,6 +17,7 @@ import net.spy.memcached.ops.OperationException;
 import net.spy.memcached.ops.OperationState;
 import net.spy.memcached.ops.OperationStatus;
 import net.spy.memcached.ops.PipedOperationCallback;
+import net.spy.memcached.ops.StatusCode;
 
 abstract class PipeOperationImpl extends OperationImpl {
 
@@ -141,7 +142,13 @@ abstract class PipeOperationImpl extends OperationImpl {
         return;
       }
       /* ENABLE_MIGRATION end */
-      complete((successAll) ? END : FAILED_END);
+      OperationStatus status;
+      if (exception == null) {
+        status = (successAll) ? END : FAILED_END;
+      } else {
+        status = new OperationStatus(false, exception.getMessage(), StatusCode.ERR_INTERNAL);
+      }
+      complete(status);
     } else if (line.startsWith("RESPONSE ")) {
       getLogger().debug("Got line %s", line);
 


### PR DESCRIPTION
### 🔗 Related Issue

<!-- Please link related issue. ex) https://github.com/naver/arcus-java-client/issues/{issue_number} -->
- 

### ⌨️ What I did

<!-- Please describe this PR and what you've been working on. -->
- handleError에서 에러 발생 시와 동일하게 OperationStatus를 생성해 Future로 전달하도록 합니다.
- pipe error가 발생하지 않았을 경우에만 END / FAILED_END를 Future로 전달하도록 합니다.