### PR TITLE
FEATURE: deprecate SMGetMode

### DIFF
--- a/docs/user_guide/07-btree-API.md
+++ b/docs/user_guide/07-btree-API.md
@@ -1183,9 +1183,9 @@ sort-merge get을 수행하는 함수는 아래와 같다.
 
 ```java
 SMGetFuture<List<SMGetElement<Object>>>
-asyncBopSortMergeGet(List<String> keyList, long from, long to, ElementFlagFilter eFlagFilter, int count, SMGetMode smgetMode)
+asyncBopSortMergeGet(List<String> keyList, long from, long to, ElementFlagFilter eFlagFilter, int count, boolean unique)
 SMGetFuture<List<SMGetElement<Object>>>
-asyncBopSortMergeGet(List<String> keyList, byte[] from, byte[] to, ElementFlagFilter eFlagFilter, int count, SMGetMode smgetMode)
+asyncBopSortMergeGet(List<String> keyList, byte[] from, byte[] to, ElementFlagFilter eFlagFilter, int count, boolean unique)
 ```
 
 - keyList: b+tree items의 key list
@@ -1195,8 +1195,7 @@ asyncBopSortMergeGet(List<String> keyList, byte[] from, byte[] to, ElementFlagFi
 - count: bkey range와 eflag filter 조건을 만족하는 elements에서 실제 조회할 element의 count 지정
   - **count 값은 1 이상 1000이하이어야 한다.**
   - 이는 sort-merge get 연산을 부담이 너무 크지 않은 연산으로 제한하기 위해서이다.
-- smgetMode: smget 수행 결과에서 중복 bkey를 허용할 지 아닐지를 지정하는 조건
-  - unique 또는 duplicate 타입을 지정한다.
+- unique: smget 수행 결과에서 중복 bkey를 허용할 지 아닐지를 지정하는 조건
 
 수행 결과는 future 객체를 통해 얻는다.
 
@@ -1223,11 +1222,10 @@ long bkeyFrom = 0L; // (1)
 long bkeyTo = 100L;
 int count = 10;
 
-SMGetMode smgetMode = SMGetMode.DUPLICATE;
 SMGetFuture<List<SMGetElement<Object>>> future = null;
 
 try {
-    future = mc.asyncBopSortMergeGet(keyList, bkeyFrom, bkeyTo, ElementFlagFilter.DO_NOT_FILTER, count, smgetMode); // (2)
+    future = mc.asyncBopSortMergeGet(keyList, bkeyFrom, bkeyTo, ElementFlagFilter.DO_NOT_FILTER, count, false); // (2)
 } catch (IllegalStateException e) {
     // handle exception
 }

--- a/src/main/java/net/spy/memcached/ArcusClientIF.java
+++ b/src/main/java/net/spy/memcached/ArcusClientIF.java
@@ -1332,6 +1332,7 @@ public interface ArcusClientIF extends MemcachedClientIF {
    * @param smgetMode   smgetMode
    * @return a future that will hold the return value list of the fetch.
    */
+  @Deprecated
   SMGetFuture<List<SMGetElement<Object>>> asyncBopSortMergeGet(
           List<String> keyList, long from, long to, ElementFlagFilter eFlagFilter,
           int count, SMGetMode smgetMode);
@@ -1865,9 +1866,42 @@ public interface ArcusClientIF extends MemcachedClientIF {
    * @param smgetMode   smgetMode
    * @return a future that will hold the return value list of the fetch.
    */
+  @Deprecated
   SMGetFuture<List<SMGetElement<Object>>> asyncBopSortMergeGet(
           List<String> keyList, byte[] from, byte[] to, ElementFlagFilter eFlagFilter,
           int count, SMGetMode smgetMode);
+
+  /**
+   * Get elements that matched both filter and bkey range criteria from
+   * multiple b+tree. The result is sorted by order of bkey.
+   *
+   * @param keyList     b+ tree key list
+   * @param from        bkey index from
+   * @param to          bkey index to
+   * @param eFlagFilter element flag filter
+   * @param count       number of returning values. must be larger than 0 and not more than 1000.
+   * @param unique      true if only unique bkeys are returned.
+   * @return a future that will hold the return value list of the fetch.
+   */
+  SMGetFuture<List<SMGetElement<Object>>> asyncBopSortMergeGet(
+          List<String> keyList, byte[] from, byte[] to, ElementFlagFilter eFlagFilter,
+          int count, boolean unique);
+
+  /**
+   * Get elements that matched both filter and bkey range criteria from
+   * multiple b+tree. The result is sorted by order of bkey.
+   *
+   * @param keyList     b+ tree key list
+   * @param from        bkey index from
+   * @param to          bkey index to
+   * @param eFlagFilter element flag filter
+   * @param count       number of returning values. must be larger than 0 and not more than 1000.
+   * @param unique      true if only unique bkeys are returned.
+   * @return a future that will hold the return value list of the fetch.
+   */
+  SMGetFuture<List<SMGetElement<Object>>> asyncBopSortMergeGet(
+          List<String> keyList, long from, long to, ElementFlagFilter eFlagFilter,
+          int count, boolean unique);
 
   /**
    * Insert one item into multiple b+trees at once.

--- a/src/main/java/net/spy/memcached/ArcusClientPool.java
+++ b/src/main/java/net/spy/memcached/ArcusClientPool.java
@@ -1086,6 +1086,7 @@ public class ArcusClientPool implements MemcachedClientIF, ArcusClientIF {
     return this.getClient().flush(prefix, delay);
   }
 
+  @Deprecated
   @Override
   public SMGetFuture<List<SMGetElement<Object>>> asyncBopSortMergeGet(
           List<String> keyList, long from, long to,
@@ -1337,12 +1338,29 @@ public class ArcusClientPool implements MemcachedClientIF, ArcusClientIF {
             count, withDelete, dropIfEmpty, tc);
   }
 
+  @Deprecated
   @Override
   public SMGetFuture<List<SMGetElement<Object>>> asyncBopSortMergeGet(
           List<String> keyList, byte[] from, byte[] to,
           ElementFlagFilter eFlagFilter, int count, SMGetMode smgetMode) {
     return this.getClient().asyncBopSortMergeGet(keyList, from, to,
             eFlagFilter, count, smgetMode);
+  }
+
+  @Override
+  public SMGetFuture<List<SMGetElement<Object>>> asyncBopSortMergeGet(
+          List<String> keyList, byte[] from, byte[] to, ElementFlagFilter eFlagFilter,
+          int count, boolean unique) {
+    return this.getClient().asyncBopSortMergeGet(keyList, from, to,
+            eFlagFilter, count, unique);
+  }
+
+  @Override
+  public SMGetFuture<List<SMGetElement<Object>>> asyncBopSortMergeGet(
+          List<String> keyList, long from, long to, ElementFlagFilter eFlagFilter,
+          int count, boolean unique) {
+    return this.getClient().asyncBopSortMergeGet(keyList, from, to,
+            eFlagFilter, count, unique);
   }
 
   @Override

--- a/src/main/java/net/spy/memcached/collection/BTreeSMGetImpl.java
+++ b/src/main/java/net/spy/memcached/collection/BTreeSMGetImpl.java
@@ -36,7 +36,7 @@ public abstract class BTreeSMGetImpl<T> implements BTreeSMGet<T> {
   protected final String range;
   protected final ElementFlagFilter eFlagFilter;
   protected final int count;
-  protected final SMGetMode smgetMode;
+  protected final boolean unique;
 
   private String key;
   private int flags;
@@ -47,13 +47,13 @@ public abstract class BTreeSMGetImpl<T> implements BTreeSMGet<T> {
   protected BTreeSMGetImpl(MemcachedNode node, List<String> keyList,
                            String range,
                            ElementFlagFilter eFlagFilter,
-                           int count, SMGetMode smgetMode) {
+                           int count, boolean unique) {
     this.node = node;
     this.keyList = keyList;
     this.range = range;
     this.eFlagFilter = eFlagFilter;
     this.count = count;
-    this.smgetMode = smgetMode;
+    this.unique = unique;
   }
 
   public void setKeySeparator(String keySeparator) {
@@ -98,7 +98,11 @@ public abstract class BTreeSMGetImpl<T> implements BTreeSMGet<T> {
       b.append(" ").append(eFlagFilter);
     }
     b.append(" ").append(count);
-    b.append(" ").append(smgetMode.getMode());
+    if (unique) {
+      b.append(" unique");
+    } else {
+      b.append(" duplicate");
+    }
 
     str = b.toString();
     return str;

--- a/src/main/java/net/spy/memcached/collection/BTreeSMGetWithByteTypeBkey.java
+++ b/src/main/java/net/spy/memcached/collection/BTreeSMGetWithByteTypeBkey.java
@@ -26,16 +26,16 @@ public class BTreeSMGetWithByteTypeBkey<T> extends BTreeSMGetImpl<T> {
   public BTreeSMGetWithByteTypeBkey(MemcachedNode node, List<String> keyList,
                                     byte[] from, byte[] to,
                                     ElementFlagFilter eFlagFilter,
-                                    int count, SMGetMode smgetMode) {
+                                    int count, boolean unique) {
     super(node, keyList, BTreeUtil.toHex(from) + ".." + BTreeUtil.toHex(to),
-        eFlagFilter, count, smgetMode);
+        eFlagFilter, count, unique);
   }
 
   private BTreeSMGetWithByteTypeBkey(MemcachedNode node, List<String> keyList,
                                      String range,
                                      ElementFlagFilter eFlagFilter,
-                                     int count, SMGetMode smgetMode) {
-    super(node, keyList, range, eFlagFilter, count, smgetMode);
+                                     int count, boolean unique) {
+    super(node, keyList, range, eFlagFilter, count, unique);
   }
 
   @Override
@@ -51,6 +51,6 @@ public class BTreeSMGetWithByteTypeBkey<T> extends BTreeSMGetImpl<T> {
   @Override
   public BTreeSMGet<T> clone(MemcachedNode node, List<String> keyList) {
     return new BTreeSMGetWithByteTypeBkey<>(node, keyList,
-            range, eFlagFilter, count, smgetMode);
+            range, eFlagFilter, count, unique);
   }
 }

--- a/src/main/java/net/spy/memcached/collection/BTreeSMGetWithLongTypeBkey.java
+++ b/src/main/java/net/spy/memcached/collection/BTreeSMGetWithLongTypeBkey.java
@@ -25,15 +25,15 @@ public class BTreeSMGetWithLongTypeBkey<T> extends BTreeSMGetImpl<T> {
   public BTreeSMGetWithLongTypeBkey(MemcachedNode node, List<String> keyList,
                                     long from, long to,
                                     ElementFlagFilter eFlagFilter,
-                                    int count, SMGetMode smgetMode) {
-    super(node, keyList, from + ".." + to, eFlagFilter, count, smgetMode);
+                                    int count, boolean unique) {
+    super(node, keyList, from + ".." + to, eFlagFilter, count, unique);
   }
 
   private BTreeSMGetWithLongTypeBkey(MemcachedNode node, List<String> keyList,
                                      String range,
                                      ElementFlagFilter eFlagFilter,
-                                     int count, SMGetMode smgetMode) {
-    super(node, keyList, range, eFlagFilter, count, smgetMode);
+                                     int count, boolean unique) {
+    super(node, keyList, range, eFlagFilter, count, unique);
   }
 
   @Override
@@ -49,6 +49,6 @@ public class BTreeSMGetWithLongTypeBkey<T> extends BTreeSMGetImpl<T> {
   @Override
   public BTreeSMGet<T> clone(MemcachedNode node, List<String> keyList) {
     return new BTreeSMGetWithLongTypeBkey<>(node, keyList,
-            range, eFlagFilter, count, smgetMode);
+            range, eFlagFilter, count, unique);
   }
 }

--- a/src/main/java/net/spy/memcached/collection/SMGetMode.java
+++ b/src/main/java/net/spy/memcached/collection/SMGetMode.java
@@ -3,6 +3,7 @@ package net.spy.memcached.collection;
 /**
  * A type component for "bop smgetmode"
  */
+@Deprecated
 public enum SMGetMode {
   UNIQUE("unique"),
   DUPLICATE("duplicate");

--- a/src/test/java/net/spy/memcached/ArcusTimeoutTest.java
+++ b/src/test/java/net/spy/memcached/ArcusTimeoutTest.java
@@ -30,7 +30,6 @@ import java.util.concurrent.TimeoutException;
 import net.spy.memcached.collection.CollectionAttributes;
 import net.spy.memcached.collection.ElementFlagFilter;
 import net.spy.memcached.collection.SMGetElement;
-import net.spy.memcached.collection.SMGetMode;
 import net.spy.memcached.internal.CollectionFuture;
 import net.spy.memcached.internal.OperationFuture;
 import net.spy.memcached.internal.SMGetFuture;
@@ -233,10 +232,8 @@ class ArcusTimeoutTest {
       keyList.add(KEY + i);
     }
 
-    SMGetMode smgetMode = SMGetMode.UNIQUE;
-
     SMGetFuture<List<SMGetElement<Object>>> future = mc.asyncBopSortMergeGet(
-            keyList, 0, 1000, ElementFlagFilter.DO_NOT_FILTER, 500, smgetMode);
+            keyList, 0, 1000, ElementFlagFilter.DO_NOT_FILTER, 500, true);
     assertThrows(TimeoutException.class, () -> future.get(1L, TimeUnit.MILLISECONDS));
   }
 
@@ -250,10 +247,8 @@ class ArcusTimeoutTest {
     byte[] from = new byte[]{(byte) 0};
     byte[] to = new byte[]{(byte) 1000};
 
-    SMGetMode smgetMode = SMGetMode.UNIQUE;
-
     SMGetFuture<List<SMGetElement<Object>>> future = mc.asyncBopSortMergeGet(
-            keyList, from, to, ElementFlagFilter.DO_NOT_FILTER, 500, smgetMode);
+            keyList, from, to, ElementFlagFilter.DO_NOT_FILTER, 500, true);
     assertThrows(TimeoutException.class, () -> future.get(1L, TimeUnit.MILLISECONDS));
   }
 

--- a/src/test/manual/net/spy/memcached/LongKeyTest/BaseLongKeyTest.java
+++ b/src/test/manual/net/spy/memcached/LongKeyTest/BaseLongKeyTest.java
@@ -12,7 +12,6 @@ import net.spy.memcached.collection.CollectionAttributes;
 import net.spy.memcached.collection.Element;
 import net.spy.memcached.collection.ElementFlagFilter;
 import net.spy.memcached.collection.SMGetElement;
-import net.spy.memcached.collection.SMGetMode;
 import net.spy.memcached.internal.BulkFuture;
 import net.spy.memcached.internal.CollectionGetBulkFuture;
 import net.spy.memcached.internal.SMGetFuture;
@@ -175,10 +174,9 @@ class BaseLongKeyTest extends BaseIntegrationTest {
       assertTrue(mc.asyncBopInsert(keys.get(i), i, null, "VALUE" + i,
               new CollectionAttributes()).get());
     }
-    SMGetMode smgetMode = SMGetMode.UNIQUE;
     SMGetFuture<List<SMGetElement<Object>>> future = mc
             .asyncBopSortMergeGet(keys, 0, 10,
-                    ElementFlagFilter.DO_NOT_FILTER, 10, smgetMode);
+                    ElementFlagFilter.DO_NOT_FILTER, 10, true);
     try {
       List<SMGetElement<Object>> map = future
               .get();

--- a/src/test/manual/net/spy/memcached/MultibyteKeyTest.java
+++ b/src/test/manual/net/spy/memcached/MultibyteKeyTest.java
@@ -49,7 +49,6 @@ import net.spy.memcached.collection.CollectionPipedUpdate;
 import net.spy.memcached.collection.Element;
 import net.spy.memcached.collection.ElementFlagFilter;
 import net.spy.memcached.collection.ElementFlagUpdate;
-import net.spy.memcached.collection.SMGetMode;
 import net.spy.memcached.collection.SetExist;
 import net.spy.memcached.collection.SetPipedExist;
 import net.spy.memcached.ops.BTreeFindPositionOperation;
@@ -280,7 +279,7 @@ class MultibyteKeyTest {
     try {
       opFact.bopsmget(
               new BTreeSMGetWithLongTypeBkey<>(null,
-                      keyList, 0L, 100L, ElementFlagFilter.DO_NOT_FILTER, 0, SMGetMode.UNIQUE),
+                      keyList, 0L, 100L, ElementFlagFilter.DO_NOT_FILTER, 0, true),
           new BTreeSortMergeGetOperation.Callback() {
             @Override
             public void gotData(String key, int flags, Object bkey, byte[] eflag, byte[] data) {

--- a/src/test/manual/net/spy/memcached/btreesmget/ByteArrayBKeySMGetErrorTest.java
+++ b/src/test/manual/net/spy/memcached/btreesmget/ByteArrayBKeySMGetErrorTest.java
@@ -27,7 +27,6 @@ import net.spy.memcached.collection.CollectionOverflowAction;
 import net.spy.memcached.collection.ElementFlagFilter;
 import net.spy.memcached.collection.ElementValueType;
 import net.spy.memcached.collection.SMGetElement;
-import net.spy.memcached.collection.SMGetMode;
 import net.spy.memcached.internal.SMGetFuture;
 
 import org.junit.jupiter.api.AfterEach;
@@ -90,11 +89,10 @@ class ByteArrayBKeySMGetErrorTest extends BaseIntegrationTest {
     }
 
     // sort merge get
-    SMGetMode smgetMode = SMGetMode.DUPLICATE;
     SMGetFuture<List<SMGetElement<Object>>> future = mc
             .asyncBopSortMergeGet(KEY_LIST, new byte[]{(byte) 0},
                     new byte[]{(byte) 10},
-                    ElementFlagFilter.DO_NOT_FILTER, 10, smgetMode);
+                    ElementFlagFilter.DO_NOT_FILTER, 10, false);
     try {
       List<SMGetElement<Object>> map = future.get(1000L, TimeUnit.SECONDS);
       assertEquals(3, map.size());
@@ -130,11 +128,10 @@ class ByteArrayBKeySMGetErrorTest extends BaseIntegrationTest {
     }
 
     // sort merge get
-    SMGetMode smgetMode = SMGetMode.UNIQUE;
     SMGetFuture<List<SMGetElement<Object>>> future = mc
             .asyncBopSortMergeGet(KEY_LIST, new byte[]{(byte) 0},
                     new byte[]{(byte) 15},
-                    ElementFlagFilter.DO_NOT_FILTER, 20, smgetMode);
+                    ElementFlagFilter.DO_NOT_FILTER, 20, true);
     try {
       List<SMGetElement<Object>> map = future.get(1000L, TimeUnit.SECONDS);
       assertEquals(0, map.size());
@@ -180,10 +177,9 @@ class ByteArrayBKeySMGetErrorTest extends BaseIntegrationTest {
     byte[] to = new byte[]{(byte) 10};
     long count = 100;
 
-    SMGetMode smgetMode = SMGetMode.UNIQUE;
     SMGetFuture<List<SMGetElement<Object>>> future = mc
             .asyncBopSortMergeGet(KEY_LIST, from, to,
-                    ElementFlagFilter.DO_NOT_FILTER, (int) count, smgetMode);
+                    ElementFlagFilter.DO_NOT_FILTER, (int) count, true);
     try {
       List<SMGetElement<Object>> map = future.get(1000L, TimeUnit.SECONDS);
       assertEquals(1, map.size());
@@ -229,10 +225,9 @@ class ByteArrayBKeySMGetErrorTest extends BaseIntegrationTest {
     byte[] to = new byte[]{(byte) 0};
     long count = 100;
 
-    SMGetMode smgetMode = SMGetMode.UNIQUE;
     SMGetFuture<List<SMGetElement<Object>>> future = mc
             .asyncBopSortMergeGet(KEY_LIST, from, to,
-                    ElementFlagFilter.DO_NOT_FILTER, (int) count, smgetMode);
+                    ElementFlagFilter.DO_NOT_FILTER, (int) count, true);
     try {
       List<SMGetElement<Object>> map = future.get(1000L, TimeUnit.SECONDS);
       assertEquals(9, map.size());
@@ -260,10 +255,9 @@ class ByteArrayBKeySMGetErrorTest extends BaseIntegrationTest {
     }
 
     // sort merge get
-    SMGetMode smgetMode = SMGetMode.DUPLICATE;
     SMGetFuture<List<SMGetElement<Object>>> future = mc
             .asyncBopSortMergeGet(KEY_LIST, 10, 0,
-                    ElementFlagFilter.DO_NOT_FILTER, 10, smgetMode);
+                    ElementFlagFilter.DO_NOT_FILTER, 10, false);
     try {
       List<SMGetElement<Object>> map = future.get(1000L, TimeUnit.SECONDS);
       assertEquals(10, map.size());

--- a/src/test/manual/net/spy/memcached/btreesmget/ByteArrayBKeySMGetIrregularEflagTest.java
+++ b/src/test/manual/net/spy/memcached/btreesmget/ByteArrayBKeySMGetIrregularEflagTest.java
@@ -24,7 +24,6 @@ import net.spy.memcached.collection.BaseIntegrationTest;
 import net.spy.memcached.collection.CollectionAttributes;
 import net.spy.memcached.collection.ElementFlagFilter;
 import net.spy.memcached.collection.SMGetElement;
-import net.spy.memcached.collection.SMGetMode;
 
 import org.junit.jupiter.api.Test;
 
@@ -65,10 +64,9 @@ class ByteArrayBKeySMGetIrregularEflagTest extends BaseIntegrationTest {
       mc.asyncBopInsert(key2, new byte[]{4}, eFlag, value + "2",
               new CollectionAttributes()).get();
 
-      SMGetMode smgetMode = SMGetMode.UNIQUE;
       List<SMGetElement<Object>> list = mc.asyncBopSortMergeGet(
               testKeyList, new byte[]{0}, new byte[]{10},
-              ElementFlagFilter.DO_NOT_FILTER, 10, smgetMode).get();
+              ElementFlagFilter.DO_NOT_FILTER, 10, true).get();
 
       for (int i = 0; i < list.size(); i++) {
         System.out.println(list.get(i));

--- a/src/test/manual/net/spy/memcached/btreesmget/ByteArrayBKeySMGetTest.java
+++ b/src/test/manual/net/spy/memcached/btreesmget/ByteArrayBKeySMGetTest.java
@@ -27,7 +27,6 @@ import net.spy.memcached.collection.BaseIntegrationTest;
 import net.spy.memcached.collection.CollectionAttributes;
 import net.spy.memcached.collection.ElementFlagFilter;
 import net.spy.memcached.collection.SMGetElement;
-import net.spy.memcached.collection.SMGetMode;
 import net.spy.memcached.internal.SMGetFuture;
 import net.spy.memcached.ops.CollectionOperationStatus;
 
@@ -75,10 +74,9 @@ class ByteArrayBKeySMGetTest extends BaseIntegrationTest {
     byte[] from = new byte[]{(byte) 1};
     byte[] to = new byte[]{(byte) 2};
 
-    SMGetMode smgetMode = SMGetMode.UNIQUE;
     SMGetFuture<List<SMGetElement<Object>>> future = mc
             .asyncBopSortMergeGet(keyList, from, to,
-                    ElementFlagFilter.DO_NOT_FILTER, 10, smgetMode);
+                    ElementFlagFilter.DO_NOT_FILTER, 10, true);
     try {
       List<SMGetElement<Object>> map = future.get(1000L, TimeUnit.SECONDS);
       assertTrue(map.isEmpty());
@@ -109,10 +107,9 @@ class ByteArrayBKeySMGetTest extends BaseIntegrationTest {
     byte[] from = new byte[]{(byte) 0};
     byte[] to = new byte[]{(byte) 10};
 
-    SMGetMode smgetMode = SMGetMode.UNIQUE;
     SMGetFuture<List<SMGetElement<Object>>> future = mc
             .asyncBopSortMergeGet(keyList, from, to,
-                    ElementFlagFilter.DO_NOT_FILTER, 10, smgetMode);
+                    ElementFlagFilter.DO_NOT_FILTER, 10, true);
     try {
       List<SMGetElement<Object>> map = future.get(1000L, TimeUnit.SECONDS);
       assertEquals(10, map.size());
@@ -150,10 +147,9 @@ class ByteArrayBKeySMGetTest extends BaseIntegrationTest {
     byte[] from = new byte[]{(byte) 0};
     byte[] to = new byte[]{(byte) 10};
 
-    SMGetMode smgetMode = SMGetMode.DUPLICATE;
     SMGetFuture<List<SMGetElement<Object>>> future = mc
             .asyncBopSortMergeGet(keyList, from, to,
-                    ElementFlagFilter.DO_NOT_FILTER, 10, smgetMode);
+                    ElementFlagFilter.DO_NOT_FILTER, 10, false);
     try {
       List<SMGetElement<Object>> map = future.get(1000L, TimeUnit.SECONDS);
       assertEquals(10, map.size());
@@ -191,10 +187,9 @@ class ByteArrayBKeySMGetTest extends BaseIntegrationTest {
     byte[] from = new byte[]{(byte) 0};
     byte[] to = new byte[]{(byte) 10};
 
-    SMGetMode smgetMode = SMGetMode.DUPLICATE;
     SMGetFuture<List<SMGetElement<Object>>> future = mc
             .asyncBopSortMergeGet(keyList, from, to,
-                    ElementFlagFilter.DO_NOT_FILTER, 10, smgetMode);
+                    ElementFlagFilter.DO_NOT_FILTER, 10, false);
     try {
       List<SMGetElement<Object>> map = future.get(1000L, TimeUnit.SECONDS);
       assertEquals(10, map.size());
@@ -232,10 +227,9 @@ class ByteArrayBKeySMGetTest extends BaseIntegrationTest {
     byte[] from = new byte[]{(byte) 0};
     byte[] to = new byte[]{(byte) 10};
 
-    SMGetMode smgetMode = SMGetMode.DUPLICATE;
     SMGetFuture<List<SMGetElement<Object>>> future = mc
             .asyncBopSortMergeGet(keyList, from, to,
-                    ElementFlagFilter.DO_NOT_FILTER, 10, smgetMode);
+                    ElementFlagFilter.DO_NOT_FILTER, 10, false);
     try {
       List<SMGetElement<Object>> map = future.get(1000L, TimeUnit.SECONDS);
       assertEquals(9, map.size());
@@ -273,10 +267,9 @@ class ByteArrayBKeySMGetTest extends BaseIntegrationTest {
     byte[] from = new byte[]{(byte) 0};
     byte[] to = new byte[]{(byte) 10};
 
-    SMGetMode smgetMode = SMGetMode.UNIQUE;
     SMGetFuture<List<SMGetElement<Object>>> future = mc
             .asyncBopSortMergeGet(keyList, from, to,
-                    ElementFlagFilter.DO_NOT_FILTER, 10, smgetMode);
+                    ElementFlagFilter.DO_NOT_FILTER, 10, true);
     try {
       List<SMGetElement<Object>> map = future.get(1000L, TimeUnit.SECONDS);
       assertEquals(10, map.size());
@@ -308,10 +301,9 @@ class ByteArrayBKeySMGetTest extends BaseIntegrationTest {
     byte[] from = new byte[]{(byte) 0};
     byte[] to = new byte[]{(byte) 10};
 
-    SMGetMode smgetMode = SMGetMode.UNIQUE;
     SMGetFuture<List<SMGetElement<Object>>> future = mc
             .asyncBopSortMergeGet(keyList, from, to,
-                    ElementFlagFilter.DO_NOT_FILTER, 10, smgetMode);
+                    ElementFlagFilter.DO_NOT_FILTER, 10, true);
     try {
       List<SMGetElement<Object>> map = future.get(1000L, TimeUnit.SECONDS);
       assertEquals(5, map.size());
@@ -343,10 +335,9 @@ class ByteArrayBKeySMGetTest extends BaseIntegrationTest {
     byte[] from = new byte[]{(byte) 0};
     byte[] to = new byte[]{(byte) 10};
 
-    SMGetMode smgetMode = SMGetMode.UNIQUE;
     SMGetFuture<List<SMGetElement<Object>>> future = mc
             .asyncBopSortMergeGet(keyList, from, to,
-                    ElementFlagFilter.DO_NOT_FILTER, 10, smgetMode);
+                    ElementFlagFilter.DO_NOT_FILTER, 10, true);
     try {
       List<SMGetElement<Object>> map = future.get(1000L, TimeUnit.SECONDS);
       assertEquals(5, map.size());
@@ -380,10 +371,9 @@ class ByteArrayBKeySMGetTest extends BaseIntegrationTest {
     byte[] from = new byte[]{(byte) 0};
     byte[] to = new byte[]{(byte) 1000};
 
-    SMGetMode smgetMode = SMGetMode.DUPLICATE;
     SMGetFuture<List<SMGetElement<Object>>> future = mc
             .asyncBopSortMergeGet(keyList, from, to,
-                    ElementFlagFilter.DO_NOT_FILTER, 500, smgetMode);
+                    ElementFlagFilter.DO_NOT_FILTER, 500, false);
     try {
       List<SMGetElement<Object>> map = future.get(1000L, TimeUnit.MILLISECONDS);
       // System.out.println("elapsed 1 "
@@ -423,10 +413,9 @@ class ByteArrayBKeySMGetTest extends BaseIntegrationTest {
     byte[] from = new byte[]{(byte) 0};
     byte[] to = new byte[]{(byte) 100};
 
-    SMGetMode smgetMode = SMGetMode.UNIQUE;
     SMGetFuture<List<SMGetElement<Object>>> future = mc
             .asyncBopSortMergeGet(keyList, from, to,
-                    ElementFlagFilter.DO_NOT_FILTER, 500, smgetMode);
+                    ElementFlagFilter.DO_NOT_FILTER, 500, true);
     try {
       List<SMGetElement<Object>> map = future.get(1000L, TimeUnit.SECONDS);
       assertEquals(50, map.size());

--- a/src/test/manual/net/spy/memcached/btreesmget/SMGetErrorTest.java
+++ b/src/test/manual/net/spy/memcached/btreesmget/SMGetErrorTest.java
@@ -29,7 +29,6 @@ import net.spy.memcached.collection.Element;
 import net.spy.memcached.collection.ElementFlagFilter;
 import net.spy.memcached.collection.ElementValueType;
 import net.spy.memcached.collection.SMGetElement;
-import net.spy.memcached.collection.SMGetMode;
 import net.spy.memcached.internal.SMGetFuture;
 
 import org.junit.jupiter.api.AfterEach;
@@ -89,10 +88,9 @@ class SMGetErrorTest extends BaseIntegrationTest {
     }
 
     // sort merge get
-    SMGetMode smgetMode = SMGetMode.DUPLICATE;
     SMGetFuture<List<SMGetElement<Object>>> future = mc
             .asyncBopSortMergeGet(KEY_LIST, 0, 10,
-                    ElementFlagFilter.DO_NOT_FILTER, 10, smgetMode);
+                    ElementFlagFilter.DO_NOT_FILTER, 10, false);
     try {
       List<SMGetElement<Object>> map = future.get(1000L, TimeUnit.SECONDS);
       assertEquals(3, map.size());
@@ -129,10 +127,9 @@ class SMGetErrorTest extends BaseIntegrationTest {
     }
 
     // sort merge get
-    SMGetMode smgetMode = SMGetMode.UNIQUE;
     SMGetFuture<List<SMGetElement<Object>>> future = mc
             .asyncBopSortMergeGet(KEY_LIST, 0, 15,
-                    ElementFlagFilter.DO_NOT_FILTER, 20, smgetMode);
+                    ElementFlagFilter.DO_NOT_FILTER, 20, true);
     try {
       List<SMGetElement<Object>> map = future.get(1000L, TimeUnit.SECONDS);
       assertEquals(0, map.size());
@@ -204,10 +201,9 @@ class SMGetErrorTest extends BaseIntegrationTest {
     long to = 10;
     long count = from - to;
 
-    SMGetMode smgetMode = SMGetMode.UNIQUE;
     SMGetFuture<List<SMGetElement<Object>>> future = mc
             .asyncBopSortMergeGet(KEY_LIST, from, to,
-                    ElementFlagFilter.DO_NOT_FILTER, (int) count, smgetMode);
+                    ElementFlagFilter.DO_NOT_FILTER, (int) count, true);
     try {
       List<SMGetElement<Object>> map = future.get(1000L, TimeUnit.SECONDS);
       assertEquals(1, map.size());
@@ -279,10 +275,9 @@ class SMGetErrorTest extends BaseIntegrationTest {
     long to = 0;
     long count = from - to;
 
-    SMGetMode smgetMode = SMGetMode.UNIQUE;
     SMGetFuture<List<SMGetElement<Object>>> future = mc
             .asyncBopSortMergeGet(KEY_LIST, from, to,
-                    ElementFlagFilter.DO_NOT_FILTER, (int) count, smgetMode);
+                    ElementFlagFilter.DO_NOT_FILTER, (int) count, true);
     try {
       List<SMGetElement<Object>> map = future.get(1000L, TimeUnit.SECONDS);
       assertEquals(9, map.size());
@@ -310,10 +305,9 @@ class SMGetErrorTest extends BaseIntegrationTest {
     }
 
     // sort merge get
-    SMGetMode smgetMode = SMGetMode.DUPLICATE;
     SMGetFuture<List<SMGetElement<Object>>> future = mc
             .asyncBopSortMergeGet(KEY_LIST, 10, 0,
-                    ElementFlagFilter.DO_NOT_FILTER, 10, smgetMode);
+                    ElementFlagFilter.DO_NOT_FILTER, 10, false);
     try {
       List<SMGetElement<Object>> map = future.get(1000L, TimeUnit.SECONDS);
       assertEquals(10, map.size());
@@ -349,9 +343,8 @@ class SMGetErrorTest extends BaseIntegrationTest {
     testKeyList.add(KEY_LIST.get(1));
 
     // sort merge get
-    SMGetMode smgetMode = SMGetMode.UNIQUE;
     SMGetFuture<List<SMGetElement<Object>>> future = mc.asyncBopSortMergeGet(
-        testKeyList, 10, 0, ElementFlagFilter.DO_NOT_FILTER, 10, smgetMode);
+        testKeyList, 10, 0, ElementFlagFilter.DO_NOT_FILTER, 10, true);
     try {
       List<SMGetElement<Object>> map = future.get(1000L, TimeUnit.SECONDS);
       assertEquals(0, map.size());
@@ -388,9 +381,8 @@ class SMGetErrorTest extends BaseIntegrationTest {
     }
 
     // keylist is null
-    SMGetMode smgetMode = SMGetMode.UNIQUE;
     try {
-      mc.asyncBopSortMergeGet(null, 10, 0, ElementFlagFilter.DO_NOT_FILTER, 10, smgetMode);
+      mc.asyncBopSortMergeGet(null, 10, 0, ElementFlagFilter.DO_NOT_FILTER, 10, true);
       fail("This should be an exception");
     } catch (Exception e) {
       assertEquals("Key list is null.", e.getMessage());
@@ -399,7 +391,7 @@ class SMGetErrorTest extends BaseIntegrationTest {
     // keylist is empty
     try {
       mc.asyncBopSortMergeGet(
-              new ArrayList<>(), 10, 0, ElementFlagFilter.DO_NOT_FILTER, 10, smgetMode);
+              new ArrayList<>(), 10, 0, ElementFlagFilter.DO_NOT_FILTER, 10, true);
       fail("This should be an exception");
     } catch (Exception e) {
       assertEquals("Key list is empty.", e.getMessage());
@@ -407,7 +399,7 @@ class SMGetErrorTest extends BaseIntegrationTest {
 
     // count == 0
     try {
-      mc.asyncBopSortMergeGet(testKeyList, 10, 0, ElementFlagFilter.DO_NOT_FILTER, 0, smgetMode);
+      mc.asyncBopSortMergeGet(testKeyList, 10, 0, ElementFlagFilter.DO_NOT_FILTER, 0, true);
       fail("This should be an exception");
     } catch (Exception e) {
       assertEquals("Count must be larger than 0.", e.getMessage());
@@ -417,7 +409,7 @@ class SMGetErrorTest extends BaseIntegrationTest {
     try {
       // add duplicate key to testKeyList
       testKeyList.add(KEY_LIST.get(1));
-      mc.asyncBopSortMergeGet(testKeyList, 10, 0, ElementFlagFilter.DO_NOT_FILTER, 10, smgetMode);
+      mc.asyncBopSortMergeGet(testKeyList, 10, 0, ElementFlagFilter.DO_NOT_FILTER, 10, true);
       fail("This should be an exception");
     } catch (Exception e) {
       assertEquals("Duplicate keys exist in key list.", e.getMessage());

--- a/src/test/manual/net/spy/memcached/btreesmget/SMGetTest.java
+++ b/src/test/manual/net/spy/memcached/btreesmget/SMGetTest.java
@@ -28,7 +28,6 @@ import net.spy.memcached.collection.CollectionAttributes;
 import net.spy.memcached.collection.ElementFlagFilter;
 import net.spy.memcached.collection.ElementMultiFlagsFilter;
 import net.spy.memcached.collection.SMGetElement;
-import net.spy.memcached.collection.SMGetMode;
 import net.spy.memcached.internal.SMGetFuture;
 import net.spy.memcached.ops.CollectionOperationStatus;
 
@@ -71,10 +70,9 @@ class SMGetTest extends BaseIntegrationTest {
       fail(e.getMessage());
     }
 
-    SMGetMode smgetMode = SMGetMode.UNIQUE;
     SMGetFuture<List<SMGetElement<Object>>> future = mc
             .asyncBopSortMergeGet(keyList, 1, 2,
-                    ElementFlagFilter.DO_NOT_FILTER, 10, smgetMode);
+                    ElementFlagFilter.DO_NOT_FILTER, 10, true);
     try {
       List<SMGetElement<Object>> map = future.get(1000L, TimeUnit.SECONDS);
       assertTrue(map.isEmpty());
@@ -102,10 +100,9 @@ class SMGetTest extends BaseIntegrationTest {
       fail(e.getMessage());
     }
 
-    SMGetMode smgetMode = SMGetMode.UNIQUE;
     SMGetFuture<List<SMGetElement<Object>>> future = mc
             .asyncBopSortMergeGet(keyList, 0, 10,
-                    ElementFlagFilter.DO_NOT_FILTER, 10, smgetMode);
+                    ElementFlagFilter.DO_NOT_FILTER, 10, true);
     try {
       List<SMGetElement<Object>> map = future.get(1000L, TimeUnit.SECONDS);
       assertEquals(10, map.size());
@@ -139,10 +136,9 @@ class SMGetTest extends BaseIntegrationTest {
       fail(e.getMessage());
     }
 
-    SMGetMode smgetMode = SMGetMode.UNIQUE;
     SMGetFuture<List<SMGetElement<Object>>> future = mc
             .asyncBopSortMergeGet(keyList, 0, 10,
-                    ElementFlagFilter.DO_NOT_FILTER, 10, smgetMode);
+                    ElementFlagFilter.DO_NOT_FILTER, 10, true);
     try {
       List<SMGetElement<Object>> map = future.get(1000L, TimeUnit.SECONDS);
       assertEquals(10, map.size());
@@ -176,10 +172,9 @@ class SMGetTest extends BaseIntegrationTest {
       fail(e.getMessage());
     }
 
-    SMGetMode smgetMode = SMGetMode.UNIQUE;
     SMGetFuture<List<SMGetElement<Object>>> future = mc
             .asyncBopSortMergeGet(keyList, 0, 10,
-                    ElementFlagFilter.DO_NOT_FILTER, 10, smgetMode);
+                    ElementFlagFilter.DO_NOT_FILTER, 10, true);
     try {
       List<SMGetElement<Object>> map = future.get(1000L, TimeUnit.SECONDS);
       assertEquals(10, map.size());
@@ -213,10 +208,9 @@ class SMGetTest extends BaseIntegrationTest {
       fail(e.getMessage());
     }
 
-    SMGetMode smgetMode = SMGetMode.UNIQUE;
     SMGetFuture<List<SMGetElement<Object>>> future = mc
             .asyncBopSortMergeGet(keyList, 0, 10,
-                    ElementFlagFilter.DO_NOT_FILTER, 10, smgetMode);
+                    ElementFlagFilter.DO_NOT_FILTER, 10, true);
     try {
       List<SMGetElement<Object>> map = future.get(1000L, TimeUnit.SECONDS);
       assertEquals(9, map.size());
@@ -250,10 +244,9 @@ class SMGetTest extends BaseIntegrationTest {
       fail(e.getMessage());
     }
 
-    SMGetMode smgetMode = SMGetMode.UNIQUE;
     SMGetFuture<List<SMGetElement<Object>>> future = mc
             .asyncBopSortMergeGet(keyList, 10, 0,
-                    ElementFlagFilter.DO_NOT_FILTER, 10, smgetMode);
+                    ElementFlagFilter.DO_NOT_FILTER, 10, true);
     try {
       List<SMGetElement<Object>> map = future.get(1000L, TimeUnit.SECONDS);
       assertEquals(10, map.size());
@@ -283,10 +276,9 @@ class SMGetTest extends BaseIntegrationTest {
       fail(e.getMessage());
     }
 
-    SMGetMode smgetMode = SMGetMode.UNIQUE;
     SMGetFuture<List<SMGetElement<Object>>> future = mc
             .asyncBopSortMergeGet(keyList, 0, 10,
-                    ElementFlagFilter.DO_NOT_FILTER, 10, smgetMode);
+                    ElementFlagFilter.DO_NOT_FILTER, 10, true);
     try {
       List<SMGetElement<Object>> map = future.get(1000L, TimeUnit.SECONDS);
       assertEquals(5, map.size());
@@ -315,10 +307,9 @@ class SMGetTest extends BaseIntegrationTest {
       fail(e.getMessage());
     }
 
-    SMGetMode smgetMode = SMGetMode.UNIQUE;
     SMGetFuture<List<SMGetElement<Object>>> future = mc
             .asyncBopSortMergeGet(keyList, 10, 0,
-                    ElementFlagFilter.DO_NOT_FILTER, 10, smgetMode);
+                    ElementFlagFilter.DO_NOT_FILTER, 10, true);
     try {
       List<SMGetElement<Object>> map = future.get(1000L, TimeUnit.SECONDS);
       assertEquals(5, map.size());
@@ -351,10 +342,9 @@ class SMGetTest extends BaseIntegrationTest {
       fail(e.getMessage());
     }
 
-    SMGetMode smgetMode = SMGetMode.UNIQUE;
     SMGetFuture<List<SMGetElement<Object>>> future = mc
             .asyncBopSortMergeGet(keyList, 0, 1000,
-                    ElementFlagFilter.DO_NOT_FILTER, 500, smgetMode);
+                    ElementFlagFilter.DO_NOT_FILTER, 500, true);
     try {
       List<SMGetElement<Object>> map = future.get(1000L, TimeUnit.MILLISECONDS);
     } catch (TimeoutException e) {
@@ -388,10 +378,9 @@ class SMGetTest extends BaseIntegrationTest {
       fail(e.getMessage());
     }
 
-    SMGetMode smgetMode = SMGetMode.UNIQUE;
     SMGetFuture<List<SMGetElement<Object>>> future = mc
             .asyncBopSortMergeGet(keyList, 0, testSize,
-                    ElementFlagFilter.DO_NOT_FILTER, 500, smgetMode);
+                    ElementFlagFilter.DO_NOT_FILTER, 500, true);
     try {
       List<SMGetElement<Object>> map = future.get(1000L, TimeUnit.SECONDS);
       assertEquals(500, map.size());
@@ -429,9 +418,8 @@ class SMGetTest extends BaseIntegrationTest {
     }
     multiFlagsFilter.addCompValue(new byte[]{(byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF});
 
-    SMGetMode smgetMode = SMGetMode.UNIQUE;
     SMGetFuture<List<SMGetElement<Object>>> future = mc
-            .asyncBopSortMergeGet(keyList, 0, testSize, multiFlagsFilter, 1000, smgetMode);
+            .asyncBopSortMergeGet(keyList, 0, testSize, multiFlagsFilter, 1000, true);
 
     try {
       List<SMGetElement<Object>> map = future.get(1000L, TimeUnit.SECONDS);
@@ -470,11 +458,10 @@ class SMGetTest extends BaseIntegrationTest {
     }
     multiFlagsFilter.addCompValue(new byte[]{(byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF});
 
-    SMGetMode smgetMode = SMGetMode.UNIQUE;
     SMGetFuture<List<SMGetElement<Object>>> future = mc
             .asyncBopSortMergeGet(keyList, new byte[]{0, 0, 0, 0},
                     ByteBuffer.allocate(4).putInt(testSize).array(),
-                    multiFlagsFilter, 1000, smgetMode);
+                    multiFlagsFilter, 1000, true);
 
     try {
       List<SMGetElement<Object>> map = future.get(1000L, TimeUnit.SECONDS);
@@ -491,7 +478,7 @@ class SMGetTest extends BaseIntegrationTest {
   void testSMGetOverflowMaxCount() {
     try {
       mc.asyncBopSortMergeGet(keyList, 0, 1000,
-              ElementFlagFilter.DO_NOT_FILTER, 1001, SMGetMode.UNIQUE);
+              ElementFlagFilter.DO_NOT_FILTER, 1001, true);
     } catch (IllegalArgumentException e) {
       return;
     }

--- a/src/test/manual/net/spy/memcached/btreesmget/SMGetWithCombinationEflagTest.java
+++ b/src/test/manual/net/spy/memcached/btreesmget/SMGetWithCombinationEflagTest.java
@@ -26,7 +26,6 @@ import net.spy.memcached.collection.BaseIntegrationTest;
 import net.spy.memcached.collection.CollectionAttributes;
 import net.spy.memcached.collection.ElementFlagFilter;
 import net.spy.memcached.collection.SMGetElement;
-import net.spy.memcached.collection.SMGetMode;
 import net.spy.memcached.internal.SMGetFuture;
 import net.spy.memcached.ops.CollectionOperationStatus;
 
@@ -75,10 +74,9 @@ class SMGetWithCombinationEflagTest extends BaseIntegrationTest {
       fail(e.getMessage());
     }
 
-    SMGetMode smgetMode = SMGetMode.UNIQUE;
     SMGetFuture<List<SMGetElement<Object>>> future = mc
             .asyncBopSortMergeGet(keyList, 1, 2,
-                    ElementFlagFilter.DO_NOT_FILTER, 10, smgetMode);
+                    ElementFlagFilter.DO_NOT_FILTER, 10, true);
     try {
       List<SMGetElement<Object>> map = future.get(1000L, TimeUnit.SECONDS);
       assertTrue(map.isEmpty());
@@ -111,10 +109,9 @@ class SMGetWithCombinationEflagTest extends BaseIntegrationTest {
       fail(e.getMessage());
     }
 
-    SMGetMode smgetMode = SMGetMode.UNIQUE;
     SMGetFuture<List<SMGetElement<Object>>> future = mc
             .asyncBopSortMergeGet(keyList, 0, 10,
-                    ElementFlagFilter.DO_NOT_FILTER, 10, smgetMode);
+                    ElementFlagFilter.DO_NOT_FILTER, 10, true);
     try {
       List<SMGetElement<Object>> map = future.get(1000L, TimeUnit.SECONDS);
       assertEquals(10, map.size());
@@ -153,10 +150,9 @@ class SMGetWithCombinationEflagTest extends BaseIntegrationTest {
       fail(e.getMessage());
     }
 
-    SMGetMode smgetMode = SMGetMode.UNIQUE;
     SMGetFuture<List<SMGetElement<Object>>> future = mc
             .asyncBopSortMergeGet(keyList, 0, 10,
-                    ElementFlagFilter.DO_NOT_FILTER, 10, smgetMode);
+                    ElementFlagFilter.DO_NOT_FILTER, 10, true);
     try {
       List<SMGetElement<Object>> map = future.get(1000L, TimeUnit.SECONDS);
       assertEquals(10, map.size());
@@ -195,10 +191,9 @@ class SMGetWithCombinationEflagTest extends BaseIntegrationTest {
       fail(e.getMessage());
     }
 
-    SMGetMode smgetMode = SMGetMode.UNIQUE;
     SMGetFuture<List<SMGetElement<Object>>> future = mc
             .asyncBopSortMergeGet(keyList, 0, 10,
-                    ElementFlagFilter.DO_NOT_FILTER, 10, smgetMode);
+                    ElementFlagFilter.DO_NOT_FILTER, 10, true);
     try {
       List<SMGetElement<Object>> map = future.get(1000L, TimeUnit.SECONDS);
       assertEquals(10, map.size());
@@ -237,10 +232,9 @@ class SMGetWithCombinationEflagTest extends BaseIntegrationTest {
       fail(e.getMessage());
     }
 
-    SMGetMode smgetMode = SMGetMode.UNIQUE;
     SMGetFuture<List<SMGetElement<Object>>> future = mc
             .asyncBopSortMergeGet(keyList, 0, 10,
-                    ElementFlagFilter.DO_NOT_FILTER, 10, smgetMode);
+                    ElementFlagFilter.DO_NOT_FILTER, 10, true);
     try {
       List<SMGetElement<Object>> map = future.get(1000L, TimeUnit.SECONDS);
       assertEquals(9, map.size());
@@ -279,10 +273,9 @@ class SMGetWithCombinationEflagTest extends BaseIntegrationTest {
       fail(e.getMessage());
     }
 
-    SMGetMode smgetMode = SMGetMode.UNIQUE;
     SMGetFuture<List<SMGetElement<Object>>> future = mc
             .asyncBopSortMergeGet(keyList, 10, 0,
-                    ElementFlagFilter.DO_NOT_FILTER, 10, smgetMode);
+                    ElementFlagFilter.DO_NOT_FILTER, 10, true);
     try {
       List<SMGetElement<Object>> map = future.get(1000L, TimeUnit.SECONDS);
       assertEquals(10, map.size());
@@ -316,10 +309,9 @@ class SMGetWithCombinationEflagTest extends BaseIntegrationTest {
       fail(e.getMessage());
     }
 
-    SMGetMode smgetMode = SMGetMode.UNIQUE;
     SMGetFuture<List<SMGetElement<Object>>> future = mc
             .asyncBopSortMergeGet(keyList, 0, 10,
-                    ElementFlagFilter.DO_NOT_FILTER, 10, smgetMode);
+                    ElementFlagFilter.DO_NOT_FILTER, 10, true);
     try {
       List<SMGetElement<Object>> map = future.get(1000L, TimeUnit.SECONDS);
       assertEquals(5, map.size());
@@ -353,10 +345,9 @@ class SMGetWithCombinationEflagTest extends BaseIntegrationTest {
       fail(e.getMessage());
     }
 
-    SMGetMode smgetMode = SMGetMode.UNIQUE;
     SMGetFuture<List<SMGetElement<Object>>> future = mc
             .asyncBopSortMergeGet(keyList, 10, 0,
-                    ElementFlagFilter.DO_NOT_FILTER, 10, smgetMode);
+                    ElementFlagFilter.DO_NOT_FILTER, 10, true);
     try {
       List<SMGetElement<Object>> map = future.get(1000L, TimeUnit.SECONDS);
       assertEquals(5, map.size());
@@ -395,10 +386,9 @@ class SMGetWithCombinationEflagTest extends BaseIntegrationTest {
       fail(e.getMessage());
     }
 
-    SMGetMode smgetMode = SMGetMode.UNIQUE;
     SMGetFuture<List<SMGetElement<Object>>> future = mc
             .asyncBopSortMergeGet(keyList, 0, 1000,
-                    ElementFlagFilter.DO_NOT_FILTER, 500, smgetMode);
+                    ElementFlagFilter.DO_NOT_FILTER, 500, true);
     try {
       List<SMGetElement<Object>> map = future.get(1000L, TimeUnit.MILLISECONDS);
     } catch (TimeoutException e) {
@@ -432,10 +422,9 @@ class SMGetWithCombinationEflagTest extends BaseIntegrationTest {
       fail(e.getMessage());
     }
 
-    SMGetMode smgetMode = SMGetMode.UNIQUE;
     SMGetFuture<List<SMGetElement<Object>>> future = mc
             .asyncBopSortMergeGet(keyList, 0, testSize,
-                    ElementFlagFilter.DO_NOT_FILTER, 500, smgetMode);
+                    ElementFlagFilter.DO_NOT_FILTER, 500, true);
     try {
       List<SMGetElement<Object>> map = future.get(1000L, TimeUnit.SECONDS);
       assertEquals(50, map.size());

--- a/src/test/manual/net/spy/memcached/btreesmget/SMGetWithEflagTest.java
+++ b/src/test/manual/net/spy/memcached/btreesmget/SMGetWithEflagTest.java
@@ -26,7 +26,6 @@ import net.spy.memcached.collection.BaseIntegrationTest;
 import net.spy.memcached.collection.CollectionAttributes;
 import net.spy.memcached.collection.ElementFlagFilter;
 import net.spy.memcached.collection.SMGetElement;
-import net.spy.memcached.collection.SMGetMode;
 import net.spy.memcached.internal.SMGetFuture;
 import net.spy.memcached.ops.CollectionOperationStatus;
 
@@ -71,10 +70,9 @@ class SMGetWithEflagTest extends BaseIntegrationTest {
       fail(e.getMessage());
     }
 
-    SMGetMode smgetMode = SMGetMode.UNIQUE;
     SMGetFuture<List<SMGetElement<Object>>> future = mc
             .asyncBopSortMergeGet(keyList, 1, 2,
-                    ElementFlagFilter.DO_NOT_FILTER, 10, smgetMode);
+                    ElementFlagFilter.DO_NOT_FILTER, 10, true);
     try {
       List<SMGetElement<Object>> map = future.get(1000L, TimeUnit.SECONDS);
       assertTrue(map.isEmpty());
@@ -102,10 +100,9 @@ class SMGetWithEflagTest extends BaseIntegrationTest {
       fail(e.getMessage());
     }
 
-    SMGetMode smgetMode = SMGetMode.UNIQUE;
     SMGetFuture<List<SMGetElement<Object>>> future = mc
             .asyncBopSortMergeGet(keyList, 0, 10,
-                    ElementFlagFilter.DO_NOT_FILTER, 10, smgetMode);
+                    ElementFlagFilter.DO_NOT_FILTER, 10, true);
     try {
       List<SMGetElement<Object>> map = future.get(1000L, TimeUnit.SECONDS);
       assertEquals(10, map.size());
@@ -139,10 +136,9 @@ class SMGetWithEflagTest extends BaseIntegrationTest {
       fail(e.getMessage());
     }
 
-    SMGetMode smgetMode = SMGetMode.UNIQUE;
     SMGetFuture<List<SMGetElement<Object>>> future = mc
             .asyncBopSortMergeGet(keyList, 0, 10,
-                    ElementFlagFilter.DO_NOT_FILTER, 10, smgetMode);
+                    ElementFlagFilter.DO_NOT_FILTER, 10, true);
     try {
       List<SMGetElement<Object>> map = future.get(1000L, TimeUnit.SECONDS);
       assertEquals(10, map.size());
@@ -176,10 +172,9 @@ class SMGetWithEflagTest extends BaseIntegrationTest {
       fail(e.getMessage());
     }
 
-    SMGetMode smgetMode = SMGetMode.UNIQUE;
     SMGetFuture<List<SMGetElement<Object>>> future = mc
             .asyncBopSortMergeGet(keyList, 0, 10,
-                    ElementFlagFilter.DO_NOT_FILTER, 10, smgetMode);
+                    ElementFlagFilter.DO_NOT_FILTER, 10, true);
     try {
       List<SMGetElement<Object>> map = future.get(1000L, TimeUnit.SECONDS);
       assertEquals(10, map.size());
@@ -213,10 +208,9 @@ class SMGetWithEflagTest extends BaseIntegrationTest {
       fail(e.getMessage());
     }
 
-    SMGetMode smgetMode = SMGetMode.UNIQUE;
     SMGetFuture<List<SMGetElement<Object>>> future = mc
             .asyncBopSortMergeGet(keyList, 0, 10,
-                    ElementFlagFilter.DO_NOT_FILTER, 10, smgetMode);
+                    ElementFlagFilter.DO_NOT_FILTER, 10, true);
     try {
       List<SMGetElement<Object>> map = future.get(1000L, TimeUnit.SECONDS);
       assertEquals(9, map.size());
@@ -250,10 +244,9 @@ class SMGetWithEflagTest extends BaseIntegrationTest {
       fail(e.getMessage());
     }
 
-    SMGetMode smgetMode = SMGetMode.UNIQUE;
     SMGetFuture<List<SMGetElement<Object>>> future = mc
             .asyncBopSortMergeGet(keyList, 10, 0,
-                    ElementFlagFilter.DO_NOT_FILTER, 10, smgetMode);
+                    ElementFlagFilter.DO_NOT_FILTER, 10, true);
     try {
       List<SMGetElement<Object>> map = future.get(1000L, TimeUnit.SECONDS);
       assertEquals(10, map.size());
@@ -282,10 +275,9 @@ class SMGetWithEflagTest extends BaseIntegrationTest {
       fail(e.getMessage());
     }
 
-    SMGetMode smgetMode = SMGetMode.UNIQUE;
     SMGetFuture<List<SMGetElement<Object>>> future = mc
             .asyncBopSortMergeGet(keyList, 0, 10,
-                    ElementFlagFilter.DO_NOT_FILTER, 10, smgetMode);
+                    ElementFlagFilter.DO_NOT_FILTER, 10, true);
     try {
       List<SMGetElement<Object>> map = future.get(1000L, TimeUnit.SECONDS);
       assertEquals(5, map.size());
@@ -314,10 +306,9 @@ class SMGetWithEflagTest extends BaseIntegrationTest {
       fail(e.getMessage());
     }
 
-    SMGetMode smgetMode = SMGetMode.UNIQUE;
     SMGetFuture<List<SMGetElement<Object>>> future = mc
             .asyncBopSortMergeGet(keyList, 10, 0,
-                    ElementFlagFilter.DO_NOT_FILTER, 10, smgetMode);
+                    ElementFlagFilter.DO_NOT_FILTER, 10, true);
     try {
       List<SMGetElement<Object>> map = future.get(1000L, TimeUnit.SECONDS);
       assertEquals(5, map.size());
@@ -350,10 +341,9 @@ class SMGetWithEflagTest extends BaseIntegrationTest {
       fail(e.getMessage());
     }
 
-    SMGetMode smgetMode = SMGetMode.UNIQUE;
     SMGetFuture<List<SMGetElement<Object>>> future = mc
             .asyncBopSortMergeGet(keyList, 0, 1000,
-                    ElementFlagFilter.DO_NOT_FILTER, 500, smgetMode);
+                    ElementFlagFilter.DO_NOT_FILTER, 500, true);
     try {
       List<SMGetElement<Object>> map = future.get(1000L, TimeUnit.MILLISECONDS);
       // System.out.println((System.currentTimeMillis() - start) + "ms");
@@ -388,10 +378,9 @@ class SMGetWithEflagTest extends BaseIntegrationTest {
       fail(e.getMessage());
     }
 
-    SMGetMode smgetMode = SMGetMode.UNIQUE;
     SMGetFuture<List<SMGetElement<Object>>> future = mc
             .asyncBopSortMergeGet(keyList, 0, testSize,
-                    ElementFlagFilter.DO_NOT_FILTER, 500, smgetMode);
+                    ElementFlagFilter.DO_NOT_FILTER, 500, true);
     try {
       List<SMGetElement<Object>> map = future.get(1000L, TimeUnit.SECONDS);
       // System.out.println(System.currentTimeMillis() - start + "ms");

--- a/src/test/manual/net/spy/memcached/collection/btree/BopSortMergeTest.java
+++ b/src/test/manual/net/spy/memcached/collection/btree/BopSortMergeTest.java
@@ -28,7 +28,6 @@ import net.spy.memcached.collection.CollectionOverflowAction;
 import net.spy.memcached.collection.CollectionResponse;
 import net.spy.memcached.collection.ElementFlagFilter;
 import net.spy.memcached.collection.SMGetElement;
-import net.spy.memcached.collection.SMGetMode;
 import net.spy.memcached.collection.SMGetTrimKey;
 import net.spy.memcached.internal.SMGetFuture;
 import net.spy.memcached.ops.CollectionOperationStatus;
@@ -102,13 +101,12 @@ class BopSortMergeTest extends BaseIntegrationTest {
     bkeyTo = 5L;
     queryCount = 10;
 
-    SMGetMode smgetMode = SMGetMode.DUPLICATE;
     SMGetFuture<List<SMGetElement<Object>>> future = null;
     List<SMGetElement<Object>> result;
 
     try {
       future = mc.asyncBopSortMergeGet(
-          keyList3, bkeyFrom, bkeyTo, ElementFlagFilter.DO_NOT_FILTER, queryCount, smgetMode);
+          keyList3, bkeyFrom, bkeyTo, ElementFlagFilter.DO_NOT_FILTER, queryCount, false);
     } catch (IllegalStateException e) {
       fail(e.getMessage());
     }
@@ -191,13 +189,12 @@ class BopSortMergeTest extends BaseIntegrationTest {
     bkeyTo = 5L;
     queryCount = 10;
 
-    SMGetMode smgetMode = SMGetMode.UNIQUE;
     SMGetFuture<List<SMGetElement<Object>>> future = null;
     List<SMGetElement<Object>> result;
 
     try {
       future = mc.asyncBopSortMergeGet(
-          keyList3, bkeyFrom, bkeyTo, ElementFlagFilter.DO_NOT_FILTER, queryCount, smgetMode);
+          keyList3, bkeyFrom, bkeyTo, ElementFlagFilter.DO_NOT_FILTER, queryCount, true);
     } catch (IllegalStateException e) {
       fail(e.getMessage());
     }
@@ -281,7 +278,6 @@ class BopSortMergeTest extends BaseIntegrationTest {
     bkeyFrom = 5L;
     bkeyTo = 0L;
 
-    SMGetMode smgetMode = SMGetMode.DUPLICATE;
     SMGetFuture<List<SMGetElement<Object>>> future10 = null;
     SMGetFuture<List<SMGetElement<Object>>> future6 = null;
     SMGetFuture<List<SMGetElement<Object>>> future5 = null;
@@ -295,15 +291,15 @@ class BopSortMergeTest extends BaseIntegrationTest {
 
     try {
       future10 = mc.asyncBopSortMergeGet(
-          keyList3, bkeyFrom, bkeyTo, ElementFlagFilter.DO_NOT_FILTER, 10, smgetMode);
+          keyList3, bkeyFrom, bkeyTo, ElementFlagFilter.DO_NOT_FILTER, 10, false);
       future6 = mc.asyncBopSortMergeGet(
-          keyList3, bkeyFrom, bkeyTo, ElementFlagFilter.DO_NOT_FILTER, 6, smgetMode);
+          keyList3, bkeyFrom, bkeyTo, ElementFlagFilter.DO_NOT_FILTER, 6, false);
       future5 = mc.asyncBopSortMergeGet(
-          keyList3, bkeyFrom, bkeyTo, ElementFlagFilter.DO_NOT_FILTER, 5, smgetMode);
+          keyList3, bkeyFrom, bkeyTo, ElementFlagFilter.DO_NOT_FILTER, 5, false);
       future3 = mc.asyncBopSortMergeGet(
-          keyList3, bkeyFrom, bkeyTo, ElementFlagFilter.DO_NOT_FILTER, 3, smgetMode);
+          keyList3, bkeyFrom, bkeyTo, ElementFlagFilter.DO_NOT_FILTER, 3, false);
       future1 = mc.asyncBopSortMergeGet(
-          keyList3, bkeyFrom, bkeyTo, ElementFlagFilter.DO_NOT_FILTER, 1, smgetMode);
+          keyList3, bkeyFrom, bkeyTo, ElementFlagFilter.DO_NOT_FILTER, 1, false);
     } catch (IllegalStateException e) {
       fail(e.getMessage());
     }
@@ -449,7 +445,6 @@ class BopSortMergeTest extends BaseIntegrationTest {
     bkeyFrom = 5L;
     bkeyTo = 0L;
 
-    SMGetMode smgetMode = SMGetMode.UNIQUE;
     SMGetFuture<List<SMGetElement<Object>>> future10 = null;
     SMGetFuture<List<SMGetElement<Object>>> future6 = null;
     SMGetFuture<List<SMGetElement<Object>>> future5 = null;
@@ -463,15 +458,15 @@ class BopSortMergeTest extends BaseIntegrationTest {
 
     try {
       future10 = mc.asyncBopSortMergeGet(
-          keyList3, bkeyFrom, bkeyTo, ElementFlagFilter.DO_NOT_FILTER, 10, smgetMode);
+          keyList3, bkeyFrom, bkeyTo, ElementFlagFilter.DO_NOT_FILTER, 10, true);
       future6 = mc.asyncBopSortMergeGet(
-          keyList3, bkeyFrom, bkeyTo, ElementFlagFilter.DO_NOT_FILTER, 6, smgetMode);
+          keyList3, bkeyFrom, bkeyTo, ElementFlagFilter.DO_NOT_FILTER, 6, true);
       future5 = mc.asyncBopSortMergeGet(
-          keyList3, bkeyFrom, bkeyTo, ElementFlagFilter.DO_NOT_FILTER, 5, smgetMode);
+          keyList3, bkeyFrom, bkeyTo, ElementFlagFilter.DO_NOT_FILTER, 5, true);
       future3 = mc.asyncBopSortMergeGet(
-          keyList3, bkeyFrom, bkeyTo, ElementFlagFilter.DO_NOT_FILTER, 3, smgetMode);
+          keyList3, bkeyFrom, bkeyTo, ElementFlagFilter.DO_NOT_FILTER, 3, true);
       future1 = mc.asyncBopSortMergeGet(
-          keyList3, bkeyFrom, bkeyTo, ElementFlagFilter.DO_NOT_FILTER, 1, smgetMode);
+          keyList3, bkeyFrom, bkeyTo, ElementFlagFilter.DO_NOT_FILTER, 1, true);
     } catch (IllegalStateException e) {
       fail(e.getMessage());
     }
@@ -621,13 +616,12 @@ class BopSortMergeTest extends BaseIntegrationTest {
     bkeyTo = 5L;
     queryCount = 10;
 
-    SMGetMode smgetMode = SMGetMode.DUPLICATE;
     SMGetFuture<List<SMGetElement<Object>>> future = null;
     List<SMGetElement<Object>> result;
 
     try {
       future = mc.asyncBopSortMergeGet(
-          keyList3, bkeyFrom, bkeyTo, ElementFlagFilter.DO_NOT_FILTER, queryCount, smgetMode);
+          keyList3, bkeyFrom, bkeyTo, ElementFlagFilter.DO_NOT_FILTER, queryCount, false);
     } catch (IllegalStateException e) {
       fail(e.getMessage());
     }
@@ -710,13 +704,12 @@ class BopSortMergeTest extends BaseIntegrationTest {
     bkeyTo = 5L;
     queryCount = 10;
 
-    SMGetMode smgetMode = SMGetMode.UNIQUE;
     SMGetFuture<List<SMGetElement<Object>>> future = null;
     List<SMGetElement<Object>> result;
 
     try {
       future = mc.asyncBopSortMergeGet(
-          keyList3, bkeyFrom, bkeyTo, ElementFlagFilter.DO_NOT_FILTER, queryCount, smgetMode);
+          keyList3, bkeyFrom, bkeyTo, ElementFlagFilter.DO_NOT_FILTER, queryCount, true);
     } catch (IllegalStateException e) {
       fail(e.getMessage());
     }
@@ -800,7 +793,6 @@ class BopSortMergeTest extends BaseIntegrationTest {
     bkeyFrom = 5L;
     bkeyTo = 0L;
 
-    SMGetMode smgetMode = SMGetMode.DUPLICATE;
     SMGetFuture<List<SMGetElement<Object>>> future10 = null;
     SMGetFuture<List<SMGetElement<Object>>> future6 = null;
     SMGetFuture<List<SMGetElement<Object>>> future5 = null;
@@ -814,15 +806,15 @@ class BopSortMergeTest extends BaseIntegrationTest {
 
     try {
       future10 = mc.asyncBopSortMergeGet(
-          keyList3, bkeyFrom, bkeyTo, ElementFlagFilter.DO_NOT_FILTER, 10, smgetMode);
+          keyList3, bkeyFrom, bkeyTo, ElementFlagFilter.DO_NOT_FILTER, 10, false);
       future6 = mc.asyncBopSortMergeGet(
-          keyList3, bkeyFrom, bkeyTo, ElementFlagFilter.DO_NOT_FILTER, 6, smgetMode);
+          keyList3, bkeyFrom, bkeyTo, ElementFlagFilter.DO_NOT_FILTER, 6, false);
       future5 = mc.asyncBopSortMergeGet(
-          keyList3, bkeyFrom, bkeyTo, ElementFlagFilter.DO_NOT_FILTER, 5, smgetMode);
+          keyList3, bkeyFrom, bkeyTo, ElementFlagFilter.DO_NOT_FILTER, 5, false);
       future3 = mc.asyncBopSortMergeGet(
-          keyList3, bkeyFrom, bkeyTo, ElementFlagFilter.DO_NOT_FILTER, 3, smgetMode);
+          keyList3, bkeyFrom, bkeyTo, ElementFlagFilter.DO_NOT_FILTER, 3, false);
       future1 = mc.asyncBopSortMergeGet(
-          keyList3, bkeyFrom, bkeyTo, ElementFlagFilter.DO_NOT_FILTER, 1, smgetMode);
+          keyList3, bkeyFrom, bkeyTo, ElementFlagFilter.DO_NOT_FILTER, 1, false);
     } catch (IllegalStateException e) {
       fail(e.getMessage());
     }
@@ -968,7 +960,6 @@ class BopSortMergeTest extends BaseIntegrationTest {
     bkeyFrom = 5L;
     bkeyTo = 0L;
 
-    SMGetMode smgetMode = SMGetMode.UNIQUE;
     SMGetFuture<List<SMGetElement<Object>>> future10 = null;
     SMGetFuture<List<SMGetElement<Object>>> future6 = null;
     SMGetFuture<List<SMGetElement<Object>>> future5 = null;
@@ -982,15 +973,15 @@ class BopSortMergeTest extends BaseIntegrationTest {
 
     try {
       future10 = mc.asyncBopSortMergeGet(
-          keyList3, bkeyFrom, bkeyTo, ElementFlagFilter.DO_NOT_FILTER, 10, smgetMode);
+          keyList3, bkeyFrom, bkeyTo, ElementFlagFilter.DO_NOT_FILTER, 10, true);
       future6 = mc.asyncBopSortMergeGet(
-          keyList3, bkeyFrom, bkeyTo, ElementFlagFilter.DO_NOT_FILTER, 6, smgetMode);
+          keyList3, bkeyFrom, bkeyTo, ElementFlagFilter.DO_NOT_FILTER, 6, true);
       future5 = mc.asyncBopSortMergeGet(
-          keyList3, bkeyFrom, bkeyTo, ElementFlagFilter.DO_NOT_FILTER, 5, smgetMode);
+          keyList3, bkeyFrom, bkeyTo, ElementFlagFilter.DO_NOT_FILTER, 5, true);
       future3 = mc.asyncBopSortMergeGet(
-          keyList3, bkeyFrom, bkeyTo, ElementFlagFilter.DO_NOT_FILTER, 3, smgetMode);
+          keyList3, bkeyFrom, bkeyTo, ElementFlagFilter.DO_NOT_FILTER, 3, true);
       future1 = mc.asyncBopSortMergeGet(
-          keyList3, bkeyFrom, bkeyTo, ElementFlagFilter.DO_NOT_FILTER, 1, smgetMode);
+          keyList3, bkeyFrom, bkeyTo, ElementFlagFilter.DO_NOT_FILTER, 1, true);
     } catch (IllegalStateException e) {
       fail(e.getMessage());
     }
@@ -1129,7 +1120,6 @@ class BopSortMergeTest extends BaseIntegrationTest {
     // - key0: 29, 28, 27, 26, 25, 24, 23, 22, 21, 20, trim
     // - key1:  9,  8,  7,  6,  5,  4,  3,  2,  1
 
-    SMGetMode smgetMode = SMGetMode.DUPLICATE;
     SMGetFuture<List<SMGetElement<Object>>> future1 = null; // bop smget 9 2 20..10 100 duplicate
     SMGetFuture<List<SMGetElement<Object>>> future2 = null; // bop smget 9 2 9..5 100 duplicate
     List<SMGetElement<Object>> result1;
@@ -1137,9 +1127,9 @@ class BopSortMergeTest extends BaseIntegrationTest {
 
     try {
       future1 = mc.asyncBopSortMergeGet(
-          keyList2, 20, 10, ElementFlagFilter.DO_NOT_FILTER, 100, smgetMode);
+          keyList2, 20, 10, ElementFlagFilter.DO_NOT_FILTER, 100, false);
       future2 = mc.asyncBopSortMergeGet(
-          keyList2, 9, 5, ElementFlagFilter.DO_NOT_FILTER, 100, smgetMode);
+          keyList2, 9, 5, ElementFlagFilter.DO_NOT_FILTER, 100, false);
     } catch (IllegalStateException e) {
       fail(e.getMessage());
     }
@@ -1224,7 +1214,6 @@ class BopSortMergeTest extends BaseIntegrationTest {
     // - key0: 29, 28, 27, 26, 25, 24, 23, 22, 21, 20, trim
     // - key1:  9,  8,  7,  6,  5,  4,  3,  2,  1
 
-    SMGetMode smgetMode = SMGetMode.UNIQUE;
     SMGetFuture<List<SMGetElement<Object>>> future1 = null; // bop smget 9 2 20..10 100 unique
     SMGetFuture<List<SMGetElement<Object>>> future2 = null; // bop smget 9 2 9..5 100 unique
     List<SMGetElement<Object>> result1;
@@ -1232,9 +1221,9 @@ class BopSortMergeTest extends BaseIntegrationTest {
 
     try {
       future1 = mc.asyncBopSortMergeGet(
-          keyList2, 20, 10, ElementFlagFilter.DO_NOT_FILTER, 100, smgetMode);
+          keyList2, 20, 10, ElementFlagFilter.DO_NOT_FILTER, 100, true);
       future2 = mc.asyncBopSortMergeGet(
-          keyList2, 9, 5, ElementFlagFilter.DO_NOT_FILTER, 100, smgetMode);
+          keyList2, 9, 5, ElementFlagFilter.DO_NOT_FILTER, 100, true);
     } catch (IllegalStateException e) {
       fail(e.getMessage());
     }

--- a/src/test/manual/net/spy/memcached/collection/internal/CancelFutureTest.java
+++ b/src/test/manual/net/spy/memcached/collection/internal/CancelFutureTest.java
@@ -9,7 +9,6 @@ import net.spy.memcached.collection.BaseIntegrationTest;
 import net.spy.memcached.collection.CollectionResponse;
 import net.spy.memcached.collection.ElementFlagFilter;
 import net.spy.memcached.collection.SMGetElement;
-import net.spy.memcached.collection.SMGetMode;
 import net.spy.memcached.internal.BTreeStoreAndGetFuture;
 import net.spy.memcached.internal.BroadcastFuture;
 import net.spy.memcached.internal.CollectionFuture;
@@ -266,7 +265,7 @@ class CancelFutureTest extends BaseIntegrationTest {
     // given
     SMGetFuture<List<SMGetElement<Object>>> future = mc.asyncBopSortMergeGet(
         Arrays.asList("btree1", "btree2"),
-        0, 10, ElementFlagFilter.DO_NOT_FILTER, 100, SMGetMode.UNIQUE);
+        0, 10, ElementFlagFilter.DO_NOT_FILTER, 100, true);
 
     // when
     boolean cancelled = false;


### PR DESCRIPTION
### 🔗 Related Issue

<!-- Please link related issue. ex) https://github.com/naver/arcus-java-client/issues/{issue_number} -->
- https://github.com/naver/arcus-java-client/issues/1007

### ⌨️ What I did

<!-- Please describe this PR and what you've been working on. -->
- SMGetMode 클래스를 deprecate 시킵니다.
- 기존에 SMGetMode를 사용하던 API 역시 deprecate 시키고, 대신 boolean 타입의 unique 인자를 넘기는 API를 추가합니다.