### PR TITLE
 FEATURE: Add CompletableFuture Pipeline API

### DIFF
--- a/src/main/java/net/spy/memcached/OperationFactory.java
+++ b/src/main/java/net/spy/memcached/OperationFactory.java
@@ -531,4 +531,15 @@ public interface OperationFactory {
                                              BTreeInsertAndGet<?> get, byte[] dataToInsert,
                                              OperationCallback cb);
 
+  /**
+   * Create a pipeline operation for executing multiple commands in batch.
+   *
+   * @param ops  the list of operations to execute
+   * @param keys the unique keys related to the pipe operation
+   * @param cb   the status callback
+   * @return a new pipeline operation
+   */
+  Operation pipeline(List<KeyedOperation> ops, List<String> keys,
+                     OperationCallback cb);
+
 }

--- a/src/main/java/net/spy/memcached/ops/APIType.java
+++ b/src/main/java/net/spy/memcached/ops/APIType.java
@@ -66,6 +66,7 @@ public enum APIType {
   SETATTR(OperationType.WRITE), GETATTR(OperationType.READ),
 
   // Other API
+  PIPE(OperationType.WRITE),
   FLUSH(OperationType.WRITE),
   STATS(OperationType.ETC),
   VERSION(OperationType.ETC),

--- a/src/main/java/net/spy/memcached/ops/MultiPipelineOperationCallback.java
+++ b/src/main/java/net/spy/memcached/ops/MultiPipelineOperationCallback.java
@@ -1,0 +1,31 @@
+/*
+ * arcus-java-client : Arcus Java client
+ * Copyright 2010-2014 NAVER Corp.
+ * Copyright 2014-present JaM2in Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.spy.memcached.ops;
+
+public class MultiPipelineOperationCallback extends MultiOperationCallback
+    implements PipelineOperation.Callback {
+
+  public MultiPipelineOperationCallback(OperationCallback original, int todo) {
+    super(original, todo);
+  }
+
+  @Override
+  public void gotStatus(Operation op, OperationStatus status) {
+    ((PipelineOperation.Callback) originalCallback).gotStatus(op, status);
+  }
+}

--- a/src/main/java/net/spy/memcached/ops/PipelineOperation.java
+++ b/src/main/java/net/spy/memcached/ops/PipelineOperation.java
@@ -1,0 +1,12 @@
+package net.spy.memcached.ops;
+
+import java.util.List;
+
+public interface PipelineOperation extends KeyedOperation {
+
+  List<KeyedOperation> getOps();
+
+  interface Callback extends OperationCallback {
+    void gotStatus(Operation op, OperationStatus status);
+  }
+}

--- a/src/main/java/net/spy/memcached/protocol/ascii/AsciiOperationFactory.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/AsciiOperationFactory.java
@@ -17,6 +17,7 @@
 package net.spy.memcached.protocol.ascii;
 
 import java.util.Collection;
+import java.util.List;
 
 import javax.security.sasl.SaslClient;
 
@@ -66,9 +67,11 @@ import net.spy.memcached.ops.FlushOperation;
 import net.spy.memcached.ops.GetAttrOperation;
 import net.spy.memcached.ops.GetOperation;
 import net.spy.memcached.ops.GetsOperation;
+import net.spy.memcached.ops.KeyedOperation;
 import net.spy.memcached.ops.Mutator;
 import net.spy.memcached.ops.MutatorOperation;
 import net.spy.memcached.ops.NoopOperation;
+import net.spy.memcached.ops.Operation;
 import net.spy.memcached.ops.OperationCallback;
 import net.spy.memcached.ops.SASLAuthOperation;
 import net.spy.memcached.ops.SASLMechsOperation;
@@ -297,6 +300,12 @@ public class AsciiOperationFactory extends BaseOperationFactory {
                                                     BTreeInsertAndGet<?> get, byte[] dataToInsert,
                                                     OperationCallback cb) {
     return new BTreeInsertAndGetOperationImpl(key, get, dataToInsert, cb);
+  }
+
+  @Override
+  public Operation pipeline(List<KeyedOperation> ops, List<String> keys,
+                            OperationCallback cb) {
+    return new PipelineOperationImpl(ops, keys, cb);
   }
 
 }

--- a/src/main/java/net/spy/memcached/protocol/ascii/PipelineOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/PipelineOperationImpl.java
@@ -1,0 +1,291 @@
+/*
+ * arcus-java-client : Arcus Java client
+ * Copyright 2010-2014 NAVER Corp.
+ * Copyright 2014-present JaM2in Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.spy.memcached.protocol.ascii;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.List;
+
+import net.spy.memcached.ops.APIType;
+import net.spy.memcached.ops.KeyedOperation;
+import net.spy.memcached.ops.Operation;
+import net.spy.memcached.ops.OperationCallback;
+import net.spy.memcached.ops.OperationErrorType;
+import net.spy.memcached.ops.OperationException;
+import net.spy.memcached.ops.OperationState;
+import net.spy.memcached.ops.OperationStatus;
+import net.spy.memcached.ops.OperationType;
+import net.spy.memcached.ops.PipelineOperation;
+import net.spy.memcached.ops.StatusCode;
+
+/**
+ * Operation for executing multiple commands as pipeline.
+ */
+public final class PipelineOperationImpl extends OperationImpl implements PipelineOperation {
+
+  // PIPE RESPONSES
+  private static final OperationStatus END =
+      new OperationStatus(true, "END", StatusCode.SUCCESS);
+  private static final OperationStatus FAILED_END =
+      new OperationStatus(false, "FAILED_END", StatusCode.ERR_FAILED_END);
+
+  // EACH COMMAND'S SUCCEED RESPONSES
+  private static final OperationStatus CREATED_STORED =
+      new OperationStatus(true, "CREATED_STORED", StatusCode.SUCCESS);
+  private static final OperationStatus STORED =
+      new OperationStatus(true, "STORED", StatusCode.SUCCESS);
+  private static final OperationStatus REPLACED =
+      new OperationStatus(true, "REPLACED", StatusCode.SUCCESS);
+  private static final OperationStatus UPDATED =
+      new OperationStatus(true, "UPDATED", StatusCode.SUCCESS);
+  private static final OperationStatus EXIST =
+      new OperationStatus(true, "EXIST", StatusCode.EXIST);
+  private static final OperationStatus NOT_EXIST =
+      new OperationStatus(true, "NOT_EXIST", StatusCode.NOT_EXIST);
+  private static final OperationStatus DELETED =
+      new OperationStatus(true, "DELETED", StatusCode.SUCCESS);
+  private static final OperationStatus DELETED_DROPPED =
+      new OperationStatus(true, "DELETED_DROPPED", StatusCode.SUCCESS);
+
+  // EACH COMMAND'S FAILED RESPONSES
+  private static final OperationStatus NOT_FOUND =
+      new OperationStatus(false, "NOT_FOUND", StatusCode.ERR_NOT_FOUND);
+  private static final OperationStatus NOT_FOUND_ELEMENT =
+      new OperationStatus(false, "NOT_FOUND_ELEMENT", StatusCode.ERR_NOT_FOUND_ELEMENT);
+  private static final OperationStatus NOTHING_TO_UPDATE =
+      new OperationStatus(false, "NOTHING_TO_UPDATE", StatusCode.ERR_NOTHING_TO_UPDATE);
+  private static final OperationStatus ELEMENT_EXISTS =
+      new OperationStatus(false, "ELEMENT_EXISTS", StatusCode.ERR_ELEMENT_EXISTS);
+  private static final OperationStatus OVERFLOWED =
+      new OperationStatus(false, "OVERFLOWED", StatusCode.ERR_OVERFLOWED);
+  private static final OperationStatus OUT_OF_RANGE =
+      new OperationStatus(false, "OUT_OF_RANGE", StatusCode.ERR_OUT_OF_RANGE);
+  private static final OperationStatus TYPE_MISMATCH =
+      new OperationStatus(false, "TYPE_MISMATCH", StatusCode.ERR_TYPE_MISMATCH);
+  private static final OperationStatus BKEY_MISMATCH =
+      new OperationStatus(false, "BKEY_MISMATCH", StatusCode.ERR_BKEY_MISMATCH);
+  private static final OperationStatus EFLAG_MISMATCH =
+      new OperationStatus(false, "EFLAG_MISMATCH", StatusCode.ERR_EFLAG_MISMATCH);
+  private static final OperationStatus UNREADABLE =
+      new OperationStatus(false, "UNREADABLE", StatusCode.ERR_UNREADABLE);
+
+  private final List<KeyedOperation> ops;
+  private final List<String> keys;
+  private final PipelineOperation.Callback cb;
+
+  private int responseIndex = 0;
+  private boolean expectingResponse = false;
+  private boolean successAll = true;
+
+  /**
+   * @param ops  each command's operation to be pipelined
+   * @param keys keys involved in this pipeline operation without duplicate
+   * @param cb   callback for this pipeline operation
+   */
+  public PipelineOperationImpl(List<KeyedOperation> ops, List<String> keys,
+                               OperationCallback cb) {
+    super(cb);
+    if (ops == null || ops.isEmpty()) {
+      throw new IllegalArgumentException("Ops cannot be null or empty");
+    }
+    this.ops = ops;
+    this.keys = keys;
+    this.cb = (PipelineOperation.Callback) cb;
+    setAPIType(APIType.PIPE);
+    setOperationType(OperationType.WRITE);
+  }
+
+  /**
+   * Make a pipelined command buffer using each command's buffer.
+   */
+  @Override
+  public void initialize() {
+    // 1) Initialize operations and collect each buffers
+    // to handle switchover/redirect single key situations,
+    // make buffer from responseIndex Operation
+    int opCount = ops.size() - responseIndex;
+    ByteBuffer[] buffers = new ByteBuffer[opCount];
+    int bufferCount = 0;
+    for (int i = responseIndex; i < ops.size(); i++) {
+      Operation op = ops.get(i);
+      op.initialize();
+      ByteBuffer buffer = op.getBuffer();
+      if (i != ops.size() - 1) {
+        buffer = addPipeToBuffer(buffer);
+      }
+      buffers[bufferCount++] = buffer;
+    }
+
+    // 2) Create a concatenated pipedBuffer
+    int totalSize = 0;
+    for (int i = 0; i < bufferCount; i++) {
+      totalSize += buffers[i].remaining();
+    }
+
+    ByteBuffer pipedBuffer = ByteBuffer.allocate(totalSize);
+    for (int i = 0; i < bufferCount; i++) {
+      pipedBuffer.put(buffers[i]);
+    }
+
+    pipedBuffer.flip();
+    setBuffer(pipedBuffer);
+  }
+
+  private static ByteBuffer addPipeToBuffer(ByteBuffer buffer) {
+    byte[] bytes = new byte[buffer.remaining()];
+    buffer.mark();
+    buffer.get(bytes);
+    buffer.reset();
+
+    String command = new String(bytes);
+    String modified = command.replaceFirst("\r\n", " pipe\r\n");
+    byte[] modifiedBytes = modified.getBytes();
+    ByteBuffer newBuffer = ByteBuffer.allocate(modifiedBytes.length);
+    newBuffer.put(modifiedBytes);
+    newBuffer.flip();
+    return newBuffer;
+  }
+
+  @Override
+  public void handleLine(String line) {
+
+    /* ENABLE_REPLICATION if */
+    if (hasSwitchedOver(line)) {
+      prepareSwitchover(line);
+      return;
+    }
+    /* ENABLE_REPLICATION end */
+
+    /* ENABLE_MIGRATION if */
+    if (hasNotMyKey(line)) {
+      String key = ops.get(responseIndex).getKeys().iterator().next();
+      if (isBulkOperation()) {
+        addRedirectMultiKeyOperation(line, key);
+        responseIndex++;
+      } else {
+        // Only one NOT_MY_KEY is provided in response of
+        // single key piped operation when redirection.
+        addRedirectSingleKeyOperation(line, key);
+        transitionState(OperationState.REDIRECT);
+      }
+      return;
+    }
+    /* ENABLE_MIGRATION end */
+
+    /*
+      RESPONSE <count>\r\n
+      <status of the 1st pipelined command>\r\n
+      [ ... ]
+      <status of the last pipelined command>\r\n
+      END|PIPE_ERROR <error_string>\r\n
+    */
+    if (line.startsWith("END")) {
+      /* ENABLE_MIGRATION if */
+      if (needRedirect()) {
+        transitionState(OperationState.REDIRECT);
+        return;
+      }
+      /* ENABLE_MIGRATION end */
+
+      OperationStatus status = successAll ? END : FAILED_END;
+      complete(status);
+    } else if (line.startsWith("PIPE_ERROR")) {
+      String errorMessage = line.substring(11);
+      OperationStatus status =
+          new OperationStatus(false, errorMessage, StatusCode.ERR_INTERNAL);
+      complete(status);
+    } else if (line.startsWith("RESPONSE ")) {
+      expectingResponse = true;
+      responseIndex = 0;
+    } else if (expectingResponse) {
+      // Handle status line for each command
+      OperationStatus status = parseStatusLine(line);
+      if (!status.isSuccess()) {
+        successAll = false;
+      }
+
+      // Notify callback with current response index
+      cb.gotStatus(ops.get(responseIndex), status);
+      responseIndex++;
+    } else {
+      // Handle single command response (non-pipe case)
+      // When only one command or last command without "pipe", server sends direct status
+      OperationStatus status = parseStatusLine(line);
+      if (!status.isSuccess()) {
+        successAll = false;
+      }
+
+      // Notify callback for single command
+      cb.gotStatus(ops.get(0), status);
+
+      // Complete the operation immediately for single command
+      complete(successAll ? END : FAILED_END);
+    }
+  }
+
+  private OperationStatus parseStatusLine(String line) {
+    boolean allDigit = line.chars().allMatch(Character::isDigit);
+    if (allDigit) {
+      return new OperationStatus(true, line, StatusCode.SUCCESS);
+    } else {
+      return matchStatus(line,
+          END, FAILED_END, CREATED_STORED, STORED, REPLACED, UPDATED,
+          EXIST, NOT_EXIST, DELETED, DELETED_DROPPED, NOT_FOUND, NOT_FOUND_ELEMENT,
+          NOTHING_TO_UPDATE, ELEMENT_EXISTS, OVERFLOWED, OUT_OF_RANGE,
+          TYPE_MISMATCH, BKEY_MISMATCH, EFLAG_MISMATCH, UNREADABLE);
+    }
+  }
+
+  @Override
+  protected void handleError(OperationErrorType eType, String line) throws IOException {
+    cb.gotStatus(ops.get(responseIndex), new OperationStatus(false,
+            line + " @ " + getHandlingNode().getNodeName(), StatusCode.ERR_INTERNAL));
+
+    // 2) Handle error for I/O Thread.
+    if (!expectingResponse) {
+      // this case means that error message came without 'RESPONSE <count>'.
+      // so it doesn't need to read 'PIPE_ERROR'.
+      super.handleError(eType, line);
+    } else {
+      // this case means that error message came after 'RESPONSE <count>'.
+      // so it needs to read 'PIPE_ERROR'.
+      getLogger().error("Error:  %s by %s", line, this);
+      exception = new OperationException(eType, line + " @ " + getHandlingNode().getNodeName());
+    }
+  }
+
+  @Override
+  public boolean isPipeOperation() {
+    return ops.size() > 1;
+  }
+
+  @Override
+  public boolean isBulkOperation() {
+    return keys.size() > 1;
+  }
+
+  @Override
+  public List<String> getKeys() {
+    return keys;
+  }
+
+  @Override
+  public List<KeyedOperation> getOps() {
+    return ops;
+  }
+}

--- a/src/main/java/net/spy/memcached/protocol/binary/BinaryOperationFactory.java
+++ b/src/main/java/net/spy/memcached/protocol/binary/BinaryOperationFactory.java
@@ -17,6 +17,7 @@
 package net.spy.memcached.protocol.binary;
 
 import java.util.Collection;
+import java.util.List;
 
 import javax.security.sasl.SaslClient;
 
@@ -67,9 +68,11 @@ import net.spy.memcached.ops.GetAttrOperation;
 import net.spy.memcached.ops.GetOperation;
 import net.spy.memcached.ops.GetOperation.Callback;
 import net.spy.memcached.ops.GetsOperation;
+import net.spy.memcached.ops.KeyedOperation;
 import net.spy.memcached.ops.Mutator;
 import net.spy.memcached.ops.MutatorOperation;
 import net.spy.memcached.ops.NoopOperation;
+import net.spy.memcached.ops.Operation;
 import net.spy.memcached.ops.OperationCallback;
 import net.spy.memcached.ops.SASLAuthOperation;
 import net.spy.memcached.ops.SASLMechsOperation;
@@ -327,6 +330,13 @@ public class BinaryOperationFactory extends BaseOperationFactory {
                                                     OperationCallback cb) {
     throw new RuntimeException(
             "BTree insert and get operation is not supported in binary protocol yet.");
+  }
+
+  @Override
+  public Operation pipeline(List<KeyedOperation> ops, List<String> keys,
+                            OperationCallback cb) {
+    throw new RuntimeException(
+        "Pipeline operation is not supported in binary protocol yet.");
   }
 
 }

