### PR TITLE
FEATURE: Implement SASL authentication for the ASCII protocol

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,6 +17,7 @@
         <ehcache.version>3.10.8</ehcache.version>
         <junit.version>5.10.2</junit.version>
         <jmock.version>2.13.1</jmock.version>
+        <bolyartech.version>2.0.2</bolyartech.version>
         <jackson.version>2.19.0</jackson.version>
     </properties>
     <licenses>
@@ -118,6 +119,11 @@
                     <artifactId>slf4j-reload4j</artifactId>
                 </exclusion>
             </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>com.bolyartech.scram_sasl</groupId>
+            <artifactId>scram_sasl</artifactId>
+            <version>${bolyartech.version}</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>

--- a/src/main/java/net/spy/memcached/auth/AuthDescriptor.java
+++ b/src/main/java/net/spy/memcached/auth/AuthDescriptor.java
@@ -45,6 +45,19 @@ public class AuthDescriptor {
             new PlainCallbackHandler(u, p));
   }
 
+  /**
+   * Get a typical auth descriptor for SCRAM-SHA-256 auth with the given
+   * username and password.
+   *
+   * @param u the username
+   * @param p the password
+   * @return an AuthDescriptor
+   */
+  public static AuthDescriptor scramSha256(String u, String p) {
+    return new AuthDescriptor(new String[]{"SCRAM-SHA-256"},
+            new PlainCallbackHandler(u, p));
+  }
+
   public boolean authThresholdReached() {
     if (allowedAuthAttempts < 0) {
       return false; // negative value means auth forever

--- a/src/main/java/net/spy/memcached/auth/AuthThread.java
+++ b/src/main/java/net/spy/memcached/auth/AuthThread.java
@@ -36,6 +36,10 @@ public class AuthThread extends SpyThread {
     } catch (Exception e) {
       throw new IllegalStateException("Can't create SaslClient", e);
     }
+
+    if (sc == null) {
+      throw new IllegalStateException("SaslClient is null");
+    }
   }
 
   @Override
@@ -90,7 +94,8 @@ public class AuthThread extends SpyThread {
       if (priorStatus != null) {
         if (!priorStatus.isSuccess()) {
           getLogger().warn("Authentication failed to "
-                  + node.getSocketAddress());
+                  + node.getSocketAddress() + ": " + priorStatus.getMessage());
+          break;
         }
       }
     }

