### PR TITLE
INTERNAL: Add sasluser to client_list

### DIFF
--- a/src/main/java/net/spy/memcached/ConnectionFactoryBuilder.java
+++ b/src/main/java/net/spy/memcached/ConnectionFactoryBuilder.java
@@ -341,6 +341,15 @@ public class ConnectionFactoryBuilder {
   }
 
   /**
+   * Get the auth descriptor.
+   *
+   * @return the auth descriptor
+   */
+  public AuthDescriptor getAuthDescriptor() {
+    return authDescriptor;
+  }
+
+  /**
    * Set the maximum timeout exception threshold. Should be larger than 2 because
    * this property is to detect continuously occurred exceptions.
    */


### PR DESCRIPTION
### 🔗 Related Issue

- jam2in/arcus-works#809

### ⌨️ What I did

- client_list에 sasluser를 추가합니다.

```
/arcus/client_list/long_running_community/devbox_10.178.0.39_1_java_NONE_20251117115741_73440153582976612_jre=17.0.17_sasluser=namsic
/arcus/client_list/long_running_community/devbox_10.178.0.39_1_java_NONE_20251117115904_73440153582976615_jre=17.0.17_sasluser=null
```

- ConnectionFactoryBuilder에 getSaslUsername()을 추가합니다.
