### PR TITLE
FEAT: add support for shard key in ketama hashing

### DIFF
--- a/src/main/java/net/spy/memcached/ConnectionFactory.java
+++ b/src/main/java/net/spy/memcached/ConnectionFactory.java
@@ -121,6 +121,11 @@ public interface ConnectionFactory {
   boolean getDnsCacheTtlCheck();
 
   /**
+   * If true, the shard key logic will be used for hashing.
+   */
+  boolean isShardKeyEnabled();
+
+  /**
    * Observers that should be established at the time of connection
    * instantiation.
    *

--- a/src/main/java/net/spy/memcached/DefaultConnectionFactory.java
+++ b/src/main/java/net/spy/memcached/DefaultConnectionFactory.java
@@ -313,6 +313,11 @@ public class DefaultConnectionFactory extends SpyObject
   }
 
   @Override
+  public boolean isShardKeyEnabled() {
+    return false;
+  }
+
+  @Override
   public boolean getDnsCacheTtlCheck() {
     return true;
   }

--- a/src/main/java/net/spy/memcached/KeyValidator.java
+++ b/src/main/java/net/spy/memcached/KeyValidator.java
@@ -75,7 +75,8 @@ public final class KeyValidator {
         }
         if (!(('a' <= b && b <= 'z') || ('A' <= b && b <= 'Z') ||
             ('0' <= b && b <= '9') ||
-            (b == '_') || (b == '-') || (b == '+') || (b == '.'))) {
+            (b == '_') || (b == '-') || (b == '+') || (b == '.') ||
+            (b == '{') || (b == '}'))) {
           throw new IllegalArgumentException(
               "Key contains invalid prefix: ``" + key + "''");
         }

--- a/src/main/java/net/spy/memcached/util/ArcusKetamaNodeLocatorConfiguration.java
+++ b/src/main/java/net/spy/memcached/util/ArcusKetamaNodeLocatorConfiguration.java
@@ -24,6 +24,8 @@ import net.spy.memcached.MemcachedNodeROImpl;
 public class ArcusKetamaNodeLocatorConfiguration extends
         DefaultKetamaNodeLocatorConfiguration {
 
+  private boolean enableShardKey = false;
+
   /**
    * insert a node from the internal node-address map.
    *
@@ -40,6 +42,23 @@ public class ArcusKetamaNodeLocatorConfiguration extends
    */
   public void removeNode(MemcachedNode node) {
     super.socketAddresses.remove(node);
+  }
+  /**
+   * Returns whether the shard key feature is enabled.
+   *
+   * @return true if the shard key feature is enabled; false otherwise.
+   */
+  public boolean isShardKeyEnabled() {
+    return enableShardKey;
+  }
+
+  /**
+   * Sets the enable status of the shard key feature.
+   *
+   * @param useShardKey true to enable the shard key feature; false to disable.
+   */
+  public void enableShardKey(boolean useShardKey) {
+    enableShardKey = useShardKey;
   }
 
   public class NodeNameComparator implements Comparator<MemcachedNode> {

--- a/src/main/java/net/spy/memcached/util/ArcusReplKetamaNodeLocatorConfiguration.java
+++ b/src/main/java/net/spy/memcached/util/ArcusReplKetamaNodeLocatorConfiguration.java
@@ -31,6 +31,25 @@ public class ArcusReplKetamaNodeLocatorConfiguration implements
         KetamaNodeLocatorConfiguration {
 
   private static final int NUM_REPS = 160;
+  private boolean enableShardKey = false;
+
+  /**
+   * Returns whether the shard key feature is enabled.
+   *
+   * @return true if the shard key feature is enabled; false otherwise.
+   */
+  public boolean isShardKeyEnabled() {
+    return enableShardKey;
+  }
+
+  /**
+   * Sets the enable status of the shard key feature.
+   *
+   * @param useShardKey true to enable the shard key feature; false to disable.
+   */
+  public void enableShardKey(boolean useShardKey) {
+    enableShardKey = useShardKey;
+  }
 
   public String getKeyForNode(MemcachedNode node, int repetition) {
     ArcusReplNodeAddress addr = (ArcusReplNodeAddress) node.getSocketAddress();

--- a/src/test/java/net/spy/memcached/ArcusKetamaHashingTest.java
+++ b/src/test/java/net/spy/memcached/ArcusKetamaHashingTest.java
@@ -8,6 +8,8 @@ import java.util.Map;
 import java.util.SortedMap;
 import java.util.SortedSet;
 
+import net.spy.memcached.util.ArcusKetamaNodeLocatorConfiguration;
+
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -75,8 +77,10 @@ class ArcusKetamaHashingTest {
     MemcachedNode oddManOut = larger.get(larger.size() - 1);
     assertFalse(smaller.contains(oddManOut));
 
-    ArcusKetamaNodeLocator lgLocator = new ArcusKetamaNodeLocator(larger);
-    ArcusKetamaNodeLocator smLocator = new ArcusKetamaNodeLocator(smaller);
+    ArcusKetamaNodeLocator lgLocator =
+            new ArcusKetamaNodeLocator(larger, new ArcusKetamaNodeLocatorConfiguration());
+    ArcusKetamaNodeLocator smLocator =
+            new ArcusKetamaNodeLocator(smaller, new ArcusKetamaNodeLocatorConfiguration());
 
     SortedMap<Long, SortedSet<MemcachedNode>> lgMap = lgLocator.getKetamaNodes();
     SortedMap<Long, SortedSet<MemcachedNode>> smMap = smLocator.getKetamaNodes();

--- a/src/test/java/net/spy/memcached/ArcusShardKeyTest.java
+++ b/src/test/java/net/spy/memcached/ArcusShardKeyTest.java
@@ -1,0 +1,51 @@
+package net.spy.memcached;
+
+import net.spy.memcached.collection.BaseIntegrationTest;
+import net.spy.memcached.ops.APIType;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+public class ArcusShardKeyTest extends BaseIntegrationTest {
+
+  @BeforeEach
+  protected void setUp() throws Exception {
+    assumeTrue(BaseIntegrationTest.USE_ZK);
+    super.setUp();
+
+    ConnectionFactoryBuilder cfb = new ConnectionFactoryBuilder();
+    cfb.setArcusReplEnabled(true);
+    cfb.enableShardKey(true);
+    mc = ArcusClient.createArcusClient(ZK_ADDRESS, SERVICE_CODE, cfb);
+  }
+
+  @Test
+  void testShardKey_SetAndGet() throws Exception {
+    String key1 = "user:{groupA}:test1";
+    String key2 = "user:{groupA}:test2";
+    String key3 = "order:{groupA}:test3";
+    String value1 = "test1";
+    String value2 = "test2";
+    String value3 = "test3";
+
+    MemcachedNode node1 = mc.getMemcachedConnection().getPrimaryNode(key1, APIType.SET);
+    MemcachedNode node2 = mc.getMemcachedConnection().getPrimaryNode(key2, APIType.SET);
+    MemcachedNode node3 = mc.getMemcachedConnection().getPrimaryNode(key3, APIType.SET);
+
+    assertSame(node1, node2);
+    assertSame(node1, node3);
+
+    assertTrue(mc.set(key1, 60, value1).get());
+    assertTrue(mc.set(key2, 60, value2).get());
+    assertTrue(mc.set(key3, 60, value3).get());
+
+    assertEquals(value1, mc.get(key1));
+    assertEquals(value2, mc.get(key2));
+    assertEquals(value3, mc.get(key3));
+  }
+}


### PR DESCRIPTION
### 🔗 Related Issue

<!-- Please link related issue. ex) https://github.com/naver/arcus-java-client/issues/{issue_number} -->
- https://github.com/jam2in/arcus-works/issues/594
- https://github.com/jam2in/arcus-works/issues/790
- https://github.com/naver/arcus-memcached/pull/919

### ⌨️ What I did

<!-- Please describe this PR and what you've been working on. -->

원하는 key string을 하나의 노드에 저장할 수 있도록 그룹화하는 Shard Key 기능을 구현합니다.
shard 결정을 위해서는 key의 일부만을 사용하며, 해당 조건은 아래와 같습니다.
- 키에 `{...}` 패턴이 포함될 경우, 전체 키 대신 `{`와 `}` 사이의 문자열만을 해싱하여 저장할 노드를 결정합니다.
    - 처음 등장하는 `{`와 처음 등장하는 `}` 사이의 하나 이상의 문자열을 해싱
- 이를 통해 동일한 Shard Key를 가진 키들은 항상 같은 노드에 배치됨을 보장하도록 합니다.


- 테스트코드는 새로운 `ArcusShardKeyTest`클래스를 추가했습니다.
    - 키 전체가 서로 다르더라도 하나의 노드에 모두 저장되는지 확인
    - shard key값이 다르다면 서로 다른 노드로 분산되는지 확인
    - 키에 Shard key 규칙에 관한 패턴이 없다면 전체 키를 통해 해싱하는지 확인