### PR TITLE
FEATURE: Add CompletableFuture incr, decr API

### DIFF
--- a/src/main/java/net/spy/memcached/v2/AsyncArcusCommands.java
+++ b/src/main/java/net/spy/memcached/v2/AsyncArcusCommands.java
@@ -59,6 +59,7 @@ import net.spy.memcached.ops.CollectionGetOperation;
 import net.spy.memcached.ops.CollectionInsertOperation;
 import net.spy.memcached.ops.ConcatenationType;
 import net.spy.memcached.ops.GetOperation;
+import net.spy.memcached.ops.Mutator;
 import net.spy.memcached.ops.GetsOperation;
 import net.spy.memcached.ops.Operation;
 import net.spy.memcached.ops.OperationCallback;
@@ -436,6 +437,70 @@ public class AsyncArcusCommands<T> implements AsyncArcusCommandsIF<T> {
     Operation op = client.getOpFact().get(keyList, cb, node.enabledMGetOp());
     future.setOp(op);
     client.addOp(node, op);
+
+    return future;
+  }
+
+
+  public ArcusFuture<Long> incr(String key, int delta) {
+    return mutate(Mutator.incr, key, delta, -1L, 0);
+  }
+
+  public ArcusFuture<Long> incr(String key, int delta, long initial, int exp) {
+    if (initial < 0) {
+      throw new IllegalArgumentException("Initial value must be 0 or greater.");
+    }
+    return mutate(Mutator.incr, key, delta, initial, exp);
+  }
+
+  public ArcusFuture<Long> decr(String key, int delta) {
+    return mutate(Mutator.decr, key, delta, -1L, 0);
+  }
+
+  public ArcusFuture<Long> decr(String key, int delta, long initial, int exp) {
+    if (initial < 0) {
+      throw new IllegalArgumentException("Initial value must be 0 or greater.");
+    }
+    return mutate(Mutator.decr, key, delta, initial, exp);
+  }
+
+  private ArcusFuture<Long> mutate(Mutator mutator, String key, int delta, long initial, int exp) {
+    if (delta <= 0) {
+      throw new IllegalArgumentException("Delta must be greater than 0.");
+    }
+
+    AbstractArcusResult<Long> result = new AbstractArcusResult<>(new AtomicReference<>());
+    ArcusFutureImpl<Long> future = new ArcusFutureImpl<>(result);
+    ArcusClient client = arcusClientSupplier.get();
+
+    OperationCallback cb = new OperationCallback() {
+      @Override
+      public void receivedStatus(OperationStatus status) {
+        switch (status.getStatusCode()) {
+          case SUCCESS:
+            result.set(Long.parseLong(status.getMessage()));
+            break;
+          case ERR_NOT_FOUND:
+            result.set(-1L);
+            break;
+          case CANCELLED:
+            future.internalCancel();
+            break;
+          default:
+            // TYPE_MISMATCH or unknown statement
+            result.addError(key, status);
+            break;
+        }
+      }
+
+      @Override
+      public void complete() {
+        future.complete();
+      }
+    };
+    Operation op = client.getOpFact().mutate(mutator, key, delta, initial, exp, cb);
+    future.setOp(op);
+    client.addOp(key, op);
 
     return future;
   }