--- a/src/main/java/net/spy/memcached/auth/ScramMechanism.java
+++ b/src/main/java/net/spy/memcached/auth/ScramMechanism.java
@@ -1,0 +1,68 @@
+/*
+ * arcus-java-client : Arcus Java client
+ * Copyright 2010-2014 NAVER Corp.
+ * Copyright 2014-present JaM2in Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.spy.memcached.auth;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+public enum ScramMechanism {
+  SCRAM_SHA_256("SHA-256", "HmacSHA256");
+
+  private static final Map<String, ScramMechanism> MECHANISMS_MAP;
+
+  private final String mechanismName;
+  private final String hashAlgorithm;
+  private final String macAlgorithm;
+
+  static {
+    Map<String, ScramMechanism> map = new HashMap<>();
+    for (ScramMechanism mech : values()) {
+      map.put(mech.mechanismName, mech);
+    }
+    MECHANISMS_MAP = Collections.unmodifiableMap(map);
+  }
+
+  private ScramMechanism(String ha, String ma) {
+    mechanismName = "SCRAM-" + ha;
+    hashAlgorithm = ha;
+    macAlgorithm = ma;
+  }
+
+  public final String mechanismName() {
+    return mechanismName;
+  }
+
+  public String hashAlgorithm() {
+    return hashAlgorithm;
+  }
+
+  public String macAlgorithm() {
+    return macAlgorithm;
+  }
+
+  public static ScramMechanism forMechanismName(String mechanismName) {
+    return MECHANISMS_MAP.get(mechanismName);
+  }
+
+  public static Collection<String> mechanismNames() {
+    return MECHANISMS_MAP.keySet();
+  }
+}

--- a/src/main/java/net/spy/memcached/auth/ScramSaslClient.java
+++ b/src/main/java/net/spy/memcached/auth/ScramSaslClient.java
@@ -1,0 +1,215 @@
+/*
+ * arcus-java-client : Arcus Java client
+ * Copyright 2010-2014 NAVER Corp.
+ * Copyright 2014-present JaM2in Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.spy.memcached.auth;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Map;
+
+import javax.security.auth.callback.Callback;
+import javax.security.auth.callback.CallbackHandler;
+import javax.security.auth.callback.NameCallback;
+import javax.security.auth.callback.PasswordCallback;
+import javax.security.sasl.SaslClient;
+import javax.security.sasl.SaslClientFactory;
+import javax.security.sasl.SaslException;
+
+import com.bolyartech.scram_sasl.client.ScramClientFunctionality;
+import com.bolyartech.scram_sasl.client.ScramClientFunctionalityImpl;
+import com.bolyartech.scram_sasl.common.ScramException;
+
+public class ScramSaslClient implements SaslClient {
+
+  enum State {
+    SEND_CLIENT_FIRST_MESSAGE,
+    RECEIVE_SERVER_FIRST_MESSAGE,
+    RECEIVE_SERVER_FINAL_MESSAGE,
+    COMPLETE,
+    FAILED
+  }
+
+  private final ScramMechanism mechanism;
+  private final CallbackHandler callbackHandler;
+  private final ScramClientFunctionality scf;
+  private State state;
+
+  public ScramSaslClient(ScramMechanism mech, CallbackHandler cbh) {
+    callbackHandler = cbh;
+    mechanism = mech;
+    scf = new ScramClientFunctionalityImpl(
+            mech.hashAlgorithm(), mech.macAlgorithm());
+    state = State.SEND_CLIENT_FIRST_MESSAGE;
+  }
+
+  @Override
+  public String getMechanismName() {
+    return mechanism.mechanismName();
+  }
+
+  @Override
+  public boolean hasInitialResponse() {
+    return true;
+  }
+
+  @Override
+  public byte[] evaluateChallenge(byte[] challenge) throws SaslException {
+    try {
+      switch (state) {
+        /**
+         * Initiates the authentication exchange by creating the client-first-message,
+         * which contains the username and a client-generated nonce.
+         *
+         * @return A byte array of the client-first-message to be sent.
+         * (ex: "n,,n=user,r=nonce")
+         */
+        case SEND_CLIENT_FIRST_MESSAGE:
+          if (challenge != null && challenge.length != 0) {
+            throw new SaslException("Expected empty challenge");
+          }
+
+          NameCallback nameCallback = new NameCallback("Name: ");
+          try {
+            callbackHandler.handle(new Callback[]{nameCallback});
+          } catch (Throwable e) {
+            throw new SaslException("User name could not be obtained", e);
+          }
+
+          String username = nameCallback.getName();
+          byte[] clientFirstMessage = scf.prepareFirstMessage(username).getBytes();
+          state = State.RECEIVE_SERVER_FIRST_MESSAGE;
+          return clientFirstMessage;
+        /**
+         * Process the server's challenge and generate client's proof.
+         * Generate a password-based cryptographic proof by using the server nonce, salt
+         * and iteration count.
+         *
+         * @return A byte array of the client-final-message to be sent.
+         * (ex: "c=....,r=...,p=....")
+         */
+        case RECEIVE_SERVER_FIRST_MESSAGE:
+          String serverFirstMessage = new String(challenge, StandardCharsets.UTF_8);
+
+          PasswordCallback passwordCallback = new PasswordCallback("Password: ", false);
+          try {
+            callbackHandler.handle(new Callback[]{passwordCallback});
+          } catch (Throwable e) {
+            throw new SaslException("Password could not be obtained", e);
+          }
+
+          String password = String.valueOf(passwordCallback.getPassword());
+          String clientFinalMessage = scf.prepareFinalMessage(
+                  password, serverFirstMessage);
+          if (clientFinalMessage == null) {
+            throw new SaslException("clientFinalMessage should not be null");
+          }
+          state = State.RECEIVE_SERVER_FINAL_MESSAGE;
+          return clientFinalMessage.getBytes();
+        /**
+         * Verifies the server's final signature.
+         * If success, the authentication exchange is complete,
+         *
+         * @return An empty byte array.
+         */
+        case RECEIVE_SERVER_FINAL_MESSAGE:
+          String serverFinalMessage = new String(challenge, StandardCharsets.UTF_8);
+          if (!scf.checkServerFinalMessage(serverFinalMessage)) {
+            throw new SaslException("Sasl authentication using " + mechanism +
+                    " failed with error: invalid server final message");
+          }
+          state = State.COMPLETE;
+          return new byte[]{};
+
+        default:
+          throw new SaslException("Unexpected challenge in Sasl client state " + state);
+      }
+    } catch (ScramException e) {
+      state = State.FAILED;
+      throw new SaslException("Authentication failed due to ScramException", e);
+    } catch (SaslException e) {
+      state = State.FAILED;
+      throw e;
+    }
+  }
+
+  @Override
+  public boolean isComplete() {
+    return state == State.COMPLETE;
+  }
+
+  @Override
+  public byte[] unwrap(byte[] incoming, int offset, int len) throws SaslException {
+    if (!isComplete()) {
+      throw new IllegalStateException("Authentication exchange has not completed");
+    }
+    throw new IllegalStateException("SCRAM supports neither integrity nor privacy");
+  }
+
+  @Override
+  public byte[] wrap(byte[] outgoing, int offset, int len) throws SaslException {
+    if (!isComplete()) {
+      throw new IllegalStateException("Authentication exchange has not completed");
+    }
+    throw new IllegalStateException("SCRAM supports neither integrity nor privacy");
+  }
+
+  @Override
+  public Object getNegotiatedProperty(String propName) {
+    if (!isComplete()) {
+      throw new IllegalStateException("Authentication exchange has not completed");
+    }
+    return null;
+  }
+
+  @Override
+  public void dispose() throws SaslException {
+  }
+
+  public static class ScramSaslClientFactory implements SaslClientFactory {
+    @Override
+    public SaslClient createSaslClient(String[] mechanisms,
+                                       String authorizationId,
+                                       String protocol,
+                                       String serverName,
+                                       Map<String, ?> props,
+                                       CallbackHandler cbh) throws SaslException {
+
+      ScramMechanism mechanism = null;
+      for (String mech : mechanisms) {
+        mechanism = ScramMechanism.forMechanismName(mech);
+        if (mechanism != null) {
+          break;
+        }
+      }
+      if (mechanism == null) {
+        throw new SaslException(String.format("Requested mechanisms '%s' not supported."
+                        + " Supported mechanisms are '%s'.",
+                Arrays.toString(mechanisms), ScramMechanism.mechanismNames()));
+      }
+
+      return new ScramSaslClient(mechanism, cbh);
+    }
+
+    @Override
+    public String[] getMechanismNames(Map<String, ?> props) {
+      Collection<String> mechanisms = ScramMechanism.mechanismNames();
+      return mechanisms.toArray(new String[0]);
+    }
+  }
+}

