### PR TITLE
FEATURE: Add isForceSerializeForCollection method to Transcoder

### DIFF
--- a/src/main/java/net/spy/memcached/transcoders/SerializingTranscoder.java
+++ b/src/main/java/net/spy/memcached/transcoders/SerializingTranscoder.java
@@ -138,6 +138,11 @@ public class SerializingTranscoder extends BaseSerializingTranscoder
     return rv;
   }
 
+  @Override
+  public boolean isForceSerializeForCollection() {
+    return forceJDKSerializeForCollection;
+  }
+
   public CachedData encode(Object o) {
     byte[] b;
     int flags = 0;

--- a/src/main/java/net/spy/memcached/transcoders/Transcoder.java
+++ b/src/main/java/net/spy/memcached/transcoders/Transcoder.java
@@ -30,4 +30,11 @@ public interface Transcoder<T> {
    * Get the maximum size of objects handled by this transcoder.
    */
   int getMaxSize();
+
+  /**
+   * Get if this transcoder forces serialization every type.
+   */
+  default boolean isForceSerializeForCollection() {
+    return false;
+  }
 }

--- a/src/test/java/net/spy/memcached/transcoders/SerializingTranscoderTest.java
+++ b/src/test/java/net/spy/memcached/transcoders/SerializingTranscoderTest.java
@@ -32,6 +32,11 @@ class SerializingTranscoderTest extends BaseTranscoderCase {
   }
 
   @Test
+  void forceJDKSerializationReturnFalse() {
+    assertFalse(tc.isForceSerializeForCollection());
+  }
+
+  @Test
   void testNonserializable() throws Exception {
     try {
       tc.encode(new Object());

--- a/src/test/manual/net/spy/memcached/collection/transcoder/CollectionTranscoderTest.java
+++ b/src/test/manual/net/spy/memcached/collection/transcoder/CollectionTranscoderTest.java
@@ -30,6 +30,11 @@ class CollectionTranscoderTest extends BaseIntegrationTest {
   }
 
   @Test
+  void forceJDKSerializationReturnTrue() {
+    assertTrue(transcoder.isForceSerializeForCollection());
+  }
+
+  @Test
   void decodeIntegerAsString() throws ExecutionException, InterruptedException {
     // given
     Boolean b1 = mc.asyncMopInsert(KEY, "mkey1", "value", new CollectionAttributes()).get();


### PR DESCRIPTION
### 🔗 Related Issue

<!-- Please link related issue. ex) https://github.com/naver/arcus-java-client/issues/{issue_number} -->
- https://github.com/jam2in/spring-session-arcus/issues/60#issuecomment-3889477251

### ⌨️ What I did

<!-- Please describe this PR and what you've been working on. -->
- Transcoder 인터페이스에서 forceJDKSerializeForCollection 옵션이 켜져있는지 확인 가능한 메서드를 제공합니다.