### PR TITLE
ENHANCE: Allow queuing operations on nodes going to immediately reconnect

### DIFF
--- a/src/main/java/net/spy/memcached/MemcachedClient.java
+++ b/src/main/java/net/spy/memcached/MemcachedClient.java
@@ -2142,7 +2142,7 @@ public class MemcachedClient extends SpyThread
     boolean rv = conn.addObserver(obs);
     if (rv) {
       for (MemcachedNode node : conn.getLocator().getAll()) {
-        if (node.isActive()) {
+        if (node.isConnected()) {
           obs.connectionEstablished(node.getSocketAddress(), -1);
         }
       }

--- a/src/main/java/net/spy/memcached/MemcachedConnection.java
+++ b/src/main/java/net/spy/memcached/MemcachedConnection.java
@@ -828,7 +828,7 @@ public final class MemcachedConnection extends SpyObject {
       // Now process the queue.
       for (MemcachedNode qa : todo) {
         boolean readyForIO = false;
-        if (qa.isActive()) {
+        if (qa.isConnected()) {
           if (qa.getCurrentWriteOp() != null) {
             readyForIO = true;
             getLogger().debug("Handling queued write %s", qa);
@@ -1089,7 +1089,7 @@ public final class MemcachedConnection extends SpyObject {
       op.cancel("Redirect failure. No node.");
       return false;
     }
-    if (!node.isActive() && !node.isFirstConnecting()) {
+    if (!node.isActive()) {
       op.cancel("Redirect failure. Inactive node.");
       return false;
     }
@@ -1129,7 +1129,7 @@ public final class MemcachedConnection extends SpyObject {
         clonedOp.cancel("Redirect failure. No node.");
         continue;
       }
-      if (!node.isActive() && !node.isFirstConnecting()) {
+      if (!node.isActive()) {
         clonedOp.cancel("Redirect failure. Inactive node.");
         continue;
       }
@@ -1183,6 +1183,7 @@ public final class MemcachedConnection extends SpyObject {
       }
     }
     /* ENABLE_REPLICATION end */
+    qa.reconnecting(type);
 
     getLogger().warn("Closing, and reopening %s, attempt %d.", qa,
             qa.getReconnectCount());
@@ -1191,7 +1192,6 @@ public final class MemcachedConnection extends SpyObject {
     } catch (IOException e) {
       getLogger().warn("IOException trying to close a socket", e);
     }
-    qa.reconnecting();
 
     // Need to do a little queue management.
     qa.setupResend(cause);
@@ -1445,8 +1445,7 @@ public final class MemcachedConnection extends SpyObject {
       o.cancel("no node");
       return;
     }
-    if ((!node.isActive() && !node.isFirstConnecting()) &&
-        failureMode == FailureMode.Cancel) {
+    if (!node.isActive() && failureMode == FailureMode.Cancel) {
       o.setHandlingNode(node);
       o.cancel("inactive node");
       return;
@@ -1590,7 +1589,7 @@ public final class MemcachedConnection extends SpyObject {
     if (node == null) {
       return null;
     }
-    if (node.isActive() || node.isFirstConnecting()) {
+    if (node.isActive()) {
       return node;
     }
     if (failureMode == FailureMode.Redistribute) {
@@ -1618,7 +1617,7 @@ public final class MemcachedConnection extends SpyObject {
     if (node == null) {
       return null;
     }
-    if (node.isActive() || node.isFirstConnecting()) {
+    if (node.isActive()) {
       return node;
     }
     if (failureMode == FailureMode.Redistribute) {

--- a/src/main/java/net/spy/memcached/MemcachedNode.java
+++ b/src/main/java/net/spy/memcached/MemcachedNode.java
@@ -24,6 +24,7 @@ import java.nio.channels.SelectionKey;
 import java.nio.channels.SocketChannel;
 import java.util.Collection;
 
+import net.spy.memcached.internal.ReconnDelay;
 import net.spy.memcached.ops.Operation;
 
 /**
@@ -156,15 +157,12 @@ public interface MemcachedNode {
    */
   boolean isActive();
 
-  /**
-   * True if it is the first connecting attempt.
-   */
-  boolean isFirstConnecting();
+  boolean isConnected();
 
   /**
    * Notify this node that it will be reconnecting.
    */
-  void reconnecting();
+  void reconnecting(ReconnDelay delay);
 
   /**
    * Notify this node that it has reconnected.

--- a/src/main/java/net/spy/memcached/MemcachedNodeROImpl.java
+++ b/src/main/java/net/spy/memcached/MemcachedNodeROImpl.java
@@ -24,6 +24,7 @@ import java.nio.channels.SelectionKey;
 import java.nio.channels.SocketChannel;
 import java.util.Collection;
 
+import net.spy.memcached.internal.ReconnDelay;
 import net.spy.memcached.ops.Operation;
 
 public final class MemcachedNodeROImpl implements MemcachedNode {
@@ -125,15 +126,15 @@ public final class MemcachedNodeROImpl implements MemcachedNode {
     return root.hasReadOp();
   }
 
+  public boolean isConnected() {
+    return root.isConnected();
+  }
+
   public boolean isActive() {
     return root.isActive();
   }
 
-  public boolean isFirstConnecting() {
-    return root.isFirstConnecting();
-  }
-
-  public void reconnecting() {
+  public void reconnecting(ReconnDelay delay) {
     throw new UnsupportedOperationException();
   }
 

--- a/src/main/java/net/spy/memcached/internal/CheckedOperationTimeoutException.java
+++ b/src/main/java/net/spy/memcached/internal/CheckedOperationTimeoutException.java
@@ -95,9 +95,6 @@ public class CheckedOperationTimeoutException extends TimeoutException {
       }
       if (node != null) {
         rv.append(" [").append(node.getOpQueueStatus()).append("]");
-        if (!node.isActive() && node.isFirstConnecting()) {
-          rv.append(" (Not connected yet)");
-        }
       }
     }
     return rv.toString();

--- a/src/test/java/net/spy/memcached/MemcachedNodeROImplTest.java
+++ b/src/test/java/net/spy/memcached/MemcachedNodeROImplTest.java
@@ -56,7 +56,7 @@ class MemcachedNodeROImplTest {
     Set<String> acceptable = new HashSet<>(Arrays.asList(
             "toString", "getSocketAddress", "getBytesRemainingToWrite",
             "getReconnectCount", "getSelectionOps", "getNodeName", "hasReadOp",
-            "hasWriteOp", "isActive", "isFirstConnecting"));
+            "hasWriteOp", "isActive", "isConnected"));
 
     for (Method meth : MemcachedNode.class.getMethods()) {
       if (acceptable.contains(meth.getName())) {

--- a/src/test/java/net/spy/memcached/MockMemcachedNode.java
+++ b/src/test/java/net/spy/memcached/MockMemcachedNode.java
@@ -25,6 +25,7 @@ import java.nio.channels.SelectionKey;
 import java.nio.channels.SocketChannel;
 import java.util.Collection;
 
+import net.spy.memcached.internal.ReconnDelay;
 import net.spy.memcached.ops.Operation;
 
 public class MockMemcachedNode implements MemcachedNode {
@@ -133,11 +134,11 @@ public class MockMemcachedNode implements MemcachedNode {
     return false;
   }
 
-  public boolean isFirstConnecting() {
+  public boolean isConnected() {
     return false;
   }
 
-  public void reconnecting() {
+  public void reconnecting(ReconnDelay delay) {
     // noop
   }
 


### PR DESCRIPTION
### 🔗 Related Issue

<!-- Please link related issue. ex) https://github.com/naver/arcus-java-client/issues/{issue_number} -->
- ReconnDelay 타입을 IMMEDIATE로 설정하여 재연결을 하는 경우, 연결에 문제가 있는 것이 아니라 단지 TCP 버퍼의 데이터를 비우기 위해 재연결을 하는 것이다.
- 기존에는 재연결을 해야 하는 상황에서는 어떠한 사유로 재연결을 하는지에 관계 없이, 연산이 들어오면 inactive node로 캔슬시킨다.
- ReconnDelay 타입이 IMMEDIATE라면 inactive node로 간주할 상태가 아니므로, 이때에는 연산을 InputQ에 넣을 수 있도록 해야 한다.

### ⌨️ What I did

<!-- Please describe this PR and what you've been working on. -->
- MemcachedNode의 현재 재연결 딜레이 타입이 무엇인지 설정하는 메소드를 추가합니다.
- 현재 재연결 딜레이 타입이 무엇인지에 관계 없이, 소켓 연결이 되어 있는지 확인하는 메소드를 추가합니다.
- 재연결 딜레이 타입의 기본값은 IMMEDIATE로 초기화합니다.
- queueReconnect() 호출 시 MemcachedNode의 재연결 딜레이 타입을 설정합니다.
- isActive() 내에서 재연결 딜레이 타입이 IMMEDIATE이면 true를 반환합니다.
- 소켓 관련 연산을 해야 하는 경우, 재연결 딜레이 타입을 참조하지 않고 소켓 연결이 되어 있는지만 확인하도록 합니다.