### PR TITLE
INTERNAL: Remove unnecessary setupResend() call in setupForAuth()

### DIFF
--- a/src/main/java/net/spy/memcached/protocol/TCPMemcachedNodeImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/TCPMemcachedNodeImpl.java
@@ -644,7 +644,6 @@ public abstract class TCPMemcachedNodeImpl extends SpyObject
         inputQueue.drainTo(reconnectBlocked);
       }
       assert (inputQueue.isEmpty());
-      setupResend(cause);
     } else {
       authLatch = new CountDownLatch(0);
     }


### PR DESCRIPTION
### 🔗 Related Issue

<!-- Please link related issue. ex) https://github.com/naver/arcus-java-client/issues/{issue_number} -->
- https://github.com/jam2in/arcus-works/issues/793

### ⌨️ What I did

<!-- Please describe this PR and what you've been working on. -->
- setupForAuth()에서 setupResend() 호출을 제거합니다.