### PR TITLE
CLEANUP: Deprecate CollectionGetBulkFuture#getOperationStatus

### DIFF
--- a/src/main/java/net/spy/memcached/internal/CollectionGetBulkFuture.java
+++ b/src/main/java/net/spy/memcached/internal/CollectionGetBulkFuture.java
@@ -123,6 +123,12 @@ public class CollectionGetBulkFuture<T> implements Future<T> {
     return true;
   }
 
+  /**
+   * @deprecated Operations are performed asynchronously and distributed
+   * across multiple keys or nodes. So, a single OperationStatus does not provide
+   * meaningful information.
+   */
+  @Deprecated
   public CollectionOperationStatus getOperationStatus() {
     if (isCancelled()) {
       return new CollectionOperationStatus(false, "CANCELED", CollectionResponse.CANCELED);

--- a/src/test/manual/net/spy/memcached/collection/internal/CancelFutureTest.java
+++ b/src/test/manual/net/spy/memcached/collection/internal/CancelFutureTest.java
@@ -233,6 +233,7 @@ class CancelFutureTest extends BaseIntegrationTest {
   }
 
   @Test
+  @SuppressWarnings("deprecation")
   void cancelWithCollectionGetBulkFuture() {
     // given
     CollectionGetBulkFuture<Map<String, BTreeGetResult<Long, Object>>> future =


### PR DESCRIPTION
### 🔗 Related Issue

<!-- Please link related issue. ex) https://github.com/naver/arcus-java-client/issues/{issue_number} -->
- https://github.com/jam2in/arcus-works/issues/716

### ⌨️ What I did

<!-- Please describe this PR and what you've been working on. -->
- `CollectionGetBulkFuture#getOperationStatus` 메서드를 deprecate합니다.