### PR TITLE
CLEANUP: Rename constant field `command` to `COMMAND`

### DIFF
--- a/src/main/java/net/spy/memcached/collection/BTreeGetBulkImpl.java
+++ b/src/main/java/net/spy/memcached/collection/BTreeGetBulkImpl.java
@@ -24,7 +24,7 @@ import net.spy.memcached.util.BTreeUtil;
 
 public abstract class BTreeGetBulkImpl<T> implements BTreeGetBulk<T> {
 
-  private static final String command = "bop mget";
+  private static final String COMMAND = "bop mget";
 
   private final MemcachedNode node;
   private String str;
@@ -130,7 +130,7 @@ public abstract class BTreeGetBulkImpl<T> implements BTreeGetBulk<T> {
   }
 
   public String getCommand() {
-    return command;
+    return COMMAND;
   }
 
   public boolean headerReady(int spaceCount) {

--- a/src/main/java/net/spy/memcached/collection/BTreeInsert.java
+++ b/src/main/java/net/spy/memcached/collection/BTreeInsert.java
@@ -18,14 +18,14 @@ package net.spy.memcached.collection;
 
 public class BTreeInsert<T> extends CollectionInsert<T> {
 
-  private static final String command = "bop insert";
+  private static final String COMMAND = "bop insert";
 
   public BTreeInsert(T value, byte[] eFlag, RequestMode requestMode, CollectionAttributes attr) {
     super(CollectionType.btree, value, eFlag, requestMode, attr);
   }
 
   public String getCommand() {
-    return command;
+    return COMMAND;
   }
 
 }

--- a/src/main/java/net/spy/memcached/collection/BTreeSMGet.java
+++ b/src/main/java/net/spy/memcached/collection/BTreeSMGet.java
@@ -22,7 +22,7 @@ import net.spy.memcached.MemcachedNode;
 
 public interface BTreeSMGet<T> {
 
-  int headerCount = 4;
+  int HEADER_COUNT = 4;
 
   void setKeySeparator(String keySeparator);
 

--- a/src/main/java/net/spy/memcached/collection/BTreeSMGetImpl.java
+++ b/src/main/java/net/spy/memcached/collection/BTreeSMGetImpl.java
@@ -24,7 +24,7 @@ import net.spy.memcached.MemcachedNode;
 import net.spy.memcached.util.BTreeUtil;
 
 public abstract class BTreeSMGetImpl<T> implements BTreeSMGet<T> {
-  private static final String command = "bop smget";
+  private static final String COMMAND = "bop smget";
 
   private final MemcachedNode node;
   private String str;
@@ -129,11 +129,11 @@ public abstract class BTreeSMGetImpl<T> implements BTreeSMGet<T> {
   }
 
   public String getCommand() {
-    return command;
+    return COMMAND;
   }
 
   public boolean headerReady(int spaceCount) {
-    return headerCount == spaceCount;
+    return HEADER_COUNT == spaceCount;
   }
 
   public String getKey() {

--- a/src/main/java/net/spy/memcached/collection/BTreeUpdate.java
+++ b/src/main/java/net/spy/memcached/collection/BTreeUpdate.java
@@ -18,14 +18,14 @@ package net.spy.memcached.collection;
 
 public class BTreeUpdate<T> extends CollectionUpdate<T> {
 
-  private static final String command = "bop update";
+  private static final String COMMAND = "bop update";
 
   public BTreeUpdate(T newValue, ElementFlagUpdate elementFlagUpdate, boolean noreply) {
     super(newValue, elementFlagUpdate, noreply);
   }
 
   public String getCommand() {
-    return command;
+    return COMMAND;
   }
 
 }

--- a/src/main/java/net/spy/memcached/collection/BTreeUpsert.java
+++ b/src/main/java/net/spy/memcached/collection/BTreeUpsert.java
@@ -18,14 +18,14 @@ package net.spy.memcached.collection;
 
 public class BTreeUpsert<T> extends CollectionInsert<T> {
 
-  private static final String command = "bop upsert";
+  private static final String COMMAND = "bop upsert";
 
   public BTreeUpsert(T value, byte[] eFlag, RequestMode requestMode, CollectionAttributes attr) {
     super(CollectionType.btree, value, eFlag, requestMode, attr);
   }
 
   public String getCommand() {
-    return command;
+    return COMMAND;
   }
 
 }

--- a/src/main/java/net/spy/memcached/collection/ListCreate.java
+++ b/src/main/java/net/spy/memcached/collection/ListCreate.java
@@ -18,7 +18,7 @@ package net.spy.memcached.collection;
 
 public class ListCreate extends CollectionCreate {
 
-  private static final String command = "lop create";
+  private static final String COMMAND = "lop create";
 
   public ListCreate(int flags, Integer expTime, Long maxCount,
                     CollectionOverflowAction overflowAction, Boolean readable, boolean noreply) {
@@ -26,7 +26,7 @@ public class ListCreate extends CollectionCreate {
   }
 
   public String getCommand() {
-    return command;
+    return COMMAND;
   }
 
 }

--- a/src/main/java/net/spy/memcached/collection/ListDelete.java
+++ b/src/main/java/net/spy/memcached/collection/ListDelete.java
@@ -18,7 +18,7 @@ package net.spy.memcached.collection;
 
 public class ListDelete extends CollectionDelete {
 
-  private static final String command = "lop delete";
+  private static final String COMMAND = "lop delete";
 
   public ListDelete(int index, boolean dropIfEmpty, boolean noreply) {
     this.range = String.valueOf(index);
@@ -58,7 +58,7 @@ public class ListDelete extends CollectionDelete {
   }
 
   public String getCommand() {
-    return command;
+    return COMMAND;
   }
 
 }

--- a/src/main/java/net/spy/memcached/collection/ListGet.java
+++ b/src/main/java/net/spy/memcached/collection/ListGet.java
@@ -20,7 +20,7 @@ import java.util.List;
 
 public class ListGet extends CollectionGet {
 
-  private static final String command = "lop get";
+  private static final String COMMAND = "lop get";
 
   private ListGet(String range, boolean delete, boolean dropIfEmpty) {
     this.range = range;
@@ -62,7 +62,7 @@ public class ListGet extends CollectionGet {
   }
 
   public String getCommand() {
-    return command;
+    return COMMAND;
   }
 
   @Override

--- a/src/main/java/net/spy/memcached/collection/ListInsert.java
+++ b/src/main/java/net/spy/memcached/collection/ListInsert.java
@@ -18,14 +18,14 @@ package net.spy.memcached.collection;
 
 public class ListInsert<T> extends CollectionInsert<T> {
 
-  private static final String command = "lop insert";
+  private static final String COMMAND = "lop insert";
 
   public ListInsert(T value, RequestMode requestMode, CollectionAttributes attr) {
     super(CollectionType.list, value, null, requestMode, attr);
   }
 
   public String getCommand() {
-    return command;
+    return COMMAND;
   }
 
 }

--- a/src/main/java/net/spy/memcached/collection/MapCreate.java
+++ b/src/main/java/net/spy/memcached/collection/MapCreate.java
@@ -18,13 +18,13 @@ package net.spy.memcached.collection;
 
 public class MapCreate extends CollectionCreate {
 
-  private static final String command = "mop create";
+  private static final String COMMAND = "mop create";
 
   public MapCreate(int flags, Integer expTime, Long maxCount, Boolean readable, boolean noreply) {
     super(CollectionType.map, flags, expTime, maxCount, null, readable, noreply);
   }
 
   public String getCommand() {
-    return command;
+    return COMMAND;
   }
 }

--- a/src/main/java/net/spy/memcached/collection/MapDelete.java
+++ b/src/main/java/net/spy/memcached/collection/MapDelete.java
@@ -19,7 +19,7 @@ package net.spy.memcached.collection;
 import java.util.List;
 
 public class MapDelete extends CollectionDelete {
-  private static final String command = "mop delete";
+  private static final String COMMAND = "mop delete";
 
   protected List<String> mkeyList;
   private String keySeparator;
@@ -88,6 +88,6 @@ public class MapDelete extends CollectionDelete {
   }
 
   public String getCommand() {
-    return command;
+    return COMMAND;
   }
 }

--- a/src/main/java/net/spy/memcached/collection/MapGet.java
+++ b/src/main/java/net/spy/memcached/collection/MapGet.java
@@ -20,7 +20,7 @@ import java.util.List;
 
 public class MapGet extends CollectionGet {
 
-  private static final String command = "mop get";
+  private static final String COMMAND = "mop get";
 
   protected List<String> mkeyList;
   protected byte[] data;
@@ -93,7 +93,7 @@ public class MapGet extends CollectionGet {
   }
 
   public String getCommand() {
-    return command;
+    return COMMAND;
   }
 
   @Override

--- a/src/main/java/net/spy/memcached/collection/MapInsert.java
+++ b/src/main/java/net/spy/memcached/collection/MapInsert.java
@@ -18,14 +18,14 @@ package net.spy.memcached.collection;
 
 public class MapInsert<T> extends CollectionInsert<T> {
 
-  private static final String command = "mop insert";
+  private static final String COMMAND = "mop insert";
 
   public MapInsert(T value, RequestMode requestMode, CollectionAttributes attr) {
     super(CollectionType.map, value, null, requestMode, attr);
   }
 
   public String getCommand() {
-    return command;
+    return COMMAND;
   }
 
 }

--- a/src/main/java/net/spy/memcached/collection/MapUpdate.java
+++ b/src/main/java/net/spy/memcached/collection/MapUpdate.java
@@ -18,14 +18,14 @@ package net.spy.memcached.collection;
 
 public class MapUpdate<T> extends CollectionUpdate<T> {
 
-  private static final String command = "mop update";
+  private static final String COMMAND = "mop update";
 
   public MapUpdate(T newValue, boolean noreply) {
     super(newValue, null, noreply);
   }
 
   public String getCommand() {
-    return command;
+    return COMMAND;
   }
 
 }

--- a/src/main/java/net/spy/memcached/collection/MapUpsert.java
+++ b/src/main/java/net/spy/memcached/collection/MapUpsert.java
@@ -2,7 +2,7 @@ package net.spy.memcached.collection;
 
 public class MapUpsert<T> extends CollectionInsert<T> {
 
-  private static final String command = "mop upsert";
+  private static final String COMMAND = "mop upsert";
 
   public MapUpsert(T value, CollectionAttributes attr) {
     super(CollectionType.map, value, null, null, attr);
@@ -10,7 +10,7 @@ public class MapUpsert<T> extends CollectionInsert<T> {
 
   @Override
   public String getCommand() {
-    return command;
+    return COMMAND;
   }
 
 }

--- a/src/main/java/net/spy/memcached/collection/SetCreate.java
+++ b/src/main/java/net/spy/memcached/collection/SetCreate.java
@@ -18,14 +18,14 @@ package net.spy.memcached.collection;
 
 public class SetCreate extends CollectionCreate {
 
-  private static final String command = "sop create";
+  private static final String COMMAND = "sop create";
 
   public SetCreate(int flags, Integer expTime, Long maxCount, Boolean readable, boolean noreply) {
     super(CollectionType.set, flags, expTime, maxCount, null, readable, noreply);
   }
 
   public String getCommand() {
-    return command;
+    return COMMAND;
   }
 
 }

--- a/src/main/java/net/spy/memcached/collection/SetDelete.java
+++ b/src/main/java/net/spy/memcached/collection/SetDelete.java
@@ -20,7 +20,7 @@ import net.spy.memcached.transcoders.Transcoder;
 
 public class SetDelete<T> extends CollectionDelete {
 
-  private static final String command = "sop delete";
+  private static final String COMMAND = "sop delete";
 
   protected T value;
   protected byte[] additionalArgs;
@@ -59,7 +59,7 @@ public class SetDelete<T> extends CollectionDelete {
   }
 
   public String getCommand() {
-    return command;
+    return COMMAND;
   }
 
 }

--- a/src/main/java/net/spy/memcached/collection/SetExist.java
+++ b/src/main/java/net/spy/memcached/collection/SetExist.java
@@ -20,7 +20,7 @@ import net.spy.memcached.transcoders.Transcoder;
 
 public class SetExist<T> extends CollectionExist {
 
-  private static final String command = "sop exist";
+  private static final String COMMAND = "sop exist";
 
   protected T value;
   protected byte[] additionalArgs;
@@ -42,7 +42,7 @@ public class SetExist<T> extends CollectionExist {
   }
 
   public String getCommand() {
-    return command;
+    return COMMAND;
   }
 
 }

--- a/src/main/java/net/spy/memcached/collection/SetGet.java
+++ b/src/main/java/net/spy/memcached/collection/SetGet.java
@@ -20,7 +20,7 @@ import java.util.List;
 
 public class SetGet extends CollectionGet {
 
-  private static final String command = "sop get";
+  private static final String COMMAND = "sop get";
 
   protected int count;
 
@@ -56,7 +56,7 @@ public class SetGet extends CollectionGet {
   }
 
   public String getCommand() {
-    return command;
+    return COMMAND;
   }
 
   @Override

--- a/src/main/java/net/spy/memcached/collection/SetInsert.java
+++ b/src/main/java/net/spy/memcached/collection/SetInsert.java
@@ -18,14 +18,14 @@ package net.spy.memcached.collection;
 
 public class SetInsert<T> extends CollectionInsert<T> {
 
-  private static final String command = "sop insert";
+  private static final String COMMAND = "sop insert";
 
   public SetInsert(T value, RequestMode requestMode, CollectionAttributes attr) {
     super(CollectionType.set, value, null, requestMode, attr);
   }
 
   public String getCommand() {
-    return command;
+    return COMMAND;
   }
 
 }

--- a/src/main/java/net/spy/memcached/protocol/ascii/BTreeSortMergeGetOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/BTreeSortMergeGetOperationImpl.java
@@ -169,7 +169,7 @@ public final class BTreeSortMergeGetOperationImpl extends OperationImpl implemen
             // Adjust space count if item header has a element flag.
             String itemHeader = byteBuffer.toString();
             String[] chunk = itemHeader.split(" ");
-            if (chunk.length == BTreeSMGet.headerCount
+            if (chunk.length == BTreeSMGet.HEADER_COUNT
                     && chunk[3].startsWith("0x")) {
               spaceCount--;
               byteBuffer.write(b);

--- a/src/main/java/net/spy/memcached/protocol/ascii/BTreeSortMergeGetOperationOldImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/BTreeSortMergeGetOperationOldImpl.java
@@ -136,7 +136,7 @@ public final class BTreeSortMergeGetOperationOldImpl extends OperationImpl imple
 
           // Adjust space count if item header has a element flag.
           String[] chunk = byteBuffer.toString().split(" ");
-          if (chunk.length == BTreeSMGet.headerCount) {
+          if (chunk.length == BTreeSMGet.HEADER_COUNT) {
             if (chunk[3].startsWith("0x")) {
               spaceCount--;
             }


### PR DESCRIPTION
### 🔗 Related Issue

<!-- Please link related issue. ex) https://github.com/naver/arcus-java-client/issues/{issue_number} -->
- https://github.com/jam2in/arcus-works/issues/562

https://rules.sonarsource.com/java/RSPEC-115/

Constants should be named consistently to communicate intent and improve maintainability. Rename your constants to follow your project’s naming convention to address this issue.
First, familiarize yourself with the particular naming convention of the project in question. Then, update the name of the constant to match the convention, as well as all usages of the name. For many IDEs, you can use built-in renaming and refactoring features to update all usages of a constant at once.

# Code examples
## Noncompliant code example

The following example assumes that constant names should match the default regular expression ^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$:

```java
public class MyClass {
  public static final float pi = 3.14159f; // Noncompliant: Constant is not capitalized

  void myMethod() {
    System.out.println(pi);
  }
}

public enum MyEnum {
  optionOne, // Noncompliant
  optionTwo; // Noncompliant
}
```

## Compliant solution

```java
public class MyClass {
  public static final float PI = 3.14159f;

  void myMethod() {
    System.out.println(PI);
  }
}

public enum MyEnum {
  OPTION_ONE,
  OPTION_TWO;
}
```

## Exceptions

The rule applies to fields of primitive types (for example, float), boxed primitives (Float), and Strings. We do not apply it to other types, which can be mutated, or have methods with side effects.

```java
public static final Logger log = getLogger(MyClass.class);
public static final List<Integer> myList = new ArrayList<>();

// call with side-effects
log.info("message")

// mutating an object
myList.add(28);
```

### ⌨️ What I did

<!-- Please describe this PR and what you've been working on. -->
- 상수 필드 이름을 전부 대문자로 변경합니다.