### PR TITLE
INTERNAL: Use KeyValidator class for validating keys

### DIFF
--- a/src/main/java/net/spy/memcached/ArcusClient.java
+++ b/src/main/java/net/spy/memcached/ArcusClient.java
@@ -200,7 +200,6 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
 
   private static final int MAX_GETBULK_ELEMENT_COUNT = 50;
   private static final int MAX_SMGET_COUNT = 1000; // server configuration is 2000.
-  private static final int MAX_MKEY_LENGTH = 250;
 
   private static final int SHUTDOWN_TIMEOUT_MILLISECONDS = 2000;
   private static final AtomicInteger CLIENT_ID = new AtomicInteger(1);
@@ -447,26 +446,12 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
     this.shutdown(SHUTDOWN_TIMEOUT_MILLISECONDS, TimeUnit.MILLISECONDS);
   }
 
-  private void validateMKey(String mkey) {
-    byte[] keyBytes = KeyUtil.getKeyBytes(mkey);
-    if (keyBytes.length > MAX_MKEY_LENGTH) {
-      throw new IllegalArgumentException("MKey is too long (maxlen = "
-              + MAX_MKEY_LENGTH + ")");
-    }
-    if (keyBytes.length == 0) {
-      throw new IllegalArgumentException("MKey must contain at least one character.");
-    }
-    // Validate the mkey
-    for (byte b : keyBytes) {
-      if (b == ' ' || b == '\n' || b == '\r' || b == 0) {
-        throw new IllegalArgumentException("MKey contains invalid characters:  ``"
-                + mkey + "''");
-      }
-    }
-  }
-
   public Transcoder<Object> getCollectionTranscoder() {
     return collectionTranscoder;
+  }
+
+  public KeyValidator getKeyValidator() {
+    return keyValidator;
   }
 
   public <T> AsyncArcusCommands<T> asyncCommands() {
@@ -849,7 +834,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
                                                                  final List<String> keyList,
                                                                  final int exp, final T o,
                                                                  final Transcoder<T> tc) {
-    validateKeys(keyList);
+    keyValidator.validateKey(keyList);
 
     final CachedData co = tc.encode(o);
     final CountDownLatch latch = new CountDownLatch(keyList.size());
@@ -894,9 +879,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
       throw new IllegalArgumentException("Map is empty.");
     }
 
-    for (final String key : o.keySet()) {
-      validateKey(key);
-    }
+    keyValidator.validateKey(o.keySet());
 
     final CountDownLatch latch = new CountDownLatch(o.size());
     final BulkOperationFuture<OperationStatus> rv = new BulkOperationFuture<>(latch, operationTimeout);
@@ -932,7 +915,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
 
   @Override
   public Future<Map<String, OperationStatus>> asyncDeleteBulk(List<String> keyList) {
-    validateKeys(keyList);
+    keyValidator.validateKey(keyList);
 
     final CountDownLatch latch = new CountDownLatch(keyList.size());
     final BulkOperationFuture<OperationStatus> rv = new BulkOperationFuture<>(latch, operationTimeout);
@@ -1105,7 +1088,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
                                                                  boolean withDelete,
                                                                  boolean dropIfEmpty,
                                                                  Transcoder<T> tc) {
-    BTreeUtil.validateBkey(bkey);
+    KeyValidator.validateBKey(bkey);
     BTreeGet get = new BTreeGet(bkey, eFlagFilter, withDelete, dropIfEmpty);
     return asyncBopGet(key, get, tc);
   }
@@ -1127,7 +1110,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
                                                                  boolean withDelete,
                                                                  boolean dropIfEmpty,
                                                                  Transcoder<T> tc) {
-    BTreeUtil.validateBkey(from, to);
+    KeyValidator.validateBKey(from, to);
     BTreeGet get = new BTreeGet(from, to, eFlagFilter, offset, count, withDelete, dropIfEmpty);
     return asyncBopGet(key, get, tc);
   }
@@ -1194,10 +1177,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
                                                           String mkey,
                                                           boolean withDelete, boolean dropIfEmpty,
                                                           Transcoder<T> tc) {
-    if (mkey == null) {
-      throw new IllegalArgumentException("mkey is null");
-    }
-    validateMKey(mkey);
+    keyValidator.validateMKey(mkey);
     List<String> mkeyList = new ArrayList<>(1);
     mkeyList.add(mkey);
     MapGet get = new MapGet(mkeyList, withDelete, dropIfEmpty);
@@ -1214,12 +1194,8 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
                                                           List<String> mkeyList,
                                                           boolean withDelete, boolean dropIfEmpty,
                                                           Transcoder<T> tc) {
-    if (mkeyList == null) {
-      throw new IllegalArgumentException("mkeyList is null");
-    }
-    for (int i = 0; i < mkeyList.size(); i++) {
-      validateMKey(mkeyList.get(i));
-    }
+    keyValidator.validateMKey(mkeyList);
+
     MapGet get = new MapGet(mkeyList, withDelete, dropIfEmpty);
     return asyncMopGet(key, get, tc);
   }
