### PR TITLE
TEST: Temporarily disable touch test

### DIFF
--- a/src/test/java/net/spy/memcached/ProtocolBaseCase.java
+++ b/src/test/java/net/spy/memcached/ProtocolBaseCase.java
@@ -41,6 +41,7 @@ import net.spy.memcached.ops.StatusCode;
 import net.spy.memcached.transcoders.SerializingTranscoder;
 import net.spy.memcached.transcoders.Transcoder;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import org.opentest4j.AssertionFailedError;
@@ -693,6 +694,7 @@ abstract class ProtocolBaseCase extends ClientBaseCase {
   }
 
   @Test
+  @Disabled
   void testTouch() throws Exception {
     assertNull(client.get("touchtest"));
     assertNull(client.get("nonexistent"));

--- a/src/test/manual/net/spy/memcached/collection/attribute/GetAttrTest.java
+++ b/src/test/manual/net/spy/memcached/collection/attribute/GetAttrTest.java
@@ -25,6 +25,7 @@ import net.spy.memcached.collection.CollectionResponse;
 import net.spy.memcached.collection.CollectionType;
 import net.spy.memcached.internal.CollectionFuture;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -108,6 +109,7 @@ class GetAttrTest extends BaseIntegrationTest {
   }
 
   @Test
+  @Disabled
   void testGetAttr_Touch() throws Exception {
     String key = "getattr_touch_attribute";
 


### PR DESCRIPTION
### 🔗 Related Issue

<!-- Please link related issue. ex) https://github.com/naver/arcus-java-client/issues/{issue_number} -->
- 아직 touch 커맨드가 릴리즈되지 않아서 touch 테스트가 항상 실패하고, CI도 실패하게 된다.

### ⌨️ What I did

<!-- Please describe this PR and what you've been working on. -->
- touch 테스트를 임시로 비활성화합니다.
- 서버에서 touch 커맨드 릴리즈한 다음, 클라이언트를 릴리즈하기 전에 활성화할 예정입니다.