--- a/src/main/java/net/spy/memcached/v2/AsyncArcusCommands.java
+++ b/src/main/java/net/spy/memcached/v2/AsyncArcusCommands.java
@@ -20,10 +20,15 @@ package net.spy.memcached.v2;
 import java.util.AbstractMap;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
 
@@ -56,18 +61,22 @@ import net.spy.memcached.ops.CollectionCreateOperation;
 import net.spy.memcached.ops.CollectionGetOperation;
 import net.spy.memcached.ops.CollectionInsertOperation;
 import net.spy.memcached.ops.GetOperation;
+import net.spy.memcached.ops.KeyedOperation;
 import net.spy.memcached.ops.Operation;
 import net.spy.memcached.ops.OperationCallback;
 import net.spy.memcached.ops.OperationStatus;
+import net.spy.memcached.ops.PipelineOperation;
 import net.spy.memcached.ops.StatusCode;
 import net.spy.memcached.ops.StoreType;
 import net.spy.memcached.transcoders.Transcoder;
 import net.spy.memcached.transcoders.TranscoderUtils;
+import net.spy.memcached.v2.pipe.PipelineCompositeException;
 import net.spy.memcached.v2.vo.BKey;
 import net.spy.memcached.v2.vo.BTreeElement;
 import net.spy.memcached.v2.vo.BTreeElements;
 import net.spy.memcached.v2.vo.BopGetArgs;
 import net.spy.memcached.v2.vo.SMGetElements;