@@ -1301,7 +1277,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
   public CollectionFuture<Boolean> asyncBopDelete(String key, long bkey,
                                                   ElementFlagFilter eFlagFilter,
                                                   boolean dropIfEmpty) {
-    BTreeUtil.validateBkey(bkey);
+    KeyValidator.validateBKey(bkey);
     BTreeDelete delete = new BTreeDelete(bkey, eFlagFilter, dropIfEmpty, false);
     return asyncCollectionDelete(key, delete);
   }
@@ -1311,7 +1287,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
                                                   long from, long to,
                                                   ElementFlagFilter eFlagFilter, int count,
                                                   boolean dropIfEmpty) {
-    BTreeUtil.validateBkey(from, to);
+    KeyValidator.validateBKey(from, to);
     BTreeDelete delete = new BTreeDelete(from, to, count, eFlagFilter, dropIfEmpty, false);
     return asyncCollectionDelete(key, delete);
   }
@@ -1327,10 +1303,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
   @Override
   public CollectionFuture<Boolean> asyncMopDelete(String key, String mkey,
                                                   boolean dropIfEmpty) {
-    if (mkey == null) {
-      throw new IllegalArgumentException("mkey is null");
-    }
-    validateMKey(mkey);
+    keyValidator.validateMKey(mkey);
     List<String> mkeyList = new ArrayList<>(1);
     mkeyList.add(mkey);
     MapDelete delete = new MapDelete(mkeyList, dropIfEmpty, false);
@@ -1345,7 +1318,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
 //      throw new IllegalArgumentException("mkeyList is null");
 //    }
 //    for (int i = 0; i < mkeyList.size(); i++) {
-//      validateMKey(mkeyList.get(i));
+//      keyValidator.validateMKey(mkeyList.get(i), MAX_MKEY_LENGTH);
 //    }
 //    MapDelete delete = new MapDelete(mkeyList, false, dropIfEmpty);
 //    return asyncCollectionDelete(key, delete);
@@ -1423,7 +1396,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
   public CollectionFuture<Integer> asyncBopGetItemCount(String key,
                                                         long from, long to,
                                                         ElementFlagFilter eFlagFilter) {
-    BTreeUtil.validateBkey(from, to);
+    KeyValidator.validateBKey(from, to);
     CollectionCount collectionCount = new BTreeCount(from, to, eFlagFilter);
     return asyncCollectionCount(key, collectionCount);
   }
@@ -1460,7 +1433,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
                                                       byte[] eFlag, T value,
                                                       CollectionAttributes attributesForCreate,
                                                       Transcoder<T> tc) {
-    BTreeUtil.validateBkey(bkey);
+    KeyValidator.validateBKey(bkey);
     BTreeInsert<T> bTreeInsert = new BTreeInsert<>(value, eFlag, null, attributesForCreate);
     return asyncCollectionInsert(key, String.valueOf(bkey), bTreeInsert, tc);
   }
@@ -1470,7 +1443,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
                                                       T value,
                                                       CollectionAttributes attributesForCreate,
                                                       Transcoder<T> tc) {
-    validateMKey(mkey);
+    keyValidator.validateMKey(mkey);
     MapInsert<T> mapInsert = new MapInsert<>(value, null, attributesForCreate);
     return asyncCollectionInsert(key, mkey, mapInsert, tc);
   }
@@ -1583,9 +1556,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
               "The number of piped operations must be larger than 0.");
     }
 
-    for (Map.Entry<String, T> checkMKey : elements.entrySet()) {
-      validateMKey(checkMKey.getKey());
-    }
+    keyValidator.validateMKey(elements.keySet());
 
     List<CollectionPipedInsert<T>> insertList = new ArrayList<>();
 
