### PR TITLE
ENHANCE: Enhance auth process

### DIFF
--- a/src/main/java/net/spy/memcached/MemcachedClient.java
+++ b/src/main/java/net/spy/memcached/MemcachedClient.java
@@ -2161,12 +2161,18 @@ public class MemcachedClient extends SpyThread
   }
 
   public void connectionEstablished(SocketAddress sa, int reconnectCount) {
-    if (authDescriptor != null) {
-      if (authDescriptor.authThresholdReached()) {
-        this.shutdown();
-      }
-      authMonitor.authConnection(conn, opFact, authDescriptor, findNode(sa));
+    if (authDescriptor == null) {
+      return;
     }
+
+    MemcachedNode node = findNode(sa);
+    if (!node.authNeeded()) {
+      return;
+    }
+    if (authDescriptor.authThresholdReached()) {
+      this.shutdown();
+    }
+    authMonitor.authConnection(conn, opFact, authDescriptor, node, operationTimeout);
   }
 
   private MemcachedNode findNode(SocketAddress sa) {

--- a/src/main/java/net/spy/memcached/MemcachedNode.java
+++ b/src/main/java/net/spy/memcached/MemcachedNode.java
@@ -254,6 +254,14 @@ public interface MemcachedNode {
    */
   void setupForAuth(String cause);
 
+  void authSkip();
+
+  void authFail();
+
+  boolean authNeeded();
+
+  boolean authSkipping();
+
   /**
    * Count 'time out' exceptions to drop connections that fail perpetually
    *

--- a/src/main/java/net/spy/memcached/MemcachedNodeROImpl.java
+++ b/src/main/java/net/spy/memcached/MemcachedNodeROImpl.java
@@ -201,6 +201,22 @@ public final class MemcachedNodeROImpl implements MemcachedNode {
     throw new UnsupportedOperationException();
   }
 
+  public boolean authNeeded() {
+    throw new UnsupportedOperationException();
+  }
+
+  public boolean authSkipping() {
+    throw new UnsupportedOperationException();
+  }
+
+  public void authSkip() {
+    throw new UnsupportedOperationException();
+  }
+
+  public void authFail() {
+    throw new UnsupportedOperationException();
+  }
+
   public int getContinuousTimeout() {
     throw new UnsupportedOperationException();
   }

--- a/src/main/java/net/spy/memcached/auth/AuthException.java
+++ b/src/main/java/net/spy/memcached/auth/AuthException.java
@@ -1,0 +1,25 @@
+package net.spy.memcached.auth;
+
+import net.spy.memcached.internal.ReconnDelay;
+
+public class AuthException extends RuntimeException {
+  private static final long serialVersionUID = -3995370629401633195L;
+
+  private final AuthExceptionType type;
+  private final ReconnDelay delay;
+
+  public AuthException(String message, AuthExceptionType type, ReconnDelay delay) {
+    super(message);
+
+    this.type = type;
+    this.delay = delay;
+  }
+
+  public AuthExceptionType getType() {
+    return type;
+  }
+
+  public ReconnDelay getDelay() {
+    return delay;
+  }
+}

--- a/src/main/java/net/spy/memcached/auth/AuthExceptionType.java
+++ b/src/main/java/net/spy/memcached/auth/AuthExceptionType.java
@@ -1,0 +1,6 @@
+package net.spy.memcached.auth;
+
+public enum AuthExceptionType {
+  SKIP_AUTH,
+  RETRY_AUTH,
+}

--- a/src/main/java/net/spy/memcached/auth/AuthThreadMonitor.java
+++ b/src/main/java/net/spy/memcached/auth/AuthThreadMonitor.java
@@ -35,10 +35,10 @@ public class AuthThreadMonitor extends SpyObject {
    */
   public synchronized void authConnection(MemcachedConnection conn,
                                           OperationFactory opFact, AuthDescriptor authDescriptor,
-                                          MemcachedNode node) {
+                                          MemcachedNode node, long operationTimeout) {
     interruptOldAuth(node);
     AuthThread newSASLAuthenticator = new AuthThread(conn, opFact,
-            authDescriptor, node);
+            authDescriptor, node, operationTimeout);
     newSASLAuthenticator.start();
     nodeMap.put(node, newSASLAuthenticator);
   }

--- a/src/main/java/net/spy/memcached/ops/Operation.java
+++ b/src/main/java/net/spy/memcached/ops/Operation.java
@@ -129,6 +129,8 @@ public interface Operation {
 
   boolean isIdempotentOperation();
 
+  boolean doThrowException(OperationErrorType eType);
+
   /* ENABLE_MIGRATION if */
   RedirectHandler getAndClearRedirectHandler();
   /* ENABLE_MIGRATION end */

--- a/src/main/java/net/spy/memcached/protocol/BaseOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/BaseOperationImpl.java
@@ -264,7 +264,10 @@ public abstract class BaseOperationImpl extends SpyObject implements Operation {
     }
     exception = new OperationException(eType, line + " @ " + handlingNode.getNodeName());
     complete(new OperationStatus(false, line, StatusCode.ERR_INTERNAL));
-    throw exception;
+
+    if (doThrowException(eType)) {
+      throw exception;
+    }
   }
 
   public void handleRead(ByteBuffer data) {
@@ -312,6 +315,10 @@ public abstract class BaseOperationImpl extends SpyObject implements Operation {
   }
 
   public boolean isIdempotentOperation() {
+    return true;
+  }
+
+  public boolean doThrowException(OperationErrorType eType) {
     return true;
   }
 }

--- a/src/main/java/net/spy/memcached/protocol/ascii/SASLBaseOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/SASLBaseOperationImpl.java
@@ -23,6 +23,7 @@ import java.nio.ByteBuffer;
 import javax.security.sasl.SaslClient;
 
 import net.spy.memcached.ops.OperationCallback;
+import net.spy.memcached.ops.OperationErrorType;
 import net.spy.memcached.ops.OperationStatus;
 import net.spy.memcached.ops.OperationType;
 import net.spy.memcached.ops.StatusCode;
@@ -97,5 +98,10 @@ abstract class SASLBaseOperationImpl extends OperationImpl {
     if (found == '\n') {
       complete(new OperationStatus(true, new String(challenge), StatusCode.SUCCESS));
     }
+  }
+
+  @Override
+  public boolean doThrowException(OperationErrorType eType) {
+    return eType != OperationErrorType.GENERAL;
   }
 }

--- a/src/main/java/net/spy/memcached/protocol/binary/SASLBaseOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/binary/SASLBaseOperationImpl.java
@@ -6,6 +6,7 @@ import javax.security.sasl.SaslClient;
 import javax.security.sasl.SaslException;
 
 import net.spy.memcached.ops.OperationCallback;
+import net.spy.memcached.ops.OperationErrorType;
 import net.spy.memcached.ops.OperationStatus;
 import net.spy.memcached.ops.StatusCode;
 
@@ -69,4 +70,8 @@ public abstract class SASLBaseOperationImpl extends OperationImpl {
     return false;
   }
 
+  @Override
+  public boolean doThrowException(OperationErrorType eType) {
+    return eType != OperationErrorType.GENERAL;
+  }
 }

