### PR TITLE
FEAT: Add gat(get and touch) command to get item & update item expira…

### DIFF
--- a/src/main/java/net/spy/memcached/ArcusClientPool.java
+++ b/src/main/java/net/spy/memcached/ArcusClientPool.java
@@ -248,6 +248,26 @@ public class ArcusClientPool implements MemcachedClientIF, ArcusClientIF {
   }
 
   @Override
+  public <T> GetFuture<T> asyncGetAndTouch(String key, int exp, Transcoder<T> tc) {
+    return this.getClient().asyncGetAndTouch(key, exp, tc);
+  }
+
+  @Override
+  public GetFuture<Object> asyncGetAndTouch(String key, int exp) {
+    return this.getClient().asyncGetAndTouch(key, exp);
+  }
+
+  @Override
+  public <T> GetFuture<CASValue<T>> asyncGetsAndTouch(String key, int exp, Transcoder<T> tc) {
+    return this.getClient().asyncGetsAndTouch(key, exp, tc);
+  }
+
+  @Override
+  public GetFuture<CASValue<Object>> asyncGetsAndTouch(String key, int exp) {
+    return this.getClient().asyncGetsAndTouch(key, exp);
+  }
+
+  @Override
   public <T> CASValue<T> gets(String key, Transcoder<T> tc)
           throws OperationTimeoutException {
     return this.getClient().gets(key, tc);

--- a/src/main/java/net/spy/memcached/MemcachedClientIF.java
+++ b/src/main/java/net/spy/memcached/MemcachedClientIF.java
@@ -82,6 +82,15 @@ public interface MemcachedClientIF {
 
   Future<CASValue<Object>> asyncGets(String key);
 
+  <T> Future<T> asyncGetAndTouch(final String key, final int exp, final Transcoder<T> tc);
+
+  Future<Object> asyncGetAndTouch(final String key, final int exp);
+
+  <T> Future<CASValue<T>> asyncGetsAndTouch(final String key, final int exp,
+                                            final Transcoder<T> tc);
+
+  Future<CASValue<Object>> asyncGetsAndTouch(final String key, final int exp);
+
   <T> CASValue<T> gets(String key, Transcoder<T> tc)
           throws OperationTimeoutException;
 

--- a/src/main/java/net/spy/memcached/OperationFactory.java
+++ b/src/main/java/net/spy/memcached/OperationFactory.java
@@ -153,6 +153,26 @@ public interface OperationFactory {
   GetsOperation gets(Collection<String> keys, GetsOperation.Callback cb, boolean isMGet);
 
   /**
+   * Get the key and resets its timeout.
+   *
+   * @param key the key to get a value for and reset its timeout
+   * @param expiration the new expiration for the key
+   * @param cb the callback that will contain the result
+   * @return a new GetAndTouchOperation
+   */
+  GetOperation getAndTouch(String key, int expiration, GetOperation.Callback cb);
+
+  /**
+   * Gets (with CAS support) the key and resets its timeout.
+   *
+   * @param key the key to get a value for and reset its timeout
+   * @param expiration the new expiration for the key
+   * @param cb the callback that will contain the result
+   * @return a new GetsAndTouchOperation
+   */
+  GetsOperation getsAndTouch(String key, int expiration, GetsOperation.Callback cb);
+
+  /**
    * Create a mutator operation.
    *
    * @param m   the mutator type

--- a/src/main/java/net/spy/memcached/ops/APIType.java
+++ b/src/main/java/net/spy/memcached/ops/APIType.java
@@ -25,6 +25,7 @@ public enum APIType {
   INCR(OperationType.WRITE), DECR(OperationType.WRITE),
   DELETE(OperationType.WRITE),
   GET(OperationType.READ), GETS(OperationType.READ),
+  GAT(OperationType.WRITE), GATS(OperationType.WRITE),
 
   // List API Type
   LOP_CREATE(OperationType.WRITE),

--- a/src/main/java/net/spy/memcached/ops/OperationType.java
+++ b/src/main/java/net/spy/memcached/ops/OperationType.java
@@ -25,6 +25,7 @@ public enum OperationType {
    * BTreeInsertAndGetOperationImpl (asyncBopInsertAndGetTrimmed)
    * FlushOperationImpl / FlushByPrefixOperationImpl (flush)
    * SetAttrOperationImpl (asyncSetAttr)
+   * GetAndTouchOperationImpl / GetsAndTouchOperationImpl (asyncGetAndTouch / asyncGetsAndTouch)
    */
   WRITE,
 

--- a/src/main/java/net/spy/memcached/protocol/ascii/AsciiOperationFactory.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/AsciiOperationFactory.java
@@ -109,6 +109,14 @@ public class AsciiOperationFactory extends BaseOperationFactory {
     return new GetsOperationImpl(keys, cb, isMGet);
   }
 
+  public GetOperation getAndTouch(String key, int expiration, GetOperation.Callback cb) {
+    return new GetAndTouchOperationImpl(key, expiration, cb);
+  }
+
+  public GetsOperation getsAndTouch(String key, int expiration, GetsOperation.Callback cb) {
+    return new GetsAndTouchOperationImpl(key, expiration, cb);
+  }
+
   public MutatorOperation mutate(Mutator m, String key, int by,
                                  long def, int exp, OperationCallback cb) {
     return new MutatorOperationImpl(m, key, by, def, exp, cb);

--- a/src/main/java/net/spy/memcached/protocol/ascii/GetAndTouchOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/GetAndTouchOperationImpl.java
@@ -1,0 +1,36 @@
+/*
+ * arcus-java-client : Arcus Java client
+ * Copyright 2010-2014 NAVER Corp.
+ * Copyright 2014-present JaM2in Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.spy.memcached.protocol.ascii;
+
+import java.util.Collections;
+
+import net.spy.memcached.ops.APIType;
+import net.spy.memcached.ops.GetOperation;
+
+/**
+ * Implementation of the get and touch operation.
+ */
+class GetAndTouchOperationImpl extends BaseGetOpImpl implements GetOperation {
+  private static final String CMD = "gat";
+
+  public GetAndTouchOperationImpl(String k, int e, GetOperation.Callback cb) {
+    super(CMD, e, cb, Collections.singleton(k));
+    setAPIType(APIType.GAT);
+  }
+}

--- a/src/main/java/net/spy/memcached/protocol/ascii/GetsAndTouchOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/GetsAndTouchOperationImpl.java
@@ -1,0 +1,36 @@
+/*
+ * arcus-java-client : Arcus Java client
+ * Copyright 2010-2014 NAVER Corp.
+ * Copyright 2014-present JaM2in Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.spy.memcached.protocol.ascii;
+
+import java.util.Collections;
+
+import net.spy.memcached.ops.APIType;
+import net.spy.memcached.ops.GetsOperation;
+
+/**
+ * Implementation of the gets and touch operation.
+ */
+class GetsAndTouchOperationImpl extends BaseGetOpImpl implements GetsOperation {
+  private static final String CMD = "gats";
+
+  public GetsAndTouchOperationImpl(String k, int e, GetsOperation.Callback cb) {
+    super(CMD, e, cb, Collections.singleton(k));
+    setAPIType(APIType.GATS);
+  }
+}

--- a/src/main/java/net/spy/memcached/protocol/binary/BinaryOperationFactory.java
+++ b/src/main/java/net/spy/memcached/protocol/binary/BinaryOperationFactory.java
@@ -112,6 +112,16 @@ public class BinaryOperationFactory extends BaseOperationFactory {
             "multiple key gets is not supported in binary protocol yet.");
   }
 
+  public GetOperation getAndTouch(String key, int expiration, GetOperation.Callback cb) {
+    throw new RuntimeException(
+            "GetAndTouchOperation is not supported in binary protocol yet.");
+  }
+
+  public GetsOperation getsAndTouch(String key, int expiration, GetsOperation.Callback cb) {
+    throw new RuntimeException(
+            "GetsAndTouchOperation is not supported in binary protocol yet.");
+  }
+
   public MutatorOperation mutate(Mutator m, String key, int by,
                                  long def, int exp, OperationCallback cb) {
     return new MutatorOperationImpl(m, key, by, def, exp, cb);

--- a/src/test/java/net/spy/memcached/ProtocolBaseCase.java
+++ b/src/test/java/net/spy/memcached/ProtocolBaseCase.java
@@ -122,6 +122,25 @@ abstract class ProtocolBaseCase extends ClientBaseCase {
     assertTrue(val.matches("\\[acctime=\\d+, exptime=\\d+\\]"), val + "doesn't match");
   }
 
+//  @Test
+//  void testGetAndTouch() throws Exception {
+//    assertNull(client.get("testgat"));
+//    assertTrue(client.set("testgat", 3, "testgatvalue").get());
+//    GetFuture<Object> future = client.asyncGetAndTouch("testgat", 5);
+//    assertNotNull(future.get());
+//    assertEquals("testgatvalue", future.get());
+//  }
+//
+//  @Test
+//  void testGetsAndTouch() throws Exception {
+//    assertNull(client.get("testgats"));
+//    assertTrue(client.set("testgats", 3, "testgatsvalue").get());
+//    GetFuture<CASValue<Object>> future = client.asyncGetsAndTouch("testgats", 5);
+//    assertNotNull(future.get());
+//    assertEquals("testgatsvalue", future.get().getValue());
+//    assertTrue(future.get().getCas() > 0);
+//  }
+
   @Test
   void testDelayedFlush() throws Exception {
     assertNull(client.get("test1"));

--- a/src/test/manual/net/spy/memcached/collection/attribute/GetAttrTest.java
+++ b/src/test/manual/net/spy/memcached/collection/attribute/GetAttrTest.java
@@ -118,4 +118,17 @@ class GetAttrTest extends BaseIntegrationTest {
     CollectionAttributes rattrs = mc.asyncGetAttr(key).get(1000, TimeUnit.MILLISECONDS);
     assertTrue(rattrs.getExpireTime() > 10);
   }
+
+//  @Test
+//  void testGetAttr_GetAndTouch() throws Exception {
+//    String key = "getattr_gat_attribute";
+//
+//    mc.set(key, 10, "v").get();
+//    GetFuture<Object> future = mc.asyncGetAndTouch(key, 100);
+//    assertNotNull(future.get());
+//    assertEquals(future.get(), "v");
+//
+//    CollectionAttributes rattrs = mc.asyncGetAttr(key).get(1000, TimeUnit.MILLISECONDS);
+//    assertTrue(rattrs.getExpireTime() > 10);
+//  }
 }


### PR DESCRIPTION
### 🔗 Related Issue

<!-- Please link related issue. ex) https://github.com/naver/arcus-java-client/issues/{issue_number} -->
- #295 
- naver/arcus-memcached#487

### ⌨️ What I did

<!-- Please describe this PR and what you've been working on. -->
memcached 서버의 `gat`를 java-client에도 추가합니다.
이를 통해 expire time을 재설정 가능하도록 합니다.

- `Operation` 인터페이스 및 Ascii, Binary 프로토콜 구현체 추가
- `OperationFactory`에 `GetAndTouch` 추가
- `MemcachedClient`에 사용자가 호출할 수 있는 `gat` 기능 추가
- `gat` 기능을 위한 테스트 코드 추가

### CI Test 실패 관련
현재 실패하고 있는 CI Test는 `JDK 21, ubuntu-latest`에서 Test ARCUS Client with ZK를 실패하고 있습니다.
코드에서는 `AsciiClientTest`의 `gat`관련 테스트를 실패하고 있습니다.
해당 테스트는 현재 도커에 릴리즈된 memcached 서버는 `gat` 기능이 아직 반영되지 않았기에, 테스트코드에서 `gat`명령을 요청해도 응답이 없는 문제입니다.