### PR TITLE
TEST: Add printing docker logs on `docker compose up -d` failure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,9 @@ jobs:
           # build server
           cd ~/arcus && docker compose up -d
 
+      - name: Print Docker Logs On Failure
+        if: failure()
+        run: docker compose logs
       - name: Test ARCUS Client Without ZK
         run: mvn clean verify -DUSE_ZK=false -Dtest=ObserverTest,ArcusClientCreateTest
       - name: Test ARCUS Client With ZK


### PR DESCRIPTION
### 🔗 Related Issue

<!-- Please link related issue. ex) https://github.com/naver/arcus-java-client/issues/{issue_number} -->
- https://github.com/naver/arcus/pull/68 PR이 반영된 이후, ZK 노드 구동이 정상적으로 수행되지 않으면 아주 빠르게 CI가 실패하고 있다.
- ZK 노드가 정상적으로 구동되지 않았을 때, 원인을 확인하기 위해서는 docker 로그를 출력해봐야 한다.

### ⌨️ What I did

<!-- Please describe this PR and what you've been working on. -->
- 캐시 서버 구동에 실패하면 docker 로그를 출력합니다.