### PR TITLE
INTERNAL: Add version op to writeQ instead of temp writeQ when auth is in progress

### DIFF
--- a/src/main/java/net/spy/memcached/MemcachedConnection.java
+++ b/src/main/java/net/spy/memcached/MemcachedConnection.java
@@ -693,7 +693,7 @@ public final class MemcachedConnection extends SpyObject {
       }
     });
 
-    node.addOpToWriteQ(op);
+    node.insertOp(op);
     addedQueue.offer(node);
     Selector s = selector.wakeup();
     assert s == selector : "Wakeup returned the wrong selector.";
@@ -926,8 +926,8 @@ public final class MemcachedConnection extends SpyObject {
     for (ConnectionObserver observer : connObservers) {
       observer.connectionEstablished(qa, rt);
     }
-    prepareAuthentication(qa);
     prepareVersionInfo(qa);
+    prepareAuthentication(qa);
   }
 
   private void lostConnection(MemcachedNode qa, ReconnDelay type, String cause) {


### PR DESCRIPTION
### 🔗 Related Issue

<!-- Please link related issue. ex) https://github.com/naver/arcus-java-client/issues/{issue_number} -->
- auth가 진행 중일 때, 기존에는 version 연산이 writeQ가 아닌 임시 큐에 들어갔었다.
- version은 auth와 섞여도 괜찮고, auth 외의 다른 연산보다 먼저 수행되는 것이 권장되므로 임시 큐가 아닌 writeQ에 넣는 것이 더 좋다.

### ⌨️ What I did

<!-- Please describe this PR and what you've been working on. -->
- auth가 진행 중이어도 version 연산을 writeQ에 넣습니다.