### PR TITLE
CLEANUP: Refactored argument for `AbstractLogger#getThrowable(Object[])` method

### DIFF
--- a/src/main/java/net/spy/memcached/compat/log/AbstractLogger.java
+++ b/src/main/java/net/spy/memcached/compat/log/AbstractLogger.java
@@ -53,7 +53,7 @@ public abstract class AbstractLogger implements Logger {
    * Get the throwable from the last element of this array if it is
    * Throwable, else null.
    */
-  public Throwable getThrowable(Object args[]) {
+  public Throwable getThrowable(Object[] args) {
     if (args.length > 0 && args[args.length - 1] instanceof Throwable) {
       return (Throwable) args[args.length - 1];
     }


### PR DESCRIPTION
### 🔗 Related Issue

<!-- Please link related issue. ex) https://github.com/naver/arcus-java-client/issues/{issue_number} -->
- https://github.com/jam2in/arcus-works/issues/562

https://rules.sonarsource.com/java/RSPEC-1197/

Array designators should always be located on the type for better code readability. Otherwise, developers must look both at the type and the variable name to know whether or not a variable is an array.

Noncompliant code example

```java
int matrix[][];   // Noncompliant
int[] matrix[];   // Noncompliant
```

Compliant solution

```java
int[][] matrix;   // Compliant
```

### ⌨️ What I did

<!-- Please describe this PR and what you've been working on. -->
- 배열 타입 선언의 위치를 옮겼습니다.