### PR TITLE
INTERNAL: Refactor common constants and methods into TranscoderUtils

### DIFF
--- a/src/main/java/net/spy/memcached/ArcusClient.java
+++ b/src/main/java/net/spy/memcached/ArcusClient.java
@@ -150,8 +150,8 @@ import net.spy.memcached.ops.StatusCode;
 import net.spy.memcached.ops.StoreType;
 import net.spy.memcached.plugin.FrontCacheMemcachedClient;
 import net.spy.memcached.protocol.BaseOperationImpl;
-import net.spy.memcached.transcoders.CollectionTranscoder;
 import net.spy.memcached.transcoders.Transcoder;
+import net.spy.memcached.transcoders.TranscoderUtils;
 import net.spy.memcached.util.BTreeUtil;
 
 /**
@@ -1099,7 +1099,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
   public CollectionFuture<Boolean> asyncBopCreate(String key,
                                                   ElementValueType valueType,
                                                   CollectionAttributes attributes) {
-    int flag = CollectionTranscoder.examineFlags(valueType);
+    int flag = TranscoderUtils.examineFlags(valueType);
     boolean noreply = false;
     CollectionCreate bTreeCreate = new BTreeCreate(flag,
             attributes.getExpireTime(), attributes.getMaxCount(),
@@ -1111,7 +1111,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
   public CollectionFuture<Boolean> asyncMopCreate(String key,
                                                   ElementValueType type,
                                                   CollectionAttributes attributes) {
-    int flag = CollectionTranscoder.examineFlags(type);
+    int flag = TranscoderUtils.examineFlags(type);
     boolean noreply = false;
     CollectionCreate mapCreate = new MapCreate(flag,
             attributes.getExpireTime(), attributes.getMaxCount(),
@@ -1123,7 +1123,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
   public CollectionFuture<Boolean> asyncSopCreate(String key,
                                                   ElementValueType type,
                                                   CollectionAttributes attributes) {
-    int flag = CollectionTranscoder.examineFlags(type);
+    int flag = TranscoderUtils.examineFlags(type);
     boolean noreply = false;
     CollectionCreate setCreate = new SetCreate(flag,
             attributes.getExpireTime(), attributes.getMaxCount(),
@@ -1135,7 +1135,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
   public CollectionFuture<Boolean> asyncLopCreate(String key,
                                                   ElementValueType type,
                                                   CollectionAttributes attributes) {
-    int flag = CollectionTranscoder.examineFlags(type);
+    int flag = TranscoderUtils.examineFlags(type);
     boolean noreply = false;
     CollectionCreate listCreate = new ListCreate(flag,
             attributes.getExpireTime(), attributes.getMaxCount(),

--- a/src/main/java/net/spy/memcached/transcoders/CollectionTranscoder.java
+++ b/src/main/java/net/spy/memcached/transcoders/CollectionTranscoder.java
@@ -21,6 +21,17 @@ import java.util.Date;
 import net.spy.memcached.CachedData;
 import net.spy.memcached.collection.ElementValueType;
 
+import static net.spy.memcached.transcoders.TranscoderUtils.SERIALIZED;
+import static net.spy.memcached.transcoders.TranscoderUtils.SPECIAL_BOOLEAN;
+import static net.spy.memcached.transcoders.TranscoderUtils.SPECIAL_BYTE;
+import static net.spy.memcached.transcoders.TranscoderUtils.SPECIAL_BYTEARRAY;
+import static net.spy.memcached.transcoders.TranscoderUtils.SPECIAL_DATE;
+import static net.spy.memcached.transcoders.TranscoderUtils.SPECIAL_DOUBLE;
+import static net.spy.memcached.transcoders.TranscoderUtils.SPECIAL_FLOAT;
+import static net.spy.memcached.transcoders.TranscoderUtils.SPECIAL_INT;
+import static net.spy.memcached.transcoders.TranscoderUtils.SPECIAL_LONG;
+import static net.spy.memcached.transcoders.TranscoderUtils.SPECIAL_MASK;
+
 /**
  * Transcoder that serialized and compresses objects for collection elements.
  */