+import net.spy.memcached.v2.pipe.Pipeline;
 
 public class AsyncArcusCommands<T> implements AsyncArcusCommandsIF<T> {
 
@@ -962,5 +971,225 @@ public class AsyncArcusCommands<T> implements AsyncArcusCommandsIF<T> {
           (byte[]) from.getData(), (byte[]) to.getData(), args.getElementFlagFilter(),
           args.getCount(), unique);
     }
+  }
+
+  public Pipeline<T> pipeline() {
+    ArcusClient arcusClient = arcusClientSupplier.get();
+    return new Pipeline<>(arcusClient.getOpFact(), tc);
+  }
+
+  public ArcusFuture<List<Boolean>> execute(Pipeline<T> pipeline) {
+    Set<String> keys = pipeline.getKeys();
+    List<KeyedOperation> ops = pipeline.getOps();
+
+    ArcusClient client = arcusClientSupplier.get();
+    validatePipeline(keys, ops);
+
+    Collection<Map.Entry<MemcachedNode, List<String>>> arrangedKeys =
+        client.groupingKeys(keys, ArcusClient.MAX_PIPED_ITEM_COUNT, APIType.PIPE);
+
+    // If Pipeline's whole operations are mapped to single node,
+    // return result without index mapping.
+    if (arrangedKeys.size() == 1) {
+      Map.Entry<MemcachedNode, List<String>> entry = arrangedKeys.iterator().next();
+      PipeResourceForNode pipeResourceForNode = new PipeResourceForNode();
+      pipeResourceForNode.keys.addAll(entry.getValue());
+      for (int nodeIdx = 0; nodeIdx < ops.size(); nodeIdx++) {
+        pipeResourceForNode.opToNodeIdx.put(ops.get(nodeIdx), nodeIdx);
+      }
+      CompletableFuture<List<Boolean>> future =
+          executeByNode(client, entry.getKey(), pipeResourceForNode).toCompletableFuture();
+      return new ArcusMultiFuture<>(Collections.singletonList(future),
+          () -> joinResult(future, pipeResourceForNode.opToNodeIdx.size()));
+    }
+
+    Map<MemcachedNode, PipeResourceForNode> resourceByNode = getResourceByNode(ops, arrangedKeys);
+
+    Map<CompletableFuture<List<Boolean>>, MemcachedNode> futureToNode =
+        getFutureToNode(resourceByNode, client);
+
+    return new ArcusMultiFuture<>(new ArrayList<>(futureToNode.keySet()),
+        () -> combineResults(ops.size(), resourceByNode, futureToNode));
+  }
+
+  /*
+   * Map node with its PipeNodeResource for executing pipeline operations.
+   */
+  private Map<MemcachedNode, PipeResourceForNode> getResourceByNode(
+      List<KeyedOperation> ops, Collection<Map.Entry<MemcachedNode, List<String>>> arrangedKeys) {
+    Map<MemcachedNode, PipeResourceForNode> resourceByNode = new HashMap<>();
+
+    // 1) Map key-to-node and save keys into NodeResource.
+    Map<String, MemcachedNode> keyToNode = new HashMap<>(500);
+    for (Map.Entry<MemcachedNode, List<String>> entry : arrangedKeys) {
+      for (String key : entry.getValue()) {
+        keyToNode.put(key, entry.getKey());
+      }
+      resourceByNode
+          .computeIfAbsent(entry.getKey(), k -> new PipeResourceForNode())
+          .keys
+          .addAll(entry.getValue());
+    }
+
+    // 2) Map operations and indexes by node and save into NodeResource.
+    for (int pipeIdx = 0; pipeIdx < ops.size(); pipeIdx++) {
+      KeyedOperation op = ops.get(pipeIdx);
+      String key = op.getKeys().iterator().next();
+      MemcachedNode node = keyToNode.get(key);
+      Map<KeyedOperation, Integer> opToNodeIdx = resourceByNode.get(node).opToNodeIdx;
+      int nodeIdx = opToNodeIdx.size();
+      opToNodeIdx.put(op, nodeIdx);
+      resourceByNode.get(node).nodeIdxToPipeIdx.put(nodeIdx, pipeIdx);
+    }
+
+    return resourceByNode;
+  }
+
+  /*
+   * Map future from executeByNode with its MemcachedNode.
+   */
+  private Map<CompletableFuture<List<Boolean>>, MemcachedNode> getFutureToNode(
+      Map<MemcachedNode, PipeResourceForNode> resourceByNode, ArcusClient client) {
+    Map<CompletableFuture<List<Boolean>>, MemcachedNode> futureToNode =
+        new HashMap<>(resourceByNode.size());
+    for (Map.Entry<MemcachedNode, PipeResourceForNode> entry : resourceByNode.entrySet()) {
+      MemcachedNode node = entry.getKey();
+      PipeResourceForNode pipeResourceForNode = entry.getValue();
+
+      CompletableFuture<List<Boolean>> future = executeByNode(client, node, pipeResourceForNode)
+          .toCompletableFuture();
+      futureToNode.put(future, node);
+    }
+
+    return futureToNode;
+  }
+
+  private void validatePipeline(Collection<String> keys, List<KeyedOperation> ops) {
+    keyValidator.validateKey(keys);
+
+    if (ops.isEmpty() || ops.size() > 500) {
+      throw new IllegalArgumentException("Pipeline must have 1 to 500 operations.");
+    }
+  }
+
+  /**
+   * Use only in {@link AsyncArcusCommands#execute(Pipeline)}
+   *
+   * @param client              the ArcusClient instance to use
+   * @param node                the MemcachedNode to execute operations on
+   * @param pipeResourceForNode operations to execute and their pipeline indexes
+   * @return {@link ArcusFuture} with each pipe results as Boolean (true/false/null)
+   */
+  private ArcusFuture<List<Boolean>> executeByNode(ArcusClient client,
+                                                   MemcachedNode node,
+                                                   PipeResourceForNode pipeResourceForNode) {
+    AtomicReference<List<Boolean>> atomicReference = new AtomicReference<>(
+        new ArrayList<>(Collections.nCopies(pipeResourceForNode.opToNodeIdx.size(), null)));
+    PipelineArcusResult<List<Boolean>> result = new PipelineArcusResult<>(atomicReference);
+    ArcusFutureImpl<List<Boolean>> future = new ArcusFutureImpl<>(result);
+
+    OperationCallback cb = new PipelineOperation.Callback() {
+      @Override
+      public void gotStatus(Operation op, OperationStatus status) {
+        int nodeIdx = pipeResourceForNode.opToNodeIdx.get(op);
+        int pipeIdx;
+        if (!status.isSuccess()) {
+          switch (status.getStatusCode()) {
+            case ERR_NOT_FOUND:
+            case ERR_NOT_FOUND_ELEMENT:
+            case ERR_ELEMENT_EXISTS:
+            case ERR_NOTHING_TO_UPDATE:
+              break;
+            case ERR_INTERNAL:
+              pipeIdx = pipeResourceForNode.nodeIdxToPipeIdx.getOrDefault(nodeIdx, nodeIdx);
+              result.addError(pipeIdx, status);
+              return;
+            default:
+              /*
+               * TYPE_MISMATCH, BKEY_MISMATCH, EFLAG_MISMATCH, OVERFLOWED,
+               * OUT_OF_RANGE, NOT_SUPPORTED
+               * or unknown statement
+               */
+              pipeIdx = pipeResourceForNode.nodeIdxToPipeIdx.getOrDefault(nodeIdx, nodeIdx);
+              result.addError(pipeIdx, status);
+              return;
+          }
+        }
+        result.get().set(nodeIdx, status.isSuccess());
+      }
+
+      /**
+       * @param status If `ERR_FAILED_END` or `ERR_INTERNAL` is received, gotStatus callback method
+       *               already handled failed status.
+       *               So in this method, only need to handle CANCELLED status.
+       */
+      @Override
+      public void receivedStatus(OperationStatus status) {
+        if (status.getStatusCode() == StatusCode.CANCELLED) {
+          future.internalCancel();
+        }
+      }
+
+      @Override
+      public void complete() {
+        future.complete();
+      }
+    };
+
+    Operation pipelineOp = client.getOpFact()
+        .pipeline(new ArrayList<>(pipeResourceForNode.opToNodeIdx.keySet()),
+            pipeResourceForNode.keys, cb);
+    future.setOp(pipelineOp);
+    client.addOp(node, pipelineOp);
+
+    return future;
+  }
+
+  /*
+   * Always return joined result from MemcachedNode with exception handling.
+   */
+  private List<Boolean> joinResult(CompletableFuture<List<Boolean>> future, int size) {
+    try {
+      return future.join();
+    } catch (CompletionException ce) {
+      if (ce.getCause() instanceof PipelineCompositeException) {
+        return ((PipelineCompositeException) ce.getCause()).getResult();
+      }
+      return new ArrayList<>(Collections.nCopies(size, null));
+    } catch (CancellationException ce) {
+      return new ArrayList<>(Collections.nCopies(size, null));
+    }
+  }
+
+  /*
+   * Combine into single List<Boolean> according to pipe indexes
+   * from each MemcachedNode's results.
+   */
+  private List<Boolean> combineResults(
+      int totalSize, Map<MemcachedNode, PipeResourceForNode> resourceToNode,
+      Map<CompletableFuture<List<Boolean>>, MemcachedNode> futureToNode) {
+    List<Boolean> results = new ArrayList<>(Collections.nCopies(totalSize, null));
+    for (Map.Entry<CompletableFuture<List<Boolean>>, MemcachedNode> entry
+        : futureToNode.entrySet()) {
+      PipeResourceForNode resource = resourceToNode.get(entry.getValue());
+      List<Boolean> joinResult = joinResult(entry.getKey(), resource.opToNodeIdx.size());
+      if (joinResult != null && !joinResult.isEmpty()) {
+        Map<Integer, Integer> nodeIdxToPipeIdx =
+            resourceToNode.get(entry.getValue()).nodeIdxToPipeIdx;
+        for (int i = 0; i < joinResult.size(); i++) {
+          results.set(nodeIdxToPipeIdx.get(i), joinResult.get(i));
+        }
+      }
+    }
+    return results;
+  }
+
+  /*
+   * Resources for operations and keys per MemcachedNode in Pipeline processing.
+   */
+  private static final class PipeResourceForNode {
+    private final Map<KeyedOperation, Integer> opToNodeIdx = new LinkedHashMap<>(500);
+    private final Map<Integer, Integer> nodeIdxToPipeIdx = new HashMap<>(500);
+    private final List<String> keys = new ArrayList<>(500);
   }
 }

