### PR TITLE
FEATURE: Add CompletableFuture Map-based multiStore APIs

### DIFF
--- a/src/main/java/net/spy/memcached/v2/AsyncArcusCommands.java
+++ b/src/main/java/net/spy/memcached/v2/AsyncArcusCommands.java
@@ -228,17 +228,28 @@ public class AsyncArcusCommands<T> implements AsyncArcusCommandsIF<T> {
     return future;
   }
 
-
   public ArcusFuture<Map<String, Boolean>> multiSet(List<String> keys, int exp, T value) {
     return multiStore(StoreType.set, keys, exp, value);
+  }
+
+  public ArcusFuture<Map<String, Boolean>> multiSet(Map<String, T> items, int exp) {
+    return multiStore(StoreType.set, items, exp);
   }
 
   public ArcusFuture<Map<String, Boolean>> multiAdd(List<String> keys, int exp, T value) {
     return multiStore(StoreType.add, keys, exp, value);
   }
 
+  public ArcusFuture<Map<String, Boolean>> multiAdd(Map<String, T> items, int exp) {
+    return multiStore(StoreType.add, items, exp);
+  }
+
   public ArcusFuture<Map<String, Boolean>> multiReplace(List<String> keys, int exp, T value) {
     return multiStore(StoreType.replace, keys, exp, value);
+  }
+
+  public ArcusFuture<Map<String, Boolean>> multiReplace(Map<String, T> items, int exp) {
+    return multiStore(StoreType.replace, items, exp);
   }
 
   /**
@@ -258,15 +269,46 @@ public class AsyncArcusCommands<T> implements AsyncArcusCommandsIF<T> {
       keyToFuture.put(key, future);
     }
 
+    return buildMultiFuture(keyToFuture);
+  }
+
+  /**
+   * @param type     store type
+   * @param items map of key to value to store
+   * @param exp      expiration time
+   * @return ArcusFuture with Map of key to Boolean result. If an operation fails exceptionally,
+   * the corresponding value in the map will be null.
+   */
+  private ArcusFuture<Map<String, Boolean>> multiStore(StoreType type,
+                                                       Map<String, T> items,
+                                                       int exp) {
+    Map<String, CompletableFuture<?>> keyToFuture = new HashMap<>(items.size());
+
+    items.forEach((key, value) -> {
+      CompletableFuture<Boolean> future = store(type, key, exp, value).toCompletableFuture();
+      keyToFuture.put(key, future);
+    });
+
+    return buildMultiFuture(keyToFuture);
+  }
+
+  /**
+   * Combine multiple CompletableFutures into a single ArcusFuture.
+   *
+   * @param keyToFuture a map of keys to their corresponding CompletableFutures
+   * @return an ArcusFuture that completes with a map of keys to their Boolean results.
+   */
+  private ArcusMultiFuture<Map<String, Boolean>> buildMultiFuture(
+      Map<String, CompletableFuture<?>> keyToFuture) {
     return new ArcusMultiFuture<>(keyToFuture.values(), () -> {
       Map<String, Boolean> results = new HashMap<>();
-      for (Map.Entry<String, CompletableFuture<?>> entry : keyToFuture.entrySet()) {
-        if (entry.getValue().isCompletedExceptionally()) {
-          results.put(entry.getKey(), null);
+      keyToFuture.forEach((key, future) -> {
+        if (future.isCompletedExceptionally()) {
+          results.put(key, null);
         } else {
-          results.put(entry.getKey(), (Boolean) entry.getValue().join());
+          results.put(key, (Boolean) future.join());
         }
-      }
+      });
       return results;
     });
   }
@@ -932,7 +974,7 @@ public class AsyncArcusCommands<T> implements AsyncArcusCommandsIF<T> {
 
     for (Map.Entry<MemcachedNode, List<String>> entry : arrangedKeys) {
       BTreeGetBulk<T> getBulk =
-              createBTreeGetBulk(entry.getKey(), entry.getValue(), from, to, args);
+          createBTreeGetBulk(entry.getKey(), entry.getValue(), from, to, args);
       CompletableFuture<Map<String, BTreeElements<T>>> future =
           bopMultiGetPerNode(client, getBulk).toCompletableFuture();
       futureToKeys.put(future, entry.getValue());

--- a/src/main/java/net/spy/memcached/v2/AsyncArcusCommandsIF.java
+++ b/src/main/java/net/spy/memcached/v2/AsyncArcusCommandsIF.java
@@ -93,7 +93,7 @@ public interface AsyncArcusCommandsIF<T> {
   ArcusFuture<Boolean> prepend(String key, T val);
 
   /**
-   * Set values for multiple keys.
+   * Sets the same value for multiple keys.
    *
    * @param keys  list of keys to store
    * @param exp   expiration time in seconds
@@ -103,7 +103,16 @@ public interface AsyncArcusCommandsIF<T> {
   ArcusFuture<Map<String, Boolean>> multiSet(List<String> keys, int exp, T value);
 
   /**
-   * Add values for multiple keys if they do not exist.
+   * Sets multiple key-value pairs.
+   *
+   * @param items map of keys and values to store
+   * @param exp      expiration time in seconds
+   * @return Map of key to Boolean result
+   */
+  ArcusFuture<Map<String, Boolean>> multiSet(Map<String, T> items, int exp);
+
+  /**
+   * Add the same value for multiple keys if they do not exist.
    *
    * @param keys  list of keys to store
    * @param exp   expiration time in seconds
@@ -113,7 +122,17 @@ public interface AsyncArcusCommandsIF<T> {
   ArcusFuture<Map<String, Boolean>> multiAdd(List<String> keys, int exp, T value);
 
   /**
-   * Replace values for multiple keys if they exist.
+   * Add multiple key-value pairs if they do not exist.
+   *
+   * @param items map of keys and values to store
+   * @param exp      expiration time in seconds
+   * @return Map of key to Boolean result
+   */
+  ArcusFuture<Map<String, Boolean>> multiAdd(Map<String, T> items, int exp);
+
+
+  /**
+   * Replace the same value for multiple keys if they exist.
    *
    * @param keys  list of keys to store
    * @param exp   expiration time in seconds
@@ -121,6 +140,15 @@ public interface AsyncArcusCommandsIF<T> {
    * @return Map of key to Boolean result
    */
   ArcusFuture<Map<String, Boolean>> multiReplace(List<String> keys, int exp, T value);
+
+  /**
+   * Replace multiple key-value pairs if they exist.
+   *
+   * @param items map of keys and values to store
+   * @param exp      expiration time in seconds
+   * @return Map of key to Boolean result
+   */
+  ArcusFuture<Map<String, Boolean>> multiReplace(Map<String, T> items, int exp);
 
   /**
    * Get a value for the given key.

--- a/src/test/java/net/spy/memcached/v2/KVAsyncArcusCommandsTest.java
+++ b/src/test/java/net/spy/memcached/v2/KVAsyncArcusCommandsTest.java
@@ -1,5 +1,6 @@
 package net.spy.memcached.v2;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CancellationException;
@@ -19,6 +20,7 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -90,7 +92,7 @@ class KVAsyncArcusCommandsTest extends AsyncArcusCommandsTest {
   }
 
   @Test
-  void multiSetFail() throws ExecutionException, InterruptedException, TimeoutException {
+  void multiAddFail() throws ExecutionException, InterruptedException, TimeoutException {
     // given
     async.set(keys.get(0), 0, VALUE)
         // when
@@ -421,5 +423,198 @@ class KVAsyncArcusCommandsTest extends AsyncArcusCommandsTest {
             .thenAccept(result -> assertTrue(result.isEmpty()))
             .toCompletableFuture()
             .get(300L, TimeUnit.MILLISECONDS);
+  }
+
+  @Test
+  void multiSetMapSuccess() throws ExecutionException, InterruptedException, TimeoutException {
+    // given
+    Map<String, Object> elements = new HashMap<>();
+
+    for (int i = 0; i < keys.size(); i++) {
+      elements.put(keys.get(i), VALUE + i);
+    }
+
+    // when
+    async.multiSet(elements, 60)
+        .thenCompose(result -> {
+          assertEquals(keys.size(), result.size());
+          for (Boolean b : result.values()) {
+            assertTrue(b);
+          }
+          return async.multiGet(keys);
+        })
+        // then
+        .thenAccept(result -> {
+          assertEquals(keys.size(), result.size());
+          for (int i = 0; i < keys.size(); i++) {
+            assertEquals(VALUE + i, result.get(keys.get(i)));
+          }
+        })
+        .toCompletableFuture()
+        .get(300L, TimeUnit.MILLISECONDS);
+  }
+
+  @Test
+  void multiAddMapSuccess() throws ExecutionException, InterruptedException, TimeoutException {
+    // given
+    Map<String, Object> elements = new HashMap<>();
+    for (int i = 0; i < keys.size(); i++) {
+      elements.put(keys.get(i), VALUE + i);
+    }
+
+    // when
+    async.multiAdd(elements, 60)
+        .thenCompose(result -> {
+          assertEquals(keys.size(), result.size());
+          for (Boolean b : result.values()) {
+            assertTrue(b);
+          }
+          return async.multiGet(keys);
+        })
+        // then
+        .thenAccept(result -> {
+          assertEquals(keys.size(), result.size());
+          for (int i = 0; i < keys.size(); i++) {
+            assertEquals(VALUE + i, result.get(keys.get(i)));
+          }
+        })
+        .toCompletableFuture()
+        .get(300L, TimeUnit.MILLISECONDS);
+  }
+
+  @Test
+  void multiAddMapPartialSuccess() throws ExecutionException, InterruptedException,
+      TimeoutException {
+
+    // given
+    Map<String, Object> elements = new HashMap<>();
+    for (int i = 0; i < keys.size(); i++) {
+      elements.put(keys.get(i), VALUE + i);
+    }
+
+    /* 0th key is added before multiAdd, so it should fail. */
+    async.set(keys.get(0), 60, VALUE + "-old")
+        .thenAccept(Assertions::assertTrue)
+        .toCompletableFuture()
+        .get(300L, TimeUnit.MILLISECONDS);
+
+    // when
+    async.multiAdd(elements, 60)
+        .thenCompose(result -> {
+          assertEquals(keys.size(), result.size());
+          assertFalse(result.get(keys.get(0)));
+          for (int i = 1; i < keys.size(); i++) {
+            assertTrue(result.get(keys.get(i)));
+          }
+          return async.multiGet(keys);
+        })
+        // then
+        .thenAccept(result -> {
+          assertEquals(keys.size(), result.size());
+          assertEquals(VALUE + "-old", result.get(keys.get(0)));
+          for (int i = 1; i < keys.size(); i++) {
+            assertEquals(VALUE + i, result.get(keys.get(i)));
+          }
+        })
+        .toCompletableFuture()
+        .get(300L, TimeUnit.MILLISECONDS);
+  }
+
+  @Test
+  void multiReplaceMapSuccess() throws ExecutionException, InterruptedException,
+      TimeoutException {
+
+    // given
+    Map<String, Object> oldElements = new HashMap<>();
+    for (int i = 0; i < keys.size(); i++) {
+      oldElements.put(keys.get(i), VALUE + "-old-" + i);
+    }
+
+    Map<String, Object> newElements = new HashMap<>();
+    for (int i = 0; i < keys.size(); i++) {
+      newElements.put(keys.get(i), VALUE + "-new-" + i);
+    }
+
+    async.multiSet(oldElements, 60)
+        .thenAccept(result -> {
+          assertEquals(keys.size(), result.size());
+          for (Boolean b : result.values()) {
+            assertTrue(b);
+          }
+        })
+        .toCompletableFuture()
+        .get(300L, TimeUnit.MILLISECONDS);
+
+    // when
+    async.multiReplace(newElements, 60)
+        .thenCompose(result -> {
+          assertEquals(keys.size(), result.size());
+          for (Boolean b : result.values()) {
+            assertTrue(b);
+          }
+          return async.multiGet(keys);
+        })
+        // then
+        .thenAccept(result -> {
+          assertEquals(keys.size(), result.size());
+          for (int i = 0; i < keys.size(); i++) {
+            assertEquals(VALUE + "-new-" + i, result.get(keys.get(i)));
+          }
+        })
+        .toCompletableFuture()
+        .get(300L, TimeUnit.MILLISECONDS);
+  }
+
+  @Test
+  void multiReplaceMapPartialSuccess() throws ExecutionException, InterruptedException,
+      TimeoutException {
+
+    // given
+    Map<String, Object> oldElements = new HashMap<>();
+    for (int i = 0; i < 2; i++) {
+      oldElements.put(keys.get(i), VALUE + "-old-" + i);
+    }
+
+    Map<String, Object> newElements = new HashMap<>();
+    for (int i = 0; i < keys.size(); i++) {
+      newElements.put(keys.get(i), VALUE + "-new-" + i);
+    }
+
+    /* 0, 1st keys are added before multiReplace, so only they should succeed. */
+    async.multiSet(oldElements, 60)
+        .thenAccept(result -> {
+          assertEquals(oldElements.size(), result.size());
+          for (Boolean b : result.values()) {
+            assertTrue(b);
+          }
+        })
+        .toCompletableFuture()
+        .get(300L, TimeUnit.MILLISECONDS);
+
+    // when
+    async.multiReplace(newElements, 60)
+        .thenCompose(result -> {
+          assertEquals(keys.size(), result.size());
+          for (int i = 0; i < 2; i++) {
+            assertTrue(result.get(keys.get(i)));
+          }
+
+          for (int i = 2; i < keys.size(); i++) {
+            assertFalse(result.get(keys.get(i)));
+          }
+          return async.multiGet(keys);
+        })
+        // then
+        .thenAccept(result -> {
+          assertEquals(2, result.size());
+          for (int i = 0; i < 2; i++) {
+            assertEquals(VALUE + "-new-" + i, result.get(keys.get(i)));
+          }
+          for (int i = 2; i < keys.size(); i++) {
+            assertNull(result.get(keys.get(i)));
+          }
+        })
+        .toCompletableFuture()
+        .get(300L, TimeUnit.MILLISECONDS);
   }
 }


### PR DESCRIPTION
### 🔗 Related Issue

<!-- Please link related issue. ex) https://github.com/naver/arcus-java-client/issues/{issue_number} -->
- https://github.com/jam2in/arcus-works/issues/832#event-23130177064

### ⌨️ What I did

<!-- Please describe this PR and what you've been working on. -->
- 다건 저장 (`multiSet`, `multiAdd`, `multiReplace`) API를 구현합니다.
  - Key-Value 쌍인 Map을 기반으로 저장 명령을 수행합니다. 