--- a/src/main/java/net/spy/memcached/auth/ScramSaslClientProvider.java
+++ b/src/main/java/net/spy/memcached/auth/ScramSaslClientProvider.java
@@ -1,0 +1,37 @@
+/*
+ * arcus-java-client : Arcus Java client
+ * Copyright 2010-2014 NAVER Corp.
+ * Copyright 2014-present JaM2in Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.spy.memcached.auth;
+
+import java.security.Provider;
+import java.security.Security;
+
+public final class ScramSaslClientProvider extends Provider {
+
+  private static final long serialVersionUID = 1L;
+
+  @SuppressWarnings("deprecation")
+  public ScramSaslClientProvider(String m) {
+    super("ARCUS SASL Client Provider", 1.0, "SASL Client Provider for Arcus");
+    put("SaslClientFactory." + m, ScramSaslClient.ScramSaslClientFactory.class.getName());
+  }
+
+  public static void initialize(String mech) {
+    Security.addProvider(new ScramSaslClientProvider(mech));
+  }
+}

--- a/src/main/java/net/spy/memcached/ops/APIType.java
+++ b/src/main/java/net/spy/memcached/ops/APIType.java
@@ -68,6 +68,9 @@ public enum APIType {
   FLUSH(OperationType.WRITE),
   STATS(OperationType.ETC),
   VERSION(OperationType.ETC),
+  SASL_MECHS(OperationType.ETC),
+  SASL_AUTH(OperationType.ETC),
+  SASL_STEP(OperationType.ETC),
 
   // undefined API
   UNDEFINED(OperationType.UNDEFINED);

--- a/src/main/java/net/spy/memcached/ops/OperationType.java
+++ b/src/main/java/net/spy/memcached/ops/OperationType.java
@@ -47,6 +47,9 @@ public enum OperationType {
   /*
    * StatsOperationImpl (getStats)
    * VersionOperationImpl (getVersions)
+   * SASLMechsOperationImpl (sasl mechs)
+   * SASLAuthOperationImpl (sasl auth)
+   * SASLStepOperationImpl (sasl auth)
    */
   ETC,
 

