### PR TITLE
FIX: Fix bug of ConnectionObserver login in initArcusClient()

### DIFF
--- a/src/main/java/net/spy/memcached/ArcusClient.java
+++ b/src/main/java/net/spy/memcached/ArcusClient.java
@@ -317,6 +317,9 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
     if (serviceCode.isEmpty()) {
       throw new IllegalArgumentException("Service code is empty.");
     }
+    if (poolSize <= 0) {
+      throw new IllegalArgumentException("Pool size must be greater than 0.");
+    }
 
     CacheManager exe = new CacheManager(hostPorts, serviceCode, cfb, poolSize, waitTimeForConnect);
     exe.start();


### PR DESCRIPTION
### 🔗 Related Issue

<!-- Please link related issue. ex) https://github.com/naver/arcus-java-client/issues/{issue_number} -->
- https://github.com/jam2in/arcus-works/issues/794

### ⌨️ What I did

<!-- Please describe this PR and what you've been working on. -->
- initArcusClient()의 ConnectionObserver 로직에서 잘못된 점을 수정하고 보완합니다.
  - 기존에는 모든 연결이 완료되기 전에 재연결이 1회라도 발생한 경우에도 latch의 count 값이 0이 되었습니다.
  - 이제는 연결이 완료된 횟수를 구하고, 필요한 총 연결 갯수와 비교하여 latch의 count를 0으로 설정합니다.
- ConnectionObserver의 역할이 다 한 이후에는 removeObserver()를 호출합니다.