--- a/src/main/java/net/spy/memcached/v2/AsyncArcusCommandsIF.java
+++ b/src/main/java/net/spy/memcached/v2/AsyncArcusCommandsIF.java
@@ -28,6 +28,8 @@ import net.spy.memcached.v2.vo.BTreeElements;
 import net.spy.memcached.v2.vo.BopGetArgs;
 import net.spy.memcached.v2.vo.SMGetElements;
 
+import net.spy.memcached.v2.pipe.Pipeline;
+
 public interface AsyncArcusCommandsIF<T> {
 
   /**
@@ -261,4 +263,25 @@ public interface AsyncArcusCommandsIF<T> {
    */
   ArcusFuture<SMGetElements<T>> bopSortMergeGet(List<String> keys, BKey from, BKey to,
                                                 boolean unique, BopGetArgs args);
+
+  /**
+   * Create a pipeline for batch operations.
+   * Operations can be added by chaining methods up to 500 operations.
+   *
+   * @return pipeline instance.
+   */
+  Pipeline<T> pipeline();
+
+  /**
+   * Execute multiple operations in a pipeline using Arcus Command Pipelining feature.
+   * Does not guarantee atomicity.
+   * Does not guarantee order of execution when multiple keys are used in the pipeline.
+   *
+   * @param pipeline which contains multiple operations
+   * @return list of Boolean results for each operation in the pipeline.
+   * True/False if operation executed.
+   * null if operation not executed due to its failure/error or prior error.
+   */
+  ArcusFuture<List<Boolean>> execute(Pipeline<T> pipeline);
+
 }

--- a/src/main/java/net/spy/memcached/v2/PipelineArcusResult.java
+++ b/src/main/java/net/spy/memcached/v2/PipelineArcusResult.java
@@ -1,0 +1,70 @@
+/*
+ * arcus-java-client : Arcus Java client
+ * Copyright 2010-2014 NAVER Corp.
+ * Copyright 2014-present JaM2in Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.spy.memcached.v2;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+
+import net.spy.memcached.ops.OperationStatus;
+import net.spy.memcached.v2.pipe.PipelineOperationException;
+
+/**
+ * Custom result class for pipeline operations that supports indexed exceptions.
+ */
+public class PipelineArcusResult<T> implements ArcusResult<T> {
+
+  protected AtomicReference<T> value;
+  private final List<Exception> exceptions = new ArrayList<>();
+
+  public PipelineArcusResult(AtomicReference<T> value) {
+    this.value = value;
+  }
+
+  @Override
+  public T get() {
+    return value.get();
+  }
+
+  @Override
+  public void set(T value) {
+    this.value.set(value);
+  }
+
+  @Override
+  public void addError(String key, OperationStatus status) {
+    throw new UnsupportedOperationException(
+        "Use another overloaded addError method for pipeline operations");
+  }
+
+  public void addError(int index, OperationStatus status) {
+    exceptions.add(new PipelineOperationException(index, "Pipeline operation at index "
+        + index + " failed: { message: " + status.getMessage() + " }"));
+  }
+
+  @Override
+  public boolean hasError() {
+    return !exceptions.isEmpty();
+  }
+
+  @Override
+  public List<Exception> getError() {
+    return Collections.unmodifiableList(exceptions);
+  }
+}

