### PR TITLE
INTERNAL: Add logging for NOT_SUPPORTED response while authenticating

### DIFF
--- a/src/main/java/net/spy/memcached/MemcachedConnection.java
+++ b/src/main/java/net/spy/memcached/MemcachedConnection.java
@@ -635,11 +635,16 @@ public final class MemcachedConnection extends SpyObject {
       @Override
       public void receivedStatus(OperationStatus val) {
         String msg = val.getMessage();
-        // If the status we found was SASL_OK or NOT_SUPPORTED, we're authDone.
-        if ("SASL_OK".equals(msg) || "NOT_SUPPORTED".equals(msg)) {
+        // If the status we found was SASL_OK, we're authDone.
+        if ("SASL_OK".equals(msg)) {
           authDone = true;
           node.authComplete(true);
           getLogger().info("Authenticated to " + node.getSocketAddress());
+        } else if ("NOT_SUPPORTED".equals(msg)) {
+          authDone = true;
+          node.authComplete(true);
+          getLogger().warn("Authentication not supported by server, skipping auth flow: "
+                  + node.getSocketAddress());
         } else if (!val.isSuccess()) {
           authDone = true;
           node.authComplete(false);


### PR DESCRIPTION
### 🔗 Related Issue

<!-- Please link related issue. ex) https://github.com/naver/arcus-java-client/issues/{issue_number} -->
- https://github.com/jam2in/arcus-works/issues/822

### ⌨️ What I did

<!-- Please describe this PR and what you've been working on. -->
- 서버가 인증 기능을 제공하지 않아 인증 과정을 생략한다는 내용의 로깅을 추가합니다.