### PR TITLE
INTERNAL: Deprecate setMaxSMGetKeyChunkSize and use fixed chunk size

### DIFF
--- a/docs/user-guide/02-arcus-java-client.md
+++ b/docs/user-guide/02-arcus-java-client.md
@@ -546,12 +546,6 @@ SLF4J: See http://www.slf4j.org/codes.html#multiple_bindings for an explanation.
       100회 이상의 timeout이 연속적으로 발생하면 reconnect를 시도한다. 따라서 정말 네트워크 연결에 문제가 발생하지 않는 상황이더라도
       reconnect가 발생할 수 있다. 따라서 burst 트래픽 요청이 자주 발생하는 애플리케이션이라면 TimeoutDurationThreshold를 0으로 설정하는 것을 권장하지 않는다.
 
-- setMaxSMGetKeyChunkSize(int size)
-
-  Arcus 캐시 서버에서 제공하는 SMGet 명령어를 사용할 때 여러 키들이 한 노드에 배치되어 있는 경우, 하나의 요청에 들어가는 키의 최대 개수를 설정한다.
-  만약 이 값을 초과하는 키가 요청되면, ARCUS Java Client는 자동으로 요청을 나누어 보낸다.
-  기본값은 500이다. 최대 10000까지 지정 가능하다.
-
 - setDelimiter(byte to)
 
   Arcus 캐시 서버에 `-D <char>` 옵션으로 Prefix와 Subkey를 구분하기 위한 구분자를 직접 지정한 경우

--- a/src/main/java/net/spy/memcached/ArcusClient.java
+++ b/src/main/java/net/spy/memcached/ArcusClient.java
@@ -193,9 +193,8 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
 
   private final Transcoder<Object> collectionTranscoder;
 
-  private final int smgetKeyChunkSize;
-
   private static final int BOPGET_BULK_CHUNK_SIZE = 200;
+  private static final int SMGET_CHUNK_SIZE = 500;
   private static final int NON_PIPED_BULK_INSERT_CHUNK_SIZE = 500;
 
   private static final int MAX_GETBULK_ELEMENT_COUNT = 50;
@@ -361,7 +360,6 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
       throw new IllegalStateException("DNS cache TTL is out of range from 0 to " + MAX_DNS_CACHE_TTL);
     }
     collectionTranscoder = cf.getDefaultCollectionTranscoder();
-    smgetKeyChunkSize = cf.getDefaultMaxSMGetKeyChunkSize();
     registerMbean(name);
   }
 
@@ -2667,7 +2665,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
     }
 
     Collection<Entry<MemcachedNode, List<String>>> arrangedKey =
-            groupingKeys(keyList, smgetKeyChunkSize, APIType.BOP_SMGET);
+            groupingKeys(keyList, SMGET_CHUNK_SIZE, APIType.BOP_SMGET);
     List<BTreeSMGet<Object>> smGetList = new ArrayList<>(
             arrangedKey.size());
     for (Entry<MemcachedNode, List<String>> entry : arrangedKey) {
@@ -2694,7 +2692,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
     }
 
     Collection<Entry<MemcachedNode, List<String>>> arrangedKey =