@@ -1841,7 +1812,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
                                                       CollectionAttributes attributesForCreate,
                                                       Transcoder<T> tc) {
 
-    BTreeUtil.validateBkey(bkey);
+    KeyValidator.validateBKey(bkey);
     BTreeUpsert<T> bTreeUpsert = new BTreeUpsert<>(value, elementFlag, null, attributesForCreate);
 
     return asyncCollectionInsert(key, String.valueOf(bkey), bTreeUpsert, tc);
@@ -1857,7 +1828,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
   public <T> CollectionFuture<Boolean> asyncMopUpsert(String key, String mkey, T value,
                                                       CollectionAttributes attributesForCreate,
                                                       Transcoder<T> tc) {
-    validateMKey(mkey);
+    keyValidator.validateMKey(mkey);
     MapUpsert<T> mapUpsert = new MapUpsert<>(value, attributesForCreate);
 
     return asyncCollectionInsert(key, mkey, mapUpsert, tc);
@@ -1873,7 +1844,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
   public <T> CollectionFuture<Boolean> asyncBopUpdate(String key, long bkey,
                                                       ElementFlagUpdate eFlagUpdate, T value,
                                                       Transcoder<T> tc) {
-    BTreeUtil.validateBkey(bkey);
+    KeyValidator.validateBKey(bkey);
     BTreeUpdate<T> collectionUpdate = new BTreeUpdate<>(value, eFlagUpdate, false);
     return asyncCollectionUpdate(key, String.valueOf(bkey), collectionUpdate, tc);
   }
@@ -1890,7 +1861,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
                                                       byte[] bkey,
                                                       ElementFlagUpdate eFlagUpdate, T value,
                                                       Transcoder<T> tc) {
-    BTreeUtil.validateBkey(bkey);
+    KeyValidator.validateBKey(bkey);
     BTreeUpdate<T> collectionUpdate = new BTreeUpdate<>(value, eFlagUpdate, false);
     return asyncCollectionUpdate(key, BTreeUtil.toHex(bkey), collectionUpdate, tc);
   }
@@ -1904,7 +1875,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
   @Override
   public <T> CollectionFuture<Boolean> asyncMopUpdate(String key, String mkey,
                                                       T value, Transcoder<T> tc) {
-    validateMKey(mkey);
+    keyValidator.validateMKey(mkey);
     MapUpdate<T> collectionUpdate = new MapUpdate<>(value, false);
     return asyncCollectionUpdate(key, mkey, collectionUpdate, tc);
   }
@@ -2001,9 +1972,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
               "The number of piped operations must be larger than 0.");
     }
 
-    for (Map.Entry<String, T> checkMKey : elements.entrySet()) {
-      validateMKey(checkMKey.getKey());
-    }
+    keyValidator.validateMKey(elements.keySet());
 
     List<CollectionPipedUpdate<T>> updateList = new ArrayList<>();
 
@@ -2084,7 +2053,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
                                                       byte[] bkey, byte[] eFlag, T value,
                                                       CollectionAttributes attributesForCreate,
                                                       Transcoder<T> tc) {
-    BTreeUtil.validateBkey(bkey);
+    KeyValidator.validateBKey(bkey);
     BTreeInsert<T> bTreeInsert = new BTreeInsert<>(value, eFlag, null, attributesForCreate);
     return asyncCollectionInsert(key, BTreeUtil.toHex(bkey), bTreeInsert, tc);
   }
@@ -2112,7 +2081,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
   public <T> CollectionFuture<Map<ByteArrayBKey, Element<T>>> asyncBopGet(
           String key, byte[] bkey, ElementFlagFilter eFlagFilter,
           boolean withDelete, boolean dropIfEmpty, Transcoder<T> tc) {
-    BTreeUtil.validateBkey(bkey);
+    KeyValidator.validateBKey(bkey);
     BTreeGet get = new BTreeGet(bkey, eFlagFilter, withDelete, dropIfEmpty);
     return asyncBopExtendedGet(key, get, tc);
   }
@@ -2144,7 +2113,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
           String key, byte[] from, byte[] to, ElementFlagFilter eFlagFilter, int offset,
           int count, boolean withDelete, boolean dropIfEmpty,
           Transcoder<T> tc) {
-    BTreeUtil.validateBkey(from, to);
+    KeyValidator.validateBKey(from, to);
     BTreeGet get = new BTreeGet(from, to, eFlagFilter, offset, count, withDelete, dropIfEmpty);
     return asyncBopExtendedGet(key, get, tc);
   }
