### PR TITLE
FIX: Check if writeQ is empty before move its operations to reconnectBlocked

### DIFF
--- a/src/main/java/net/spy/memcached/protocol/TCPMemcachedNodeImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/TCPMemcachedNodeImpl.java
@@ -626,7 +626,7 @@ public abstract class TCPMemcachedNodeImpl extends SpyObject
   public final void setupForAuth(String cause) {
     if (shouldAuth) {
       authLatch = new CountDownLatch(1);
-      if (!inputQueue.isEmpty()) {
+      if (!writeQ.isEmpty() || !inputQueue.isEmpty()) {
         reconnectBlocked = new ArrayList<>(
                 inputQueue.size() + writeQ.size() + 1);
         writeQ.drainTo(reconnectBlocked);


### PR DESCRIPTION
### 🔗 Related Issue

<!-- Please link related issue. ex) https://github.com/naver/arcus-java-client/issues/{issue_number} -->
- https://github.com/jam2in/arcus-works/issues/796

### ⌨️ What I did

<!-- Please describe this PR and what you've been working on. -->
- writeQ가 비어 있는지 확인합니다.