--- a/src/main/java/net/spy/memcached/v2/pipe/Pipeline.java
+++ b/src/main/java/net/spy/memcached/v2/pipe/Pipeline.java
@@ -1,0 +1,313 @@
+/*
+ * arcus-java-client : Arcus Java client
+ * Copyright 2010-2014 NAVER Corp.
+ * Copyright 2014-present JaM2in Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.spy.memcached.v2.pipe;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import net.spy.memcached.OperationFactory;
+import net.spy.memcached.collection.BTreeDelete;
+import net.spy.memcached.collection.BTreeInsert;
+import net.spy.memcached.collection.BTreeMutate;
+import net.spy.memcached.collection.BTreeUpdate;
+import net.spy.memcached.collection.BTreeUpsert;
+import net.spy.memcached.collection.ListDelete;
+import net.spy.memcached.collection.MapDelete;
+import net.spy.memcached.collection.MapInsert;
+import net.spy.memcached.collection.MapUpdate;
+import net.spy.memcached.collection.MapUpsert;
+import net.spy.memcached.collection.SetDelete;
+import net.spy.memcached.collection.SetExist;
+import net.spy.memcached.ops.KeyedOperation;
+import net.spy.memcached.ops.Mutator;
+import net.spy.memcached.collection.CollectionAttributes;
+import net.spy.memcached.collection.ListInsert;
+import net.spy.memcached.collection.SetInsert;
+import net.spy.memcached.transcoders.Transcoder;
+import net.spy.memcached.v2.vo.BKey;
+import net.spy.memcached.v2.vo.BTreeElement;
+
+/**
+ * Data class for pipelined commands.
+ * If multiple keys are mapped to the same node, commands for those keys are sent in one batch.
+ * The atomicity for commands is not guaranteed but the order of commands
+ * for each key is guaranteed.
+ * Max number of commands is limited as 500.
+ *
+ * @param <V>
+ */
+public class Pipeline<V> {
+  private final Set<String> keys;
+  private final List<KeyedOperation> ops;
+  private final OperationFactory opFact;
+  private final Transcoder<V> tc;
+
+  public Pipeline(OperationFactory opFact, Transcoder<V> tc) {
+    this.opFact = opFact;
+    this.tc = tc;
+    this.keys = new HashSet<>();
+    this.ops = new ArrayList<>();
+  }
+
+  public Pipeline<V> lopInsert(String key, int index, V value) {
+    return lopInsert(key, index, value, null);
+  }
+
+  public Pipeline<V> lopInsert(String key, int index, V value, CollectionAttributes attributes) {
+    checkNumOfCommands();
+
+    ListInsert<V> listInsert = new ListInsert<>(value, null, attributes);
+    keys.add(key);
+    ops.add(opFact.collectionInsert(key, String.valueOf(index),
+        listInsert, tc.encode(value).getData(), null));
+    return this;
+  }
+
+  public Pipeline<V> lopDelete(String key, int index, boolean dropIfEmpty) {
+    checkNumOfCommands();
+
+    ListDelete listDelete = new ListDelete(index, dropIfEmpty, false);
+    keys.add(key);
+    ops.add(opFact.collectionDelete(key, listDelete, null));
+    return this;
+  }
+
+  public Pipeline<V> lopDelete(String key, int from, int to, boolean dropIfEmpty) {
+    checkNumOfCommands();
+
+    ListDelete listDelete = new ListDelete(from, to, dropIfEmpty, false);
+    keys.add(key);
+    ops.add(opFact.collectionDelete(key, listDelete, null));
+    return this;
+  }
+
+  public Pipeline<V> sopInsert(String key, V value) {
+    return sopInsert(key, value, null);
+  }
+
+  public Pipeline<V> sopInsert(String key, V value, CollectionAttributes attributes) {
+    checkNumOfCommands();
+
+    SetInsert<V> setInsert = new SetInsert<>(value, null, attributes);
+    keys.add(key);
+    ops.add(opFact.collectionInsert(key, "",
+        setInsert, tc.encode(value).getData(), null));
+    return this;
+  }
+
+  public Pipeline<V> sopExist(String key, V value) {
+    checkNumOfCommands();
+
+    SetExist<V> setExist = new SetExist<>(value, tc);
+    keys.add(key);
+    ops.add(opFact.collectionExist(key, "", setExist, null));
+    return this;
+  }
+
+  public Pipeline<V> sopDelete(String key, V value, boolean dropIfEmpty) {
+    checkNumOfCommands();
+
+    SetDelete<V> setDelete = new SetDelete<>(value, dropIfEmpty, false, tc);
+    keys.add(key);
+    ops.add(opFact.collectionDelete(key, setDelete, null));
+    return this;
+  }
+
+  public Pipeline<V> mopInsert(String key, String mkey, V value) {
+    return this.mopInsert(key, mkey, value, null);
+  }
+
+  public Pipeline<V> mopInsert(String key, String mkey, V value,
+                               CollectionAttributes attributes) {
+    checkNumOfCommands();
+
+    MapInsert<V> mapInsert = new MapInsert<>(value, null, attributes);
+    keys.add(key);
+    ops.add(opFact.collectionInsert(key, mkey,
+        mapInsert, tc.encode(value).getData(), null));
+    return this;
+  }
+
+  public Pipeline<V> mopUpsert(String key, String mkey, V value) {
+    checkNumOfCommands();
+
+    MapUpsert<V> mapUpsert = new MapUpsert<>(value, null);
+    keys.add(key);
+    ops.add(opFact.collectionInsert(key, mkey,
+        mapUpsert, tc.encode(value).getData(), null));
+    return this;
+  }
+
+  public Pipeline<V> mopUpsert(String key, String mkey, V value,
+                               CollectionAttributes attributes) {
+    checkNumOfCommands();
+
+    MapUpsert<V> mapUpsert = new MapUpsert<>(value, attributes);
+    keys.add(key);
+    ops.add(opFact.collectionInsert(key, mkey,
+        mapUpsert, tc.encode(value).getData(), null));
+    return this;
+  }
+
+  public Pipeline<V> mopUpdate(String key, String mkey, V value) {
+    checkNumOfCommands();
+
+    MapUpdate<V> mapUpdate = new MapUpdate<>(value, false);
+    keys.add(key);
+    ops.add(opFact.collectionUpdate(key, mkey, mapUpdate, tc.encode(value).getData(), null));
+    return this;
+  }
+
+  public Pipeline<V> mopDelete(String key, String mkey, boolean dropIfEmpty) {
+    checkNumOfCommands();
+
+    MapDelete mapDelete = new MapDelete(Collections.singletonList(mkey), dropIfEmpty, false);
+    keys.add(key);
+    ops.add(opFact.collectionDelete(key, mapDelete, null));
+    return this;
+  }
+
+  public Pipeline<V> bopInsert(String key, BTreeElement<V> element) {
+    return this.bopInsert(key, element, null);
+  }
+
+  public Pipeline<V> bopInsert(String key, BTreeElement<V> element,
+                               CollectionAttributes attributes) {
+    checkNumOfCommands();
+
+    BTreeInsert<V> mapInsert = new BTreeInsert<>(
+        element.getValue(), element.getEFlag(), null, attributes);
+    keys.add(key);
+    ops.add(opFact.collectionInsert(key, element.getBkey().toString(),
+        mapInsert, tc.encode(element.getValue()).getData(), null));
+    return this;
+  }
+
+  public Pipeline<V> bopUpsert(String key, BTreeElement<V> element) {
+    return this.bopUpsert(key, element, null);
+  }
+
+  public Pipeline<V> bopUpsert(String key, BTreeElement<V> element,
+                               CollectionAttributes attributes) {
+    checkNumOfCommands();
+
+    BTreeUpsert<V> mapInsert = new BTreeUpsert<>(
+        element.getValue(), element.getEFlag(), null, attributes);
+    keys.add(key);
+    ops.add(opFact.collectionInsert(key, element.getBkey().toString(),
+        mapInsert, tc.encode(element.getValue()).getData(), null));
+    return this;
+  }
+
+  public Pipeline<V> bopDelete(String key, BKey bkey, boolean dropIfEmpty) {
+    checkNumOfCommands();
+
+    BTreeDelete bTreeDelete;
+    if (bkey.getType() == BKey.BKeyType.LONG) {
+      bTreeDelete = new BTreeDelete((Long) bkey.getData(), null, dropIfEmpty, false);
+    } else {
+      bTreeDelete = new BTreeDelete((byte[]) bkey.getData(), null, dropIfEmpty, false);
+    }
+    keys.add(key);
+    ops.add(opFact.collectionDelete(key, bTreeDelete, null));
+    return this;
+  }
+
+  public Pipeline<V> bopUpdate(String key, BKey bkey, V value) {
+    checkNumOfCommands();
+
+    BTreeUpdate<V> bTreeUpdate = new BTreeUpdate<>(value, null, false);
+    keys.add(key);
+    ops.add(opFact.collectionUpdate(key, bkey.toString(), bTreeUpdate,
+        tc.encode(value).getData(), null));
+    return this;
+  }
+
+  public Pipeline<V> bopDelete(String key, BKey from, BKey to, boolean dropIfEmpty) {
+    checkNumOfCommands();
+
+    if (from.getType() != to.getType()) {
+      throw new IllegalArgumentException("BKey types must match for range delete");
+    }
+
+    BTreeDelete bTreeDelete;
+    if (from.getType() == BKey.BKeyType.LONG) {
+      bTreeDelete = new BTreeDelete((Long) from.getData(), (Long) to.getData(),
+          -1, null, dropIfEmpty, false);
+    } else {
+      bTreeDelete = new BTreeDelete((byte[]) from.getData(), (byte[]) to.getData(),
+          -1, null, dropIfEmpty, false);
+    }
+    keys.add(key);
+    ops.add(opFact.collectionDelete(key, bTreeDelete, null));
+    return this;
+  }
+
+  public Pipeline<V> bopIncr(String key, BKey bkey, int delta) {
+    checkNumOfCommands();
+
+    BTreeMutate bTreeMutate = new BTreeMutate(Mutator.incr, delta);
+    keys.add(key);
+    ops.add(opFact.collectionMutate(key, bkey.toString(), bTreeMutate, null));
+    return this;
+  }
+
+  public Pipeline<V> bopIncr(String key, BKey bkey, int delta, int initial, byte[] eFlag) {
+    checkNumOfCommands();
+
+    BTreeMutate bTreeMutate = new BTreeMutate(Mutator.incr, delta, initial, eFlag);
+    keys.add(key);
+    ops.add(opFact.collectionMutate(key, bkey.toString(), bTreeMutate, null));
+    return this;
+  }
+
+  public Pipeline<V> bopDecr(String key, BKey bkey, int delta) {
+    checkNumOfCommands();
+
+    BTreeMutate bTreeMutate = new BTreeMutate(Mutator.decr, delta);
+    keys.add(key);
+    ops.add(opFact.collectionMutate(key, bkey.toString(), bTreeMutate, null));
+    return this;
+  }
+
+  public Pipeline<V> bopDecr(String key, BKey bkey, int delta, int initial, byte[] eFlag) {
+    checkNumOfCommands();
+
+    BTreeMutate bTreeMutate = new BTreeMutate(Mutator.decr, delta, initial, eFlag);
+    keys.add(key);
+    ops.add(opFact.collectionMutate(key, bkey.toString(), bTreeMutate, null));
+    return this;
+  }
+
+  public Set<String> getKeys() {
+    return Collections.unmodifiableSet(keys);
+  }
+
+  public List<KeyedOperation> getOps() {
+    return Collections.unmodifiableList(ops);
+  }
+
+  private void checkNumOfCommands() {
+    if (ops.size() >= 500) {
+      throw new IllegalStateException("The number of commands in a pipeline cannot exceed 500");
+    }
+  }
+}

--- a/src/main/java/net/spy/memcached/v2/pipe/PipelineCompositeException.java
+++ b/src/main/java/net/spy/memcached/v2/pipe/PipelineCompositeException.java
@@ -1,0 +1,25 @@
+package net.spy.memcached.v2.pipe;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import net.spy.memcached.internal.CompositeException;
+
+/**
+ * For Internal Use.
+ */
+public class PipelineCompositeException extends CompositeException {
+
+  private static final long serialVersionUID = -3901204588665566485L;
+  private final ArrayList<Boolean> result = new ArrayList<>();
+
+  public PipelineCompositeException(List<Exception> exceptions, List<Boolean> result) {
+    super(exceptions);
+    this.result.addAll(result);
+  }
+
+  public List<Boolean> getResult() {
+    return Collections.unmodifiableList(result);
+  }
+}

--- a/src/main/java/net/spy/memcached/v2/pipe/PipelineOperationException.java
+++ b/src/main/java/net/spy/memcached/v2/pipe/PipelineOperationException.java
@@ -1,0 +1,47 @@
+/*
+ * arcus-java-client : Arcus Java client
+ * Copyright 2010-2014 NAVER Corp.
+ * Copyright 2014-present JaM2in Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.spy.memcached.v2.pipe;
+
+import java.util.concurrent.ExecutionException;
+
+/**
+ * Exception thrown when a pipeline operation fails.
+ * Contains the index of the failed operation in the original pipeline.
+ */
+public final class PipelineOperationException extends ExecutionException {
+
+  private static final long serialVersionUID = -8364928364928364928L;
+  private final int index;
+
+  /**
+   * Create a new PipelineOperationException.
+   */
+  public PipelineOperationException(int index, String message) {
+    super(message);
+    this.index = index;
+  }
+
+  /**
+   * Get the index of the failed operation.
+   *
+   * @return the index
+   */
+  public int getIndex() {
+    return index;
+  }
+}

