### PR TITLE
FIX: Do not modify UnmodifiableList object while validating replication group addresses

### DIFF
--- a/src/main/java/net/spy/memcached/CacheManager.java
+++ b/src/main/java/net/spy/memcached/CacheManager.java
@@ -657,14 +657,14 @@ public final class CacheManager extends SpyThread implements Watcher,
             ArcusReplNodeAddress.makeGroupAddrs(socketList);
 
     // recreate socket list
-    socketList.clear();
+    List<InetSocketAddress> result = new ArrayList<>(socketList.size());
     for (Map.Entry<String, List<ArcusReplNodeAddress>> entry : newAllGroups.entrySet()) {
       if (ArcusReplNodeAddress.validateGroup(entry)) {
-        socketList.addAll(entry.getValue());
+        result.addAll(entry.getValue());
       }
     }
 
-    return socketList;
+    return result;
   }
   /* ENABLE_REPLICATION end */
 


### PR DESCRIPTION
### 🔗 Related Issue

<!-- Please link related issue. ex) https://github.com/naver/arcus-java-client/issues/{issue_number} -->
- https://github.com/naver/arcus-java-client/pull/917 반영 이후 `List<SocketAddress>` 객체는 불변 List 객체이다.
- 하지만 `CacheManager.validateReplicaGroup()` 메소드에서는 불변 List 객체를 변경하려고 시도하고 있다.

### ⌨️ What I did

<!-- Please describe this PR and what you've been working on. -->
- 불변 List 객체를 변경하지 않도록 합니다.