### PR TITLE
CLEANUP: Remove redundant abstract methods in `AbstractLogger`

### DIFF
--- a/src/main/java/net/spy/memcached/compat/log/AbstractLogger.java
+++ b/src/main/java/net/spy/memcached/compat/log/AbstractLogger.java
@@ -61,22 +61,6 @@ public abstract class AbstractLogger implements Logger {
   }
 
   /**
-   * True if debug is enabled for this logger.
-   * Default implementation always returns false
-   *
-   * @return true if debug messages would be displayed
-   */
-  public abstract boolean isDebugEnabled();
-
-  /**
-   * True if debug is enabled for this logger.
-   * Default implementation always returns false
-   *
-   * @return true if info messages would be displayed
-   */
-  public abstract boolean isInfoEnabled();
-
-  /**
    * Log a message at trace level.
    *
    * @param message   the message to log
@@ -265,15 +249,5 @@ public abstract class AbstractLogger implements Logger {
   public void log(Level level, Object message) {
     log(level, message, null);
   }
-
-  /**
-   * Subclasses should implement this method to determine what to do when
-   * a client wants to log at a particular level.
-   *
-   * @param level   the level to log at (see the fields of this class)
-   * @param message the message to log
-   * @param e       the exception that caused the message (or null)
-   */
-  public abstract void log(Level level, Object message, Throwable e);
 
 }


### PR DESCRIPTION
### 🔗 Related Issue

<!-- Please link related issue. ex) https://github.com/naver/arcus-java-client/issues/{issue_number} -->
- https://github.com/jam2in/arcus-works/issues/562

https://rules.sonarsource.com/java/RSPEC-3038/

There’s no point in redundantly defining an abstract method with the same signature as a method in an interface that the class implements. Any concrete child classes will have to implement the method either way.

Noncompliant code example

```java
public interface Reportable {
  String getReport();
}

public abstract class AbstractRuleReport implements Reportable{
  public abstract String getReport();  // Noncompliant

  // ...
}
```

### ⌨️ What I did

<!-- Please describe this PR and what you've been working on. -->
- 불필요한 추상 메소드를 제거합니다.