--- a/src/test/java/net/spy/memcached/MockMemcachedNode.java
+++ b/src/test/java/net/spy/memcached/MockMemcachedNode.java
@@ -218,6 +218,22 @@ public class MockMemcachedNode implements MemcachedNode {
     // noop
   }
 
+  public boolean authNeeded() {
+    return false;
+  }
+
+  public boolean authSkipping() {
+    return false;
+  }
+
+  public void authSkip() {
+    // noop
+  }
+
+  public void authFail() {
+    // noop
+  }
+
   public int getContinuousTimeout() {
     return 0;
   }


### PR DESCRIPTION
# 🔗 Related Issue

- https://github.com/jam2in/arcus-works/issues/754
- https://github.com/naver/arcus-java-client/pull/976#discussion_r2393492777

# ⌨️ What I did

## 케이스 별 동작

<table class="tg"><thead> <tr> <th class="tg-f4yw">받은 응답</th> <th class="tg-f4yw">동작</th> </tr></thead> <tbody> <tr> <td class="tg-f4yw">NOT_SUPPORTED</td> <td class="tg-f4yw">auth가 성공한 것으로 간주</td> </tr> <tr> <td class="tg-f4yw">AUTH_ERROR</td> <td class="tg-f4yw">연결을 끊지 않고 1초 후에 auth를 처음부터 재시도</td> </tr> <tr> <td class="tg-f4yw">CLIENT_ERROR, SERVER_ERROR</td> <td class="tg-f4yw">다른 연산에서 이 응답을 받았을 때와 동일하게 처리</td> </tr> </tbody> </table>