@@ -2274,7 +2243,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
   @Override
   public CollectionFuture<Integer> asyncBopFindPosition(String key, long bkey,
                                                         BTreeOrder order) {
-    BTreeUtil.validateBkey(bkey);
+    KeyValidator.validateBKey(bkey);
     if (order == null) {
       throw new IllegalArgumentException("BTreeOrder must not be null.");
     }
@@ -2285,7 +2254,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
   @Override
   public CollectionFuture<Integer> asyncBopFindPosition(String key, byte[] bkey,
                                                         BTreeOrder order) {
-    BTreeUtil.validateBkey(bkey);
+    KeyValidator.validateBKey(bkey);
     if (order == null) {
       throw new IllegalArgumentException("BTreeOrder must not be null.");
     }
@@ -2526,7 +2495,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
                                                   byte[] from, byte[] to,
                                                   ElementFlagFilter eFlagFilter, int count,
                                                   boolean dropIfEmpty) {
-    BTreeUtil.validateBkey(from, to);
+    KeyValidator.validateBKey(from, to);
     BTreeDelete delete = new BTreeDelete(from, to, count, eFlagFilter, dropIfEmpty, false);
     return asyncCollectionDelete(key, delete);
   }
@@ -2535,7 +2504,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
   public CollectionFuture<Boolean> asyncBopDelete(String key,
                                                   byte[] bkey, ElementFlagFilter eFlagFilter,
                                                   boolean dropIfEmpty) {
-    BTreeUtil.validateBkey(bkey);
+    KeyValidator.validateBKey(bkey);
     BTreeDelete delete = new BTreeDelete(bkey, eFlagFilter, dropIfEmpty, false);
     return asyncCollectionDelete(key, delete);
   }
@@ -2552,7 +2521,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
                                                       byte[] bkey, byte[] elementFlag, T value,
                                                       CollectionAttributes attributesForCreate,
                                                       Transcoder<T> tc) {
-    BTreeUtil.validateBkey(bkey);
+    KeyValidator.validateBKey(bkey);
     BTreeUpsert<T> bTreeUpsert = new BTreeUpsert<>(value, elementFlag, null, attributesForCreate);
     return asyncCollectionInsert(key, BTreeUtil.toHex(bkey), bTreeUpsert, tc);
   }
@@ -2561,7 +2530,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
   public CollectionFuture<Integer> asyncBopGetItemCount(String key,
                                                         byte[] from, byte[] to,
                                                         ElementFlagFilter eFlagFilter) {
-    BTreeUtil.validateBkey(from, to);
+    KeyValidator.validateBKey(from, to);
     CollectionCount collectionCount = new BTreeCount(from, to, eFlagFilter);
     return asyncCollectionCount(key, collectionCount);
   }
