### PR TITLE
FIX: Call `MemcachedNode#setupForAuth()` on ClosedChannelException

### DIFF
--- a/src/main/java/net/spy/memcached/MemcachedConnection.java
+++ b/src/main/java/net/spy/memcached/MemcachedConnection.java
@@ -919,6 +919,7 @@ public final class MemcachedConnection extends SpyObject {
       }
     } catch (ClosedChannelException e) {
       // Note, not all channel closes end up here
+      qa.setupForAuth("closed channel"); // noop if !shouldAuth
       getLogger().warn("Closed channel.  "
               + "Queueing reconnect on %s", qa, e);
       lostConnection(qa, ReconnDelay.DEFAULT, "closed channel");


### PR DESCRIPTION
### 🔗 Related Issue

<!-- Please link related issue. ex) https://github.com/naver/arcus-java-client/issues/{issue_number} -->
- https://github.com/jam2in/arcus-works/issues/792

### ⌨️ What I did

<!-- Please describe this PR and what you've been working on. -->
- handleIO 로직에서 ClosedChannelException 발생 시 auth 설정을 하지 않던 점을 수정합니다.