### PR TITLE
ENHANCE: Enhance handling response on auth process

### DIFF
--- a/src/main/java/net/spy/memcached/MemcachedClient.java
+++ b/src/main/java/net/spy/memcached/MemcachedClient.java
@@ -1988,7 +1988,7 @@ public class MemcachedClient extends SpyThread
 
     checkState();
     for (MemcachedNode node : nodes) {
-      Operation op = opFact.saslMechs(new OperationCallback() {
+      Operation op = opFact.saslMechs(false, new OperationCallback() {
         @Override
         public void receivedStatus(OperationStatus status) {
           for (String s : status.getMessage().split(" ")) {

--- a/src/main/java/net/spy/memcached/MemcachedConnection.java
+++ b/src/main/java/net/spy/memcached/MemcachedConnection.java
@@ -47,6 +47,7 @@ import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
+import net.spy.memcached.auth.AuthException;
 import net.spy.memcached.compat.SpyObject;
 import net.spy.memcached.compat.log.LoggerFactory;
 import net.spy.memcached.internal.ReconnDelay;
@@ -874,6 +875,7 @@ public final class MemcachedConnection extends SpyObject {
   private void connected(MemcachedNode qa) {
     assert qa.getChannel().isConnected() : "Not connected.";
     int rt = qa.getReconnectCount();
+    qa.setupForAuth();
     qa.connected();
     for (ConnectionObserver observer : connObservers) {
       observer.connectionEstablished(qa.getSocketAddress(), rt);
@@ -931,6 +933,9 @@ public final class MemcachedConnection extends SpyObject {
       getLogger().warn("Reconnection due to exception " +
               "handling a memcached exception on %s.", qa, e);
       lostConnection(qa, ReconnDelay.IMMEDIATE, "operation exception");
+    } catch (AuthException e) {
+      getLogger().warn("Reconnecting due to %s on %s", e.getMessage(), qa);
+      lostConnection(qa, ReconnDelay.DEFAULT, e.getMessage());
     } catch (Exception e) {
       // Any particular error processing an item should simply
       // cause us to reconnect to the server.
@@ -1183,6 +1188,7 @@ public final class MemcachedConnection extends SpyObject {
       }
     }
     /* ENABLE_REPLICATION end */
+    qa.authComplete(false);
     qa.reconnecting(type);
 
     getLogger().warn("Closing, and reopening %s, attempt %d.", qa,
@@ -1206,7 +1212,6 @@ public final class MemcachedConnection extends SpyObject {
       }
     }
 
-    qa.setupForAuth(cause);
     reconnectQueue.add(qa, type);
   }
 
@@ -1443,6 +1448,11 @@ public final class MemcachedConnection extends SpyObject {
   public void addOperation(final MemcachedNode node, final Operation o) {
     if (node == null) {
       o.cancel("no node");
+      return;
+    }
+    if (node.isAuthFailed()) {
+      o.setHandlingNode(node);
+      o.cancel("authentication failed");
       return;
     }
     if (!node.isActive() && failureMode == FailureMode.Cancel) {

--- a/src/main/java/net/spy/memcached/MemcachedNode.java
+++ b/src/main/java/net/spy/memcached/MemcachedNode.java
@@ -242,7 +242,7 @@ public interface MemcachedNode {
    * mean the node can start processing and accept new operations to
    * its input queue.
    */
-  void authComplete();
+  void authComplete(boolean isSuccessful);
 
   /**
    * Tell a node to set up for authentication.  Typically this would
@@ -250,7 +250,9 @@ public interface MemcachedNode {
    * this may mean putting any queued operations on hold to get to
    * an auth complete state.
    */
-  void setupForAuth(String cause);
+  void setupForAuth();
+
+  boolean isAuthFailed();
 
   /**
    * Count 'time out' exceptions to drop connections that fail perpetually

--- a/src/main/java/net/spy/memcached/MemcachedNodeROImpl.java
+++ b/src/main/java/net/spy/memcached/MemcachedNodeROImpl.java
@@ -194,11 +194,15 @@ public final class MemcachedNodeROImpl implements MemcachedNode {
     throw new UnsupportedOperationException();
   }
 
-  public void authComplete() {
+  public void authComplete(boolean isSuccessful) {
     throw new UnsupportedOperationException();
   }
 
-  public void setupForAuth(String cause) {
+  public void setupForAuth() {
+    throw new UnsupportedOperationException();
+  }
+
+  public boolean isAuthFailed() {
     throw new UnsupportedOperationException();
   }
 

--- a/src/main/java/net/spy/memcached/OperationFactory.java
+++ b/src/main/java/net/spy/memcached/OperationFactory.java
@@ -235,7 +235,7 @@ public interface OperationFactory {
   /**
    * Create a new SASL mechs operation.
    */
-  SASLMechsOperation saslMechs(OperationCallback cb);
+  SASLMechsOperation saslMechs(boolean isInternal, OperationCallback cb);
 
   /**
    * Create a new sasl auth operation.

--- a/src/main/java/net/spy/memcached/auth/AuthException.java
+++ b/src/main/java/net/spy/memcached/auth/AuthException.java
@@ -1,0 +1,9 @@
+package net.spy.memcached.auth;
+
+public class AuthException extends RuntimeException {
+  private static final long serialVersionUID = 7788260043728294174L;
+
+  public AuthException(String message) {
+    super(message);
+  }
+}

--- a/src/main/java/net/spy/memcached/protocol/ascii/AsciiOperationFactory.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/AsciiOperationFactory.java
@@ -147,8 +147,8 @@ public class AsciiOperationFactory extends BaseOperationFactory {
     return new ConcatenationOperationImpl(catType, key, data, cb);
   }
 
-  public SASLMechsOperation saslMechs(OperationCallback cb) {
-    return new SASLMechsOperationImpl(cb);
+  public SASLMechsOperation saslMechs(boolean isInternal, OperationCallback cb) {
+    return new SASLMechsOperationImpl(isInternal, cb);
   }
 
   public SASLStepOperation saslStep(SaslClient sc, byte[] challenge, OperationCallback cb) {

--- a/src/main/java/net/spy/memcached/protocol/ascii/SASLMechsOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/SASLMechsOperationImpl.java
@@ -18,10 +18,13 @@
 
 package net.spy.memcached.protocol.ascii;
 
+import java.io.IOException;
 import java.nio.ByteBuffer;
 
+import net.spy.memcached.auth.AuthException;
 import net.spy.memcached.ops.APIType;
 import net.spy.memcached.ops.OperationCallback;
+import net.spy.memcached.ops.OperationErrorType;
 import net.spy.memcached.ops.OperationStatus;
 import net.spy.memcached.ops.OperationType;
 import net.spy.memcached.ops.SASLMechsOperation;
@@ -35,10 +38,17 @@ final class SASLMechsOperationImpl extends OperationImpl implements SASLMechsOpe
   private static final byte[] MECHS_CMD = "sasl mech\r\n".getBytes();
   private static final String SASL_MECH_PREFIX = "SASL_MECH ";
 
-  public SASLMechsOperationImpl(OperationCallback cb) {
+  private static final OperationStatus SASL_NOT_SUPPORTED =
+          new OperationStatus(true, "NOT_SUPPORTED", StatusCode.SUCCESS);
+
+  private final boolean isInternal;
+
+  public SASLMechsOperationImpl(boolean isInternal, OperationCallback cb) {
     super(cb);
     setAPIType(APIType.SASL_MECHS);
     setOperationType(OperationType.ETC);
+
+    this.isInternal = isInternal;
   }
 
   @Override
@@ -49,14 +59,31 @@ final class SASLMechsOperationImpl extends OperationImpl implements SASLMechsOpe
   @Override
   public void handleLine(String line) {
     /**
-     * SASL_MECH SCRAM-SHA-256\r\n
+     * The server can respond with one of the following:
+     *  - SASL_MECH {mech 1} {mech 2} {mech 3} ...\r\n
+     *  - NOT_SUPPORTED\r\n
      */
     if (line.startsWith(SASL_MECH_PREFIX)) {
       String rawMechanisms = line.substring(SASL_MECH_PREFIX.length()).trim();
       String mechanisms = rawMechanisms.replaceAll("\\s+", " ").trim();
       complete(new OperationStatus(true, mechanisms, StatusCode.SUCCESS));
+    } else if (line.startsWith("NOT_SUPPORTED")) {
+      complete(SASL_NOT_SUPPORTED);
     } else {
       complete(new OperationStatus(false, line, StatusCode.fromAsciiLine(line)));
+      if (isInternal) {
+        throw new AuthException(line);
+      }
+    }
+  }
+
+  @Override
+  protected void handleError(OperationErrorType eType, String line) throws IOException {
+    if (isInternal && (line.startsWith("ERROR unknown command") ||
+                       line.startsWith("ERROR no matching command"))) {
+      complete(SASL_NOT_SUPPORTED);
+    } else {
+      super.handleError(eType, line);
     }
   }
 }

--- a/src/main/java/net/spy/memcached/protocol/binary/BinaryOperationFactory.java
+++ b/src/main/java/net/spy/memcached/protocol/binary/BinaryOperationFactory.java
@@ -156,7 +156,7 @@ public class BinaryOperationFactory extends BaseOperationFactory {
     return new SASLAuthOperationImpl(sc, cb);
   }
 
-  public SASLMechsOperation saslMechs(OperationCallback cb) {
+  public SASLMechsOperation saslMechs(boolean isInternal, OperationCallback cb) {
     return new SASLMechsOperationImpl(cb);
   }
 

--- a/src/test/java/net/spy/memcached/MockMemcachedNode.java
+++ b/src/test/java/net/spy/memcached/MockMemcachedNode.java
@@ -211,12 +211,16 @@ public class MockMemcachedNode implements MemcachedNode {
     return null;
   }
 
-  public void authComplete() {
+  public void authComplete(boolean isSuccessful) {
     // noop
   }
 
-  public void setupForAuth(String cause) {
+  public void setupForAuth() {
     // noop
+  }
+
+  public boolean isAuthFailed() {
+    return false;
   }
 
   public int getContinuousTimeout() {


### PR DESCRIPTION
### 🔗 Related Issue

- https://github.com/jam2in/arcus-works/issues/754

### ⌨️ What I did

<img width="100%" height="auto" src="https://github.com/user-attachments/assets/09bb6c42-fae4-49c3-b347-4b2b19ae2d7a" />

- NOT_SUPPORTED OperationStatus를 추가합니다.
  - NOT_SUPPORTED 응답을 받으면 SASL_OK 응답을 받은 것과 동일하게 처리합니다.
- AuthException 클래스를 추가합니다.
  - 해당 클래스는 auth 과정 중에 서버로부터 SASL_OK, SASL_CONTINUE, NOT_SUPPORTED 외의 응답을 받았을 때에 발생하는 Exception 타입입니다.
  - AuthException 객체에는 서버에서 받은 응답 메세지가 저장됩니다.
  - AuthException이 발생하면 재연결 딜레이 타입을 DEFAULT로 하여 재연결을 시도합니다.
  - 재연결이 완료되면 AuthThread 객체를 생성하여 auth 과정을 처음부터 수행합니다.
- AuthThread에서 맨 처음에 `sasl mech` 명령어를 보내도록 변경합니다.
  - unknown command 혹은 NOT_SUPPORTED 응답을 받으면 auth를 성공 처리하고 AuthThread를 종료합니다.
  - SASL 메커니즘 목록을 정상적으로 가져왔다면 `sasl auth` 명령어를 보내는 과정으로 넘어갑니다.
  - 그 외의 응답을 받은 경우 AuthException을 발생시키고 AuthThread를 종료합니다.
- `sasl auth`, `sasl step` 명령어의 응답 처리를 개선합니다.
  - SASL_OK 혹은 NOT_SUPPORTED 응답을 받으면 auth를 성공 처리하고 AuthThread를 종료합니다.
  - SASL_CONTINUE 응답을 받으면 `sasl step` 명령어를 보냅니다.
  - 그 외의 응답을 받은 경우 AuthException을 발생시키고 AuthThread를 종료합니다.
- reconnectBlocked 객체의 사용법을 개선합니다.
  - auth가 실패한 경우 reconnectBlocked에 들어가 있는 연산을 모두 캔슬시킵니다.