### PR TITLE
FIX: Split piped operations into single-key and multi-key to resolve bug during migration

### DIFF
--- a/src/main/java/net/spy/memcached/ArcusClient.java
+++ b/src/main/java/net/spy/memcached/ArcusClient.java
@@ -138,11 +138,12 @@ import net.spy.memcached.ops.BTreeSortMergeGetOperation;
 import net.spy.memcached.ops.CollectionGetOperation;
 import net.spy.memcached.ops.CollectionOperationStatus;
 import net.spy.memcached.ops.GetAttrOperation;
+import net.spy.memcached.ops.MultiKeyPipedOperationCallback;
 import net.spy.memcached.ops.Mutator;
 import net.spy.memcached.ops.Operation;
 import net.spy.memcached.ops.OperationCallback;
 import net.spy.memcached.ops.OperationStatus;
-import net.spy.memcached.ops.PipedOperationCallback;
+import net.spy.memcached.ops.SingleKeyPipedOperationCallback;
 import net.spy.memcached.ops.StatusCode;
 import net.spy.memcached.ops.StoreType;
 import net.spy.memcached.plugin.FrontCacheMemcachedClient;
@@ -1660,7 +1661,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
             new PipedCollectionFuture<>(latch, operationTimeout);
 
     final List<Operation> ops = new ArrayList<>(insertList.size());
