### PR TITLE
FIX: Concurrency problem in locator allNodes

### DIFF
--- a/src/main/java/net/spy/memcached/ArcusKetamaNodeLocator.java
+++ b/src/main/java/net/spy/memcached/ArcusKetamaNodeLocator.java
@@ -41,7 +41,7 @@ import net.spy.memcached.util.ArcusKetamaNodeLocatorConfiguration;
 public final class ArcusKetamaNodeLocator extends SpyObject implements NodeLocator {
 
   private final TreeMap<Long, SortedSet<MemcachedNode>> ketamaNodes;
-  private final Collection<MemcachedNode> allNodes;
+  private volatile List<MemcachedNode> allNodes;
 
   /* ENABLE_MIGRATION if */
   private TreeMap<Long, SortedSet<MemcachedNode>> ketamaAlterNodes;
@@ -67,7 +67,7 @@ public final class ArcusKetamaNodeLocator extends SpyObject implements NodeLocat
   public ArcusKetamaNodeLocator(List<MemcachedNode> nodes,
                                 ArcusKetamaNodeLocatorConfiguration conf) {
     super();
-    allNodes = nodes;
+    allNodes = Collections.unmodifiableList(nodes);
     ketamaNodes = new TreeMap<>();
     config = conf;
     enableShardKey = conf.isShardKeyEnabled();
@@ -90,11 +90,11 @@ public final class ArcusKetamaNodeLocator extends SpyObject implements NodeLocat
   }
 
   private ArcusKetamaNodeLocator(TreeMap<Long, SortedSet<MemcachedNode>> smn,
-                                 Collection<MemcachedNode> an,
+                                 List<MemcachedNode> nodes,
                                  ArcusKetamaNodeLocatorConfiguration conf) {
     super();
     ketamaNodes = smn;
-    allNodes = an;
+    allNodes = Collections.unmodifiableList(nodes);
     config = conf;
     enableShardKey = conf.isShardKeyEnabled();
 
@@ -107,7 +107,7 @@ public final class ArcusKetamaNodeLocator extends SpyObject implements NodeLocat
   }
 
   public Collection<MemcachedNode> getAll() {
-    return Collections.unmodifiableCollection(allNodes);
+    return allNodes;
   }
 
   /* ENABLE_MIGRATION if */
@@ -203,7 +203,7 @@ public final class ArcusKetamaNodeLocator extends SpyObject implements NodeLocat
     lock.lock();
     try {
       TreeMap<Long, SortedSet<MemcachedNode>> ketamaCopy = new TreeMap<>();
-      Collection<MemcachedNode> nodesCopy = new ArrayList<>(allNodes.size());
+      List<MemcachedNode> nodesCopy = new ArrayList<>(allNodes.size());
 
       // Rewrite the values a copy of the map.
       for (Map.Entry<Long, SortedSet<MemcachedNode>> hashPoint : ketamaNodes.entrySet()) {
@@ -228,15 +228,17 @@ public final class ArcusKetamaNodeLocator extends SpyObject implements NodeLocat
                      Collection<MemcachedNode> toDelete) {
     lock.lock();
     try {
+      List<MemcachedNode> newNodes = new ArrayList<>(allNodes);
+
       // Add memcached nodes.
       for (MemcachedNode node : toAttach) {
-        allNodes.add(node);
+        newNodes.add(node);
         insertHash(node);
       }
 
       // Remove memcached nodes.
       for (MemcachedNode node : toDelete) {
-        allNodes.remove(node);
+        newNodes.remove(node);
         removeHash(node);
         try {
           node.closeChannel();
@@ -245,6 +247,8 @@ public final class ArcusKetamaNodeLocator extends SpyObject implements NodeLocat
                   "Failed to closeChannel the node : " + node);
         }
       }
+
+      allNodes = Collections.unmodifiableList(newNodes);
     } finally {
       /* ENABLE_MIGRATION if */
       if (migrationInProgress && alterNodes.isEmpty()) {

--- a/src/main/java/net/spy/memcached/ArcusReplKetamaNodeLocator.java
+++ b/src/main/java/net/spy/memcached/ArcusReplKetamaNodeLocator.java
@@ -43,7 +43,7 @@ public final class ArcusReplKetamaNodeLocator extends SpyObject implements NodeL
 
   private final TreeMap<Long, SortedSet<MemcachedReplicaGroup>> ketamaGroups;
   private final ConcurrentHashMap<String, MemcachedReplicaGroup> allGroups;
-  private final Collection<MemcachedNode> allNodes;
+  private volatile List<MemcachedNode> allNodes;
 
   /* ENABLE_MIGRATION if */
   private TreeMap<Long, SortedSet<MemcachedReplicaGroup>> ketamaAlterGroups;
@@ -67,7 +67,7 @@ public final class ArcusReplKetamaNodeLocator extends SpyObject implements NodeL
   public ArcusReplKetamaNodeLocator(List<MemcachedNode> nodes,
                                     ArcusReplKetamaNodeLocatorConfiguration conf) {
     super();
-    allNodes = nodes;
+    allNodes = Collections.unmodifiableList(nodes);
     ketamaGroups = new TreeMap<>();
     allGroups = new ConcurrentHashMap<>();
     config = conf;
@@ -108,12 +108,12 @@ public final class ArcusReplKetamaNodeLocator extends SpyObject implements NodeL
 
   private ArcusReplKetamaNodeLocator(TreeMap<Long, SortedSet<MemcachedReplicaGroup>> kg,
                                      ConcurrentHashMap<String, MemcachedReplicaGroup> ag,
-                                     Collection<MemcachedNode> an,
+                                     List<MemcachedNode> nodes,
                                      ArcusReplKetamaNodeLocatorConfiguration conf) {
     super();
     ketamaGroups = kg;
     allGroups = ag;
-    allNodes = an;
+    allNodes = Collections.unmodifiableList(nodes);
     toDeleteGroups = new HashSet<>();
     config = conf;
     enableShardKey = conf.isShardKeyEnabled();
@@ -128,7 +128,7 @@ public final class ArcusReplKetamaNodeLocator extends SpyObject implements NodeL
   }
 
   public Collection<MemcachedNode> getAll() {
-    return Collections.unmodifiableCollection(allNodes);
+    return allNodes;
   }
 
   public Map<String, MemcachedReplicaGroup> getAllGroups() {
@@ -219,7 +219,7 @@ public final class ArcusReplKetamaNodeLocator extends SpyObject implements NodeL
       TreeMap<Long, SortedSet<MemcachedReplicaGroup>> ketamaCopy = new TreeMap<>();
       ConcurrentHashMap<String, MemcachedReplicaGroup> groupsCopy
               = new ConcurrentHashMap<>(allGroups.size());
-      Collection<MemcachedNode> nodesCopy = new ArrayList<>(allNodes.size());
+      List<MemcachedNode> nodesCopy = new ArrayList<>(allNodes.size());
 
       // Rewrite the values a copy of the map
       for (Map.Entry<Long, SortedSet<MemcachedReplicaGroup>> hashPoint : ketamaGroups.entrySet()) {
@@ -259,9 +259,11 @@ public final class ArcusReplKetamaNodeLocator extends SpyObject implements NodeL
      */
     lock.lock();
     try {
+      List<MemcachedNode> newNodes = new ArrayList<>(allNodes);
+
       // Remove memcached nodes.
       for (MemcachedNode node : toDelete) {
-        allNodes.remove(node);
+        newNodes.remove(node);
         removeNodeFromGroup(node);
         try {
           node.closeChannel();
@@ -277,7 +279,7 @@ public final class ArcusReplKetamaNodeLocator extends SpyObject implements NodeL
 
       // Add memcached nodes.
       for (MemcachedNode node : toAttach) {
-        allNodes.add(node);
+        newNodes.add(node);
         insertNodeIntoGroup(node);
       }
 
@@ -288,6 +290,8 @@ public final class ArcusReplKetamaNodeLocator extends SpyObject implements NodeL
         removeHash(group);
       }
       toDeleteGroups.clear();
+
+      allNodes = Collections.unmodifiableList(newNodes);
     } finally {
       /* ENABLE_MIGRATION if */
       if (migrationInProgress && alterNodes.isEmpty()) {


### PR DESCRIPTION
### 🔗 Related Issue

<!-- Please link related issue. ex) https://github.com/naver/arcus-java-client/issues/{issue_number} -->
- closes https://github.com/naver/arcus-java-client/pull/769

### ⌨️ What I did

<!-- Please describe this PR and what you've been working on. -->
- allNodes 변수를 항상 unmodifiableList로 저장하도록 합니다. 사용자가 조회할 때 매번 unmodifiableList로 감싸지 않아도 됩니다.
- allNodes 변수를 update 시에는 copy on write 형태로 저장합니다. 이 때도 마찬가지로 unmodifiableList로 저장합니다.
- 다른 locator는 allNodes 변수 update를 허용하지 않으므로 동시성 문제 없습니다.