### PR TITLE
INTERNAL: Use more proper key separator for multi-keyed collection operations

### DIFF
--- a/src/main/java/net/spy/memcached/protocol/ascii/BTreeGetBulkOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/BTreeGetBulkOperationImpl.java
@@ -221,7 +221,7 @@ public final class BTreeGetBulkOperationImpl extends OperationImpl implements
 
   public void initialize() {
     String cmd = getBulk.getCommand();
-    if (getHandlingNode() == null || getHandlingNode().enabledSpaceSeparate()) {
+    if (getHandlingNode() != null && getHandlingNode().enabledSpaceSeparate()) {
       getBulk.setKeySeparator(" ");
     } else {
       getBulk.setKeySeparator(",");

--- a/src/main/java/net/spy/memcached/protocol/ascii/BTreeSortMergeGetOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/BTreeSortMergeGetOperationImpl.java
@@ -386,7 +386,7 @@ public final class BTreeSortMergeGetOperationImpl extends OperationImpl implemen
 
   public void initialize() {
     String cmd = smGet.getCommand();
-    if (getHandlingNode() == null || getHandlingNode().enabledSpaceSeparate()) {
+    if (getHandlingNode() != null && getHandlingNode().enabledSpaceSeparate()) {
       smGet.setKeySeparator(" ");
     } else {
       smGet.setKeySeparator(",");

--- a/src/main/java/net/spy/memcached/protocol/ascii/BTreeSortMergeGetOperationOldImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/BTreeSortMergeGetOperationOldImpl.java
@@ -277,7 +277,7 @@ public final class BTreeSortMergeGetOperationOldImpl extends OperationImpl imple
 
   public void initialize() {
     String cmd = smGet.getCommand();
-    if (getHandlingNode() == null || getHandlingNode().enabledSpaceSeparate()) {
+    if (getHandlingNode() != null && getHandlingNode().enabledSpaceSeparate()) {
       smGet.setKeySeparator(" ");
     } else {
       smGet.setKeySeparator(",");

--- a/src/main/java/net/spy/memcached/protocol/ascii/CollectionDeleteOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/CollectionDeleteOperationImpl.java
@@ -106,7 +106,7 @@ public final class CollectionDeleteOperationImpl extends OperationImpl
     String cmd = collectionDelete.getCommand();
     if (collectionDelete instanceof MapDelete) {
       MapDelete mapDelete = (MapDelete) collectionDelete;
-      if (getHandlingNode() == null || getHandlingNode().enabledSpaceSeparate()) {
+      if (getHandlingNode() != null && getHandlingNode().enabledSpaceSeparate()) {
         mapDelete.setKeySeparator(" ");
       } else {
         mapDelete.setKeySeparator(",");

--- a/src/main/java/net/spy/memcached/protocol/ascii/CollectionGetOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/CollectionGetOperationImpl.java
@@ -255,7 +255,7 @@ public final class CollectionGetOperationImpl extends OperationImpl
     String cmd = collectionGet.getCommand();
     if (collectionGet instanceof MapGet) {
       MapGet mapGet = (MapGet) collectionGet;
-      if (getHandlingNode() == null || getHandlingNode().enabledSpaceSeparate()) {
+      if (getHandlingNode() != null && getHandlingNode().enabledSpaceSeparate()) {
         mapGet.setKeySeparator(" ");
       } else {
         mapGet.setKeySeparator(",");


### PR DESCRIPTION
### 🔗 Related Issue

<!-- Please link related issue. ex) https://github.com/naver/arcus-java-client/issues/{issue_number} -->
- https://github.com/jam2in/arcus-works/issues/787#issuecomment-3400480726

### ⌨️ What I did

<!-- Please describe this PR and what you've been working on. -->
- 연산의 담당 노드가 없을 때에는 키 구분자로 콤마를 사용하도록 합니다.