### PR TITLE
FIX: Add static methods to replace the mutable static final fields

### DIFF
--- a/src/main/java/net/spy/memcached/collection/ByteArrayBKey.java
+++ b/src/main/java/net/spy/memcached/collection/ByteArrayBKey.java
@@ -23,8 +23,16 @@ import net.spy.memcached.util.BTreeUtil;
 
 public class ByteArrayBKey implements Comparable<ByteArrayBKey> {
 
+  /**
+   * @deprecated Replaced by {@link ByteArrayBKey#getMin()}
+   */
+  @Deprecated
   public static final byte[] MIN = new byte[]{(byte) 0};
 
+  /**
+   * @deprecated Replaced by {@link ByteArrayBKey#getMax()}
+   */
+  @Deprecated
   public static final byte[] MAX = new byte[]{(byte) 255, (byte) 255,
       (byte) 255, (byte) 255, (byte) 255, (byte) 255, (byte) 255,
       (byte) 255, (byte) 255, (byte) 255, (byte) 255, (byte) 255,
@@ -33,6 +41,21 @@ public class ByteArrayBKey implements Comparable<ByteArrayBKey> {
       (byte) 255, (byte) 255, (byte) 255, (byte) 255, (byte) 255,
       (byte) 255, (byte) 255, (byte) 255, (byte) 255
   };
+
+  public static byte[] getMin() {
+    return new byte[]{(byte) 0};
+  }
+
+  public static byte[] getMax() {
+    return new byte[]{(byte) 255, (byte) 255,
+      (byte) 255, (byte) 255, (byte) 255, (byte) 255, (byte) 255,
+      (byte) 255, (byte) 255, (byte) 255, (byte) 255, (byte) 255,
+      (byte) 255, (byte) 255, (byte) 255, (byte) 255, (byte) 255,
+      (byte) 255, (byte) 255, (byte) 255, (byte) 255, (byte) 255,
+      (byte) 255, (byte) 255, (byte) 255, (byte) 255, (byte) 255,
+      (byte) 255, (byte) 255, (byte) 255, (byte) 255
+    };
+  }
 
   private final byte[] bkey;
 

--- a/src/test/manual/net/spy/memcached/collection/btree/longbkey/BopGetBulkTest.java
+++ b/src/test/manual/net/spy/memcached/collection/btree/longbkey/BopGetBulkTest.java
@@ -90,8 +90,8 @@ class BopGetBulkTest extends BaseIntegrationTest {
       ElementFlagFilter filter = ElementFlagFilter.DO_NOT_FILTER;
 
       CollectionGetBulkFuture<Map<String, BTreeGetResult<ByteArrayBKey, Object>>> f = mc
-              .asyncBopGetBulk(keyList, ByteArrayBKey.MIN,
-                      ByteArrayBKey.MAX, filter, 0, 10);
+              .asyncBopGetBulk(keyList, ByteArrayBKey.getMin(),
+                      ByteArrayBKey.getMax(), filter, 0, 10);
 
       Map<String, BTreeGetResult<ByteArrayBKey, Object>> results = f.get(
               1000L, TimeUnit.MILLISECONDS);
@@ -158,8 +158,8 @@ class BopGetBulkTest extends BaseIntegrationTest {
       ElementFlagFilter filter = ElementFlagFilter.DO_NOT_FILTER;
 
       CollectionGetBulkFuture<Map<String, BTreeGetResult<ByteArrayBKey, Object>>> f = mc
-              .asyncBopGetBulk(keyList, ByteArrayBKey.MIN,
-                      ByteArrayBKey.MAX, filter, 0, 10);
+              .asyncBopGetBulk(keyList, ByteArrayBKey.getMin(),
+                      ByteArrayBKey.getMax(), filter, 0, 10);
 
       Map<String, BTreeGetResult<ByteArrayBKey, Object>> results = f.get(
               1000L, TimeUnit.MILLISECONDS);
@@ -210,8 +210,8 @@ class BopGetBulkTest extends BaseIntegrationTest {
       ElementFlagFilter filter = ElementFlagFilter.DO_NOT_FILTER;
 
       CollectionGetBulkFuture<Map<String, BTreeGetResult<ByteArrayBKey, Object>>> f = mc
-              .asyncBopGetBulk(keyList, ByteArrayBKey.MIN,
-                      ByteArrayBKey.MAX, filter, 0, 10);
+              .asyncBopGetBulk(keyList, ByteArrayBKey.getMin(),
+                      ByteArrayBKey.getMax(), filter, 0, 10);
 
       Map<String, BTreeGetResult<ByteArrayBKey, Object>> results = f.get(
               1000L, TimeUnit.MILLISECONDS);


### PR DESCRIPTION
### 🔗 Related Issue

<!-- Please link related issue. ex) https://github.com/naver/arcus-java-client/issues/{issue_number} -->
- https://github.com/jam2in/arcus-works/issues/562

https://rules.sonarsource.com/java/RSPEC-2386/

There is no good reason to have a mutable object as the public (by default), static member of an interface. Such variables should be moved into classes and their visibility lowered.

Similarly, mutable static members of classes and enumerations which are accessed directly, rather than through getters and setters, should be protected to the degree possible. That can be done by reducing visibility or making the field final if appropriate.

Note that making a mutable field, such as an array, final will keep the variable from being reassigned, but doing so has no effect on the mutability of the internal state of the array (i.e. it doesn’t accomplish the goal).

This rule raises issues for public static array, Collection, Date, and awt.Point members.

# Noncompliant code example

```java
public interface MyInterface {
  public static String [] strings; // Noncompliant
}

public class A {
  public static String [] strings1 = {"first","second"};  // Noncompliant
  public static String [] strings2 = {"first","second"};  // Noncompliant
  public static List<String> strings3 = new ArrayList<>();  // Noncompliant
  // ...
}
```

### ⌨️ What I did

<!-- Please describe this PR and what you've been working on. -->
- static final 필드로 선언되어 있지만 실제로는 상수로 사용할 수 없는 필드 대신 사용할 메소드를 추가합니다.
- 기존의 mutable static final 필드는 `@Deprecated` 처리합니다.