-    IntFunction<OperationCallback> makeCallback = opIdx -> new PipedOperationCallback() {
+    IntFunction<OperationCallback> makeCallback = opIdx -> new SingleKeyPipedOperationCallback() {
 
       public void receivedStatus(OperationStatus status) {
         CollectionOperationStatus cstatus = toCollectionOperationStatus(status);
@@ -2029,7 +2030,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
             new PipedCollectionFuture<>(latch, operationTimeout);
 
     final List<Operation> ops = new ArrayList<>(updateList.size());
-    IntFunction<OperationCallback> makeCallback = opIdx -> new PipedOperationCallback() {
+    IntFunction<OperationCallback> makeCallback = opIdx -> new SingleKeyPipedOperationCallback() {
 
       public void receivedStatus(OperationStatus status) {
         CollectionOperationStatus cstatus = toCollectionOperationStatus(status);
@@ -2601,7 +2602,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
             latch, operationTimeout);
 
     Operation op = opFact.collectionPipedExist(key, exist,
-        new PipedOperationCallback() {
+        new SingleKeyPipedOperationCallback() {
 
           private final Map<T, Boolean> result = new HashMap<>();
           private boolean hasAnError = false;
@@ -2876,7 +2877,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
 
     for (final CollectionBulkInsert<T> insert : insertList) {
       Operation op = opFact.collectionBulkInsert(
-              insert, new PipedOperationCallback() {
+              insert, new MultiKeyPipedOperationCallback() {
                 public void receivedStatus(OperationStatus status) {
                   // Nothing to do here because the user MUST search the result Map instance.
                 }
@@ -2885,9 +2886,8 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
                   latch.countDown();
                 }
 
-                public void gotStatus(Integer index, OperationStatus status) {
+                public void gotStatus(String key, OperationStatus status) {
                   if (!status.isSuccess()) {
-                    String key = insert.getKey(index);
                     CollectionOperationStatus cstatus = toCollectionOperationStatus(status);
                     rv.addFailedResult(key, cstatus);
                   }

--- a/src/main/java/net/spy/memcached/ops/MultiCollectionBulkInsertOperationCallback.java
+++ b/src/main/java/net/spy/memcached/ops/MultiCollectionBulkInsertOperationCallback.java
@@ -18,14 +18,14 @@
 package net.spy.memcached.ops;
 
 public class MultiCollectionBulkInsertOperationCallback extends MultiOperationCallback
-    implements PipedOperationCallback {
+    implements MultiKeyPipedOperationCallback {
 
   public MultiCollectionBulkInsertOperationCallback(OperationCallback original, int todo) {
     super(original, todo);
   }
 
   @Override
-  public void gotStatus(Integer index, OperationStatus status) {
-    ((PipedOperationCallback) originalCallback).gotStatus(index, status);
+  public void gotStatus(String key, OperationStatus status) {
+    ((MultiKeyPipedOperationCallback) originalCallback).gotStatus(key, status);
   }
 }

--- a/src/main/java/net/spy/memcached/ops/MultiKeyPipedOperationCallback.java
+++ b/src/main/java/net/spy/memcached/ops/MultiKeyPipedOperationCallback.java
@@ -1,0 +1,5 @@
+package net.spy.memcached.ops;
+
+public interface MultiKeyPipedOperationCallback extends OperationCallback {
+  void gotStatus(String key, OperationStatus status);
+}

--- a/src/main/java/net/spy/memcached/ops/SingleKeyPipedOperationCallback.java
+++ b/src/main/java/net/spy/memcached/ops/SingleKeyPipedOperationCallback.java
@@ -1,5 +1,5 @@
 package net.spy.memcached.ops;
 
-public interface PipedOperationCallback extends OperationCallback {
+public interface SingleKeyPipedOperationCallback extends OperationCallback {
   void gotStatus(Integer index, OperationStatus status);
 }

--- a/src/main/java/net/spy/memcached/protocol/ascii/CollectionBulkInsertOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/CollectionBulkInsertOperationImpl.java
@@ -27,7 +27,7 @@ import net.spy.memcached.ops.OperationType;
 /**
  * Operation to store collection data in a memcached server.
  */
-public final class CollectionBulkInsertOperationImpl extends PipeOperationImpl
+public final class CollectionBulkInsertOperationImpl extends MultiKeyPipeOperationImpl
         implements CollectionBulkInsertOperation {
 
   public CollectionBulkInsertOperationImpl(CollectionBulkInsert<?> insert, OperationCallback cb) {

--- a/src/main/java/net/spy/memcached/protocol/ascii/CollectionPipedExistOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/CollectionPipedExistOperationImpl.java
@@ -17,8 +17,6 @@
  */
 package net.spy.memcached.protocol.ascii;
 
-import java.util.Collections;
-
 import net.spy.memcached.collection.SetPipedExist;
 import net.spy.memcached.ops.APIType;
 import net.spy.memcached.ops.CollectionPipedExistOperation;
@@ -26,12 +24,12 @@ import net.spy.memcached.ops.OperationCallback;
 import net.spy.memcached.ops.OperationStatus;
 import net.spy.memcached.ops.OperationType;
 
-public final class CollectionPipedExistOperationImpl extends PipeOperationImpl implements
+public final class CollectionPipedExistOperationImpl extends SingleKeyPipeOperationImpl implements
         CollectionPipedExistOperation {
 
   public CollectionPipedExistOperationImpl(String key,
                                            SetPipedExist<?> collectionExist, OperationCallback cb) {
-    super(Collections.singletonList(key), collectionExist, cb);
+    super(key, collectionExist, cb);
     setAPIType(APIType.SOP_EXIST);
     setOperationType(OperationType.READ);
   }

--- a/src/main/java/net/spy/memcached/protocol/ascii/CollectionPipedInsertOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/CollectionPipedInsertOperationImpl.java
@@ -17,8 +17,6 @@
  */
 package net.spy.memcached.protocol.ascii;
 
-import java.util.Collections;
-
 import net.spy.memcached.collection.CollectionPipedInsert;
 import net.spy.memcached.ops.APIType;
 import net.spy.memcached.ops.CollectionPipedInsertOperation;
@@ -29,12 +27,12 @@ import net.spy.memcached.ops.OperationType;
 /**
  * Operation to store collection data in a memcached server.
  */
-public final class CollectionPipedInsertOperationImpl extends PipeOperationImpl
+public final class CollectionPipedInsertOperationImpl extends SingleKeyPipeOperationImpl
         implements CollectionPipedInsertOperation {
 
   public CollectionPipedInsertOperationImpl(String key,
                                             CollectionPipedInsert<?> insert, OperationCallback cb) {
-    super(Collections.singletonList(key), insert, cb);
+    super(key, insert, cb);
     if (insert instanceof CollectionPipedInsert.ListPipedInsert) {
       setAPIType(APIType.LOP_INSERT);
     } else if (insert instanceof CollectionPipedInsert.SetPipedInsert) {

--- a/src/main/java/net/spy/memcached/protocol/ascii/CollectionPipedUpdateOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/CollectionPipedUpdateOperationImpl.java
@@ -17,8 +17,6 @@
  */
 package net.spy.memcached.protocol.ascii;
 
-import java.util.Collections;
-
 import net.spy.memcached.collection.CollectionPipedUpdate;
 import net.spy.memcached.collection.CollectionPipedUpdate.BTreePipedUpdate;
 import net.spy.memcached.collection.CollectionPipedUpdate.MapPipedUpdate;
@@ -31,12 +29,12 @@ import net.spy.memcached.ops.OperationType;
 /**
  * Operation to update collection data in a memcached server.
  */
-public final class CollectionPipedUpdateOperationImpl extends PipeOperationImpl implements
+public final class CollectionPipedUpdateOperationImpl extends SingleKeyPipeOperationImpl implements
         CollectionPipedUpdateOperation {
 
   public CollectionPipedUpdateOperationImpl(String key,
                                             CollectionPipedUpdate<?> update, OperationCallback cb) {
-    super(Collections.singletonList(key), update, cb);
+    super(key, update, cb);
     if (update instanceof BTreePipedUpdate) {
       setAPIType(APIType.BOP_UPDATE);
     } else if (update instanceof MapPipedUpdate) {

--- a/src/main/java/net/spy/memcached/protocol/ascii/MultiKeyPipeOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/MultiKeyPipeOperationImpl.java
@@ -1,0 +1,37 @@
+package net.spy.memcached.protocol.ascii;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+import net.spy.memcached.collection.CollectionPipe;
+import net.spy.memcached.ops.MultiKeyPipedOperationCallback;
+import net.spy.memcached.ops.OperationCallback;
+import net.spy.memcached.ops.OperationStatus;
+
+abstract class MultiKeyPipeOperationImpl extends PipeOperationImpl {
+  protected final List<String> keys;
+  protected final MultiKeyPipedOperationCallback cb;
+
+  protected MultiKeyPipeOperationImpl(List<String> keys, CollectionPipe pipe,
+                                      OperationCallback cb) {
+    super(pipe, cb);
+
+    this.keys = keys;
+    this.cb = (MultiKeyPipedOperationCallback) cb;
+  }
+
+  @Override
+  protected void gotStatus(OperationStatus status) {
+    cb.gotStatus(keys.get(index), status);
+  }
+
+  @Override
+  protected String getKey(Integer index) {
+    return keys.get(index);
+  }
+
+  public Collection<String> getKeys() {
+    return Collections.unmodifiableList(keys);
+  }
+}

--- a/src/main/java/net/spy/memcached/protocol/ascii/SingleKeyPipeOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/SingleKeyPipeOperationImpl.java
@@ -1,0 +1,36 @@
+package net.spy.memcached.protocol.ascii;
+
+import java.util.Collection;
+import java.util.Collections;
+
+import net.spy.memcached.collection.CollectionPipe;
+import net.spy.memcached.ops.OperationCallback;
+import net.spy.memcached.ops.OperationStatus;
+import net.spy.memcached.ops.SingleKeyPipedOperationCallback;
+
+abstract class SingleKeyPipeOperationImpl extends PipeOperationImpl {
+  protected final String key;
+  protected final SingleKeyPipedOperationCallback cb;
+
+  protected SingleKeyPipeOperationImpl(String key, CollectionPipe pipe,
+                                       OperationCallback cb) {
+    super(pipe, cb);
+
+    this.key = key;
+    this.cb = (SingleKeyPipedOperationCallback) cb;
+  }
+
+  @Override
+  protected void gotStatus(OperationStatus status) {
+    cb.gotStatus(index, status);
+  }
+
+  @Override
+  protected String getKey(Integer index) {
+    return key;
+  }
+
+  public Collection<String> getKeys() {
+    return Collections.singletonList(key);
+  }
+}

--- a/src/test/java/net/spy/memcached/protocol/ascii/BaseOpTest.java
+++ b/src/test/java/net/spy/memcached/protocol/ascii/BaseOpTest.java
@@ -36,7 +36,7 @@ import net.spy.memcached.ops.Operation;
 import net.spy.memcached.ops.OperationCallback;
 import net.spy.memcached.ops.OperationException;
 import net.spy.memcached.ops.OperationStatus;
-import net.spy.memcached.ops.PipedOperationCallback;
+import net.spy.memcached.ops.SingleKeyPipedOperationCallback;
 import net.spy.memcached.ops.StatusCode;
 
 import org.junit.jupiter.api.Test;
@@ -46,8 +46,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 /**
@@ -124,7 +124,7 @@ class BaseOpTest {
                     Arrays.asList("a", "b"), null, null);
     PipedCollectionFuture<Object, Object> rv =
             new PipedCollectionFuture<>(new CountDownLatch(1), 700);
-    OperationCallback cb = new PipedOperationCallback() {
+    OperationCallback cb = new SingleKeyPipedOperationCallback() {
       @Override
       public void receivedStatus(OperationStatus status) {
         CollectionOperationStatus cstatus;

--- a/src/test/manual/net/spy/memcached/MultibyteKeyTest.java
+++ b/src/test/manual/net/spy/memcached/MultibyteKeyTest.java
@@ -60,10 +60,11 @@ import net.spy.memcached.ops.CollectionGetOperation;
 import net.spy.memcached.ops.ConcatenationType;
 import net.spy.memcached.ops.GetAttrOperation;
 import net.spy.memcached.ops.GetsOperation;
+import net.spy.memcached.ops.MultiKeyPipedOperationCallback;
 import net.spy.memcached.ops.Mutator;
 import net.spy.memcached.ops.OperationCallback;
 import net.spy.memcached.ops.OperationStatus;
-import net.spy.memcached.ops.PipedOperationCallback;
+import net.spy.memcached.ops.SingleKeyPipedOperationCallback;
 import net.spy.memcached.ops.StoreType;
 import net.spy.memcached.protocol.ascii.AsciiOperationFactory;
 import net.spy.memcached.transcoders.IntegerTranscoder;
@@ -308,8 +309,8 @@ class MultibyteKeyTest {
 
   @Test
   void CollectionPipedInsertOperationImplTest() {
-    PipedOperationCallback cpsCallback =
-        new PipedOperationCallback() {
+    SingleKeyPipedOperationCallback cpsCallback =
+        new SingleKeyPipedOperationCallback() {
           @Override
           public void gotStatus(Integer index, OperationStatus status) {
           }
@@ -430,10 +431,10 @@ class MultibyteKeyTest {
   @Test
   void CollectionBulkInsertOperationImplTest() {
     CollectionBulkInsert<Integer> insert = null;
-    PipedOperationCallback cbsCallback =
-        new PipedOperationCallback() {
+    MultiKeyPipedOperationCallback cbsCallback =
+        new MultiKeyPipedOperationCallback() {
           @Override
-          public void gotStatus(Integer index, OperationStatus status) {
+          public void gotStatus(String key, OperationStatus status) {
           }
 
           @Override
@@ -551,7 +552,7 @@ class MultibyteKeyTest {
       opFact.collectionPipedUpdate(MULTIBYTE_KEY,
               new CollectionPipedUpdate.BTreePipedUpdate<>(
                       MULTIBYTE_KEY, elementsList, new IntegerTranscoder()),
-          new PipedOperationCallback() {
+          new SingleKeyPipedOperationCallback() {
             @Override
             public void gotStatus(Integer index, OperationStatus status) {
             }
@@ -600,7 +601,7 @@ class MultibyteKeyTest {
     try {
       opFact.collectionPipedExist(MULTIBYTE_KEY,
               new SetPipedExist<>(MULTIBYTE_KEY, objectList, new IntegerTranscoder()),
-          new PipedOperationCallback() {
+          new SingleKeyPipedOperationCallback() {
             @Override
             public void gotStatus(Integer index, OperationStatus status) {
             }


### PR DESCRIPTION
### 🔗 Related Issue

<!-- Please link related issue. ex) https://github.com/naver/arcus-java-client/issues/{issue_number} -->
- https://github.com/jam2in/arcus-works/issues/817

### ⌨️ What I did

<!-- Please describe this PR and what you've been working on. -->
- 아래와 같은 문제를 해결하기 위해, Piped operation을 Single-key piped operation과 Multi-key piped operation으로 분리합니다.
- Single-key piped operation은 기존의 Piped operation과 동일하게 동작하며, Multi-key piped operation은 OperationCallback에 `Integer index` 대신 `String key`를 넘깁니다.
  ```
  - Original: keys = [key0, key1, key2, key3, key4]
  
  Gets migrated and split:
  - Node A: [key0, key2] →
    - calls gotStatus(0, ...) for key0 (Correct)
    - calls gotStatus(1, ...) for key2 (Error. index 1 represents key1)
  - Node B: [key1, key3, key4] → 
    - calls gotStatus(0, ...) for key1 (Error. index 0 represents key0)
    - calls gotStatus(1, ...) for key3 (Error. index 1 represents key1)
    - calls gotStatus(2, ...) for key4 (Error. index 2 represents key2)
  ```

구체적인 변경 사항은 다음과 같습니다.

**Operation 클래스**

- PipeOperationImpl
  - Single-key인 경우와 Multi-key인 경우 모두에 사용할 수 있는 공통 로직을 갖고 있습니다.
  - 일부 로직을 추상 메소드로 변경하여 자식 클래스에서 Single-key 로직 혹은 Multi-key 로직을 수행하도록 했습니다.
- SingleKeyPipeOperationImpl
  - PipeOperationImpl을 상속받는 새로운 추상 클래스입니다.
  - Single-key piped operation을 위한 공통 로직을 갖고 있습니다.
  - `String key` 필드와 `SingleKeyPipedOperationCabllack cb` 필드를 갖고 있습니다.
- MultiKeyPipeOperationImpl
  - PipeOperationImpl을 상속받는 새로운 추상 클래스입니다.
  - Multi-key piped operation을 위한 공통 로직을 갖고 있습니다.
  - `List<String> keys` 필드와 `MultiKeyPipedOperationCabllack cb` 필드를 갖고 있습니다.

**OperationCallback 클래스**

- PipedOperationCallback => SingleKeyPipedOperationCallback으로 변경
  - 기존의 로직(`gotStatus(Integer index, OperationStatus status)`)을 그대로 수행하되, 이름을 SingleKeyOperationCallback으로 변경합니다.
- MultiKeyPipedOperationCallback
  - `gotStatus(String key, OperationStatus status)` 로직을 수행하는 OperationCallback 인터페이스입니다.
  - Multi-key piped operation에서 어떤 Key에 대한 응답을 받았는지 구분하기 위해 새롭게 추가했습니다.