--- a/src/test/java/net/spy/memcached/v2/PipelineAsyncArcusCommandsTest.java
+++ b/src/test/java/net/spy/memcached/v2/PipelineAsyncArcusCommandsTest.java
@@ -1,0 +1,362 @@
+package net.spy.memcached.v2;
+
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import net.spy.memcached.collection.CollectionAttributes;
+import net.spy.memcached.collection.CollectionOverflowAction;
+import net.spy.memcached.internal.CompositeException;
+import net.spy.memcached.v2.pipe.Pipeline;
+import net.spy.memcached.v2.pipe.PipelineOperationException;
+import net.spy.memcached.v2.vo.BKey;
+import net.spy.memcached.v2.vo.BTreeElement;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class PipelineAsyncArcusCommandsTest extends AsyncArcusCommandsTest {
+
+  @Test
+  void pipelineMixedInsert() throws Exception {
+    // given
+    CollectionAttributes attr = new CollectionAttributes();
+
+    // when
+    Pipeline<Object> pipeline = async.pipeline()
+        .lopInsert("list1", 0, "value1", attr)
+        .sopInsert("set1", "value1", attr)
+        .lopInsert("list1", 0, "value2")
+        .sopInsert("set2", "value2")
+        .bopInsert("btree1", new BTreeElement<>(BKey.of(1L), "value1", null), attr)
+        .mopInsert("map1", "field1", "value1", attr)
+        .mopInsert("map1", "field1", "value2", attr);
+
+    async.execute(pipeline)
+        // then
+        .thenAccept(list -> {
+          assertEquals(7, list.size());
+          assertEquals(true, list.get(0));
+          assertEquals(true, list.get(1));
+          assertEquals(true, list.get(2));
+          assertEquals(false, list.get(3));
+          assertEquals(true, list.get(4));
+          assertEquals(true, list.get(5));
+          assertEquals(false, list.get(6));
+        })
+        .toCompletableFuture()
+        .get(300, TimeUnit.MILLISECONDS);
+  }
+
+  @Test
+  void pipelineMixedRequest() throws Exception {
+    // given
+    CollectionAttributes attr = new CollectionAttributes();
+
+    // when
+    Pipeline<Object> pipeline = async.pipeline()
+        .lopInsert("list1", 0, "value1", attr)
+        .sopInsert("set1", "value1", attr)
+        .mopInsert("map1", "mkey", "value", attr)
+        .mopUpdate("map2", "mkey", "value")
+        .lopDelete("list1", 0, false)
+        .lopDelete("list2", 0, false)
+        .lopDelete("list3", 0, false)
+        .sopDelete("set1", "value1", false)
+        .sopDelete("set2", "value2", false)
+        .mopDelete("map1", "mkey", false)
+        .mopUpsert("map3", "mkey", "value", attr)
+        .mopUpsert("map3", "mkey", "value2", attr);
+
+    async.execute(pipeline)
+        // then
+        .thenAccept(list -> {
+          assertEquals(12, list.size());
+          assertEquals(true, list.get(0));
+          assertEquals(true, list.get(1));
+          assertEquals(true, list.get(2));
+          assertEquals(false, list.get(3));
+          assertEquals(true, list.get(4));
+          assertEquals(false, list.get(5));
+          assertEquals(false, list.get(6));
+          assertEquals(true, list.get(7));
+          assertEquals(false, list.get(8));
+          assertEquals(true, list.get(9));
+          assertEquals(true, list.get(10));
+          assertEquals(true, list.get(11));
+        })
+        .toCompletableFuture()
+        .get(300, TimeUnit.MILLISECONDS);
+  }
+
+  @Test
+  void pipelineMixedBTreeRequest() throws Exception {
+    // given
+    CollectionAttributes attr = new CollectionAttributes();
+    BKey bkey1 = BKey.of(1L);
+    BKey bkey2 = BKey.of(2L);
+
+    // when
+    Pipeline<Object> pipeline = async.pipeline()
+        .bopInsert("btree1", new BTreeElement<>(bkey1, "15", null), attr)
+        .bopIncr("btree1", bkey1, 1)
+        .bopIncr("btree1", bkey2, 1, 1, null)
+        .bopInsert("btree2", new BTreeElement<>(bkey1, 15, null), attr)
+        .bopUpdate("btree2", bkey1, "value")
+        .bopInsert("btree3", new BTreeElement<>(bkey1, "10", null), attr)
+        .bopDecr("btree3", bkey1, 2)
+        .bopDecr("btree3", bkey2, 1, 1, null)
+        .bopUpsert("btree4", new BTreeElement<>(bkey1, 15, null), attr)
+        .bopUpsert("btree5", new BTreeElement<>(bkey2, 15, null), attr)
+        .bopInsert("btree6", new BTreeElement<>(bkey1, 15, null), attr)
+        .bopDelete("btree6", bkey1, false)
+        .bopInsert("btree7", new BTreeElement<>(bkey1, 15, null), attr);
+
+    async.execute(pipeline)
+        // then
+        .thenAccept(results -> {
+          assertEquals(13, results.size());
+          for (Boolean result : results) {
+            assertTrue(result);
+          }
+        })
+        .toCompletableFuture()
+        .get(300, TimeUnit.MILLISECONDS);
+  }
+
+  @Test
+  void pipeline500OpsOnSingleKey() throws Exception {
+    // given
+    CollectionAttributes attr = new CollectionAttributes();
+    String key = "btree_max";
+
+    Pipeline<Object> pipeline = async.pipeline();
+    for (long i = 0; i < 500; i++) {
+      if (i == 0) {
+        pipeline.bopInsert(key, new BTreeElement<>(BKey.of(i), "value" + i, null), attr);
+      } else {
+        pipeline.bopInsert(key, new BTreeElement<>(BKey.of(i), "value" + i, null));
+      }
+    }
+
+    // when
+    async.execute(pipeline)
+        // then
+        .thenAccept(list -> {
+          assertEquals(500, list.size());
+          for (int i = 0; i < 500; i++) {
+            assertEquals(true, list.get(i));
+          }
+        })
+        .toCompletableFuture()
+        .get(300, TimeUnit.MILLISECONDS);
+  }
+
+  @Test
+  void pipeline500OpsOnMultiKeys() throws Exception {
+    // given
+    CollectionAttributes attr = new CollectionAttributes();
+
+    Pipeline<Object> pipeline = async.pipeline();
+    for (int keyIdx = 0; keyIdx < 10; keyIdx++) {
+      String key = "btree_multi_" + keyIdx;
+      for (long i = 0; i < 50; i++) {
+        if (i == 0) {
+          pipeline.bopInsert(key, new BTreeElement<>(BKey.of(i), "value" + i, null), attr);
+        } else {
+          pipeline.bopInsert(key, new BTreeElement<>(BKey.of(i), "value" + i, null));
+        }
+      }
+    }
+
+    // when
+    async.execute(pipeline)
+        // then
+        .thenAccept(list -> {
+          assertEquals(500, list.size());
+          for (int i = 0; i < 500; i++) {
+            assertEquals(true, list.get(i));
+          }
+        })
+        .toCompletableFuture()
+        .get(300, TimeUnit.MILLISECONDS);
+  }
+
+  @Test
+  void pipelineExceed500OpsThrowsException() {
+    // given
+    CollectionAttributes attr = new CollectionAttributes();
+    String key = "btree_exceed";
+
+    Pipeline<Object> pipeline = async.pipeline();
+    for (long i = 0; i < 500; i++) {
+      if (i == 0) {
+        pipeline.bopInsert(key, new BTreeElement<>(BKey.of(i), "value" + i, null), attr);
+      } else {
+        pipeline.bopInsert(key, new BTreeElement<>(BKey.of(i), "value" + i, null));
+      }
+    }
+
+    // when & then
+    BTreeElement<Object> element = new BTreeElement<>(BKey.of(501L), "value501", null);
+    assertThrows(IllegalStateException.class, () -> pipeline.bopInsert(key, element));
+  }
+
+  @Test
+  void pipelineSingleKeyWithMixedOperations() throws Exception {
+    // given
+    CollectionAttributes attr = new CollectionAttributes();
+    String key = "btree_mixed";
+
+    Pipeline<Object> pipeline = async.pipeline()
+        .bopInsert(key, new BTreeElement<>(BKey.of(1L), "value1", null), attr)
+        .bopInsert(key, new BTreeElement<>(BKey.of(2L), "value2", null))
+        .bopUpsert(key, new BTreeElement<>(BKey.of(1L), "updated1", null))
+        .bopDelete(key, BKey.of(3L), false);
+
+    // when
+    async.execute(pipeline)
+        // then
+        .thenAccept(list -> {
+          assertEquals(4, list.size());
+          assertEquals(true, list.get(0));
+          assertEquals(true, list.get(1));
+          assertEquals(true, list.get(2));
+          assertEquals(false, list.get(3));
+        })
+        .toCompletableFuture()
+        .get(300, TimeUnit.MILLISECONDS);
+  }
+
+  @Test
+  void pipelineFailedOnce() throws Exception {
+    // given
+    CollectionAttributes attr = new CollectionAttributes();
+
+    // when
+    Pipeline<Object> pipeline = async.pipeline()
+        .lopInsert("list1", 0, "value1", attr)
+        .sopInsert("list1", "value1") // TYPE_MISMATCH
+        .lopInsert("list2", 0, "value2", attr)
+        .lopInsert("list3", 0, "value3", attr)
+        .lopInsert("list4", 0, "value4", attr)
+        .lopInsert("list5", 0, "value5", attr)
+        .lopInsert("list6", 0, "value6", attr);
+
+    ArcusMultiFuture<List<Boolean>> future =
+        (ArcusMultiFuture<List<Boolean>>) async.execute(pipeline);
+    future
+        // then
+        .handle((result, throwable) -> {
+          PipelineOperationException ex = (PipelineOperationException) throwable;
+          assertTrue(ex.getMessage()
+              .contains("Pipeline operation at index 1 failed: { message: TYPE_MISMATCH }"));
+
+          List<Boolean> resultsWithFailures = future.getResultsWithFailures();
+          assertEquals(7, resultsWithFailures.size());
+          assertEquals(true, resultsWithFailures.get(0));
+          assertNull(resultsWithFailures.get(1)); // TYPE_MISMATCH
+          assertEquals(true, resultsWithFailures.get(2));
+          assertEquals(true, resultsWithFailures.get(3));
+          assertEquals(true, resultsWithFailures.get(4));
+          assertEquals(true, resultsWithFailures.get(5));
+          assertEquals(true, resultsWithFailures.get(6));
+          return null;
+        })
+        .toCompletableFuture()
+        .get(300, TimeUnit.MILLISECONDS);
+  }
+
+  @Test
+  void pipelineFailedTwice() throws Exception {
+    // given
+    CollectionAttributes attr = new CollectionAttributes();
+
+    // when
+    Pipeline<Object> pipeline = async.pipeline()
+        .lopInsert("list1", 0, "value1", attr)
+        .sopInsert("list1", "value1") // TYPE_MISMATCH
+        .lopInsert("list2", 0, "value2", attr)
+        .lopInsert("list3", 0, "value3",
+            new CollectionAttributes(0, 1L, CollectionOverflowAction.error))
+        .lopInsert("list3", 0, "value3", attr) // OVERFLOWED
+        .lopInsert("list4", 0, "value4", attr)
+        .lopInsert("list5", 0, "value5", attr)
+        .lopInsert("list6", 0, "value6",
+            new CollectionAttributes(-1, 4000L, CollectionOverflowAction.error));
+
+    ArcusMultiFuture<List<Boolean>> future =
+        (ArcusMultiFuture<List<Boolean>>) async.execute(pipeline);
+    future
+        // then
+        .handle((result, throwable) -> {
+          CompositeException ex = (CompositeException) throwable;
+          assertEquals(3, ex.getExceptions().size());
+          assertTrue(ex.getExceptions().get(0).getMessage()
+              .contains("Pipeline operation at index 1 failed: { message: TYPE_MISMATCH }"));
+          assertTrue(ex.getExceptions().get(1).getMessage()
+              .contains("Pipeline operation at index 4 failed: { message: OVERFLOWED }"));
+          assertTrue(ex.getExceptions().get(2).getMessage()
+              .contains(
+                  "Pipeline operation at index 7 failed: { message: SERVER_ERROR out of memory"));
+
+          List<Boolean> resultsWithFailures = future.getResultsWithFailures();
+          assertEquals(8, resultsWithFailures.size());
+          assertEquals(true, resultsWithFailures.get(0));
+          assertNull(resultsWithFailures.get(1)); // TYPE_MISMATCH
+          assertEquals(true, resultsWithFailures.get(2));
+          assertEquals(true, resultsWithFailures.get(3));
+          assertNull(resultsWithFailures.get(4)); // OVERFLOWED
+          assertEquals(true, resultsWithFailures.get(5));
+          assertEquals(true, resultsWithFailures.get(6));
+          assertNull(resultsWithFailures.get(7));
+          return null;
+        })
+        .toCompletableFuture()
+        .get(300, TimeUnit.MILLISECONDS);
+  }
+
+  @Test
+  void pipelineBopIncrError() throws Exception {
+    // given
+    CollectionAttributes attr = new CollectionAttributes();
+    BKey bkey = BKey.of(1L);
+
+    // when
+    Pipeline<Object> pipeline = async.pipeline()
+        .bopInsert("btree1", new BTreeElement<>(bkey, "15", null), attr)
+        .bopIncr("btree1", bkey, 1)
+        .bopInsert("btree2", new BTreeElement<>(bkey, 15, null), attr)
+        .bopDecr("btree2", bkey, 2);
+
+    ArcusMultiFuture<List<Boolean>> future =
+        (ArcusMultiFuture<List<Boolean>>) async.execute(pipeline);
+    // then
+    future
+        .handle((result, throwable) -> {
+          PipelineOperationException ex = (PipelineOperationException) throwable;
+          assertTrue(ex.getMessage()
+              .contains("Pipeline operation at index 3 failed: " +
+                  "{ message: CLIENT_ERROR cannot increment or decrement non-numeric value"));
+          List<Boolean> resultsWithFailures = future.getResultsWithFailures();
+          assertTrue(resultsWithFailures.get(0));
+          assertTrue(resultsWithFailures.get(1));
+          assertTrue(resultsWithFailures.get(2));
+          return null;
+        })
+        .toCompletableFuture()
+        .get(300, TimeUnit.MILLISECONDS);
+  }
+
+  @Test
+  void pipelineEmptyThrowsException() {
+    // given
+    Pipeline<Object> pipeline = async.pipeline();
+
+    // when & then
+    assertThrows(IllegalArgumentException.class, () -> async.execute(pipeline));
+  }
+}

