### PR TITLE
CLEANUP: Lower log level to info in matchStatus()

### DIFF
--- a/src/main/java/net/spy/memcached/protocol/ascii/OperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/OperationImpl.java
@@ -70,7 +70,7 @@ abstract class OperationImpl extends BaseOperationImpl {
       }
     }
     if (rv == null) {
-      getLogger().warn("Unhandled state: " + line);
+      getLogger().info("Unhandled state: " + line);
       rv = new OperationStatus(false, line, StatusCode.fromAsciiLine(line));
     }
     return rv;


### PR DESCRIPTION
### 🔗 Related Issue

<!-- Please link related issue. ex) https://github.com/naver/arcus-java-client/issues/{issue_number} -->
- https://github.com/naver/arcus-java-client/issues/932

### ⌨️ What I did

<!-- Please describe this PR and what you've been working on. -->
- matchStatus의 로그 레벨을 INFO로 내립니다.