### PR TITLE
INTERNAL: Do not skip decompress even if collection transcoder

### DIFF
--- a/src/main/java/net/spy/memcached/transcoders/SerializingTranscoder.java
+++ b/src/main/java/net/spy/memcached/transcoders/SerializingTranscoder.java
@@ -94,8 +94,7 @@ public class SerializingTranscoder extends BaseSerializingTranscoder
   public Object decode(CachedData d) {
     byte[] data = d.getData();
 
-    // Skip decompression for collections
-    if (!isCollection && (d.getFlags() & COMPRESSED) != 0) {
+    if ((d.getFlags() & COMPRESSED) != 0) {
       data = decompress(data);
     }
 


### PR DESCRIPTION
### 🔗 Related Issue

<!-- Please link related issue. ex) https://github.com/naver/arcus-java-client/issues/{issue_number} -->
-  https://github.com/naver/arcus-java-client/pull/1046#discussion_r2831063338

### ⌨️ What I did

<!-- Please describe this PR and what you've been working on. -->
- SerializingTranscoder의 decode 과정에서 isCollection에 관계 없이 압축이 되어있다면 풀도록 합니다.