--- a/src/test/java/net/spy/memcached/v2/migration/PipelineOperationMigrationTest.java
+++ b/src/test/java/net/spy/memcached/v2/migration/PipelineOperationMigrationTest.java
@@ -1,0 +1,201 @@
+package net.spy.memcached.v2.migration;
+
+import java.net.InetSocketAddress;
+import java.nio.Buffer;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.stream.Collectors;
+
+import net.spy.memcached.ArcusClient;
+import net.spy.memcached.RedirectHandler;
+import net.spy.memcached.ops.Operation;
+import net.spy.memcached.ops.OperationState;
+import net.spy.memcached.ops.OperationStatus;
+import net.spy.memcached.ops.PipelineOperation;
+import net.spy.memcached.protocol.ascii.AsciiMemcachedNodeImpl;
+import net.spy.memcached.protocol.ascii.AsciiOperationFactory;
+import net.spy.memcached.protocol.ascii.PipelineOperationImpl;
+import net.spy.memcached.transcoders.SerializingTranscoder;
+import net.spy.memcached.v2.AsyncArcusCommands;
+import net.spy.memcached.v2.pipe.Pipeline;
+import net.spy.memcached.v2.vo.BKey;
+import net.spy.memcached.v2.vo.BTreeElement;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class PipelineOperationMigrationTest {
+
+  private static ArcusClient arcusClient;
+  private static AsyncArcusCommands<Object> async;
+  private static final List<String> KEYS = Arrays.asList("migration_key1", "migration_key2",
+      "migration_key3", "migration_key4");
+  private static final String VALUE = "migration_value";
+
+  @BeforeAll
+  static void setUp() {
+    arcusClient = ArcusClient.createArcusClient("localhost:2181", "test");
+    async = arcusClient.asyncCommands();
+  }
+
+  @BeforeEach
+  void cleanUp() throws ExecutionException, InterruptedException, TimeoutException {
+    async.flush(-1).get(300, TimeUnit.MILLISECONDS);
+  }
+
+  @AfterAll
+  static void tearDown() {
+    arcusClient.shutdown();
+  }
+
+  @Test
+  void redirectMultiKeysFromPipelineOperation() {
+    // given
+    SerializingTranscoder tc = SerializingTranscoder.forCollection().build();
+    Pipeline<Object> pipeline = new Pipeline<>(new AsciiOperationFactory(), tc);
+
+    pipeline.lopInsert(KEYS.get(0), 0, VALUE);
+    pipeline.sopInsert(KEYS.get(1), VALUE);
+    pipeline.mopInsert(KEYS.get(2), "mkey", VALUE);
+    pipeline.bopInsert(KEYS.get(3), new BTreeElement<>(BKey.of(0L), VALUE, null));
+
+    PipelineOperationImpl pipelineOp = getPipelineOp(pipeline);
+
+    // when
+    ByteBuffer b = ByteBuffer.allocate(200);
+
+    String line1 = "RESPONSE 3\r\n";
+    b.put(line1.getBytes());
+    ((Buffer) b).flip();
+    assertDoesNotThrow(() -> pipelineOp.readFromBuffer(b));
+    ((Buffer) b).clear();
+
+    String line2 = "STORED\r\n";
+    b.put(line2.getBytes());
+    ((Buffer) b).flip();
+    assertDoesNotThrow(() -> pipelineOp.readFromBuffer(b));
+    ((Buffer) b).clear();
+
+    String line3 = "NOT_MY_KEY 1000 2000\r\n";
+    b.put(line3.getBytes());
+    ((Buffer) b).flip();
+    assertDoesNotThrow(() -> pipelineOp.readFromBuffer(b));
+    ((Buffer) b).clear();
+
+    String line4 = "STORED\r\n";
+    b.put(line4.getBytes());
+    ((Buffer) b).flip();
+    assertDoesNotThrow(() -> pipelineOp.readFromBuffer(b));
+    ((Buffer) b).clear();
+
+    String line5 = "NOT_MY_KEY 4000 5000\r\n";
+    b.put(line5.getBytes());
+    ((Buffer) b).flip();
+    assertDoesNotThrow(() -> pipelineOp.readFromBuffer(b));
+    ((Buffer) b).clear();
+
+    String line6 = "END\r\n";
+    b.put(line6.getBytes());
+    ((Buffer) b).flip();
+    assertDoesNotThrow(() -> pipelineOp.readFromBuffer(b));
+    ((Buffer) b).clear();
+
+    // then
+    RedirectHandler redirectHandler = pipelineOp.getAndClearRedirectHandler();
+    assertEquals(OperationState.REDIRECT, pipelineOp.getState());
+    assertInstanceOf(RedirectHandler.RedirectHandlerMultiKey.class, redirectHandler);
+    List<String> keys = ((RedirectHandler.RedirectHandlerMultiKey) redirectHandler)
+        .groupRedirectKeys(arcusClient.getMemcachedConnection(), pipelineOp)
+        .values().stream().flatMap(List::stream).collect(Collectors.toList());
+    assertTrue(keys.contains(KEYS.get(1)));
+    assertTrue(keys.contains(KEYS.get(3)));
+  }
+
+  private PipelineOperationImpl getPipelineOp(Pipeline<Object> pipeline) {
+    PipelineOperation.Callback cb = new PipelineOperation.Callback() {
+      @Override
+      public void receivedStatus(OperationStatus status) {
+        // Do nothing
+      }
+
+      @Override
+      public void complete() {
+        // Do nothing
+      }
+
+      @Override
+      public void gotStatus(Operation op, OperationStatus status) {
+        // Do nothing
+      }
+    };
+
+    PipelineOperationImpl pipelineOp =
+        new PipelineOperationImpl(pipeline.getOps(), new ArrayList<>(pipeline.getKeys()), cb);
+
+    LinkedBlockingQueue<Operation> queue = new LinkedBlockingQueue<>();
+    pipelineOp.setHandlingNode(new AsciiMemcachedNodeImpl("testnode", new InetSocketAddress(11211),
+        60, queue, queue, queue, 0L, false));
+    pipelineOp.writeComplete();
+    return pipelineOp;
+  }
+
+  @Test
+  void redirectSingleKeyFromPipelineOperation() {
+    SerializingTranscoder tc = SerializingTranscoder.forCollection().build();
+    Pipeline<Object> pipeline = new Pipeline<>(new AsciiOperationFactory(), tc);
+
+    pipeline.lopInsert(KEYS.get(0), 0, VALUE);
+    pipeline.lopInsert(KEYS.get(0), 1, VALUE);
+    pipeline.lopInsert(KEYS.get(0), 2, VALUE);
+    pipeline.lopInsert(KEYS.get(0), 3, VALUE);
+
+    PipelineOperationImpl pipelineOp = getPipelineOp(pipeline);
+
+    // when
+    ByteBuffer b = ByteBuffer.allocate(200);
+
+    String line1 = "RESPONSE 2\r\n";
+    b.put(line1.getBytes());
+    ((Buffer) b).flip();
+    assertDoesNotThrow(() -> pipelineOp.readFromBuffer(b));
+    ((Buffer) b).clear();
+
+    String line2 = "STORED\r\n";
+    b.put(line2.getBytes());
+    ((Buffer) b).flip();
+    assertDoesNotThrow(() -> pipelineOp.readFromBuffer(b));
+    ((Buffer) b).clear();
+
+    String line3 = "NOT_MY_KEY 1000 2000\r\n";
+    b.put(line3.getBytes());
+    ((Buffer) b).flip();
+    assertDoesNotThrow(() -> pipelineOp.readFromBuffer(b));
+    ((Buffer) b).clear();
+
+    String line4 = "END\r\n";
+    b.put(line4.getBytes());
+    ((Buffer) b).flip();
+    assertDoesNotThrow(() -> pipelineOp.readFromBuffer(b));
+    ((Buffer) b).clear();
+
+    // then
+    RedirectHandler redirectHandler = pipelineOp.getAndClearRedirectHandler();
+    assertEquals(OperationState.REDIRECT, pipelineOp.getState());
+    assertInstanceOf(RedirectHandler.RedirectHandlerSingleKey.class, redirectHandler);
+    assertEquals(KEYS.get(0),
+        ((RedirectHandler.RedirectHandlerSingleKey) redirectHandler).getKey());
+  }
+}


