### PR TITLE
CLEANUP: Refactored `AbstractLogger#getThrowable(Object[])` method

### DIFF
--- a/src/main/java/net/spy/memcached/compat/log/AbstractLogger.java
+++ b/src/main/java/net/spy/memcached/compat/log/AbstractLogger.java
@@ -54,13 +54,10 @@ public abstract class AbstractLogger implements Logger {
    * Throwable, else null.
    */
   public Throwable getThrowable(Object args[]) {
-    Throwable rv = null;
-    if (args.length > 0) {
-      if (args[args.length - 1] instanceof Throwable) {
-        rv = (Throwable) args[args.length - 1];
-      }
+    if (args.length > 0 && args[args.length - 1] instanceof Throwable) {
+      return (Throwable) args[args.length - 1];
     }
-    return rv;
+    return null;
   }
 
   /**


### PR DESCRIPTION
### 🔗 Related Issue

<!-- Please link related issue. ex) https://github.com/naver/arcus-java-client/issues/{issue_number} -->
- https://github.com/jam2in/arcus-works/issues/562

https://rules.sonarsource.com/java/RSPEC-1066

Nested code - blocks of code inside blocks of code - is eventually necessary, but increases complexity. This is why keeping the code as flat as possible, by avoiding unnecessary nesting, is considered a good practice.
Merging `if` statements when possible will decrease the nesting of the code and improve its readability.
Code like

```java
if (condition1) {
  if (condition2) {             // Noncompliant
    /* ... */
  }
}
```

Will be more readable as

```java
if (condition1 && condition2) { // Compliant
  /* ... */
}
```

### ⌨️ What I did

<!-- Please describe this PR and what you've been working on. -->



- 하나로 합칠 수 있는 if문이 분리되어 있어서 이를 제거합니다.
- rv 변수도 제거할 수 있어서 함께 제거했습니다.