### PR TITLE
FEATURE: Add CompletableFuture append/prepend API

### DIFF
--- a/src/main/java/net/spy/memcached/v2/AsyncArcusCommands.java
+++ b/src/main/java/net/spy/memcached/v2/AsyncArcusCommands.java
@@ -55,6 +55,7 @@ import net.spy.memcached.ops.BTreeInsertAndGetOperation;
 import net.spy.memcached.ops.CollectionCreateOperation;
 import net.spy.memcached.ops.CollectionGetOperation;
 import net.spy.memcached.ops.CollectionInsertOperation;
+import net.spy.memcached.ops.ConcatenationType;
 import net.spy.memcached.ops.GetOperation;
 import net.spy.memcached.ops.Operation;
 import net.spy.memcached.ops.OperationCallback;
@@ -129,7 +130,55 @@ public class AsyncArcusCommands<T> implements AsyncArcusCommandsIF<T> {
       }
     };
     Operation op = client.getOpFact()
-        .store(type, key, co.getFlags(), exp, co.getData(), cb);
+            .store(type, key, co.getFlags(), exp, co.getData(), cb);
+    future.setOp(op);
+    client.addOp(key, op);
+
+    return future;
+  }
+
+  public ArcusFuture<Boolean> append(String key, T val) {
+    return concat(ConcatenationType.append, key, val);
+  }
+
+  public ArcusFuture<Boolean> prepend(String key, T val) {
+    return concat(ConcatenationType.prepend, key, val);
+  }
+
+  private ArcusFuture<Boolean> concat(ConcatenationType catType, String key, T val) {
+    AbstractArcusResult<Boolean> result = new AbstractArcusResult<>(new AtomicReference<>());
+    ArcusFutureImpl<Boolean> future = new ArcusFutureImpl<>(result);
+    CachedData co = tc.encode(val);
+    ArcusClient client = arcusClientSupplier.get();
+
+    OperationCallback cb = new OperationCallback() {
+      @Override
+      public void receivedStatus(OperationStatus status) {
+        StatusCode code = status.getStatusCode();
+
+        switch (code) {
+          case SUCCESS:
+            result.set(true);
+            break;
+          case ERR_NOT_STORED:
+            result.set(false);
+            break;
+          case CANCELLED:
+            future.internalCancel();
+            break;
+          default:
+            // TYPE_MISMATCH or unknown statement
+            result.addError(key, status);
+            break;
+        }
+      }
+
+      @Override
+      public void complete() {
+        future.complete();
+      }
+    };
+    Operation op = client.getOpFact().cat(catType, 0L, key, co.getData(), cb);
     future.setOp(op);
     client.addOp(key, op);
 

--- a/src/main/java/net/spy/memcached/v2/AsyncArcusCommandsIF.java
+++ b/src/main/java/net/spy/memcached/v2/AsyncArcusCommandsIF.java
@@ -61,6 +61,24 @@ public interface AsyncArcusCommandsIF<T> {
   ArcusFuture<Boolean> replace(String key, int exp, T value);
 
   /**
+   * Append String or byte[] to an existing same type of value.
+   *
+   * @param key the key
+   * @param val the value to append
+   * @return {@code Boolean.True} if appended, otherwise {@code Boolean.False}
+   */
+  ArcusFuture<Boolean> append(String key, T val);
+
+  /**
+   * Prepend String or byte[] to an existing same type of value.
+   *
+   * @param key the key
+   * @param val the value to prepend
+   * @return {@code Boolean.True} if prepended, otherwise {@code Boolean.False}
+   */
+  ArcusFuture<Boolean> prepend(String key, T val);
+
+  /**
    * Set values for multiple keys.
    *
    * @param keys  list of keys to store

--- a/src/test/java/net/spy/memcached/v2/KVAsyncArcusCommandsTest.java
+++ b/src/test/java/net/spy/memcached/v2/KVAsyncArcusCommandsTest.java
@@ -3,6 +3,7 @@ package net.spy.memcached.v2;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CancellationException;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -173,5 +174,75 @@ class KVAsyncArcusCommandsTest extends AsyncArcusCommandsTest {
         assertTrue(value == null || VALUE.equals(value));
       }
     }
+  }
+
+  @Test
+  void appendString() throws ExecutionException, InterruptedException, TimeoutException {
+    // given
+    String expected = "Hello, Arcus!";
+    String key = keys.get(0);
+
+    async.set(key, 60, "Hello, ")
+            .thenAccept(Assertions::assertTrue)
+            .toCompletableFuture()
+            .get(300L, TimeUnit.MILLISECONDS);
+
+    // when
+    async.append(key, "Arcus!")
+            .thenCompose(result -> {
+              assertTrue(result);
+              return async.get(key);
+            })
+            // then
+            .thenAccept(result -> assertEquals(expected, result))
+            .toCompletableFuture()
+            .get(300L, TimeUnit.MILLISECONDS);
+  }
+
+  @Test
+  void prependString() throws ExecutionException, InterruptedException, TimeoutException {
+    // given
+    String expected = "Hello, World!";
+    String key = keys.get(1);
+
+    async.set(key, 60, "World!")
+            .thenAccept(Assertions::assertTrue)
+            .toCompletableFuture()
+            .get(300L, TimeUnit.MILLISECONDS);
+
+    // when
+    async.prepend(key, "Hello, ")
+            .thenCompose(result -> {
+              assertTrue(result);
+              return async.get(key);
+            })
+            // then
+            .thenAccept(result -> assertEquals(expected, result))
+            .toCompletableFuture()
+            .get(300L, TimeUnit.MILLISECONDS);
+  }
+
+  @Test
+  void appendNonStringException() throws ExecutionException, InterruptedException,
+          TimeoutException {
+    // given
+    String key = keys.get(0);
+
+    async.set(key, 60, 123)
+            .thenAccept(Assertions::assertTrue)
+            .toCompletableFuture()
+            .get(300L, TimeUnit.MILLISECONDS);
+
+    // when
+    CompletableFuture<Object> future = async.append(key, "Arcus!")
+            .thenCompose(result -> {
+              assertTrue(result);
+              return async.get(key);
+            })
+            .toCompletableFuture();
+    // then
+    // AssertionError in the Transcoder causes the I/O thread to terminate abruptly.
+    // The future is never completed, leading to a TimeoutException in the main thread.
+    assertThrows(TimeoutException.class, () -> future.get(300L, TimeUnit.MILLISECONDS));
   }
 }


### PR DESCRIPTION
### 🔗 Related Issue

<!-- Please link related issue. ex) https://github.com/naver/arcus-java-client/issues/{issue_number} -->
- - https://github.com/jam2in/arcus-works/issues/832#event-23130177064

### ⌨️ What I did

<!-- Please describe this PR and what you've been working on. -->
- `append`, `prepend` API 구현을 진행했습니다.

**구현 특이사항**

- `append` / `prepend`는 서버 측에서 raw byte 단위로 값을 이어 붙이는 연산입니다.
- 서버는 저장된 값의 타입과 관계없이 단순히 기존 바이트 뒤 또는 앞에 새 바이트를 연결합니다.
- 따라서, String 또는 byte[] 타입의 값에 대해서만 정상 동작하며, 다른 타입에 사용할 경우 문제가 발생합니다.

**문제 상황 예시**

- 서버는 바이트 연결 자체는 성공하기 때문에 `SUCCESS` 를 반환합니다.
- 클라이언트 또한 연결 자체는 정상 처리로 인식합니다.
- 하지만, 이후 `get(key)` 명령을 처리할 때 flag에 기록된 타입 정보와 실제 바이트 구조가 불일치하여 Exception 또는 이상한 값이 발환됩니다.


_예시 케이스_

| 기존 값 | 연산 | append 결과 | get(key) 결과| 
| -- | -- | -- | --| 
| "Hello, " (String) | append(key, "Arcus!") | 성공(SUCCESS) | "Hello, Arcus!" (정상 처리) | 
| 1 (Integer) | append(key, 2) | 성공(SUCCESS) | 235 (잘못된 값) | 
| "Hello" (String) | append(key, 123) | 성공(SUCCESS) | "Hello " (공백문자 삽입) | 

