### PR TITLE
FEAT: Add listener to Future for compatibility with spymemcached

### DIFF
--- a/src/main/java/net/spy/memcached/ArcusClient.java
+++ b/src/main/java/net/spy/memcached/ArcusClient.java
@@ -469,7 +469,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
   public CollectionFuture<Boolean> asyncSetAttr(String key, Attributes attrs) {
     final CountDownLatch latch = new CountDownLatch(1);
     final CollectionFuture<Boolean> rv = new CollectionFuture<>(
-            latch, operationTimeout);
+            latch, operationTimeout, executorService);
     Operation op = opFact.setAttr(key, attrs, new OperationCallback() {
       public void receivedStatus(OperationStatus status) {
         CollectionOperationStatus cstatus = toCollectionOperationStatus(status);
@@ -478,6 +478,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
 
       public void complete() {
         latch.countDown();
+        rv.signalComplete();
       }
     });
     rv.setOperation(op);
@@ -489,7 +490,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
   public CollectionFuture<CollectionAttributes> asyncGetAttr(final String key) {
     final CountDownLatch latch = new CountDownLatch(1);
     final CollectionFuture<CollectionAttributes> rv = new CollectionFuture<>(
-            latch, operationTimeout);
+            latch, operationTimeout, executorService);
     Operation op = opFact.getAttr(key, new GetAttrOperation.Callback() {
       private final CollectionAttributes attrs = new CollectionAttributes();
 
@@ -500,6 +501,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
 
       public void complete() {
         latch.countDown();
+        rv.signalComplete();
       }
 
       public void gotAttribute(String k, String attr) {
@@ -525,7 +527,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
                                                     final Transcoder<T> tc) {
     final CountDownLatch latch = new CountDownLatch(1);
     final CollectionGetFuture<List<T>> rv =
-            new CollectionGetFuture<>(latch, operationTimeout);
+            new CollectionGetFuture<>(latch, operationTimeout, executorService);
 
     Operation op = opFact.collectionGet(k, collectionGet,
         new CollectionGetOperation.Callback() {
@@ -545,6 +547,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
 
           public void complete() {
             latch.countDown();
+            rv.signalComplete();
           }
 
           public void gotData(String subkey, int flags, byte[] data, byte[] eflag) {
@@ -581,7 +584,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
                                                    final Transcoder<T> tc) {
     final CountDownLatch latch = new CountDownLatch(1);
     final CollectionGetFuture<Set<T>> rv =
-            new CollectionGetFuture<>(latch, operationTimeout);
+            new CollectionGetFuture<>(latch, operationTimeout, executorService);
 
     Operation op = opFact.collectionGet(k, collectionGet,
         new CollectionGetOperation.Callback() {
@@ -601,6 +604,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
 
           public void complete() {
             latch.countDown();
+            rv.signalComplete();
           }
 
           public void gotData(String subkey, int flags, byte[] data, byte[] eflag) {
@@ -625,7 +629,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
           final String k, final CollectionGet collectionGet, final Transcoder<T> tc) {
     final CountDownLatch latch = new CountDownLatch(1);
     final CollectionGetFuture<Map<Long, Element<T>>> rv =
-            new CollectionGetFuture<>(latch, operationTimeout);
+            new CollectionGetFuture<>(latch, operationTimeout, executorService);
 
     Operation op = opFact.collectionGet(k, collectionGet,
         new CollectionGetOperation.Callback() {
@@ -646,6 +650,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
 
           public void complete() {
             latch.countDown();
+            rv.signalComplete();
           }
 
           public void gotData(String bKey, int flags, byte[] data, byte[] eflag) {
@@ -669,7 +674,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
           final String k, final CollectionGet collectionGet, final Transcoder<T> tc) {
     final CountDownLatch latch = new CountDownLatch(1);
     final CollectionGetFuture<Map<String, T>> rv =
-            new CollectionGetFuture<>(latch, operationTimeout);
+            new CollectionGetFuture<>(latch, operationTimeout, executorService);
 
     Operation op = opFact.collectionGet(k, collectionGet,
         new CollectionGetOperation.Callback() {
@@ -690,6 +695,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
 
           public void complete() {
             latch.countDown();
+            rv.signalComplete();
           }
 
           public void gotData(String mkey, int flags, byte[] data, byte[] eflag) {
@@ -736,7 +742,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
                                                       final CachedData co) {
     final CountDownLatch latch = new CountDownLatch(1);
     final CollectionFuture<Boolean> rv = new CollectionFuture<>(
-            latch, operationTimeout);
+            latch, operationTimeout, executorService);
     Operation op = opFact.collectionInsert(key, subkey, collectionInsert,
             co.getData(), new OperationCallback() {
               public void receivedStatus(OperationStatus status) {
@@ -755,6 +761,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
 
               public void complete() {
                 latch.countDown();
+                rv.signalComplete();
               }
             });
     rv.setOperation(op);
@@ -774,7 +781,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
           final String key, final CollectionDelete collectionDelete) {
     final CountDownLatch latch = new CountDownLatch(1);
     final CollectionFuture<Boolean> rv = new CollectionFuture<>(
-            latch, operationTimeout);
+            latch, operationTimeout, executorService);
     Operation op = opFact.collectionDelete(key, collectionDelete,
         new OperationCallback() {
           public void receivedStatus(OperationStatus status) {
@@ -790,6 +797,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
 
           public void complete() {
             latch.countDown();
+            rv.signalComplete();
           }
         });
     rv.setOperation(op);
@@ -810,7 +818,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
                                                              final CollectionExist collectionExist) {
     final CountDownLatch latch = new CountDownLatch(1);
     final CollectionFuture<Boolean> rv = new CollectionFuture<>(
-            latch, operationTimeout);
+            latch, operationTimeout, executorService);
     Operation op = opFact.collectionExist(key, subkey, collectionExist,
         new OperationCallback() {
           public void receivedStatus(OperationStatus status) {
@@ -828,6 +836,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
 
           public void complete() {
             latch.countDown();
+            rv.signalComplete();
           }
         });
     rv.setOperation(op);
@@ -1110,7 +1119,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
                                                   final CollectionCreate collectionCreate) {
     final CountDownLatch latch = new CountDownLatch(1);
     final CollectionFuture<Boolean> rv = new CollectionFuture<>(
-            latch, operationTimeout);
+            latch, operationTimeout, executorService);
 
     Operation op = opFact.collectionCreate(key, collectionCreate,
         new OperationCallback() {
@@ -1130,6 +1139,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
           @Override
           public void complete() {
             latch.countDown();
+            rv.signalComplete();
           }
         });
     rv.setOperation(op);
@@ -1472,7 +1482,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
     final CountDownLatch latch = new CountDownLatch(1);
 
     final CollectionFuture<Integer> rv = new CollectionFuture<>(
-            latch, operationTimeout);
+            latch, operationTimeout, executorService);
 
     Operation op = opFact.collectionCount(k, collectionCount,
         new OperationCallback() {
@@ -1491,6 +1501,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
           @Override
           public void complete() {
             latch.countDown();
+            rv.signalComplete();
           }
         });
 
@@ -1741,7 +1752,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
           final String key, final List<CollectionPipedInsert<T>> insertList) {
     final CountDownLatch latch = new CountDownLatch(1);
     final PipedCollectionFuture<Integer, CollectionOperationStatus> rv =
-            new PipedCollectionFuture<>(latch, operationTimeout);
+            new PipedCollectionFuture<>(latch, operationTimeout, executorService);
 
     final List<Operation> ops = new ArrayList<>(insertList.size());
     IntFunction<OperationCallback> makeCallback = opIdx -> new PipedOperationCallback() {
@@ -1763,6 +1774,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
           }
         }
         latch.countDown();
+        rv.signalComplete();
       }
 
       public void gotStatus(Integer index, OperationStatus status) {
@@ -1793,7 +1805,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
     Collection<MemcachedNode> nodes = getFlushNodes();
 
     final BroadcastFuture<Boolean> rv
-            = new BroadcastFuture<>(operationTimeout, Boolean.TRUE, nodes.size());
+            = new BroadcastFuture<>(operationTimeout, Boolean.TRUE, nodes.size(), executorService);
     final Map<MemcachedNode, Operation> opsMap = new HashMap<>();
 
     checkState();
@@ -2142,7 +2154,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
 
     final CountDownLatch latch = new CountDownLatch(1);
     final CollectionFuture<Boolean> rv = new CollectionFuture<>(
-            latch, operationTimeout);
+            latch, operationTimeout, executorService);
 
     Operation op = opFact.collectionUpdate(key, subkey, collectionUpdate,
             ((co == null) ? null : co.getData()), new OperationCallback() {
@@ -2162,6 +2174,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
 
               public void complete() {
                 latch.countDown();
+                rv.signalComplete();
               }
             });
     rv.setOperation(op);
@@ -2241,7 +2254,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
           final String key, final List<CollectionPipedUpdate<T>> updateList) {
     final CountDownLatch latch = new CountDownLatch(1);
     final PipedCollectionFuture<Integer, CollectionOperationStatus> rv =
-            new PipedCollectionFuture<>(latch, operationTimeout);
+            new PipedCollectionFuture<>(latch, operationTimeout, executorService);
 
     final List<Operation> ops = new ArrayList<>(updateList.size());
     IntFunction<OperationCallback> makeCallback = opIdx -> new PipedOperationCallback() {
@@ -2263,6 +2276,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
           }
         }
         latch.countDown();
+        rv.signalComplete();
       }
 
       public void gotStatus(Integer index, OperationStatus status) {
@@ -2374,7 +2388,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
 
     final CountDownLatch latch = new CountDownLatch(1);
     final CollectionGetFuture<Map<ByteArrayBKey, Element<T>>> rv
-            = new CollectionGetFuture<>(latch, operationTimeout);
+            = new CollectionGetFuture<>(latch, operationTimeout, executorService);
 
     Operation op = opFact.collectionGet(k, collectionGet,
         new CollectionGetOperation.Callback() {
@@ -2395,6 +2409,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
 
           public void complete() {
             latch.countDown();
+            rv.signalComplete();
           }
 
           public void gotData(String bkey, int flags, byte[] data, byte[] eflag) {
@@ -2447,7 +2462,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
     // Check for invalid arguments (not to get CLIENT_ERROR)
     final CountDownLatch latch = new CountDownLatch(1);
     final CollectionGetFuture<Map<Integer, Element<T>>> rv =
-            new CollectionGetFuture<>(latch, operationTimeout);
+            new CollectionGetFuture<>(latch, operationTimeout, executorService);
 
     Operation op = opFact.bopGetByPosition(k, get, new BTreeGetByPositionOperation.Callback() {
       private final HashMap<Integer, Entry<BKeyObject, CachedData>> cachedDataMap =
@@ -2469,6 +2484,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
       @Override
       public void complete() {
         latch.countDown();
+        rv.signalComplete();
       }
 
       @Override
@@ -2515,7 +2531,8 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
   private CollectionFuture<Integer> asyncBopFindPosition(final String k,
                                                          final BTreeFindPosition get) {
     final CountDownLatch latch = new CountDownLatch(1);
-    final CollectionFuture<Integer> rv = new CollectionFuture<>(latch, operationTimeout);
+    final CollectionFuture<Integer> rv =
+            new CollectionFuture<>(latch, operationTimeout, executorService);
 
     Operation op = opFact.bopFindPosition(k, get, new BTreeFindPositionOperation.Callback() {
 
@@ -2534,6 +2551,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
 
       public void complete() {
         latch.countDown();
+        rv.signalComplete();
       }
 
       public void gotData(int position) {
@@ -2586,7 +2604,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
 
     final CountDownLatch latch = new CountDownLatch(1);
     final CollectionGetFuture<Map<Integer, Element<T>>> rv
-            = new CollectionGetFuture<>(latch, operationTimeout);
+            = new CollectionGetFuture<>(latch, operationTimeout, executorService);
 
     Operation op = opFact.bopFindPositionWithGet(k, get,
         new BTreeFindPositionWithGetOperation.Callback() {
@@ -2608,6 +2626,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
 
           public void complete() {
             latch.countDown();
+            rv.signalComplete();
           }
 
           @Override
@@ -2701,7 +2720,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
 
     final CountDownLatch latch = new CountDownLatch(1);
     final BTreeStoreAndGetFuture<Boolean, E> rv =
-            new BTreeStoreAndGetFuture<>(latch, operationTimeout);
+            new BTreeStoreAndGetFuture<>(latch, operationTimeout, executorService);
 
     Operation op = opFact.bopInsertAndGet(k, get, co.getData(),
         new BTreeInsertAndGetOperation.Callback() {
@@ -2719,6 +2738,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
 
           public void complete() {
             latch.countDown();
+            rv.signalComplete();
           }
 
           @Override
@@ -2813,7 +2833,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
 
     final CountDownLatch latch = new CountDownLatch(1);
     final CollectionFuture<Map<T, Boolean>> rv = new CollectionFuture<>(
-            latch, operationTimeout);
+            latch, operationTimeout, executorService);
 
     Operation op = opFact.collectionPipedExist(key, exist,
         new PipedOperationCallback() {
@@ -2832,6 +2852,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
 
           public void complete() {
             latch.countDown();
+            rv.signalComplete();
           }
 
           public void gotStatus(Integer index, OperationStatus status) {
@@ -3388,7 +3409,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
 
     final CountDownLatch latch = new CountDownLatch(1);
 
-    final CollectionFuture<Long> rv = new CollectionFuture<>(latch, operationTimeout);
+    final CollectionFuture<Long> rv = new CollectionFuture<>(latch, operationTimeout, executorService);
 
     Operation op = opFact.collectionMutate(k, subkey, collectionMutate,
         new OperationCallback() {
@@ -3415,6 +3436,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
           @Override
           public void complete() {
             latch.countDown();
+            rv.signalComplete();
           }
         });
 

--- a/src/main/java/net/spy/memcached/ConnectionFactory.java
+++ b/src/main/java/net/spy/memcached/ConnectionFactory.java
@@ -23,6 +23,7 @@ import java.net.SocketAddress;
 import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.ExecutorService;
 
 import net.spy.memcached.auth.AuthDescriptor;
 import net.spy.memcached.ops.APIType;
@@ -75,6 +76,18 @@ public interface ConnectionFactory {
    * to wait to add a new item to a queue.
    */
   long getOpQueueMaxBlockTime();
+
+  /**
+   * Returns true if the default provided {@link ExecutorService} has not been
+   * overriden through the builder.
+   */
+  boolean isDefaultExecutorService();
+
+  /**
+   * Get the ExecutorService which is used to asynchronously execute listeners
+   * on futures.
+   */
+  ExecutorService getListenerExecutorService();
 
   /**
    * Create a NodeLocator instance for the given list of nodes.

--- a/src/main/java/net/spy/memcached/ConnectionFactoryBuilder.java
+++ b/src/main/java/net/spy/memcached/ConnectionFactoryBuilder.java
@@ -25,6 +25,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.ExecutorService;
 
 import net.spy.memcached.auth.AuthDescriptor;
 import net.spy.memcached.ops.APIType;
@@ -67,6 +68,7 @@ public class ConnectionFactoryBuilder {
   private HashAlgorithm hashAlg = HashAlgorithm.KETAMA_HASH;
   private AuthDescriptor authDescriptor = null;
   private long opQueueMaxBlockTime = -1;
+  private ExecutorService executorService = null;
 
   private int timeoutExceptionThreshold = 10;
   private int timeoutRatioThreshold = DefaultConnectionFactory.DEFAULT_MAX_TIMEOUTRATIO_THRESHOLD;
@@ -338,6 +340,21 @@ public class ConnectionFactoryBuilder {
     }
 
     authDescriptor = to;
+    return this;
+  }
+
+  /**
+   * Set a custom {@link ExecutorService} to execute the listener callbacks.
+   *
+   * Note that if a custom {@link ExecutorService} is passed in, it also needs to be properly
+   * shut down by the caller. The library itself treats it as a outside managed resource.
+   * Therefore, also make sure to not shut it down before all instances that use it are
+   * shut down.
+   *
+   * @param executorService the ExecutorService to use.
+   */
+  public ConnectionFactoryBuilder setListenerExecutorService(ExecutorService executorService) {
+    this.executorService = executorService;
     return this;
   }
 
@@ -644,6 +661,16 @@ public class ConnectionFactoryBuilder {
       @Override
       public AuthDescriptor getAuthDescriptor() {
         return authDescriptor;
+      }
+
+      @Override
+      public ExecutorService getListenerExecutorService() {
+        return executorService == null ? super.getListenerExecutorService() : executorService;
+      }
+
+      @Override
+      public boolean isDefaultExecutorService() {
+        return executorService == null;
       }
 
       @Override

--- a/src/main/java/net/spy/memcached/internal/AbstractListenableFuture.java
+++ b/src/main/java/net/spy/memcached/internal/AbstractListenableFuture.java
@@ -1,0 +1,161 @@
+/*
+ * arcus-java-client : Arcus Java client
+ * Copyright 2014-present JaM2in Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.spy.memcached.internal;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+import java.util.concurrent.locks.ReentrantLock;
+
+import net.spy.memcached.compat.SpyObject;
+
+public abstract class AbstractListenableFuture<T, L>
+    extends SpyObject implements ListenableFuture<T, L> {
+  /**
+   * The {@link ExecutorService} in which the notifications will be handled.
+   */
+  private final ExecutorService service;
+
+  /**
+   * Holds the list of listeners which will be notified upon completion.
+   */
+  private List<GenericCompletionListener<T>> listeners;
+  private final ReentrantLock lock = new ReentrantLock();
+
+  /**
+   * Creates a new {@link AbstractListenableFuture}.
+   *
+   * @param executor the executor in which the callbacks will be executed in.
+   */
+  protected AbstractListenableFuture(ExecutorService executor) {
+    if (executor == null) {
+      throw new IllegalArgumentException("Executor cannot be null");
+    }
+    service = executor;
+    listeners = new ArrayList<>();
+  }
+
+  /**
+   * Returns the current executor.
+   *
+   * @return the current executor service.
+   */
+  protected ExecutorService executor() {
+    return service;
+  }
+
+  /**
+   * Add the given listener to the total list of listeners to be notified.
+   *
+   * <p>If the future is already done, the listener will be notified
+   * immediately.</p>
+   *
+   * @param listener the listener to add.
+   * @return the current future to allow chaining.
+   */
+  protected Future<T> addToListeners(final GenericCompletionListener<T> listener) {
+    if (listener == null) {
+      throw new IllegalArgumentException("The listener can't be null.");
+    }
+
+    lock.lock();
+    try {
+      listeners.add(listener);
+    } finally {
+      lock.unlock();
+    }
+
+    if (isDone()) {
+      notifyListeners();
+    }
+
+    return this;
+  }
+
+  /**
+   * Notify a specific listener of completion.
+   *
+   * @param executor the executor to use.
+   * @param future the future to hand over.
+   * @param listener the listener to notify.
+   */
+  protected void notifyListener(final ExecutorService executor, final Future<T> future,
+                                final GenericCompletionListener<T> listener) {
+    executor.submit(() -> {
+      try {
+        listener.onComplete(future);
+      } catch (Throwable t) {
+        getLogger().warn(
+                "Exception thrown wile executing " + listener.getClass().getName()
+                        + ".operationComplete()", t);
+      }
+    });
+  }
+
+  /**
+   * Notify all registered listeners of future completion.
+   */
+  protected void notifyListeners() {
+    notifyListeners(this);
+  }
+
+  /**
+   * Notify all registered listeners with a special future on completion.
+   *
+   * This method can be used if a different future should be used for
+   * notification than the current one (for example if an enclosing future
+   * is used, but the enclosed future should be notified on).
+   *
+   * @param future the future to pass on to the listeners.
+   */
+  protected void notifyListeners(final Future<T> future) {
+    final List<GenericCompletionListener<T>> copy = new ArrayList<>();
+    lock.lock();
+    try {
+      copy.addAll(listeners);
+      listeners = new ArrayList<>();
+    } finally {
+      lock.unlock();
+    }
+    for (GenericCompletionListener<T> listener : copy) {
+      notifyListener(executor(), future, listener);
+    }
+  }
+
+  /**
+   * Remove a listener from the list of registered listeners.
+   *
+   * @param listener the listener to remove.
+   * @return the current future to allow for chaining.
+   */
+  protected Future<T> removeFromListeners(GenericCompletionListener<T> listener) {
+    if (listener == null) {
+      throw new IllegalArgumentException("The listener can't be null.");
+    }
+
+    if (!isDone()) {
+      lock.lock();
+      try {
+        listeners.remove(listener);
+      } finally {
+        lock.unlock();
+      }
+    }
+    return this;
+  }
+}

--- a/src/main/java/net/spy/memcached/internal/BTreeStoreAndGetFuture.java
+++ b/src/main/java/net/spy/memcached/internal/BTreeStoreAndGetFuture.java
@@ -19,6 +19,7 @@ package net.spy.memcached.internal;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicReference;
@@ -37,12 +38,13 @@ public class BTreeStoreAndGetFuture<T, E> extends CollectionFuture<T> {
 
   private GetResult<Element<E>> element;
 
-  public BTreeStoreAndGetFuture(CountDownLatch l, long opTimeout) {
-    this(l, new AtomicReference<>(null), opTimeout);
+  public BTreeStoreAndGetFuture(CountDownLatch l, long opTimeout, ExecutorService service) {
+    this(l, new AtomicReference<>(null), opTimeout, service);
   }
 
-  public BTreeStoreAndGetFuture(CountDownLatch l, AtomicReference<T> oref, long opTimeout) {
-    super(l, oref, opTimeout);
+  public BTreeStoreAndGetFuture(CountDownLatch l, AtomicReference<T> oref,
+                                long opTimeout, ExecutorService service) {
+    super(l, oref, opTimeout, service);
   }
 
   public Element<E> getElement() {

--- a/src/main/java/net/spy/memcached/internal/BroadcastFuture.java
+++ b/src/main/java/net/spy/memcached/internal/BroadcastFuture.java
@@ -5,6 +5,7 @@ import java.util.Collection;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
@@ -15,8 +16,8 @@ import net.spy.memcached.ops.OperationState;
 public class BroadcastFuture<T> extends OperationFuture<T> {
   private final Collection<Operation> ops;
 
-  public BroadcastFuture(long timeout , T result, int latchSize) {
-    super(new CountDownLatch(latchSize), timeout);
+  public BroadcastFuture(long timeout , T result, int latchSize, ExecutorService service) {
+    super(new CountDownLatch(latchSize), timeout, service);
     ops = new ArrayList<>(latchSize);
     objRef.set(result);
   }
@@ -92,5 +93,8 @@ public class BroadcastFuture<T> extends OperationFuture<T> {
 
   public void complete() {
     latch.countDown();
+    if (latch.getCount() == 0) {
+      this.signalComplete();
+    }
   }
 }

--- a/src/main/java/net/spy/memcached/internal/CollectionFuture.java
+++ b/src/main/java/net/spy/memcached/internal/CollectionFuture.java
@@ -17,6 +17,7 @@
 package net.spy.memcached.internal;
 
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.atomic.AtomicReference;
 
 import net.spy.memcached.ops.CollectionOperationStatus;
@@ -31,13 +32,13 @@ import net.spy.memcached.ops.CollectionOperationStatus;
 public class CollectionFuture<T> extends OperationFuture<T> {
   protected CollectionOperationStatus collectionOpStatus;
 
-  public CollectionFuture(CountDownLatch l, long opTimeout) {
-    this(l, new AtomicReference<>(null), opTimeout);
+  public CollectionFuture(CountDownLatch l, long opTimeout, ExecutorService service) {
+    this(l, new AtomicReference<>(null), opTimeout, service);
   }
 
   public CollectionFuture(CountDownLatch l, AtomicReference<T> oref,
-                          long opTimeout) {
-    super(l, oref, opTimeout);
+                          long opTimeout, ExecutorService service) {
+    super(l, oref, opTimeout, service);
   }
 
   public void set(T o, CollectionOperationStatus status) {

--- a/src/main/java/net/spy/memcached/internal/CollectionGetFuture.java
+++ b/src/main/java/net/spy/memcached/internal/CollectionGetFuture.java
@@ -2,6 +2,7 @@ package net.spy.memcached.internal;
 
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
@@ -11,8 +12,8 @@ import net.spy.memcached.ops.CollectionOperationStatus;
 public class CollectionGetFuture<T> extends CollectionFuture<T> {
   private GetResult<T> result;
 
-  public CollectionGetFuture(CountDownLatch l, long opTimeout) {
-    super(l, opTimeout);
+  public CollectionGetFuture(CountDownLatch l, long opTimeout, ExecutorService service) {
+    super(l, opTimeout, service);
   }
 
   @Override

--- a/src/main/java/net/spy/memcached/internal/GenericCompletionListener.java
+++ b/src/main/java/net/spy/memcached/internal/GenericCompletionListener.java
@@ -1,0 +1,39 @@
+/*
+ * arcus-java-client : Arcus Java client
+ * Copyright 2014-present JaM2in Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.spy.memcached.internal;
+
+import java.util.EventListener;
+import java.util.concurrent.Future;
+
+/**
+ * A generic listener that will be notified once the future completes.
+ *
+ * <p>While this listener can be used directly, it is advised to subclass
+ * it to make it easier for the API user to work with. </p>
+ */
+public interface GenericCompletionListener<T> extends EventListener {
+  /**
+   * This method will be executed once the future completes.
+   *
+   * <p>Completion includes both failure and success, so it is advised to
+   * always check the status and errors of the future.</p>
+   *
+   * @param future the future that got completed.
+   * @throws Exception can potentially throw anything in the callback.
+   */
+  void onComplete(Future<T> future) throws Exception;
+}

--- a/src/main/java/net/spy/memcached/internal/GetFuture.java
+++ b/src/main/java/net/spy/memcached/internal/GetFuture.java
@@ -2,6 +2,7 @@ package net.spy.memcached.internal;
 
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
@@ -18,8 +19,8 @@ import net.spy.memcached.ops.OperationStatus;
 public class GetFuture<T> extends OperationFuture<T> {
   private GetResult<T> result;
 
-  public GetFuture(CountDownLatch l, long opTimeout) {
-    super(l, opTimeout);
+  public GetFuture(CountDownLatch l, long opTimeout, ExecutorService service) {
+    super(l, opTimeout, service);
   }
 
   @Override

--- a/src/main/java/net/spy/memcached/internal/ListenableFuture.java
+++ b/src/main/java/net/spy/memcached/internal/ListenableFuture.java
@@ -1,0 +1,42 @@
+/*
+ * arcus-java-client : Arcus Java client
+ * Copyright 2014-present JaM2in Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.spy.memcached.internal;
+
+import java.util.concurrent.Future;
+
+/**
+ * A {@link Future} that accepts one or more listeners that will be executed
+ * asynchronously.
+ */
+public interface ListenableFuture<T, L> extends Future<T> {
+  /**
+   * Add a listener to the future, which will be executed once the operation
+   * completes.
+   *
+   * @param listener the listener which will be executed.
+   * @return the current future to allow for object-chaining.
+   */
+  Future<T> addListener(GenericCompletionListener<T> listener);
+
+  /**
+   * Remove a previously added listener from the future.
+   *
+   * @param listener the previously added listener.
+   * @return the current future to allow for object-chaining.
+   */
+  Future<T> removeListener(GenericCompletionListener<T> listener);
+}

--- a/src/main/java/net/spy/memcached/internal/PipedCollectionFuture.java
+++ b/src/main/java/net/spy/memcached/internal/PipedCollectionFuture.java
@@ -8,6 +8,7 @@ import java.util.concurrent.CancellationException;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -29,8 +30,8 @@ public class PipedCollectionFuture<K, V>
           new ConcurrentHashMap<>();
   private final AtomicBoolean cancelled = new AtomicBoolean(false);
 
-  public PipedCollectionFuture(CountDownLatch l, long opTimeout) {
-    super(l, opTimeout);
+  public PipedCollectionFuture(CountDownLatch l, long opTimeout, ExecutorService service) {
+    super(l, opTimeout, service);
   }
 
   @Override

--- a/src/main/java/net/spy/memcached/plugin/FrontCacheGetFuture.java
+++ b/src/main/java/net/spy/memcached/plugin/FrontCacheGetFuture.java
@@ -18,6 +18,7 @@ package net.spy.memcached.plugin;
 
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
@@ -38,8 +39,9 @@ public class FrontCacheGetFuture<T> extends GetFuture<T> {
   private final LocalCacheManager localCacheManager;
   private final String key;
 
-  public FrontCacheGetFuture(LocalCacheManager localCacheManager, String key, GetFuture<T> parent) {
-    super(new CountDownLatch(0), DEFAULT_OPERATION_TIMEOUT);
+  public FrontCacheGetFuture(LocalCacheManager localCacheManager, String key,
+                             GetFuture<T> parent, ExecutorService service) {
+    super(new CountDownLatch(0), DEFAULT_OPERATION_TIMEOUT, service);
     this.parent = parent;
     this.localCacheManager = localCacheManager;
     this.key = key;

--- a/src/main/java/net/spy/memcached/plugin/FrontCacheMemcachedClient.java
+++ b/src/main/java/net/spy/memcached/plugin/FrontCacheMemcachedClient.java
@@ -87,7 +87,7 @@ public class FrontCacheMemcachedClient extends MemcachedClient {
 
     final T t = localCacheManager.get(key);
     if (t != null) {
-      return new GetFuture<T>(null, 0) {
+      return new GetFuture<T>(null, 0, executorService) {
         @Override
         public boolean cancel(boolean mayInterruptIfRunning) {
           return false;
@@ -115,7 +115,7 @@ public class FrontCacheMemcachedClient extends MemcachedClient {
       };
     }
     GetFuture<T> parent = super.asyncGet(key, tc);
-    return new FrontCacheGetFuture<>(localCacheManager, key, parent);
+    return new FrontCacheGetFuture<>(localCacheManager, key, parent, executorService);
   }
 
   /**

--- a/src/test/java/net/spy/memcached/FutureListenerTest.java
+++ b/src/test/java/net/spy/memcached/FutureListenerTest.java
@@ -1,0 +1,35 @@
+package net.spy.memcached;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import net.spy.memcached.internal.OperationFuture;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class FutureListenerTest extends ClientBaseCase {
+  @Test
+  void testListener() throws Exception {
+    final String key = "listener-test-key";
+    final String value = "listener-test-value";
+    final CountDownLatch latch = new CountDownLatch(1);
+    final AtomicReference<Future<?>> futureInListener = new AtomicReference<>();
+    OperationFuture<Boolean> future = client.set(key, 60, value);
+    future.addListener(f -> {
+      futureInListener.set(f);
+      latch.countDown();
+    });
+
+    assertTrue(latch.await(1, TimeUnit.SECONDS));
+    Future<?> completedFuture = futureInListener.get();
+    assertNotNull(completedFuture);
+    assertTrue(completedFuture.isDone());
+    assertEquals(value, client.get(key));
+  }
+}

--- a/src/test/java/net/spy/memcached/protocol/ascii/BaseOpTest.java
+++ b/src/test/java/net/spy/memcached/protocol/ascii/BaseOpTest.java
@@ -26,6 +26,7 @@ import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executors;
 import java.util.concurrent.LinkedBlockingQueue;
 
 import net.spy.memcached.collection.CollectionPipedInsert;
@@ -123,7 +124,8 @@ class BaseOpTest {
             new CollectionPipedInsert.ListPipedInsert<>(key, 0,
                     Arrays.asList("a", "b"), null, null);
     PipedCollectionFuture<Object, Object> rv =
-            new PipedCollectionFuture<>(new CountDownLatch(1), 700);
+            new PipedCollectionFuture<>(new CountDownLatch(1), 700,
+                    Executors.newSingleThreadExecutor());
     OperationCallback cb = new PipedOperationCallback() {
       @Override
       public void receivedStatus(OperationStatus status) {


### PR DESCRIPTION
### 🔗 Related Issue

<!-- Please link related issue. ex) https://github.com/naver/arcus-java-client/issues/{issue_number} -->
- https://github.com/jam2in/arcus-works/issues/725

### ⌨️ What I did

<!-- Please describe this PR and what you've been working on. -->
Spymemcached와의 호환성을 맞추기 위해 Future 객체에 리스너(listener)를 추가하는 기능을 구현했습니다. 이제 `.addListener()`를 사용하여 작업 완료 후 실행될 로직을 등록할 수 있습니다.

spymemcached에서는 `GetFuture` 클래스가 
- `AbstractListenableFuture` 클래스 추가
    - ReentrantLock을 사용하여 리스너 목록 접근 시의 안정성을 확보했습니다.
- `ExecutorService`를 통한 리스너 실행
    - I/O 스레드를 방해하지 않도록, 별도의 스레드 풀에서 리스너를 실행하도록 구현했습니다.
- 기존 Future 클래스 구조 변경
    - `OperationFuture`, `BulkGetFuture`클래스는`AbstractListenableFuture`를 상속받아 리스너 기능을 갖도록 구조를 변경했습니다.
    - **`GetFuture`의 경우, Spymemcached와 달리 Arcus의 기존 구조인 `GetFuture extends OperationFuture`를 유지했습니다.** 이를 통해 `GetFuture`는 `OperationFuture`로부터 리스너 기능을 자동으로 상속받으며, 자신은 `GetResult` 객체를 처리할 수 있도록 했습니
- `MemcachedClient` 수정
    - `asyncGet`, `asyncGets`, `asyncStore` 등 `OperationFuture`를 생성하는 모든 메소드에서 `ExecutorService`를 주입하도록 수정했습니다.

---

- 현재 테스트코드는 따로 구현되지 않은 상태입니다. 테스트코드가 필요하다면 추가하도록 하겠습니다.