### PR TITLE
TEST: Add printing docker logs on `docker compose up -d` failure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
 
       - name: Print Docker Logs On Failure
         if: failure()
-        run: docker compose logs
+        run: cd ~/arcus && docker compose logs
       - name: Test ARCUS Client Without ZK
         run: mvn clean verify -DUSE_ZK=false -Dtest=ObserverTest,ArcusClientCreateTest
       - name: Test ARCUS Client With ZK


### PR DESCRIPTION
### 🔗 Related Issue

<!-- Please link related issue. ex) https://github.com/naver/arcus-java-client/issues/{issue_number} -->
- https://github.com/naver/arcus-java-client/pull/988
- docker compose logs 명령어는 docker-compose.yaml 파일이 있는 경로에서 수행하지 않으면 어떤 로그를 출력해야 하는지 알 수 없어서 실패한다.

### ⌨️ What I did

<!-- Please describe this PR and what you've been working on. -->
- docker compose logs 명령어를 arcus 디렉토리 내에서 수행합니다.