### PR TITLE
FIX: Add new StatusCode `ERR_FAILED_END` and return it when piped collection operation is failed

### DIFF
--- a/src/main/java/net/spy/memcached/collection/CollectionResponse.java
+++ b/src/main/java/net/spy/memcached/collection/CollectionResponse.java
@@ -26,6 +26,7 @@ public enum CollectionResponse {
 
   OK,
   END,
+  FAILED_END,
   NOT_FOUND,
   NOT_FOUND_ELEMENT,
   ELEMENT_EXISTS,

--- a/src/main/java/net/spy/memcached/ops/StatusCode.java
+++ b/src/main/java/net/spy/memcached/ops/StatusCode.java
@@ -71,6 +71,9 @@ public enum StatusCode {
   ERR_ATTR_NOT_FOUND("ATTR_ERROR_NOT_FOUND"),
   ERR_ATTR_BAD_VALUE("ATTR_ERROR_BAD_VALUE"),
 
+  // Piped operation specific
+  ERR_FAILED_END("FAILED_END"),
+
   // Set specific
   EXIST("EXIST"),
   NOT_EXIST("NOT_EXIST"),

--- a/src/main/java/net/spy/memcached/protocol/ascii/PipeOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/PipeOperationImpl.java
@@ -24,7 +24,7 @@ abstract class PipeOperationImpl extends OperationImpl {
   protected static final OperationStatus END = new CollectionOperationStatus(
           true, "END", CollectionResponse.END);
   protected static final OperationStatus FAILED_END = new CollectionOperationStatus(
-          false, "END", CollectionResponse.END);
+          false, "FAILED_END", CollectionResponse.FAILED_END);
 
   protected static final OperationStatus CREATED_STORED = new CollectionOperationStatus(
           true, "CREATED_STORED", CollectionResponse.CREATED_STORED);


### PR DESCRIPTION
### 🔗 Related Issue

<!-- Please link related issue. ex) https://github.com/naver/arcus-java-client/issues/{issue_number} -->
- https://github.com/jam2in/arcus-works/issues/750

### ⌨️ What I did

<!-- Please describe this PR and what you've been working on. -->
- Piped 컬렉션 연산이 실패했을 때 StatusCode가 SUCCESS가 반환되지 않도록 합니다.