### PR TITLE
CLEANUP: Move masterCandidate clear logic

### DIFF
--- a/src/main/java/net/spy/memcached/MemcachedConnection.java
+++ b/src/main/java/net/spy/memcached/MemcachedConnection.java
@@ -439,10 +439,6 @@ public final class MemcachedConnection extends SpyObject {
             removeNodes.add(oldSlaveNode);
             // move operation slave -> master.
             taskList.add(new MoveOperationTask(oldSlaveNode, oldMasterNode));
-            // clear the masterCandidate if the removed slave is the masterCandidate.
-            if (oldGroup.getMasterCandidate() == oldSlaveNode) {
-              oldGroup.clearMasterCandidate();
-            }
           }
         }
       } else if (oldSlaveAddrs.contains(newMasterAddr)) {
@@ -521,10 +517,6 @@ public final class MemcachedConnection extends SpyObject {
           removeNodes.add(oldSlaveNode);
           // move operation slave -> master.
           taskList.add(new MoveOperationTask(oldSlaveNode, newMasterNode));
-          // clear the masterCandidate if the removed slave is the masterCandidate.
-          if (oldGroup.getMasterCandidate() == oldSlaveNode) {
-            oldGroup.clearMasterCandidate();
-          }
         }
       }
     }

--- a/src/main/java/net/spy/memcached/MemcachedReplicaGroup.java
+++ b/src/main/java/net/spy/memcached/MemcachedReplicaGroup.java
@@ -86,10 +86,6 @@ public abstract class MemcachedReplicaGroup extends SpyObject {
     }
   }
 
-  public void clearMasterCandidate() {
-    this.masterCandidate = null;
-  }
-
   public void setMasterCandidateByAddr(String address) {
     for (MemcachedNode node : this.getSlaveNodes()) {
       if (address.equals(((ArcusReplNodeAddress) node.getSocketAddress()).getIPPort())) {

--- a/src/main/java/net/spy/memcached/MemcachedReplicaGroupImpl.java
+++ b/src/main/java/net/spy/memcached/MemcachedReplicaGroupImpl.java
@@ -49,6 +49,9 @@ public final class MemcachedReplicaGroupImpl extends MemcachedReplicaGroup {
       if (((ArcusReplNodeAddress) node.getSocketAddress()).isMaster()) {
         this.masterNode = null;
       } else {
+        if (this.masterCandidate == node) {
+          this.masterCandidate = null;
+        }
         this.slaveNodes.remove(node);
       }
       return true;


### PR DESCRIPTION
### 🔗 Related Issue

<!-- Please link related issue. ex) https://github.com/naver/arcus-java-client/issues/{issue_number} -->
- https://github.com/jam2in/arcus-works/issues/806

### ⌨️ What I did

<!-- Please describe this PR and what you've been working on. -->
- masterCandidate 필드 초기화 로직의 위치를 옮깁니다.