<table class="tg"><thead> <tr> <th class="tg-f4yw">상황</th> <th class="tg-f4yw">받은 응답</th> <th class="tg-f4yw">동작</th> </tr></thead> <tbody> <tr> <td class="tg-f4yw">SASL_CONTINUE 응답을 받기 전</td> <td class="tg-f4yw">ERROR</td> <td class="tg-f4yw">연결을 끊고 즉시 재연결한 다음, auth가 성공한 것으로 간주</td> </tr> <tr> <td class="tg-f4yw">SASL_CONTINUE 응답을 받은 후</td> <td class="tg-f4yw">ERROR</td> <td class="tg-f4yw">연결을 끊고 1초 후에 재연결한 다음, auth를 처음부터 재시도</td> </tr> </tbody> </table>

<table class="tg"><thead> <tr> <th class="tg-rcip">상황</th> <th class="tg-rcip">동작</th> </tr></thead> <tbody> <tr> <td class="tg-rcip">auth 연산에서 Timeout 발생</td> <td class="tg-rcip">연결을 끊고 1초 후에 재연결한 다음, auth를 처음부터 재시도</td> </tr> </tbody> </table>

<table class="tg"><thead> <tr> <th class="tg-f4yw">상황</th> <th class="tg-f4yw">공통 동작</th> <th class="tg-f4yw">세부 상황</th> <th class="tg-f4yw">동작</th> </tr></thead> <tbody> <tr> <td class="tg-f4yw" rowspan="2">auth가 완료되기 전에 연산 요청</td> <td class="tg-f4yw" rowspan="2">authLatch.await()으로 1초 대기</td> <td class="tg-f4yw">1초 이내에 auth가 성공한 경우</td> <td class="tg-f4yw">정상 처리</td> </tr> <tr> <td class="tg-f4yw">그렇지 않은 경우</td> <td class="tg-f4yw">authentication timeout으로 캔슬</td> </tr> </tbody> </table>

<table class="tg"><thead> <tr> <th class="tg-f4yw">상황</th> <th class="tg-f4yw">동작</th> </tr></thead> <tbody> <tr> <td class="tg-f4yw" rowspan="2">auth 재시도가 필요한 상태에서 연산 요청</td> <td class="tg-f4yw" rowspan="2">authentication failed로 캔슬</td> </tr> <tr> </tr> </tbody> </table>