-            groupingKeys(keyList, smgetKeyChunkSize, APIType.BOP_SMGET);
+            groupingKeys(keyList, SMGET_CHUNK_SIZE, APIType.BOP_SMGET);
     List<BTreeSMGet<Object>> smGetList = new ArrayList<>(
             arrangedKey.size());
     for (Entry<MemcachedNode, List<String>> entry : arrangedKey) {

--- a/src/main/java/net/spy/memcached/ConnectionFactory.java
+++ b/src/main/java/net/spy/memcached/ConnectionFactory.java
@@ -209,7 +209,9 @@ public interface ConnectionFactory {
 
   /**
    * get max smget key chunk size
+   * @deprecated SMGet key chunk size is fixed to 500. So this method is no longer used.
    */
+  @Deprecated
   int getDefaultMaxSMGetKeyChunkSize();
 
   /**

--- a/src/main/java/net/spy/memcached/ConnectionFactoryBuilder.java
+++ b/src/main/java/net/spy/memcached/ConnectionFactoryBuilder.java
@@ -75,7 +75,6 @@ public class ConnectionFactoryBuilder {
   private int frontCacheExpireTime = DefaultConnectionFactory.DEFAULT_FRONTCACHE_EXPIRETIME;
   private String frontCacheName;
 
-  private int maxSMGetChunkSize = DefaultConnectionFactory.DEFAULT_MAX_SMGET_KEY_CHUNK_SIZE;
   private byte delimiter = DefaultConnectionFactory.DEFAULT_DELIMITER;
 
   /* ENABLE_REPLICATION if */
@@ -418,14 +417,10 @@ public class ConnectionFactoryBuilder {
 
   /**
    * Set max smget key chunk size
+   * @deprecated max smget key chunk size is fixed to 500. So this method has no effect.
    */
+  @Deprecated
   public ConnectionFactoryBuilder setMaxSMGetKeyChunkSize(int size) {
-    if (size <= 0 || size > 10000) {
-      throw new IllegalArgumentException(
-              "Max smget key chunk size must be a positive number and less than 10000");
-    }
-
-    maxSMGetChunkSize = size;
     return this;
   }
 
@@ -691,8 +686,10 @@ public class ConnectionFactoryBuilder {
       }
 
       @Override
+      @SuppressWarnings("deprecation")
+      @Deprecated
       public int getDefaultMaxSMGetKeyChunkSize() {
-        return maxSMGetChunkSize;
+        return DefaultConnectionFactory.DEFAULT_MAX_SMGET_KEY_CHUNK_SIZE;
       }
 
       @Override

--- a/src/main/java/net/spy/memcached/DefaultConnectionFactory.java
+++ b/src/main/java/net/spy/memcached/DefaultConnectionFactory.java
@@ -146,6 +146,7 @@ public class DefaultConnectionFactory extends SpyObject
   /**
    * Max smget key chunk size per request
    */
+  @Deprecated
   public static final int DEFAULT_MAX_SMGET_KEY_CHUNK_SIZE = 500;
 
   /**
@@ -362,6 +363,7 @@ public class DefaultConnectionFactory extends SpyObject
   }
 
   @Override
+  @Deprecated
   public int getDefaultMaxSMGetKeyChunkSize() {
     return DEFAULT_MAX_SMGET_KEY_CHUNK_SIZE;
   }

--- a/src/test/java/net/spy/memcached/ConnectionFactoryBuilderTest.java
+++ b/src/test/java/net/spy/memcached/ConnectionFactoryBuilderTest.java
@@ -225,8 +225,6 @@ class ConnectionFactoryBuilderTest {
             defaultConnectionFactory.getFrontCacheCopyOnRead());
     assertEquals(connectionFactory.getFrontCacheCopyOnWrite(),
             defaultConnectionFactory.getFrontCacheCopyOnWrite());
-    assertEquals(connectionFactory.getDefaultMaxSMGetKeyChunkSize(),
-            defaultConnectionFactory.getDefaultMaxSMGetKeyChunkSize());
     assertEquals(connectionFactory.getDelimiter(),
             defaultConnectionFactory.getDelimiter());
     assertEquals(connectionFactory.getReadPriority(),


### PR DESCRIPTION
### 🔗 Related Issue

<!-- Please link related issue. ex) https://github.com/naver/arcus-java-client/issues/{issue_number} -->
- https://github.com/naver/arcus-java-client/pull/1026#discussion_r2609543762

### ⌨️ What I did

<!-- Please describe this PR and what you've been working on. -->
- 하나의 SMGet 요청에 담을 수 있는 Key 목록의 크기를 500으로 고정합니다.
- 기존에 사용자의 입력을 받아 동작하기 위해 존재했던 setMaxSMGetKeyChunkSize, getDefaultMaxSMGetKeyChunkSize 메서드는 Deprecate 시킵니다.