### PR TITLE
INTERNAL: Use getAllNodes method

### DIFF
--- a/src/main/java/net/spy/memcached/MemcachedClient.java
+++ b/src/main/java/net/spy/memcached/MemcachedClient.java
@@ -232,7 +232,7 @@ public class MemcachedClient extends SpyThread
    */
   public Collection<SocketAddress> getAvailableServers() {
     ArrayList<SocketAddress> rv = new ArrayList<>();
-    for (MemcachedNode node : conn.getLocator().getAll()) {
+    for (MemcachedNode node : getAllNodes()) {
       if (node.isActive()) {
         rv.add(node.getSocketAddress());
       }
@@ -253,7 +253,7 @@ public class MemcachedClient extends SpyThread
    */
   public Collection<SocketAddress> getUnavailableServers() {
     ArrayList<SocketAddress> rv = new ArrayList<>();
-    for (MemcachedNode node : conn.getLocator().getAll()) {
+    for (MemcachedNode node : getAllNodes()) {
       if (!node.isActive()) {
         rv.add(node.getSocketAddress());
       }
@@ -2199,7 +2199,7 @@ public class MemcachedClient extends SpyThread
   public boolean addObserver(ConnectionObserver obs) {
     boolean rv = conn.addObserver(obs);
     if (rv) {
-      for (MemcachedNode node : conn.getLocator().getAll()) {
+      for (MemcachedNode node : getAllNodes()) {
         if (node.isConnected()) {
           obs.connectionEstablished(node, -1);
         }
@@ -2237,7 +2237,7 @@ public class MemcachedClient extends SpyThread
   }
 
   /**
-   * get all memcached nodes from node locator for mbean
+   * get all memcached nodes from node locator
    *
    * @return all memcached nodes from node locator
    */
@@ -2254,7 +2254,7 @@ public class MemcachedClient extends SpyThread
               .collect(Collectors.toList());
     }
     /* ENABLE_REPLICATION end */
-    return conn.getLocator().getAll();
+    return getAllNodes();
   }
 
   /**


### PR DESCRIPTION
### 🔗 Related Issue

<!-- Please link related issue. ex) https://github.com/naver/arcus-java-client/issues/{issue_number} -->
- 

### ⌨️ What I did

<!-- Please describe this PR and what you've been working on. -->
- conn.getLocator().getAll() 메서드를 직접 호출하지 않고 getAllNodes 메서드를 호출하도록 합니다.