<table class="tg"><thead> <tr> <th class="tg-rcip">상황</th> <th class="tg-rcip">세부 상황</th> <th class="tg-rcip">동작</th> </tr></thead> <tbody> <tr> <td class="tg-rcip" rowspan="3">SASL_CONTINUE 응답을 받은 이후에 ERROR 응답을 받고 재연결을 할 때 연산 요청</td> <td class="tg-rcip">연결이 끊어지기 전</td> <td class="tg-rcip">재연결이 완료된 후에 정상 처리</td> </tr> <tr> <td class="tg-rcip">연결이 끊어진 후, 재연결이 완료되기 전</td> <td class="tg-rcip">inactive node로 캔슬</td> </tr> <tr> <td class="tg-f4yw">재연결이 완료된 후</td> <td class="tg-f4yw">정상 처리</td> </tr> </tbody> </table>

## MemcachedNode

- 신규 필드 추가
  - `boolean skippingAuth` : 현재 auth 과정을 스킵하고 있는 상태인지 여부를 나타내며, SASL_CONTINUE 응답을 받기 전에 ERROR 응답을 받은 경우에만 true로 설정됨
  - `boolean authFailed` : auth가 실패했는지 여부를 나타내며, auth 재시도가 필요한 상황이라면 항상 true로 설정됨
- 최초 연결, 재연결 관계 없이 연결이 완료된 시점에 auth가 필요한지 여부 확인 방법 변경
  - AS-IS : `authDescriptor != null`인 경우 auth가 필요한 것으로 간주
  - TO-BE : `authDescriptor != null && authLatch.getCount() > 0`인 경우 auth가 필요한 것으로 간주
    - 만약 `authLatch.getCount() == 0`이면 AuthThread 객체를 생성하지 않고 auth를 시도하지 않음
- 재연결을 시도하는 시점에 auth가 필요한지 여부 확인 방법 변경
  - AS-IS : `authDescriptor != null`인 경우 auth 시도가 필요한 것으로 간주하여 authLatch의 count를 1로 초기화
  - TO-BE : `authDescriptor != null && skippingAuth == false`인 경우 auth 시도가 필요한 것으로 간주하여 authLatch의 count를 1로 초기화
    - auth 스킵 과정 중에 재연결을 시도하는 경우, `skippingAuth == true`인 상태이므로 auth 시도가 필요하지 않은 것으로 판단하게 됨
    - auth 스킵 과정을 통해 재연결이 완료된 경우 skippingAuth의 값을 false로 변경
- 연산을 요청하는 시점에 auth가 완료되었는지 여부 확인 방법 변경
  - AS-IS : `authLatch.getCount() == 0`인 경우 auth가 성공한 것으로 간주
  - TO-BE `authLatch.getCount() == 0 && skippingAuth == false && authFailed == false`인 경우 auth가 성공한 것으로 간주
- 기존 필드 `reconnectBlocked`의 타입을 ArrayList에서 BlockingQueue로 변경
  - authLatch의 대기는 끝났지만 `skippingAuth == true`인 경우, inputQueue 대신 reconnectBlocked에 Operation 객체를 추가함
  - 재연결이 필요할 때 inputQueue의 원소들을 전부 reconnectBlocked에 원자적으로 옮김
  - 재연결과 auth가 모두 완료되었을 때 reconnectBlocked의 원소들을 전부 inputQueue에 원자적으로 옮김
  - 원자적으로 옮기는 이유는 Worker Thread, AuthThread, IO Thread가 reconnectBlocked를 동시에 사용할 가능성이 있기 때문
  - ArrayList에는 원자적으로 원소를 옮기는 기능이 없어서 BlockingQueue 타입으로 변경

## MemcachedConnection ( = IO Thread)

- 신규 필드 `ConcurrentLinkedHashSetQueue<QueueReconnectTask> reconnectRequests` 추가
  - ConcurrentLinkedHashSetQueue는 새롭게 정의한 자료구조로, 동시성이 보장되는 Queue이지만 각 원소는 유일함
  - IO Thread의 handleIO() 로직에서 Exception이 발생한 경우에는 기존의 `ReconnectQueue reconnectQueue`를 사용
  - IO Thread가 아닌 다른 Thread에서 특정 MemcachedNode 객체에 재연결이 필요한 경우에 `reconnectRequests` 객체에 재연결 요청을 추가
  - IO Thread는 handleIO() 로직에서 reconnectRequests 객체가 비어 있지 않은 경우, 재연결 요청을 reconnectQueue로 옮겨서 처리
