### PR TITLE
INTERNAL: Change auth messages of binary sasl operations

### DIFF
--- a/src/main/java/net/spy/memcached/auth/AuthThread.java
+++ b/src/main/java/net/spy/memcached/auth/AuthThread.java
@@ -50,8 +50,8 @@ public class AuthThread extends SpyThread {
 
       final OperationCallback cb = new OperationCallback() {
         public void receivedStatus(OperationStatus val) {
-          // If the status we found was null, we're done.
-          if (val.getMessage().length() == 0) {
+          // If the status we found was SASL_OK, we're done.
+          if ("SASL_OK".equals(val.getMessage())) {
             done.set(true);
             node.authComplete();
             getLogger().info("Authenticated to "

--- a/src/main/java/net/spy/memcached/ops/StatusCode.java
+++ b/src/main/java/net/spy/memcached/ops/StatusCode.java
@@ -42,6 +42,7 @@ public enum StatusCode {
   ERR_ERROR("ERROR"),
   ERR_SERVER("SERVER_ERROR"),
   ERR_CLIENT("CLIENT_ERROR"),
+  ERR_AUTH("AUTH_ERROR"),
   ERR_INTERNAL("INTERNAL_ERROR"),
 
   // error from client

--- a/src/main/java/net/spy/memcached/protocol/binary/SASLBaseOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/binary/SASLBaseOperationImpl.java
@@ -1,6 +1,7 @@
 package net.spy.memcached.protocol.binary;
 
 import java.io.IOException;
+
 import javax.security.sasl.SaslClient;
 import javax.security.sasl.SaslException;
 
@@ -10,6 +11,11 @@ import net.spy.memcached.ops.StatusCode;
 
 public abstract class SASLBaseOperationImpl extends OperationImpl {
 
+  private static final OperationStatus SASL_OK =
+          new OperationStatus(true, "SASL_OK", StatusCode.SUCCESS);
+
+  private static final int SUCCESS = 0x00;
+  private static final int AUTH_ERROR = 0x20;
   private static final int SASL_CONTINUE = 0x21;
 
   protected final SaslClient sc;
@@ -48,9 +54,11 @@ public abstract class SASLBaseOperationImpl extends OperationImpl {
     if (errorCode == SASL_CONTINUE) {
       complete(new OperationStatus(true,
               new String(pl), StatusCode.SUCCESS));
-    } else if (errorCode == 0) {
-      complete(new OperationStatus(true,
-              "", StatusCode.SUCCESS));
+    } else if (errorCode == SUCCESS) {
+      complete(SASL_OK);
+    } else if (errorCode == AUTH_ERROR) {
+      complete(new OperationStatus(false,
+              "AUTH_ERROR " + new String(pl), StatusCode.ERR_AUTH));
     } else {
       super.finishedPayload(pl);
     }


### PR DESCRIPTION
### 🔗 Related Issue

<!-- Please link related issue. ex) https://github.com/naver/arcus-java-client/issues/{issue_number} -->
- https://github.com/naver/arcus-java-client/pull/942#discussion_r2320858175

### ⌨️ What I did

<!-- Please describe this PR and what you've been working on. -->
- binary sasl 연산이 최종 성공하면 SASL_OK 메세지를 포함하게 합니다.
- binary sasl 연산이 실패하면 AUTH_ERROR 메세지를 포함하게 합니다.