### PR TITLE
INTERNAL: Set OperationStatus even if already CANCELED status exists

### DIFF
--- a/src/main/java/net/spy/memcached/internal/PipedCollectionFuture.java
+++ b/src/main/java/net/spy/memcached/internal/PipedCollectionFuture.java
@@ -12,6 +12,7 @@ import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicReference;
 
 import net.spy.memcached.MemcachedConnection;
+import net.spy.memcached.collection.CollectionResponse;
 import net.spy.memcached.ops.CollectionOperationStatus;
 import net.spy.memcached.ops.Operation;
 import net.spy.memcached.ops.OperationState;
@@ -103,7 +104,8 @@ public class PipedCollectionFuture<K, V>
   }
 
   public void setOperationStatus(CollectionOperationStatus status) {
-    if (operationStatus.get() == null) {
+    if (operationStatus.get() == null
+            || operationStatus.get().getResponse() == CollectionResponse.CANCELED) {
       operationStatus.set(status);
       super.set(null, status);
       return;


### PR DESCRIPTION
### 🔗 Related Issue

<!-- Please link related issue. ex) https://github.com/naver/arcus-java-client/issues/{issue_number} -->
- https://github.com/jam2in/arcus-works/issues/714

### ⌨️ What I did

<!-- Please describe this PR and what you've been working on. -->
- 이슈에서 결정했듯이, 다음과 같이 동작하도록 수정합니다.
  - 기존 Status가 null이거나 성공 응답인 경우, 새로운 응답이 실패이거나 CANCELED이면 저장한다.
  - 기존 Status가 실패 응답일 경우, 새로운 응답을 저장하지 않는다.
  - 기존 Status가 CANCELED인 경우, 새로운 응답을 저장한다.
- 이 PR 먼저 반영 후 https://github.com/naver/arcus-java-client/pull/887 반영하면 됩니다.