--- a/src/main/java/net/spy/memcached/protocol/ascii/AsciiMemcachedNodeImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/AsciiMemcachedNodeImpl.java
@@ -37,9 +37,9 @@ public final class AsciiMemcachedNodeImpl extends TCPMemcachedNodeImpl {
                                 SocketAddress sa,
                                 int bufSize, BlockingQueue<Operation> rq,
                                 BlockingQueue<Operation> wq, BlockingQueue<Operation> iq,
-                                Long opQueueMaxBlockTimeNs) {
+                                Long opQueueMaxBlockTimeNs, boolean waitForAuth) {
     super(name, sa, bufSize, rq, wq, iq, opQueueMaxBlockTimeNs,
-        false /* ascii never does auth */, true /* ascii protocol */);
+            waitForAuth, true /* ascii protocol */);
   }
 
   @Override

--- a/src/main/java/net/spy/memcached/protocol/ascii/AsciiOperationFactory.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/AsciiOperationFactory.java
@@ -143,15 +143,15 @@ public class AsciiOperationFactory extends BaseOperationFactory {
   }
 
   public SASLMechsOperation saslMechs(OperationCallback cb) {
-    throw new UnsupportedOperationException();
+    return new SASLMechsOperationImpl(cb);
   }
 
   public SASLStepOperation saslStep(SaslClient sc, byte[] challenge, OperationCallback cb) {
-    throw new UnsupportedOperationException();
+    return new SASLStepOperationImpl(sc, challenge, cb);
   }
 
   public SASLAuthOperation saslAuth(SaslClient sc, OperationCallback cb) {
-    throw new UnsupportedOperationException();
+    return new SASLAuthOperationImpl(sc, cb);
   }
 
   public SetAttrOperation setAttr(String key, Attributes attrs,

--- a/src/main/java/net/spy/memcached/protocol/ascii/SASLAuthOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/SASLAuthOperationImpl.java
@@ -1,0 +1,54 @@
+/*
+ * arcus-java-client : Arcus Java client
+ * Copyright 2010-2014 NAVER Corp.
+ * Copyright 2014-present JaM2in Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.spy.memcached.protocol.ascii;
+
+import javax.security.sasl.SaslClient;
+import javax.security.sasl.SaslException;
+
+import net.spy.memcached.ops.APIType;
+import net.spy.memcached.ops.OperationCallback;
+import net.spy.memcached.ops.SASLAuthOperation;
+
+/**
+ * Operation to initiate the SASL authentication process.
+ */
+final class SASLAuthOperationImpl extends SASLBaseOperationImpl
+        implements SASLAuthOperation {
+
+  public SASLAuthOperationImpl(SaslClient sc, OperationCallback cb) {
+    super(sc, cb);
+    setAPIType(APIType.SASL_AUTH);
+  }
+
+  @Override
+  public void initialize() {
+    try {
+      /**
+       * sasl auth {mech} {vlen}\r\n{value}\r\n
+       */
+      String mechanism = sc.getMechanismName();
+      byte[] response = sc.hasInitialResponse() ? sc.evaluateChallenge(new byte[0]) : new byte[0];
+      String command = CMD + mechanism + " ";
+      setSaslAuthBuffer(command, response);
+    } catch (SaslException e) {
+      getLogger().error("Error while initializing SASL auth: ", e);
+      throw new RuntimeException("Error while initializing SASL auth: ", e);
+    }
+  }
+}

--- a/src/main/java/net/spy/memcached/protocol/ascii/SASLBaseOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/SASLBaseOperationImpl.java
@@ -1,0 +1,101 @@
+/*
+ * arcus-java-client : Arcus Java client
+ * Copyright 2010-2014 NAVER Corp.
+ * Copyright 2014-present JaM2in Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.spy.memcached.protocol.ascii;
+
+import java.nio.ByteBuffer;
+
+import javax.security.sasl.SaslClient;
+
+import net.spy.memcached.ops.OperationCallback;
+import net.spy.memcached.ops.OperationStatus;
+import net.spy.memcached.ops.OperationType;
+import net.spy.memcached.ops.StatusCode;
+
+/**
+ * Base class for ascii SASL operation handlers.
+ */
+abstract class SASLBaseOperationImpl extends OperationImpl {
+
+  protected static final String CMD = "sasl auth ";
+  private static final String RN_STRING = "\r\n";
+
+  protected static final OperationStatus SASL_OK =
+          new OperationStatus(true, "SASL_OK", StatusCode.SUCCESS);
+
+  protected final SaslClient sc;
+  private byte[] challenge;
+  private int readOffset = 0;
+  private int challengeLength = -1;
+
+  public SASLBaseOperationImpl(SaslClient sc, OperationCallback cb) {
+    super(cb);
+    this.sc = sc;
+    setOperationType(OperationType.ETC);
+  }
+
+  protected void setSaslAuthBuffer(String command, byte[] data) {
+    String header = command + data.length + RN_STRING;
+    byte[] headerBytes = header.getBytes();
+    byte[] terminatorBytes = RN_STRING.getBytes();
+
+    ByteBuffer b = ByteBuffer.allocate(headerBytes.length + data.length + terminatorBytes.length);
+    b.put(headerBytes);
+    b.put(data);
+    b.put(terminatorBytes);
+
+    b.flip();
+    setBuffer(b);
+  }
+
+  @Override
+  public void handleLine(String line) {
+    /**
+     * The server can respond with one of the following:
+     *  - SASL_CONTINUE {vlen}\r\n{value}\r\n
+     *  - SASL_OK\r\n
+     */
+    if (line.startsWith("SASL_CONTINUE")) {
+      challengeLength = Integer.parseInt(line.substring("SASL_CONTINUE".length()).trim());
+      challenge = new byte[challengeLength];
+      readOffset = 0;
+      setReadType(OperationReadType.DATA);
+    } else if (line.startsWith("SASL_OK")) {
+      complete(matchStatus(line, SASL_OK));
+    } else {
+      complete(new OperationStatus(false, line, StatusCode.ERR_AUTH));
+    }
+  }
+
+  @Override
+  public void handleRead(ByteBuffer buffer) {
+    if (readOffset < challengeLength) {
+      int toRead = Math.min(challengeLength - readOffset, buffer.remaining());
+      buffer.get(challenge, readOffset, toRead);
+      readOffset += toRead;
+    }
+
+    byte found = 0;
+    while (found != '\n' && buffer.hasRemaining()) {
+      found = buffer.get();
+    }
+    if (found == '\n') {
+      complete(new OperationStatus(true, new String(challenge), StatusCode.SUCCESS));
+    }
+  }
+}

--- a/src/main/java/net/spy/memcached/protocol/ascii/SASLMechsOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/SASLMechsOperationImpl.java
@@ -1,0 +1,62 @@
+/*
+ * arcus-java-client : Arcus Java client
+ * Copyright 2010-2014 NAVER Corp.
+ * Copyright 2014-present JaM2in Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.spy.memcached.protocol.ascii;
+
+import java.nio.ByteBuffer;
+
+import net.spy.memcached.ops.APIType;
+import net.spy.memcached.ops.OperationCallback;
+import net.spy.memcached.ops.OperationStatus;
+import net.spy.memcached.ops.OperationType;
+import net.spy.memcached.ops.SASLMechsOperation;
+import net.spy.memcached.ops.StatusCode;
+
+/**
+ * Operation to request the list of supported SASL mechanisms.
+ */
+final class SASLMechsOperationImpl extends OperationImpl implements SASLMechsOperation {
+
+  private static final byte[] MECHS_CMD = "sasl mech\r\n".getBytes();
+  private static final String SASL_MECH_PREFIX = "SASL_MECH ";
+
+  public SASLMechsOperationImpl(OperationCallback cb) {
+    super(cb);
+    setAPIType(APIType.SASL_MECHS);
+    setOperationType(OperationType.ETC);
+  }
+
+  @Override
+  public void initialize() {
+    setBuffer(ByteBuffer.wrap(MECHS_CMD));
+  }
+
+  @Override
+  public void handleLine(String line) {
+    /**
+     * SASL_MECH SCRAM-SHA-256\r\n
+     */
+    if (line.startsWith(SASL_MECH_PREFIX)) {
+      String rawMechanisms = line.substring(SASL_MECH_PREFIX.length()).trim();
+      String mechanisms = rawMechanisms.replaceAll("\\s+", " ").trim();
+      complete(new OperationStatus(true, mechanisms, StatusCode.SUCCESS));
+    } else {
+      complete(new OperationStatus(false, line, StatusCode.fromAsciiLine(line)));
+    }
+  }
+}

--- a/src/main/java/net/spy/memcached/protocol/ascii/SASLStepOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/SASLStepOperationImpl.java
@@ -1,0 +1,54 @@
+/*
+ * arcus-java-client : Arcus Java client
+ * Copyright 2010-2014 NAVER Corp.
+ * Copyright 2014-present JaM2in Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.spy.memcached.protocol.ascii;
+
+import javax.security.sasl.SaslClient;
+import javax.security.sasl.SaslException;
+
+import net.spy.memcached.ops.APIType;
+import net.spy.memcached.ops.OperationCallback;
+import net.spy.memcached.ops.SASLStepOperation;
+
+/**
+ * Operation to perform a single step of the SASL authentication process.
+ */
+final class SASLStepOperationImpl extends SASLBaseOperationImpl implements SASLStepOperation {
+
+  private final byte[] challenge;
+
+  public SASLStepOperationImpl(SaslClient sc, byte[] challenge, OperationCallback cb) {
+    super(sc, cb);
+    this.challenge = challenge;
+    setAPIType(APIType.SASL_STEP);
+  }
+
+  @Override
+  public void initialize() {
+    try {
+      /**
+       * sasl auth {vlen}\r\n{value}\r\n
+       */
+      byte[] response = sc.evaluateChallenge(challenge);
+      setSaslAuthBuffer(CMD, response);
+    } catch (SaslException e) {
+      getLogger().warn("Error while initializing SASL step: ", e);
+      throw new RuntimeException("Error while initializing SASL step: ", e);
+    }
+  }
+}

--- a/src/test/java/net/spy/memcached/protocol/ascii/BaseOpTest.java
+++ b/src/test/java/net/spy/memcached/protocol/ascii/BaseOpTest.java
@@ -150,7 +150,7 @@ class BaseOpTest {
             new CollectionPipedInsertOperationImpl("test", insert, cb);
     LinkedBlockingQueue<Operation> queue = new LinkedBlockingQueue<>();
     op.setHandlingNode(new AsciiMemcachedNodeImpl("testnode", new InetSocketAddress(11211),
-            60, queue, queue, queue, 0L));
+            60, queue, queue, queue, 0L, false));
 
     ByteBuffer b = ByteBuffer.allocate(40);
     String line1 = "RESPONSE 2\r\n";


