### PR TITLE
FIX: Do not make unhandledState in matchStatus

### DIFF
--- a/src/main/java/net/spy/memcached/CASResponse.java
+++ b/src/main/java/net/spy/memcached/CASResponse.java
@@ -26,6 +26,10 @@ public enum CASResponse {
    */
   CANCELED,
   /**
+   * Status indicating the type of value is not key-value.
+   */
+  TYPE_MISMATCH,
+  /**
    * Status indicating the undefined response was delivered from the cache.
    */
   UNDEFINED

--- a/src/main/java/net/spy/memcached/protocol/ascii/BaseStoreOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/BaseStoreOperationImpl.java
@@ -42,6 +42,10 @@ abstract class BaseStoreOperationImpl extends OperationImpl {
           new OperationStatus(false, "NOT_FOUND", StatusCode.ERR_NOT_FOUND);
   private static final OperationStatus EXISTS =
           new OperationStatus(false, "EXISTS", StatusCode.ERR_EXISTS);
+  private static final OperationStatus NOT_STORED =
+          new OperationStatus(false, "NOT_STORED", StatusCode.ERR_NOT_STORED);
+  private static final OperationStatus TYPE_MISMATCH =
+          new OperationStatus(false, "TYPE_MISMATCH", StatusCode.ERR_TYPE_MISMATCH);
 
   protected final String type;
   protected final String key;
@@ -77,7 +81,7 @@ abstract class BaseStoreOperationImpl extends OperationImpl {
       return;
     }
     /* ENABLE_MIGRATION end */
-    complete(matchStatus(line, STORED, NOT_FOUND, EXISTS));
+    complete(matchStatus(line, STORED, NOT_STORED, NOT_FOUND, EXISTS, TYPE_MISMATCH));
   }
 
   @Override

--- a/src/main/java/net/spy/memcached/protocol/ascii/CASOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/CASOperationImpl.java
@@ -50,6 +50,9 @@ class CASOperationImpl extends OperationImpl implements CASOperation {
   private static final OperationStatus EXISTS =
           new CASOperationStatus(false, "EXISTS",
                   CASResponse.EXISTS, StatusCode.ERR_EXISTS);
+  private static final OperationStatus TYPE_MISMATCH =
+          new CASOperationStatus(false, "TYPE_MISMATCH",
+                  CASResponse.TYPE_MISMATCH, StatusCode.ERR_TYPE_MISMATCH);
 
   private final String key;
   private final long casValue;
@@ -86,7 +89,7 @@ class CASOperationImpl extends OperationImpl implements CASOperation {
       return;
     }
     /* ENABLE_MIGRATION end */
-    complete(matchStatus(line, STORED, NOT_FOUND, EXISTS));
+    complete(matchStatus(line, STORED, NOT_FOUND, EXISTS, TYPE_MISMATCH));
   }
 
   @Override


### PR DESCRIPTION
### 🔗 Related Issue

<!-- Please link related issue. ex) https://github.com/naver/arcus-java-client/issues/{issue_number} -->
- https://github.com/naver/arcus-java-client/issues/932

### ⌨️ What I did

<!-- Please describe this PR and what you've been working on. -->
- MISSED_KEY, TRIMMED_KEY 의 값들을 matchStatus에서 읽어보지 않도록 하기 위해 readCount라는 값을 활용하여 lineCount가 될 때 까지 읽습니다.
- lineCount만큼 모두 읽은 후에 matchStatus를 수행하여 마지막 응답을 읽도록 합니다.
- 이를 통해 matchStatus에서 `<key>` 혹은 `<key> <cause>` 를 읽지 않도록 하여 Unhandled State 워닝 로그가 뜨지 않도록 합니다.