### PR TITLE
INTERNAL: Increase default value of timeoutDurationThreshold from 1000ms to 1600ms

### DIFF
--- a/docs/user-guide/02-arcus-java-client.md
+++ b/docs/user-guide/02-arcus-java-client.md
@@ -533,7 +533,7 @@ SLF4J: See http://www.slf4j.org/codes.html#multiple_bindings for an explanation.
 
   각 인자의 단위와 기본값은 다음과 같다.
   - TimeoutExceptionThreshold Timeout의 발생 횟수를 단위로 하고, 기본값은 10이며, 2 이상 값을 지정해야 한다.
-  - TimeoutDurationThreshold의 단위는 millisecond 이고 기본값은 1000ms이다.
+  - TimeoutDurationThreshold의 단위는 millisecond 이고 기본값은 1600ms이다.
     0을 지정해 비활성화하거나, 1000 ~ 5000 사이의 값을 지정할 수 있다.
  
   쉽게 이해하기 위한 예시 상황은 다음과 같다.

--- a/src/main/java/net/spy/memcached/ConnectionFactoryBuilder.java
+++ b/src/main/java/net/spy/memcached/ConnectionFactoryBuilder.java
@@ -69,7 +69,7 @@ public class ConnectionFactoryBuilder {
   private long opQueueMaxBlockTime = -1;
 
   private int timeoutExceptionThreshold = 10;
-  private int timeoutDurationThreshold = 1000;
+  private int timeoutDurationThreshold = 1600;
 
   private int maxFrontCacheElements = DefaultConnectionFactory.DEFAULT_MAX_FRONTCACHE_ELEMENTS;
   private int frontCacheExpireTime = DefaultConnectionFactory.DEFAULT_FRONTCACHE_EXPIRETIME;

--- a/src/test/java/net/spy/memcached/ConnectionFactoryBuilderTest.java
+++ b/src/test/java/net/spy/memcached/ConnectionFactoryBuilderTest.java
@@ -283,7 +283,7 @@ class ConnectionFactoryBuilderTest {
 
     assertNotEquals(connectionFactory.getTimeoutDurationThreshold(),
             defaultConnectionFactory.getTimeoutDurationThreshold());
-    assertEquals(1000, connectionFactory.getTimeoutDurationThreshold());
+    assertEquals(1600, connectionFactory.getTimeoutDurationThreshold());
     assertEquals(DefaultConnectionFactory.DEFAULT_MAX_TIMEOUTDURATION_THRESHOLD,
             defaultConnectionFactory.getTimeoutDurationThreshold());
 


### PR DESCRIPTION
### 🔗 Related Issue

<!-- Please link related issue. ex) https://github.com/naver/arcus-java-client/issues/{issue_number} -->
- https://github.com/jam2in/arcus-works/issues/804

### ⌨️ What I did

<!-- Please describe this PR and what you've been working on. -->
- timeoutDurationThreshold의 기본값을 1000ms에서 1600ms로 변경합니다.