### PR DESCRIPTION
### 🔗 Related Issue

<!-- Please link related issue. ex) https://github.com/naver/arcus-java-client/issues/{issue_number} -->
- Pipeline API를 추가합니다.
- 사용 방법
  - Pipeline 객체를 생성하여 하나의 파이프라인으로 포함할 명령들을 조합한다.
  - 파이프라인에 포함할 수 있는 명령들을 제한할 수 있다. (명령어의 종류, 개수)
  - 명령어의 개수는 최대 500개로 제한한다. 이를 통해 한 노드에는 최대 하나의 파이프라인이 보내진다.
  ```java
  public class Pipeline<V> {
  
	  // 다양한 명령을 포함할 수 있는 PipelineOperationImpl 타입을 value에 저장한다.
	  private Map<MemcachedNode, Operation> ops;
	  
	  public Pipeline() {
	    // ...
	  }
	  
	  public Pipeline<V> lopInsert(String key, int index, V value) {
	    // ...
	    return this;
	  }
	  
	  public Pipeline<V> mopInsert(String key, String mkey, V value) {
	    // ...
	    return this;
	  }
	  
	  // ...
	  
  }
  ```

  - Pipeline 객체를 execute 메서드에 넘겨야 파이프라인이 수행되며, `List<Boolean>` 에 각 명령에 대한 응답이 담긴다.
    ```java
    ArcusFuture<List<Boolean>> execute(Pipeline<T> pipeline)
    ```
  - 서로 다른 여러 키를 파이프라인에 포함하는 경우, 각 노드 별로 파이프라인이 생성되어 노드에 전달된다.
  - 명령의 조합 순서대로 파이프라인이 만들어지지만, 서버에서 처리 도중 다른 연산이 끼어들 수 있다.
  - 만약 처리 도중 실패 응답이나 예외가 발생한 경우 `PipelineOperationException` 혹은 `CompositeException`이 발생할 수 있다. 
  - 예외가 발생했더라도 `ArcusMultiFuture#getResultsWithFailures` 메서드로 나머지 결과를 조회할 수 있다.
    - 실패/예외가 발생했거나 예외로 인해 아예 실행되지 않은 명령의 인덱스 값은 null이다.
    - 응답이 온 명령의 인덱스 값은 True/False이다.

### ⌨️ What I did

<!-- Please describe this PR and what you've been working on. -->
- switchover 처리
  - responseIndex를 사용하여 아직 응답이 오지 않은 operation들만 새로운 master 노드에서 initialize할 때 포함되도록 한다.
- migration 처리
  - gotStatus 메서드의 인자로 Operation을 받아, 여러 Operation으로 분리되더라도 원본 콜백에서 원본 index에 값을 추가할 수 있도록 한다.
- 개별 노드에서의 응답 처리
    - 일반 응답 처리
        - 성공 응답이거나, `ERR_NOT_FOUND / ERR_NOT_FOUND_ELEMENT / ERR_ELEMENT_EXISTS / ERR_NOTHING_TO_UPDATE` 실패 응답인 경우 Boolean으로 처리한다.
    - 실패 응답 처리
        - `TYPE_MISMATCH / BKEY_MISMATCH / EFLAG_MISMATCH / OVERFLOWED / OUT_OF_RANGE / UNREADABLE / NOT_SUPPORTED` 의 경우 `PipelineOperationException`을 발생시킨다.
    - 에러 응답 처리
        - IO Thead에서 에러 상황을 처리하기 위해 내부적으로 `OperationException`을 던진다.
        - ArcusMultiFuture를 통해 각 개별노드로부터의 결과를 합치기 위해, 어떤 index에서 에러 응답이 발생했는지 알 수 있는 PipelineOperationException을 발생시킨다.
    - 실패 응답, 에러 응답으로 인해 예외가 하나라도 생긴 경우, `PipelineCompositeException`로 감싸서 반환한다. 이 때 현재까지의 응답을 담은 Result가 함께 담긴다.
- 전체 노드의 응답 처리
  - 특정 노드의 응답을 처리하던 중 예외가 발생한 Future가 있는 경우 `PipelineCompositeException` 내부의 예외들을 모두 꺼내 통합한 뒤, `CompositeException` 또는 단일 `PipelineOperationException`으로 반환한다.
  - `PipelineCompositeException`을 통합하는 과정에서 각 노드로부터 받은 현재까지의 응답 Result 역시 통합한다.