### PR TITLE
INTERNAL: Move `@Deprecated` annotation on enum type SMGetMode

### DIFF
--- a/src/main/java/net/spy/memcached/collection/SMGetMode.java
+++ b/src/main/java/net/spy/memcached/collection/SMGetMode.java
@@ -3,9 +3,10 @@ package net.spy.memcached.collection;
 /**
  * A type component for "bop smgetmode"
  */
-@Deprecated
 public enum SMGetMode {
+  @Deprecated
   UNIQUE("unique"),
+  @Deprecated
   DUPLICATE("duplicate");
 
   private String mode;
@@ -14,6 +15,7 @@ public enum SMGetMode {
     this.mode = mode;
   }
 
+  @Deprecated
   public String getMode() {
     return mode;
   }


### PR DESCRIPTION
### 🔗 Related Issue

<!-- Please link related issue. ex) https://github.com/naver/arcus-java-client/issues/{issue_number} -->
- class, enum, interface 등의 타입 자체에 `@Deprecated`를 붙일 경우, 해당 타입을 import하는 문장에서도 deprecated 워닝이 발생한다.
  - `import net.spy.memcached.collection.SMGetMode;`
  - 단, JDK 버전과 벤더사에 따라서 컴파일 워닝으로 잡히지 않을 수 있음
- 컴파일 옵션의 -Werror 때문에 SMGetMode를 import할 때 발생하는 컴파일 워닝을 컴파일 에러로 처리한다.
- 이로 인해 컴파일이 불가능하다.

### ⌨️ What I did

<!-- Please describe this PR and what you've been working on. -->
- import문에서 컴파일 워닝이 발생하지 않도록 타입 자체에 붙은 `@Deprecated`를 제거합니다.
- enum 타입이므로 값에 `@Deprecated`를 추가하고, public 메소드에도 `@Deprecated`를 추가합니다.