--- a/src/main/java/net/spy/memcached/v2/AsyncArcusCommandsIF.java
+++ b/src/main/java/net/spy/memcached/v2/AsyncArcusCommandsIF.java
@@ -144,6 +144,52 @@ public interface AsyncArcusCommandsIF<T> {
   ArcusFuture<Map<String, T>> multiGet(List<String> keys);
 
   /**
+   * Increments a numeric value stored at the given key by {@code delta}.
+   *
+   * @param key   the key
+   * @param delta the amount to increment (&gt; 0)
+   * @return the new value after increment, or -1 if the key is not found
+   */
+  ArcusFuture<Long> incr(String key, int delta);
+
+  /**
+   * Increments a numeric value stored at the given key by {@code delta}.
+   * If the key does not exist,
+   * it is created with the value of {@code initial} and expiration time of {@code exp}.
+   *
+   * @param key     the key
+   * @param delta   the amount to increment (&gt; 0)
+   * @param initial the value to store if the key does not exist ({@code delta} is ignored) (&ge; 0)
+   * @param exp     expiration time in seconds, applied only when a new key is created
+   * @return the new value after increment, or {@code initial} if the key did not exist
+   */
+  ArcusFuture<Long> incr(String key, int delta, long initial, int exp);
+
+  /**
+   * Decrements a numeric value stored at the given key by {@code delta}.
+   * <p>If the value is decremented below 0, it will be set to 0.</p>
+   *
+   * @param key   the key
+   * @param delta the amount to decrement (&gt; 0)
+   * @return the new value after decrement, or -1 if the key is not found
+   */
+  ArcusFuture<Long> decr(String key, int delta);
+
+  /**
+   * Decrements a numeric value stored at the given key by {@code delta}.
+   * If the key does not exist,
+   * it is created with the value of {@code initial} and expiration time of {@code exp}.
+   * <p>If the value is decremented below 0, it will be set to 0.</p>
+   *
+   * @param key     the key
+   * @param delta   the amount to decrement (&gt; 0)
+   * @param initial the value to store if the key does not exist ({@code delta} is ignored) (&ge; 0)
+   * @param exp     expiration time in seconds, applied only when a new key is created
+   * @return the new value after decrement, or {@code initial} if the key did not exist
+   */
+  ArcusFuture<Long> decr(String key, int delta, long initial, int exp);
+
+  /**
    * Get values with CAS for multiple keys.
    *
    * @param keys list of keys to get

--- a/src/test/java/net/spy/memcached/v2/KVAsyncArcusCommandsTest.java
+++ b/src/test/java/net/spy/memcached/v2/KVAsyncArcusCommandsTest.java
@@ -9,12 +9,16 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
 import net.spy.memcached.CASValue;
+import net.spy.memcached.collection.CollectionAttributes;
+import net.spy.memcached.collection.ElementValueType;
+import net.spy.memcached.ops.OperationException;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -616,6 +620,267 @@ class KVAsyncArcusCommandsTest extends AsyncArcusCommandsTest {
                 assertFalse(b);
               }
             })
+            .toCompletableFuture()
+            .get(300L, TimeUnit.MILLISECONDS);
+  }
+
+  @Test
+  void incrSuccess() throws ExecutionException, InterruptedException, TimeoutException {
+    // given
+    String key = keys.get(0);
+    int delta = 10;
+
+    async.set(key, 60, "100")
+            .thenAccept(Assertions::assertTrue)
+            .toCompletableFuture()
+            .get(300L, TimeUnit.MILLISECONDS);
+
+    // when
+    async.incr(key, delta)
+            // then
+            .thenAccept(result -> assertEquals(110L, result))
+            .toCompletableFuture()
+            .get(300, TimeUnit.MILLISECONDS);
+  }
+
+  @Test
+  void incrNonExistingKey() throws ExecutionException, InterruptedException, TimeoutException {
+    // given
+    String key = keys.get(0);
+    int delta = 10;
+
+    // when
+    async.incr(key, delta)
+            // then
+            .thenAccept(result -> assertEquals(-1, result))
+            .toCompletableFuture()
+            .get(300L, TimeUnit.MILLISECONDS);
+  }
+
+  @Test
+  void incrInitialNonExistingKeySuccess() throws ExecutionException, InterruptedException,
+          TimeoutException {
+
+    // given
+    String key = keys.get(0);
+    int delta = 10;
+
+    // when
+    async.incr(key, delta, 100, 60)
+            // then
+            .thenAccept(result -> assertEquals(100L, result))
+            .toCompletableFuture()
+            .get(300L, TimeUnit.MILLISECONDS);
+  }
+
+  @Test
+  void incrInitialExistingKeySuccess() {
+    // given
+    String key = keys.get(0);
+    int delta = 10;
+
+    async.set(key, 60, "100")
+            .thenAccept(Assertions::assertTrue)
+            .toCompletableFuture()
+            .join();
+
+    // when
+    async.incr(key, delta, 1000, 60)
+            // then
+            .thenAccept(result -> assertEquals(110L, result))
+            .toCompletableFuture()
+            .join();
+  }
+
+  @Test
+  void incrTypeNotNumberException() throws ExecutionException, InterruptedException,
+          TimeoutException {
+
+    // given
+    String key = keys.get(0);
+
+    async.set(key, 60, "not a number")
+            .thenAccept(Assertions::assertTrue)
+            .toCompletableFuture()
+            .get(300L, TimeUnit.MILLISECONDS);
+
+    // when
+    async.incr(key, 10)
+            // then
+            .handle((res, ex) -> {
+              assertInstanceOf(ExecutionException.class, ex);
+              Throwable cause = ex.getCause();
+              assertTrue(cause.getMessage().contains("CLIENT_ERROR"));
+              return res;
+            })
+            .toCompletableFuture()
+            .get(300L, TimeUnit.MILLISECONDS);
+  }
+
+  @Test
+  void incrTypeMisMatchException() throws ExecutionException, InterruptedException,
+          TimeoutException {
+
+    // given
+    String key = keys.get(0);
+
+    async.bopCreate(key, ElementValueType.STRING, new CollectionAttributes())
+            .thenAccept(Assertions::assertTrue)
+            .toCompletableFuture()
+            .get(300L, TimeUnit.MILLISECONDS);
+
+    // when
+    async.incr(key, 10)
+            // then
+            .handle((res, ex) -> {
+              assertInstanceOf(OperationException.class, ex);
+              assertTrue(ex.getMessage().contains("TYPE_MISMATCH"));
+              return res;
+            })
+            .toCompletableFuture()
+            .get(300L, TimeUnit.MILLISECONDS);
+  }
+
+  @Test
+  void decrSuccess() throws ExecutionException, InterruptedException, TimeoutException {
+    // given
+    String key = keys.get(0);
+    int delta = 10;
+
+    async.set(key, 60, "100")
+            .thenAccept(Assertions::assertTrue)
+            .toCompletableFuture()
+            .get(300L, TimeUnit.MILLISECONDS);
+
+    // when
+    async.decr(key, delta)
+            // then
+            .thenAccept(result -> assertEquals(90L, result))
+            .toCompletableFuture()
+            .get(300L, TimeUnit.MILLISECONDS);
+  }
+
+  @Test
+  void decrNonExistingKey() throws ExecutionException, InterruptedException,
+          TimeoutException {
+
+    // given
+    String key = keys.get(0);
+    int delta = 10;
+
+    // when
+    async.decr(key, delta)
+            // then
+            .thenAccept(result -> assertEquals(-1, result))
+            .toCompletableFuture()
+            .get(300L, TimeUnit.MILLISECONDS);
+  }
+
+  @Test
+  void decrInitialNonExistingKeySuccess() throws ExecutionException, InterruptedException,
+          TimeoutException {
+
+    // given
+    String key = keys.get(0);
+    int delta = 10;
+
+    // when
+    async.decr(key, delta, 100, 60)
+            // then
+            .thenAccept(result -> assertEquals(100L, result))
+            .toCompletableFuture()
+            .get(300L, TimeUnit.MILLISECONDS);
+  }
+
+  @Test
+  void decrInitialExistingKeySuccess() throws ExecutionException, InterruptedException,
+          TimeoutException {
+
+    // given
+    String key = keys.get(0);
+    int delta = 10;
+
+    async.set(key, 60, "100")
+            .thenAccept(Assertions::assertTrue)
+            .toCompletableFuture()
+                    .get(300L, TimeUnit.MILLISECONDS);
+
+    // when
+    async.decr(key, delta, 1000, 60)
+            // then
+            .thenAccept(result -> assertEquals(90L, result))
+            .toCompletableFuture()
+            .get(300L, TimeUnit.MILLISECONDS);
+  }
+
+  @Test
+  void decrTypeNotNumberException() throws ExecutionException, InterruptedException,
+          TimeoutException {
+
+    // given
+    String key = keys.get(0);
+
+    async.set(key, 60, "not a number")
+            .thenAccept(Assertions::assertTrue)
+            .toCompletableFuture()
+            .get(300L, TimeUnit.MILLISECONDS);
+
+    // when
+    async.decr(key, 10)
+            // then
+            .handle((res, ex) -> {
+              assertInstanceOf(ExecutionException.class, ex);
+              Throwable cause = ex.getCause();
+              assertTrue(cause.getMessage().contains("CLIENT_ERROR"));
+              return res;
+            })
+            .toCompletableFuture()
+            .get(300L, TimeUnit.MILLISECONDS);
+  }
+
+  @Test
+  void decrTypeMismatchException() throws ExecutionException, InterruptedException,
+          TimeoutException {
+
+    // given
+    String key = keys.get(0);
+
+    // collection 타입 키를 생성해서 TypeMismatch 발생
+    async.bopCreate(key, ElementValueType.STRING, new CollectionAttributes())
+            .thenAccept(Assertions::assertTrue)
+            .toCompletableFuture()
+            .get(300L, TimeUnit.MILLISECONDS);
+
+
+    // when
+    async.decr(key, 10)
+            // then
+            .handle((res, ex) -> {
+              assertInstanceOf(OperationException.class, ex);
+              assertTrue(ex.getMessage().contains("TYPE_MISMATCH"));
+              return res;
+            })
+            .toCompletableFuture()
+            .get(300L, TimeUnit.MILLISECONDS);
+  }
+
+  @Test
+  void decrResultUnderZero() throws ExecutionException, InterruptedException,
+          TimeoutException {
+
+    // given
+    String key = keys.get(0);
+    int delta = 10;
+
+    async.set(key, 60, "5")
+            .thenAccept(Assertions::assertTrue)
+            .toCompletableFuture()
+                    .get(300L, TimeUnit.MILLISECONDS);
+
+    // when
+    async.decr(key, delta)
+            // then
+            .thenAccept(result -> assertEquals(0L, result))
             .toCompletableFuture()
             .get(300L, TimeUnit.MILLISECONDS);
   }


### PR DESCRIPTION
### 🔗 Related Issue

<!-- Please link related issue. ex) https://github.com/naver/arcus-java-client/issues/{issue_number} -->
- https://github.com/jam2in/arcus-works/issues/832#event-23130177064

### ⌨️ What I did

<!-- Please describe this PR and what you've been working on. -->

- 값 증감 (`incr`, `decr`) API 구현을 진행했습니다.
  - 기존 사용자의 혼란을 최소화하고자 API명을 유지하였습니다.

**두 메서드 동작 차이**

| 메서드 | 키 없을 때 동작 |
|---|---|
| `incr(key, delta)`  | -1 반환 |
| `incr(key, delta, initial, exp)` | `initial`로 초기화 (`delta` 미적용) |

`decr()`도 동일한 동작 차이를 가집니다.