@@ -2655,8 +2624,8 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
   public SMGetFuture<List<SMGetElement<Object>>> asyncBopSortMergeGet(
           List<String> keyList, byte[] from, byte[] to, ElementFlagFilter eFlagFilter,
           int count, boolean unique) {
-    BTreeUtil.validateBkey(from, to);
-    validateKeys(keyList);
+    KeyValidator.validateBKey(from, to);
+    keyValidator.validateKey(keyList);
     checkDupKey(keyList);
     if (count < 1) {
       throw new IllegalArgumentException("Count must be larger than 0.");
@@ -2683,7 +2652,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
   public SMGetFuture<List<SMGetElement<Object>>> asyncBopSortMergeGet(
           List<String> keyList, long from, long to, ElementFlagFilter eFlagFilter,
           int count, boolean unique) {
-    validateKeys(keyList);
+    keyValidator.validateKey(keyList);
     checkDupKey(keyList);
     if (count < 1) {
       throw new IllegalArgumentException("Count must be larger than 0.");
@@ -2717,8 +2686,8 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
           List<String> keyList, long bkey, byte[] eFlag, T value,
           CollectionAttributes attributesForCreate, Transcoder<T> tc) {
 
-    BTreeUtil.validateBkey(bkey);
-    validateKeys(keyList);
+    KeyValidator.validateBKey(bkey);
+    keyValidator.validateKey(keyList);
     checkDupKey(keyList);
     Collection<Entry<MemcachedNode, List<String>>> arrangedKey =
             groupingKeys(keyList, NON_PIPED_BULK_INSERT_CHUNK_SIZE, APIType.BOP_INSERT);
@@ -2751,8 +2720,8 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
           List<String> keyList, byte[] bkey, byte[] eFlag, T value,
           CollectionAttributes attributesForCreate, Transcoder<T> tc) {
 
-    BTreeUtil.validateBkey(bkey);
-    validateKeys(keyList);
+    KeyValidator.validateBKey(bkey);
+    keyValidator.validateKey(keyList);
     checkDupKey(keyList);
     Collection<Entry<MemcachedNode, List<String>>> arrangedKey =
             groupingKeys(keyList, NON_PIPED_BULK_INSERT_CHUNK_SIZE, APIType.BOP_INSERT);
@@ -2783,8 +2752,8 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
           List<String> keyList, String mkey, T value,
           CollectionAttributes attributesForCreate, Transcoder<T> tc) {
 
-    validateMKey(mkey);
-    validateKeys(keyList);
+    keyValidator.validateMKey(mkey);
+    keyValidator.validateKey(keyList);
     checkDupKey(keyList);
     Collection<Entry<MemcachedNode, List<String>>> arrangedKey =
             groupingKeys(keyList, NON_PIPED_BULK_INSERT_CHUNK_SIZE, APIType.MOP_INSERT);
@@ -2814,7 +2783,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
   public <T> Future<Map<String, CollectionOperationStatus>> asyncSopInsertBulk(
           List<String> keyList, T value,
           CollectionAttributes attributesForCreate, Transcoder<T> tc) {
-    validateKeys(keyList);
+    keyValidator.validateKey(keyList);
     checkDupKey(keyList);
 
     Collection<Entry<MemcachedNode, List<String>>> arrangedKey =
@@ -2844,7 +2813,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
   public <T> Future<Map<String, CollectionOperationStatus>> asyncLopInsertBulk(
           List<String> keyList, int index, T value,
           CollectionAttributes attributesForCreate, Transcoder<T> tc) {
-    validateKeys(keyList);
+    keyValidator.validateKey(keyList);
     checkDupKey(keyList);
 
     Collection<Entry<MemcachedNode, List<String>>> arrangedKey =
@@ -2912,7 +2881,8 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
   public <T> CollectionGetBulkFuture<Map<String, BTreeGetResult<Long, T>>> asyncBopGetBulk(
           List<String> keyList, long from, long to,
           ElementFlagFilter eFlagFilter, int offset, int count, Transcoder<T> tc) {
-    validateKeys(keyList);
+    KeyValidator.validateBKey(from, to);
+    keyValidator.validateKey(keyList);
     checkDupKey(keyList);
     if (offset < 0) {
       throw new IllegalArgumentException("Offset must be 0 or positive integer.");
@@ -2943,7 +2913,6 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
       asyncBopGetBulk(
           List<String> keyList, byte[] from, byte[] to,
           ElementFlagFilter eFlagFilter, int offset, int count) {
-    BTreeUtil.validateBkey(from, to);
     return asyncBopGetBulk(keyList, from, to, eFlagFilter, offset, count, collectionTranscoder);
   }
 
@@ -2951,8 +2920,8 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
           List<String> keyList, byte[] from, byte[] to,
           ElementFlagFilter eFlagFilter, int offset, int count,
           Transcoder<T> tc) {
-    BTreeUtil.validateBkey(from, to);
-    validateKeys(keyList);
+    KeyValidator.validateBKey(from, to);
+    keyValidator.validateKey(keyList);
     checkDupKey(keyList);
 
     if (offset < 0) {
@@ -3102,7 +3071,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
   @Override
   public CollectionFuture<Long> asyncBopIncr(String key, long bkey,
                                              int by) {
-    BTreeUtil.validateBkey(bkey);
+    KeyValidator.validateBKey(bkey);
     CollectionMutate collectionMutate = new BTreeMutate(Mutator.incr, by);
     return asyncCollectionMutate(key, String.valueOf(bkey), collectionMutate);
   }
@@ -3110,7 +3079,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
   @Override
   public CollectionFuture<Long> asyncBopIncr(String key, byte[] bkey,
                                              int by) {
-    BTreeUtil.validateBkey(bkey);
+    KeyValidator.validateBKey(bkey);
     CollectionMutate collectionMutate = new BTreeMutate(Mutator.incr, by);
     return asyncCollectionMutate(key, BTreeUtil.toHex(bkey), collectionMutate);
   }
@@ -3118,7 +3087,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
   @Override
   public CollectionFuture<Long> asyncBopIncr(String key, long bkey,
                                              int by, long initial, byte[] eFlag) {
-    BTreeUtil.validateBkey(bkey);
+    KeyValidator.validateBKey(bkey);
     CollectionMutate collectionMutate = new BTreeMutate(Mutator.incr, by, initial, eFlag);
     return asyncCollectionMutate(key, String.valueOf(bkey), collectionMutate);
   }
@@ -3126,7 +3095,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
   @Override
   public CollectionFuture<Long> asyncBopIncr(String key, byte[] bkey,
                                              int by, long initial, byte[] eFlag) {
-    BTreeUtil.validateBkey(bkey);
+    KeyValidator.validateBKey(bkey);
     CollectionMutate collectionMutate = new BTreeMutate(Mutator.incr, by, initial, eFlag);
     return asyncCollectionMutate(key, BTreeUtil.toHex(bkey), collectionMutate);
   }
@@ -3134,7 +3103,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
   @Override
   public CollectionFuture<Long> asyncBopDecr(String key, long bkey,
                                              int by) {
-    BTreeUtil.validateBkey(bkey);
+    KeyValidator.validateBKey(bkey);
     CollectionMutate collectionMutate = new BTreeMutate(Mutator.decr, by);
     return asyncCollectionMutate(key, String.valueOf(bkey), collectionMutate);
   }
@@ -3142,7 +3111,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
   @Override
   public CollectionFuture<Long> asyncBopDecr(String key, byte[] bkey,
                                              int by) {
-    BTreeUtil.validateBkey(bkey);
+    KeyValidator.validateBKey(bkey);
     CollectionMutate collectionMutate = new BTreeMutate(Mutator.decr, by);
     return asyncCollectionMutate(key, BTreeUtil.toHex(bkey), collectionMutate);
   }
@@ -3150,7 +3119,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
   @Override
   public CollectionFuture<Long> asyncBopDecr(String key, long bkey,
                                              int by, long initial, byte[] eFlag) {
-    BTreeUtil.validateBkey(bkey);
+    KeyValidator.validateBKey(bkey);
     CollectionMutate collectionMutate = new BTreeMutate(Mutator.decr, by, initial, eFlag);
     return asyncCollectionMutate(key, String.valueOf(bkey), collectionMutate);
   }
@@ -3158,7 +3127,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
   @Override
   public CollectionFuture<Long> asyncBopDecr(String key, byte[] bkey,
                                              int by, long initial, byte[] eFlag) {
-    BTreeUtil.validateBkey(bkey);
+    KeyValidator.validateBKey(bkey);
     CollectionMutate collectionMutate = new BTreeMutate(Mutator.decr, by, initial, eFlag);
     return asyncCollectionMutate(key, BTreeUtil.toHex(bkey), collectionMutate);
   }
@@ -3209,18 +3178,6 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
     rv.setOperation(op);
     addOp(k, op);
     return rv;
-  }
-
-  private void validateKeys(Collection<String> keyList) {
-    if (keyList == null) {
-      throw new IllegalArgumentException("Key list is null.");
-    } else if (keyList.isEmpty()) {
-      throw new IllegalArgumentException("Key list is empty.");
-    }
-
-    for (String key : keyList) {
-      validateKey(key);
-    }
   }
 
   private void checkDupKey(Collection<String> keyList) {

--- a/src/main/java/net/spy/memcached/KeyValidator.java
+++ b/src/main/java/net/spy/memcached/KeyValidator.java
@@ -1,0 +1,180 @@
+/*
+ * arcus-java-client : Arcus Java client
+ * Copyright 2010-2014 NAVER Corp.
+ * Copyright 2014-present JaM2in Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.spy.memcached;
+
+import java.util.Collection;
+
+/**
+ * Validator for memcached keys.
+ */
+public final class KeyValidator {
+
+  private static final int MAX_KEY_LENGTH = 4000;
+  private static final int MAX_MKEY_LENGTH = 250;
+  private static final int MAX_BKEY_BYTE_ARRAY_LENGTH = 31;
+
+  private final byte delimiter;
+
+  public KeyValidator(byte delimiter) {
+    this.delimiter = delimiter;
+  }
+
+  /**
+   * Validate cache key.
+   *
+   * @param key the cache key to validate
+   * @throws IllegalArgumentException if the key is invalid
+   */
+  public void validateKey(String key) {
+    boolean hasPrefix = false;
+
+    byte[] keyBytes = KeyUtil.getKeyBytes(key);
+    if (keyBytes.length > MAX_KEY_LENGTH) {
+      throw new IllegalArgumentException("Key is too long (maxlen = "
+          + MAX_KEY_LENGTH + ")");
+    } else if (keyBytes.length == 0) {
+      throw new IllegalArgumentException(
+          "Key must contain at least one character.");
+    }
+    // Validate the key
+    for (byte b : keyBytes) {
+      if (b == ' ' || b == '\n' || b == '\r' || b == 0) {
+        throw new IllegalArgumentException(
+            "Key contains invalid characters:  ``" + key + "''");
+      }
+      if (b == delimiter) {
+        hasPrefix = true;
+      }
+    }
+
+    // Validate the prefix
+    if (hasPrefix) {
+      if (keyBytes[0] == '-') {
+        throw new IllegalArgumentException(
+            "Key contains invalid prefix: ``" + key + "''");
+      }
+      for (byte b : keyBytes) {
+        if (b == delimiter) {
+          break;
+        }
+        if (!(('a' <= b && b <= 'z') || ('A' <= b && b <= 'Z') ||
+            ('0' <= b && b <= '9') ||
+            (b == '_') || (b == '-') || (b == '+') || (b == '.'))) {
+          throw new IllegalArgumentException(
+              "Key contains invalid prefix: ``" + key + "''");
+        }
+      }
+    }
+  }
+
+  /**
+   * Validate cache keys.
+   *
+   * @param keyList the cache keys to validate
+   * @throws IllegalArgumentException if the key list is null, empty, or contains invalid keys
+   */
+  public void validateKey(Collection<String> keyList) {
+    if (keyList == null) {
+      throw new IllegalArgumentException("Key list is null.");
+    } else if (keyList.isEmpty()) {
+      throw new IllegalArgumentException("Key list is empty.");
+    }
+
+    for (String key : keyList) {
+      validateKey(key);
+    }
+  }
+
+  /**
+   * Validate map key.
+   *
+   * @param mkey the mkey to validate
+   * @throws IllegalArgumentException if the mkey is invalid
+   */
+  public void validateMKey(String mkey) {
+    if (mkey == null) {
+      throw new IllegalArgumentException("mkey is null");
+    }
+
+    byte[] keyBytes = KeyUtil.getKeyBytes(mkey);
+    if (keyBytes.length > MAX_MKEY_LENGTH) {
+      throw new IllegalArgumentException("MKey is too long (maxlen = "
+          + MAX_MKEY_LENGTH + ")");
+    }
+    if (keyBytes.length == 0) {
+      throw new IllegalArgumentException("MKey must contain at least one character.");
+    }
+    // Validate the mkey
+    for (byte b : keyBytes) {
+      if (b == ' ' || b == '\n' || b == '\r' || b == 0) {
+        throw new IllegalArgumentException("MKey contains invalid characters:  ``"
+            + mkey + "''");
+      }
+    }
+  }
+
+  /**
+   * Validate map keys.
+   *
+   * @param mkeyList the mkeys to validate
+   * @throws IllegalArgumentException if the mkey list is null, empty, or contains invalid mkeys
+   */
+  public void validateMKey(Collection<String> mkeyList) {
+    if (mkeyList == null) {
+      throw new IllegalArgumentException("mkeyList is null.");
+    } else if (mkeyList.isEmpty()) {
+      throw new IllegalArgumentException("mkeyList is empty.");
+    }
+
+    for (String mkey : mkeyList) {
+      validateMKey(mkey);
+    }
+  }
+
+  /**
+   * Validate byte type bkeys.
+   *
+   * @param bkeys the bkeys to validate
+   * @throws IllegalArgumentException if the bkey is invalid
+   */
+  public static void validateBKey(byte[]... bkeys) {
+    for (byte[] bkey : bkeys) {
+      if (bkey == null) {
+        throw new IllegalArgumentException("bkey is null");
+      }
+      if (bkey.length > MAX_BKEY_BYTE_ARRAY_LENGTH) {
+        throw new IllegalArgumentException("bkey size exceeded 31");
+      }
+    }
+  }
+
+  /**
+   * Validate long type bkeys.
+   *
+   * @param bkeys the bkeys to validate
+   * @throws IllegalArgumentException if the bkey is invalid
+   */
+  public static void validateBKey(long... bkeys) {
+    for (long bkey : bkeys) {
+      if (bkey < 0) {
+        throw new IllegalArgumentException(
+            String.format("not supported unsigned long bkey : %s, use byte array bkey", bkey));
+      }
+    }
+  }
+}

--- a/src/main/java/net/spy/memcached/MemcachedClientIF.java
+++ b/src/main/java/net/spy/memcached/MemcachedClientIF.java
@@ -15,10 +15,6 @@ import net.spy.memcached.transcoders.Transcoder;
  * This interface is provided as a helper for testing clients of the MemcachedClient.
  */
 public interface MemcachedClientIF {
-  /**
-   * Maximum supported key length.
-   */
-  int MAX_KEY_LENGTH = 4000;
 
   Collection<SocketAddress> getAvailableServers();
 

--- a/src/main/java/net/spy/memcached/collection/BKeyObject.java
+++ b/src/main/java/net/spy/memcached/collection/BKeyObject.java
@@ -19,6 +19,7 @@ package net.spy.memcached.collection;
 
 import java.util.Objects;
 
+import net.spy.memcached.KeyValidator;
 import net.spy.memcached.util.BTreeUtil;
 
 public class BKeyObject implements Comparable<BKeyObject> {
@@ -32,14 +33,14 @@ public class BKeyObject implements Comparable<BKeyObject> {
   private final ByteArrayBKey byteArrayBKey;
 
   public BKeyObject(long longBKey) {
-    BTreeUtil.validateBkey(longBKey);
+    KeyValidator.validateBKey(longBKey);
     this.type = BKeyType.LONG;
     this.longBKey = longBKey;
     this.byteArrayBKey = null;
   }
 
   public BKeyObject(byte[] byteArrayBKey) {
-    BTreeUtil.validateBkey(byteArrayBKey);
+    KeyValidator.validateBKey(byteArrayBKey);
     this.type = BKeyType.BYTEARRAY;
     this.longBKey = null;
     this.byteArrayBKey = new ByteArrayBKey(byteArrayBKey);

--- a/src/main/java/net/spy/memcached/collection/ByteArrayBKey.java
+++ b/src/main/java/net/spy/memcached/collection/ByteArrayBKey.java
@@ -19,6 +19,7 @@ package net.spy.memcached.collection;
 
 import java.util.Arrays;
 
+import net.spy.memcached.KeyValidator;
 import net.spy.memcached.util.BTreeUtil;
 
 public class ByteArrayBKey implements Comparable<ByteArrayBKey> {
@@ -37,7 +38,7 @@ public class ByteArrayBKey implements Comparable<ByteArrayBKey> {
   private final byte[] bkey;
 
   public ByteArrayBKey(byte[] bkey) {
-    BTreeUtil.validateBkey(bkey);
+    KeyValidator.validateBKey(bkey);
     this.bkey = bkey;
   }
 

--- a/src/main/java/net/spy/memcached/util/BTreeUtil.java
+++ b/src/main/java/net/spy/memcached/util/BTreeUtil.java
@@ -25,7 +25,6 @@ import net.spy.memcached.transcoders.Transcoder;
 public final class BTreeUtil {
 
   private static final String HEXES = "0123456789ABCDEF";
-  private static final int MAX_BKEY_BYTE_ARRAY_SIZE = 31;
 
   private BTreeUtil() {
   }
@@ -84,26 +83,6 @@ public final class BTreeUtil {
       }
     }
     return array1.length - array2.length;
-  }
-
-  public static void validateBkey(byte[] ...bkeys) {
-    for (byte[] bkey : bkeys) {
-      if (bkey == null) {
-        throw new IllegalArgumentException("bkey is null");
-      }
-      if (bkey.length > MAX_BKEY_BYTE_ARRAY_SIZE) {
-        throw new IllegalArgumentException("bkey size exceeded 31");
-      }
-    }
-  }
-
-  public static void validateBkey(long ...bkeys) {
-    for (long bkey : bkeys) {
-      if (bkey < 0) {
-        throw new IllegalArgumentException(
-                String.format("not supported unsigned long bkey : %s, use byte array bkey", bkey));
-      }
-    }
   }
 
   public static <T> Element<T> makeBTreeElement(BKeyObject bkey,

--- a/src/test/java/net/spy/memcached/util/BTreeUtilTest.java
+++ b/src/test/java/net/spy/memcached/util/BTreeUtilTest.java
@@ -18,6 +18,8 @@ package net.spy.memcached.util;
 
 import java.util.Arrays;
 
+import net.spy.memcached.KeyValidator;
+
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -90,7 +92,7 @@ class BTreeUtilTest {
   @Test
   void testInValidSizeBkey() {
     assertThrows(IllegalArgumentException.class, () -> {
-      BTreeUtil.validateBkey(new byte[32]);
+      KeyValidator.validateBKey(new byte[32]);
     });
   }
 
@@ -98,7 +100,7 @@ class BTreeUtilTest {
   void testMinusLongBkey() {
     final long bkey = -1;
     assertThrows(IllegalArgumentException.class, () -> {
-      BTreeUtil.validateBkey(bkey);
+      KeyValidator.validateBKey(bkey);
     });
   }
 }


### PR DESCRIPTION
### 🔗 Related Issue

<!-- Please link related issue. ex) https://github.com/naver/arcus-java-client/issues/{issue_number} -->
- https://github.com/naver/arcus-java-client/pull/1026#discussion_r2609506917

### ⌨️ What I did

<!-- Please describe this PR and what you've been working on. -->
- cache key, mkey, bkey를 검증할 수 있는 KeyValidator 클래스를 제공합니다.
- cache key 검증의 경우 delimiter 값을 가져와야 하기 때문에 static method로 제공할 수 없습니다. 나머지 메서드들은 static method로 제공합니다.