### PR TITLE
CLENAUP: Make the constructors of abstract classes protected instead of public

### DIFF
--- a/src/main/java/net/spy/memcached/collection/BTreeSMGetImpl.java
+++ b/src/main/java/net/spy/memcached/collection/BTreeSMGetImpl.java
@@ -45,14 +45,14 @@ public abstract class BTreeSMGetImpl<T> implements BTreeSMGet<T> {
   private int dataLength;
   private byte[] eflag = null;
 
-  public BTreeSMGetImpl(MemcachedNode node, List<String> keyList,
+  protected BTreeSMGetImpl(MemcachedNode node, List<String> keyList,
                         String range,
                         ElementFlagFilter eFlagFilter,
                         int count, SMGetMode smgetMode) {
     this(node, keyList, range, eFlagFilter, -1, count, smgetMode);
   }
 
-  public BTreeSMGetImpl(MemcachedNode node, List<String> keyList,
+  protected BTreeSMGetImpl(MemcachedNode node, List<String> keyList,
                         String range,
                         ElementFlagFilter eFlagFilter,
                         int offset, int count) {

--- a/src/main/java/net/spy/memcached/collection/CollectionCreate.java
+++ b/src/main/java/net/spy/memcached/collection/CollectionCreate.java
@@ -26,7 +26,7 @@ public abstract class CollectionCreate {
 
   protected String str;
 
-  public CollectionCreate(CollectionType type, int flags, Integer expTime, Long maxCount,
+  protected CollectionCreate(CollectionType type, int flags, Integer expTime, Long maxCount,
                           CollectionOverflowAction overflowAction, Boolean readable,
                           boolean noreply) {
     checkOverflowAction(type, overflowAction);

--- a/src/main/java/net/spy/memcached/collection/CollectionInsert.java
+++ b/src/main/java/net/spy/memcached/collection/CollectionInsert.java
@@ -27,10 +27,10 @@ public abstract class CollectionInsert<T> {
   protected byte[] elementFlag;
   protected String str;
 
-  public CollectionInsert() {
+  protected CollectionInsert() {
   }
 
-  public CollectionInsert(CollectionType type, T value, byte[] elementFlag,
+  protected CollectionInsert(CollectionType type, T value, byte[] elementFlag,
                           RequestMode requestMode, CollectionAttributes attr) {
     if (attr != null) { /* item creation option */
       CollectionCreate.checkOverflowAction(type, attr.getOverflowAction());

--- a/src/main/java/net/spy/memcached/collection/CollectionUpdate.java
+++ b/src/main/java/net/spy/memcached/collection/CollectionUpdate.java
@@ -24,7 +24,7 @@ public abstract class CollectionUpdate<T> {
   protected boolean noreply = false;
   protected String str;
 
-  public CollectionUpdate(T newValue, ElementFlagUpdate eflagUpdate, boolean noreply) {
+  protected CollectionUpdate(T newValue, ElementFlagUpdate eflagUpdate, boolean noreply) {
 
     if (eflagUpdate == null) {
       if (newValue == null) {


### PR DESCRIPTION
### 🔗 Related Issue

<!-- Please link related issue. ex) https://github.com/naver/arcus-java-client/issues/{issue_number} -->
- https://github.com/jam2in/arcus-works/issues/562

https://rules.sonarsource.com/java/RSPEC-5993/

Abstract classes should not have public constructors. Constructors of abstract classes can only be called in constructors of their subclasses. So there is no point in making them public. The protected modifier should be enough.

# Noncompliant code example

```java
public abstract class AbstractClass1 {
    public AbstractClass1 () { // Noncompliant, has public modifier
        // do something here
    }
}
```

# Compliant solution

```java
public abstract class AbstractClass2 {
    protected AbstractClass2 () {
        // do something here
    }
}
```

### ⌨️ What I did

<!-- Please describe this PR and what you've been working on. -->
- 추상 클래스의 생성자에 붙은 접근 제한자를 public에서 protected로 변경합니다.