@@ -122,7 +133,7 @@ public class CollectionTranscoder extends SerializingTranscoder implements
           getLogger().warn("Undecodeable with flags %x", flags);
       }
     } else {
-      rv = decodeString(data);
+      rv = tu.decodeString(data);
     }
     return rv;
   }
@@ -139,7 +150,7 @@ public class CollectionTranscoder extends SerializingTranscoder implements
     }
 
     if (o instanceof String) {
-      b = encodeString((String) o);
+      b = tu.encodeString((String) o);
     } else if (o instanceof Long) {
       b = tu.encodeLong((Long) o);
       flags |= SPECIAL_LONG;

--- a/src/main/java/net/spy/memcached/transcoders/IntegerTranscoder.java
+++ b/src/main/java/net/spy/memcached/transcoders/IntegerTranscoder.java
@@ -11,7 +11,7 @@ import net.spy.memcached.compat.SpyObject;
 public final class IntegerTranscoder extends SpyObject
         implements Transcoder<Integer> {
 
-  private static final int flags = SerializingTranscoder.SPECIAL_INT;
+  private static final int flags = TranscoderUtils.SPECIAL_INT;
 
   private final TranscoderUtils tu = new TranscoderUtils(true);
 

--- a/src/main/java/net/spy/memcached/transcoders/LongTranscoder.java
+++ b/src/main/java/net/spy/memcached/transcoders/LongTranscoder.java
@@ -11,7 +11,7 @@ import net.spy.memcached.compat.SpyObject;
 public final class LongTranscoder extends SpyObject
         implements Transcoder<Long> {
 
-  private static final int flags = SerializingTranscoder.SPECIAL_LONG;
+  private static final int flags = TranscoderUtils.SPECIAL_LONG;
 
   private final TranscoderUtils tu = new TranscoderUtils(true);
 

--- a/src/main/java/net/spy/memcached/transcoders/SerializingTranscoder.java
+++ b/src/main/java/net/spy/memcached/transcoders/SerializingTranscoder.java
@@ -22,28 +22,23 @@ import java.util.Date;
 
 import net.spy.memcached.CachedData;
 
+import static net.spy.memcached.transcoders.TranscoderUtils.COMPRESSED;
+import static net.spy.memcached.transcoders.TranscoderUtils.SERIALIZED;
+import static net.spy.memcached.transcoders.TranscoderUtils.SPECIAL_BOOLEAN;
+import static net.spy.memcached.transcoders.TranscoderUtils.SPECIAL_BYTE;
+import static net.spy.memcached.transcoders.TranscoderUtils.SPECIAL_BYTEARRAY;
+import static net.spy.memcached.transcoders.TranscoderUtils.SPECIAL_DATE;
+import static net.spy.memcached.transcoders.TranscoderUtils.SPECIAL_DOUBLE;
+import static net.spy.memcached.transcoders.TranscoderUtils.SPECIAL_FLOAT;
+import static net.spy.memcached.transcoders.TranscoderUtils.SPECIAL_INT;
+import static net.spy.memcached.transcoders.TranscoderUtils.SPECIAL_LONG;
+import static net.spy.memcached.transcoders.TranscoderUtils.SPECIAL_MASK;
+
 /**
  * Transcoder that serializes and compresses objects.
  */
 public class SerializingTranscoder extends BaseSerializingTranscoder
         implements Transcoder<Object> {
-
-  // General flags
-  static final int SERIALIZED = 1;
-  static final int COMPRESSED = 2;
-
-  // Special flags for specially handled types.
-  protected static final int SPECIAL_MASK = 0xff00;
-  static final int SPECIAL_BOOLEAN = (1 << 8);
-  static final int SPECIAL_INT = (2 << 8);
-  static final int SPECIAL_LONG = (3 << 8);
-  static final int SPECIAL_DATE = (4 << 8);
-  static final int SPECIAL_BYTE = (5 << 8);
-  static final int SPECIAL_FLOAT = (6 << 8);
-  static final int SPECIAL_DOUBLE = (7 << 8);
-  static final int SPECIAL_BYTEARRAY = (8 << 8);
-
-  protected final TranscoderUtils tu = new TranscoderUtils(true);
 
   /**
    * Get a serializing transcoder with the default max data size.
@@ -105,7 +100,7 @@ public class SerializingTranscoder extends BaseSerializingTranscoder
           getLogger().warn("Undecodeable with flags %x", flags);
       }
     } else {
-      rv = decodeString(data);
+      rv = tu.decodeString(data);
     }
     return rv;
   }
@@ -114,7 +109,7 @@ public class SerializingTranscoder extends BaseSerializingTranscoder
     byte[] b = null;
     int flags = 0;
     if (o instanceof String) {
-      b = encodeString((String) o);
+      b = tu.encodeString((String) o);
     } else if (o instanceof Long) {
       b = tu.encodeLong((Long) o);
       flags |= SPECIAL_LONG;

--- a/src/main/java/net/spy/memcached/transcoders/WhalinTranscoder.java
+++ b/src/main/java/net/spy/memcached/transcoders/WhalinTranscoder.java
@@ -42,10 +42,8 @@ public class WhalinTranscoder extends BaseSerializingTranscoder
   static final int COMPRESSED = 2;
   static final int SERIALIZED = 8;
 
-  private final TranscoderUtils tu = new TranscoderUtils(false);
-
   public WhalinTranscoder() {
-    super(CachedData.MAX_SIZE);
+    super(CachedData.MAX_SIZE, null, false);
   }
 
   public Object decode(CachedData d) {
@@ -87,13 +85,13 @@ public class WhalinTranscoder extends BaseSerializingTranscoder
           rv = data;
           break;
         case SPECIAL_STRING:
-          rv = decodeString(data);
+          rv = tu.decodeString(data);
           break;
         case SPECIAL_STRINGBUFFER:
-          rv = new StringBuffer(decodeString(data));
+          rv = new StringBuffer(tu.decodeString(data));
           break;
         case SPECIAL_STRINGBUILDER:
-          rv = new StringBuilder(decodeString(data));
+          rv = new StringBuilder(tu.decodeString(data));
           break;
         case SPECIAL_CHARACTER:
           rv = decodeCharacter(data);
@@ -109,14 +107,14 @@ public class WhalinTranscoder extends BaseSerializingTranscoder
     byte[] b = null;
     int flags = 0;
     if (o instanceof String) {
-      b = encodeString((String) o);
+      b = tu.encodeString((String) o);
       flags |= SPECIAL_STRING;
     } else if (o instanceof StringBuffer) {
       flags |= SPECIAL_STRINGBUFFER;
-      b = encodeString(String.valueOf(o));
+      b = tu.encodeString(String.valueOf(o));
     } else if (o instanceof StringBuilder) {
       flags |= SPECIAL_STRINGBUILDER;
-      b = encodeString(String.valueOf(o));
+      b = tu.encodeString(String.valueOf(o));
     } else if (o instanceof Long) {
       b = tu.encodeLong((Long) o);
       flags |= SPECIAL_LONG;

--- a/src/main/java/net/spy/memcached/transcoders/WhalinV1Transcoder.java
+++ b/src/main/java/net/spy/memcached/transcoders/WhalinV1Transcoder.java
@@ -185,7 +185,7 @@ public class WhalinV1Transcoder extends BaseSerializingTranscoder
 
   private String decodeW1String(byte[] b) {
     try {
-      return new String(b, 1, b.length - 1, charset);
+      return new String(b, 1, b.length - 1, getCharset());
     } catch (UnsupportedEncodingException e) {
       throw new RuntimeException(e);
     }
@@ -260,7 +260,7 @@ public class WhalinV1Transcoder extends BaseSerializingTranscoder
   private byte[] encodeW1String(String value) {
     byte[] svalue = null;
     try {
-      svalue = value.getBytes(charset);
+      svalue = value.getBytes(getCharset());
     } catch (UnsupportedEncodingException e) {
       throw new RuntimeException(e);
     }

--- a/src/test/java/net/spy/memcached/transcoders/BaseSerializingTranscoderTest.java
+++ b/src/test/java/net/spy/memcached/transcoders/BaseSerializingTranscoderTest.java
@@ -10,13 +10,12 @@ import net.spy.memcached.CachedData;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertSame;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 /**
@@ -56,23 +55,8 @@ class BaseSerializingTranscoderTest {
   }
 
   @Test
-  void testDecodeStringNull() {
-    assertNull(ex.decodeString(null));
-  }
-
-  @Test
   void testDeserializeNull() {
     assertNull(ex.deserialize(null));
-  }
-
-  @Test
-  void testEncodeStringNull() {
-    try {
-      ex.encodeString(null);
-      fail("Expected an assertion error");
-    } catch (NullPointerException e) {
-      // pass
-    }
   }
 
   @Test
@@ -104,30 +88,6 @@ class BaseSerializingTranscoderTest {
   void testDeserializable() throws Exception {
     byte[] data = {-84, -19, 0, 5, 116, 0, 5, 104, 101, 108, 108, 111};
     assertEquals("hello", ex.deserialize(data));
-  }
-
-  @Test
-  void testBadCharsetDecode() {
-    ex.overrideCharsetSet("Some Crap");
-    try {
-      ex.encodeString("Woo!");
-      fail("Expected runtime exception");
-    } catch (RuntimeException e) {
-      assertSame(UnsupportedEncodingException.class,
-              e.getCause().getClass());
-    }
-  }
-
-  @Test
-  void testBadCharsetEncode() {
-    ex.overrideCharsetSet("Some Crap");
-    try {
-      ex.decodeString("Woo!".getBytes());
-      fail("Expected runtime exception");
-    } catch (RuntimeException e) {
-      assertSame(UnsupportedEncodingException.class,
-              e.getCause().getClass());
-    }
   }
 
   @Test
@@ -199,18 +159,9 @@ class BaseSerializingTranscoderTest {
       super(CachedData.MAX_SIZE);
     }
 
-    public void overrideCharsetSet(String to) {
-      charset = to;
-    }
-
     @Override
     public byte[] compress(byte[] in) {
       return super.compress(in);
-    }
-
-    @Override
-    public String decodeString(byte[] data) {
-      return super.decodeString(data);
     }
 
     @Override
@@ -221,11 +172,6 @@ class BaseSerializingTranscoderTest {
     @Override
     public Object deserialize(byte[] in) {
       return super.deserialize(in);
-    }
-
-    @Override
-    public byte[] encodeString(String in) {
-      return super.encodeString(in);
     }
 
     @Override

--- a/src/test/java/net/spy/memcached/transcoders/SerializingTranscoderTest.java
+++ b/src/test/java/net/spy/memcached/transcoders/SerializingTranscoderTest.java
@@ -59,7 +59,7 @@ class SerializingTranscoderTest extends BaseTranscoderCase {
     String s1 = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
     tc.setCompressionThreshold(8);
     CachedData cd = tc.encode(s1);
-    assertEquals(SerializingTranscoder.COMPRESSED, cd.getFlags());
+    assertEquals(TranscoderUtils.COMPRESSED, cd.getFlags());
     assertFalse(Arrays.equals(s1.getBytes(), cd.getData()));
     assertEquals(s1, tc.decode(cd));
   }
@@ -68,7 +68,7 @@ class SerializingTranscoderTest extends BaseTranscoderCase {
   void testObject() throws Exception {
     Calendar c = Calendar.getInstance();
     CachedData cd = tc.encode(c);
-    assertEquals(SerializingTranscoder.SERIALIZED, cd.getFlags());
+    assertEquals(TranscoderUtils.SERIALIZED, cd.getFlags());
     assertEquals(c, tc.decode(cd));
   }
 
@@ -77,8 +77,8 @@ class SerializingTranscoderTest extends BaseTranscoderCase {
     tc.setCompressionThreshold(8);
     Calendar c = Calendar.getInstance();
     CachedData cd = tc.encode(c);
-    assertEquals(SerializingTranscoder.SERIALIZED
-            | SerializingTranscoder.COMPRESSED, cd.getFlags());
+    assertEquals(TranscoderUtils.SERIALIZED
+            | TranscoderUtils.COMPRESSED, cd.getFlags());
     assertEquals(c, tc.decode(cd));
   }
 
@@ -96,8 +96,8 @@ class SerializingTranscoderTest extends BaseTranscoderCase {
   void testUndecodeable() throws Exception {
     CachedData cd = new CachedData(
             Integer.MAX_VALUE &
-                    ~(SerializingTranscoder.COMPRESSED
-                            | SerializingTranscoder.SERIALIZED),
+                    ~(TranscoderUtils.COMPRESSED
+                            | TranscoderUtils.SERIALIZED),
             tu.encodeInt(Integer.MAX_VALUE),
             tc.getMaxSize());
     assertNull(tc.decode(cd));
@@ -105,7 +105,7 @@ class SerializingTranscoderTest extends BaseTranscoderCase {
 
   @Test
   void testUndecodeableSerialized() throws Exception {
-    CachedData cd = new CachedData(SerializingTranscoder.SERIALIZED,
+    CachedData cd = new CachedData(TranscoderUtils.SERIALIZED,
             tu.encodeInt(Integer.MAX_VALUE),
             tc.getMaxSize());
     assertNull(tc.decode(cd));
@@ -114,7 +114,7 @@ class SerializingTranscoderTest extends BaseTranscoderCase {
   @Test
   void testUndecodeableCompressed() throws Exception {
     CachedData cd = new CachedData(
-            SerializingTranscoder.COMPRESSED,
+            TranscoderUtils.COMPRESSED,
             tu.encodeInt(Integer.MAX_VALUE),
             tc.getMaxSize());
     System.out.println("got " + tc.decode(cd));

--- a/src/test/java/net/spy/memcached/transcoders/TranscoderUtilsTest.java
+++ b/src/test/java/net/spy/memcached/transcoders/TranscoderUtilsTest.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.fail;
 
 /**
@@ -57,6 +58,21 @@ class TranscoderUtilsTest {
       long b = tu.decodeLong(oversizeBytes);
       fail("Got " + b + " expected assertion.");
     } catch (AssertionError e) {
+      // pass
+    }
+  }
+
+  @Test
+  void testDecodeStringNull() {
+    assertNull(tu.decodeString(null));
+  }
+
+  @Test
+  void testEncodeStringNull() {
+    try {
+      tu.encodeString(null);
+      fail("Expected an assertion error");
+    } catch (NullPointerException e) {
       // pass
     }
   }


### PR DESCRIPTION
### 🔗 Related Issue

<!-- Please link related issue. ex) https://github.com/naver/arcus-java-client/issues/{issue_number} -->
- https://github.com/jam2in/arcus-works/issues/732

### ⌨️ What I did

<!-- Please describe this PR and what you've been working on. -->
- 공통 상수(SERIALIZED, COMPRESSED, SPECIAL_*)를 TranscoderUtils 클래스로 이동하였습니다.
- encodeString(), decodeString(), setCharset(), examineFlags() 메서드를 TranscoderUtils로 이동하였습니다.
- 각 Transcoder 클래스에서 TranscoderUtils를 통해 공통 상수 및 메서드를 재사용하도록 변경했습니다.
- WhalinTranscoder에서 charset 변수를 활용하기 위해 getter를 추가하였습니다.
- 메서드 이동으로 인해 BaseSerializingTranscoderTest의 일부 테스트 케이스를 TranscoderUtilsTest로 이동시켰습니다.