### PR TITLE
ENHANCE: Support binary protocol authentication

### DIFF
--- a/src/main/java/net/spy/memcached/protocol/binary/BinaryOperationFactory.java
+++ b/src/main/java/net/spy/memcached/protocol/binary/BinaryOperationFactory.java
@@ -157,7 +157,7 @@ public class BinaryOperationFactory extends BaseOperationFactory {
   }
 
   public SASLMechsOperation saslMechs(boolean isInternal, OperationCallback cb) {
-    return new SASLMechsOperationImpl(cb);
+    return new SASLMechsOperationImpl(isInternal, cb);
   }
 
   public SASLStepOperation saslStep(SaslClient sc, byte[] challenge, OperationCallback cb) {

--- a/src/main/java/net/spy/memcached/protocol/binary/SASLBaseOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/binary/SASLBaseOperationImpl.java
@@ -5,6 +5,7 @@ import java.io.IOException;
 import javax.security.sasl.SaslClient;
 import javax.security.sasl.SaslException;
 
+import net.spy.memcached.auth.AuthException;
 import net.spy.memcached.ops.OperationCallback;
 import net.spy.memcached.ops.OperationStatus;
 import net.spy.memcached.ops.StatusCode;
@@ -13,10 +14,13 @@ public abstract class SASLBaseOperationImpl extends OperationImpl {
 
   private static final OperationStatus SASL_OK =
           new OperationStatus(true, "SASL_OK", StatusCode.SUCCESS);
+  private static final OperationStatus SASL_NOT_SUPPORTED =
+          new OperationStatus(true, "NOT_SUPPORTED", StatusCode.SUCCESS);
 
   private static final int SUCCESS = 0x00;
   private static final int AUTH_ERROR = 0x20;
   private static final int SASL_CONTINUE = 0x21;
+  private static final int NOT_SUPPORTED = 0x83;
 
   protected final SaslClient sc;
   protected final byte[] challenge;
@@ -44,23 +48,22 @@ public abstract class SASLBaseOperationImpl extends OperationImpl {
   protected abstract byte[] buildResponse(SaslClient sc) throws SaslException;
 
   @Override
-  protected void decodePayload(byte[] pl) {
-    getLogger().debug("Auth response:  %s", new String(pl));
-    complete(new OperationStatus(true, new String(pl), StatusCode.SUCCESS));
-  }
-
-  @Override
   protected void finishedPayload(byte[] pl) throws IOException {
     if (errorCode == SASL_CONTINUE) {
       complete(new OperationStatus(true,
               new String(pl), StatusCode.SUCCESS));
     } else if (errorCode == SUCCESS) {
       complete(SASL_OK);
+    } else if (errorCode == NOT_SUPPORTED) {
+      complete(SASL_NOT_SUPPORTED);
     } else if (errorCode == AUTH_ERROR) {
-      complete(new OperationStatus(false,
-              "AUTH_ERROR " + new String(pl), StatusCode.ERR_AUTH));
+      String line = "AUTH_ERROR " + new String(pl);
+      complete(new OperationStatus(false, line, StatusCode.ERR_AUTH));
+      throw new AuthException(line);
     } else {
-      super.finishedPayload(pl);
+      String line = new String(pl);
+      complete(new OperationStatus(false, line, StatusCode.fromAsciiLine(line)));
+      throw new AuthException(line);
     }
   }
 


### PR DESCRIPTION
### 🔗 Related Issue

<!-- Please link related issue. ex) https://github.com/naver/arcus-java-client/issues/{issue_number} -->
- https://github.com/jam2in/arcus-works/issues/754#issuecomment-3449309985

### ⌨️ What I did

<!-- Please describe this PR and what you've been working on. -->
- Binary 프로토콜에서도 auth 기능을 사용할 수 있도록 합니다.
- Binary의 finishedPayload() 메소드를 Ascii의 handleLine()과 최대한 동일하게 구현합니다.
  - 단, `sasl mech` 명령어의 handleError() 로직을 finishedPayload() 메소드에 포함합니다.
- 다른 Binary 연산 클래스의 오버라이드된 finishedPayload() 메소드 구현을 참고하여, resetInput() 메소드 호출을 추가합니다.