### PR DESCRIPTION
### 🔗 Related Issue

<!-- Please link related issue. ex) https://github.com/naver/arcus-java-client/issues/{issue_number} -->
- jam2in/arcus-works/issues/742

### ⌨️ What I did
arcus-java-client에 Ascii 프로토콜을 위한 SASL 인증 메커니즘을 구현합니다.

<!-- Please describe this PR and what you've been working on. -->
- Scram 인증을 위한 `ScramSaslClient`를 구현합니다.
    - 이전 PoC단계에서 사용했던 코드를 가져왔고, 해당 코드는 kafka의 구현을 참고했습니다. naver/arcus-java-client/pull/869
    - [com.bolyartech.scram_sasl](https://github.com/ogrebgr/scram-sasl) 의존성을 추가합니다. (kafka에서 해당 의존성을 사용하지는 않았습니다.)
- ascii 프로토콜을 통해 SASL 인증을 주고받기 위한 `SASL**Operation` 구현체를 추가했습니다.
    - `SASLAuthOperationImpl`: sasl 인증 시작하고, 인증에 필요한 데이터를 전달합니다.
    -> `sasl auth {mech} {vlen}\r\n{value}\r\n`
    - `SASLStepOperationImpl`: 시작한 인증의 추가 데이터를 주고받습니다.(`mech`명령제외)
    -> `sasl auth {vlen}\r\n{value}\r\n`
    - `SASLMechsOperationImpl`: 인증 메커니즘 방식을 전달받습니다.
    -> `sasl mech\r\n`
- 기존 `AsciiMemcachedNode` 생성 시, 인증 대기로직을 활성화할 수 있도록 합니다.

---
### 🚩 Etc
- 인터페이스: 사용자는 아래와 같이 인증을 수행할 수 있습니다.
```java
ArcusClient client = null;

ConnectionFactoryBuilder cfb = new ConnectionFactoryBuilder()
                     // ascii(text) 프로토콜로 지정.
                    .setProtocol(ConnectionFactoryBuilder.Protocol.TEXT) 
                     // sasl 인증수행. 이때 제안해주신 방식대로, 원하는 메커니즘에 대한 별도 메서드를 제공.
                    .setAuthDescriptor(AuthDescriptor.scramSha256("username", "password"));

client = ArcusClient.createArcusClient("127.0.0.1:2181", "service_code", cfb);

// AuthDescriptor.java
public static AuthDescriptor scramSha256(String u, String p) {
    return new AuthDescriptor(new String[]{"SCRAM-SHA-256"},
            new PlainCallbackHandler(u, p));
}
```
- [테스트 코드](https://www.notion.so/jam2in/AsciiSaslTest-java-2574d6fa7e6c809893a7db07daefdab2): 해당 테스트 코드는 CI 환경에 SASL용 Docker 이미지 및 Zookeeper ACL 설정이 선행되어야 하므로, CI 환경 구성과 함께 다음 PR에서 추가하도록 하겠습니다.