### PR TITLE
FIX: Reset the use of mget, mgets, " " separator, version info when connection is lost

### DIFF
--- a/src/main/java/net/spy/memcached/protocol/TCPMemcachedNodeImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/TCPMemcachedNodeImpl.java
@@ -440,13 +440,14 @@ public abstract class TCPMemcachedNodeImpl extends SpyObject
 
   public final void reconnecting() {
     reconnectAttempt.incrementAndGet();
-    isFirstConnecting = false;
-    continuousTimeout.set(0);
-    timeoutStartNanos.set(0);
-    resetTimeoutRatioCount();
   }
 
   public final void connected() {
+    version = null;
+    enabledMGetOp = false;
+    enabledMGetsOp = false;
+    enabledSpaceSeparate = false;
+
     reconnectAttempt.set(0);
     isFirstConnecting = false;
     continuousTimeout.set(0);


### PR DESCRIPTION
### 🔗 Related Issue

<!-- Please link related issue. ex) https://github.com/naver/arcus-java-client/issues/{issue_number} -->
- https://github.com/jam2in/arcus-works/issues/787#issuecomment-3400103132

### ⌨️ What I did

<!-- Please describe this PR and what you've been working on. -->
- 연결이 맺어지면 서버의 version을 통해 확인한 모든 사항을 Disable 처리합니다.