- MemcachedNode 객체 생성 직후 versioin 정보 가져오는 로직 변경
  - 아직 auth가 완료되지 않은 경우에는 version 정보를 가져오지 않고 나중에 가져오기 위해 사용하는 `Set<MemcachedNode> nodesNeedVersionOp`에 담아둠
  - IO Thread는 handleIO() 로직에서 nodesNeedVersionOp를 순회하면서 auth가 완료된 경우에 한하여 version 정보를 가져옴
- handleIO() 로직에서 ClosedChannelException 발생 시 auth 처리 변경
  - AS-IS : 재연결이 완료된 후에 auth를 수행할 필요가 없다고 간주 (버그)
  - TO-BE : 재연결 완료 후 auth를 재시도해야 하므로, MemcachedNode 내에 있는 authLatch 등의 필드들을 초기화
- handleIO() 로직에서 AuthException 처리 추가
  - AuthException은 새롭게 추가된 클래스이며, AuthThread에서만 전파해줌
  - AuthThread가 IO Thread에게 재연결을 요청할 때 사용하는 2가지 방법 중 하나임
  - AuthException 객체에는 3가지 정보가 담겨져 있음
    - Exception 메세지는 무엇인지?
    - 어떠한 종류의 재연결인지? (auth 스킵 or auth 재시도)
    - 재연결 딜레이는 어떻게 할 것인지? (즉시 or 1초 후에)

## AuthThread

- 신규 필드 `long timeout` 추가
  - auth 연산에 대한 Timeout 값을 밀리세컨드 단위로 정의
  - 생성자로 값을 주입 받으며, 외부에서는 ConnectionFactory에 명시된 operationTimeout 값을 넣어줌
- auth를 시도해야 하는 경우, 연결이 수립될 때마다 객체를 새로 생성
- 재연결이 필요하면 IO Thread에게 재연결 요청
  - OperationCallback 내에서 재연결이 필요한 경우, IO Thread에게 AuthException을 전파하여 재연결을 요청하고 AuthThread 종료
  - auth 연산 Timeout이 발생한 경우, IO Thread에 추가한 신규 public 메소드를 통해 재연결을 요청하고 AuthThread 종료
- 재연결이 완료되었을 때 AuthThread 객체가 새롭게 생성되기 때문에 항상 재연결 요청 시에는 AuthThread를 종료
- AUTH_ERROR 응답을 수신한 경우, 재연결 없이 1초 후에 auth 과정을 처음부터 재시도

## Operation

- 신규 메소드 `boolean doThrowException(OperationErrorType eType)` 추가
  - OperationErrorType은 서버 응답이 CLIENT_ERROR인지, SERVER_ERROR인지, ERROR인지 구분해주는 enum 타입
  - 기존에는 CLIENT_ERROR, SERVER_ERROR, ERROR 응답을 받으면 IO Thread는 항상 OperationException을 발생시켰음
  - auth 명령어 수행 중 ERROR 응답을 받았을 때 IO Thread가 OperationException을 전파하면 AuthThread가 ERROR 응답을 받은 이후의 로직을 수행할 수 없음
  - CLIENT_ERROR, SERVER_ERROR, ERROR 응답을 받았을 때, doThrowException() 메소드의 반환 값이 true인 경우에만 OperationException을 전파하도록 변경
  - doThrowException() 메소드의 기본 구현은 항상 true를 반환하도록 하여 기존 로직과 동일하게 동작하도록 설정
  - auth 연산 클래스에 한하여 서버 응답이 ERROR일 때에는 OperationException을 전파하지 않도록 하여 AuthThread의 OperationCallback 로직을 수행할 수 있도록 함