### PR TITLE
CLEANUP: Throw IllegalStateException instead of RuntimeException in AuthThread constructor

### DIFF
--- a/src/main/java/net/spy/memcached/auth/AuthThread.java
+++ b/src/main/java/net/spy/memcached/auth/AuthThread.java
@@ -34,7 +34,7 @@ public class AuthThread extends SpyThread {
       sc = Sasl.createSaslClient(authDescriptor.getMechs(), null,
               "memcached", node.getSocketAddress().toString(), null, authDescriptor.getCallback());
     } catch (Exception e) {
-      throw new RuntimeException("Can't create SaslClient", e);
+      throw new IllegalStateException("Can't create SaslClient", e);
     }
   }
 


### PR DESCRIPTION
### 🔗 Related Issue

<!-- Please link related issue. ex) https://github.com/naver/arcus-java-client/issues/{issue_number} -->
- https://github.com/jam2in/arcus-works/issues/562

https://rules.sonarsource.com/java/RSPEC-112/

This rule raises an issue when a generic exception (such as Error, RuntimeException, Throwable, or Exception) is thrown.
To fix this issue, make sure to throw specific exceptions that are relevant to the context in which they arise. It is recommended to either:

- Raise a specific exception from the Java standard library when one matches. For example an IllegalArgumentException should be thrown when a method receives an invalid argument.
- Create a custom exception class deriving from Exception or one of its subclasses.

# Code examples
## Noncompliant code example

```java
void checkValue(int value) throws Throwable { // Noncompliant: signature is too broad
    if (value == 42) {
        throw new RuntimeException("Value is 42"); // Noncompliant: This will be difficult for consumers to handle
    }
}
```

## Compliant solution

```java
void checkValue(int value) {
    if (value == 42) {
        throw new IllegalArgumentException("Value is 42"); // Compliant
    }
}
```

### ⌨️ What I did

<!-- Please describe this PR and what you've been working on. -->
- AuthThread 클래스의 생성자에서 RuntimeException 대신 IllegalStateException을 발생시킵니다.