### PR TITLE
FEATURE: Remove List-based multiStore (set, add, replace) APIs

### DIFF
--- a/src/main/java/net/spy/memcached/v2/AsyncArcusCommands.java
+++ b/src/main/java/net/spy/memcached/v2/AsyncArcusCommands.java
@@ -228,48 +228,16 @@ public class AsyncArcusCommands<T> implements AsyncArcusCommandsIF<T> {
     return future;
   }
 
-  public ArcusFuture<Map<String, Boolean>> multiSet(List<String> keys, int exp, T value) {
-    return multiStore(StoreType.set, keys, exp, value);
-  }
-
   public ArcusFuture<Map<String, Boolean>> multiSet(Map<String, T> items, int exp) {
     return multiStore(StoreType.set, items, exp);
-  }
-
-  public ArcusFuture<Map<String, Boolean>> multiAdd(List<String> keys, int exp, T value) {
-    return multiStore(StoreType.add, keys, exp, value);
   }
 
   public ArcusFuture<Map<String, Boolean>> multiAdd(Map<String, T> items, int exp) {
     return multiStore(StoreType.add, items, exp);
   }
 
-  public ArcusFuture<Map<String, Boolean>> multiReplace(List<String> keys, int exp, T value) {
-    return multiStore(StoreType.replace, keys, exp, value);
-  }
-
   public ArcusFuture<Map<String, Boolean>> multiReplace(Map<String, T> items, int exp) {
     return multiStore(StoreType.replace, items, exp);
-  }
-
-  /**
-   * @param type  store type
-   * @param keys  key list to store
-   * @param exp   expiration time
-   * @param value value to store for whole keys
-   * @return ArcusFuture with Map of key to Boolean result. If an operation fails exceptionally,
-   * the corresponding value in the map will be null.
-   */
-  private ArcusFuture<Map<String, Boolean>> multiStore(StoreType type,
-                                                       List<String> keys, int exp, T value) {
-    Map<String, CompletableFuture<?>> keyToFuture = new HashMap<>(keys.size());
-
-    for (String key : keys) {
-      CompletableFuture<Boolean> future = store(type, key, exp, value).toCompletableFuture();
-      keyToFuture.put(key, future);
-    }
-
-    return buildMultiFuture(keyToFuture);
   }
 
   /**
@@ -289,17 +257,7 @@ public class AsyncArcusCommands<T> implements AsyncArcusCommandsIF<T> {
       keyToFuture.put(key, future);
     });
 
-    return buildMultiFuture(keyToFuture);
-  }
-
-  /**
-   * Combine multiple CompletableFutures into a single ArcusFuture.
-   *
-   * @param keyToFuture a map of keys to their corresponding CompletableFutures
-   * @return an ArcusFuture that completes with a map of keys to their Boolean results.
-   */
-  private ArcusMultiFuture<Map<String, Boolean>> buildMultiFuture(
-      Map<String, CompletableFuture<?>> keyToFuture) {
+    /* Combine multiple CompletableFutures into a single ArcusFuture. */
     return new ArcusMultiFuture<>(keyToFuture.values(), () -> {
       Map<String, Boolean> results = new HashMap<>();
       keyToFuture.forEach((key, future) -> {

--- a/src/main/java/net/spy/memcached/v2/AsyncArcusCommandsIF.java
+++ b/src/main/java/net/spy/memcached/v2/AsyncArcusCommandsIF.java
@@ -93,16 +93,6 @@ public interface AsyncArcusCommandsIF<T> {
   ArcusFuture<Boolean> prepend(String key, T val);
 
   /**
-   * Sets the same value for multiple keys.
-   *
-   * @param keys  list of keys to store
-   * @param exp   expiration time in seconds
-   * @param value the value to store for all keys
-   * @return Map of key to Boolean result
-   */
-  ArcusFuture<Map<String, Boolean>> multiSet(List<String> keys, int exp, T value);
-
-  /**
    * Sets multiple key-value pairs.
    *
    * @param items map of keys and values to store
@@ -112,16 +102,6 @@ public interface AsyncArcusCommandsIF<T> {
   ArcusFuture<Map<String, Boolean>> multiSet(Map<String, T> items, int exp);
 
   /**
-   * Add the same value for multiple keys if they do not exist.
-   *
-   * @param keys  list of keys to store
-   * @param exp   expiration time in seconds
-   * @param value the value to store for all keys
-   * @return Map of key to Boolean result
-   */
-  ArcusFuture<Map<String, Boolean>> multiAdd(List<String> keys, int exp, T value);
-
-  /**
    * Add multiple key-value pairs if they do not exist.
    *
    * @param items map of keys and values to store
@@ -129,16 +109,6 @@ public interface AsyncArcusCommandsIF<T> {
    * @return Map of key to Boolean result
    */
   ArcusFuture<Map<String, Boolean>> multiAdd(Map<String, T> items, int exp);
-
-  /**
-   * Replace the same value for multiple keys if they exist.
-   *
-   * @param keys  list of keys to store
-   * @param exp   expiration time in seconds
-   * @param value the value to store for all keys
-   * @return Map of key to Boolean result
-   */
-  ArcusFuture<Map<String, Boolean>> multiReplace(List<String> keys, int exp, T value);
 
   /**
    * Replace multiple key-value pairs if they exist.

--- a/src/test/java/net/spy/memcached/v2/AsyncArcusCommandsTest.java
+++ b/src/test/java/net/spy/memcached/v2/AsyncArcusCommandsTest.java
@@ -1,7 +1,9 @@
 package net.spy.memcached.v2;
 
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -18,6 +20,11 @@ abstract class AsyncArcusCommandsTest {
   protected static AsyncArcusCommands<Object> async;
   protected static final List<String> keys = Arrays.asList("key0", "key1", "key2", "key3");
   protected static final String VALUE = "value";
+  protected static final Map<String, Object> items = new HashMap<>();
+
+  static {
+    keys.forEach(k -> items.put(k, VALUE));
+  }
 
   @BeforeAll
   static void setUp() {

--- a/src/test/java/net/spy/memcached/v2/KVAsyncArcusCommandsTest.java
+++ b/src/test/java/net/spy/memcached/v2/KVAsyncArcusCommandsTest.java
@@ -1,7 +1,6 @@
 package net.spy.memcached.v2;
 
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
@@ -10,16 +9,12 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
 import net.spy.memcached.CASValue;
-import net.spy.memcached.collection.CollectionAttributes;
-import net.spy.memcached.internal.CompositeException;
-import net.spy.memcached.ops.CollectionOperationStatus;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -70,83 +65,11 @@ class KVAsyncArcusCommandsTest extends AsyncArcusCommandsTest {
   }
 
   @Test
-  void multiSetAndGet() throws ExecutionException, InterruptedException, TimeoutException {
-    // given
-    // when
-    async.multiSet(keys, 0, VALUE)
-        .thenAccept(result -> {
-          for (Boolean b : result.values()) {
-            assertTrue(b);
-          }
-        })
-        .thenCompose(v -> async.multiGet(keys))
-        // then
-        .thenAccept(result -> {
-          assertEquals(keys.size(), result.size());
-          for (Object o : result.values()) {
-            assertEquals(VALUE, o);
-          }
-        })
-        .toCompletableFuture()
-        .get(300, TimeUnit.MILLISECONDS);
-  }
-
-  @Test
-  void multiAddFail() throws ExecutionException, InterruptedException, TimeoutException {
-    // given
-    async.set(keys.get(0), 0, VALUE)
-        // when
-        .thenCompose(result -> {
-          assertTrue(result);
-          return async.multiAdd(keys, 0, VALUE);
-        })
-        // then
-        .thenAccept(result -> {
-          assertEquals(keys.size(), result.size());
-          assertFalse(result.get(keys.get(0)));
-          for (int i = 1; i < 4; i++) {
-            assertTrue(result.get(keys.get(i)));
-          }
-        })
-        .toCompletableFuture()
-        .get(300, TimeUnit.MILLISECONDS);
-  }
-
-  @Test
-  void multiSetTypeMismatchException()
-      throws ExecutionException, InterruptedException, TimeoutException {
-    // given
-    Map<String, CollectionOperationStatus> result =
-        arcusClient.asyncLopInsertBulk(keys.subList(0, 2), 0, "value",
-            new CollectionAttributes()).get();
-    assertTrue(result.isEmpty());
-
-    // when
-    async.multiSet(keys, 0, VALUE)
-        // then
-        .handle((res, ex) -> {
-              assertInstanceOf(CompositeException.class, ex);
-              CompositeException ex2 = (CompositeException) ex;
-              List<Exception> exceptions = ex2.getExceptions();
-              assertEquals(2, exceptions.size());
-              for (Exception exception : exceptions) {
-                assertTrue(exception.getMessage().contains("TYPE_MISMATCH"));
-              }
-              return res;
-            }
-        )
-        .toCompletableFuture()
-        .get(300, TimeUnit.MILLISECONDS);
-  }
-
-  @Test
   void multiGetNothing() throws ExecutionException, InterruptedException, TimeoutException {
     // given
     async.multiGet(keys)
         // then
-        .thenAccept(result -> {
-          assertTrue(result.isEmpty());
-        })
+        .thenAccept(result -> assertTrue(result.isEmpty()))
         .toCompletableFuture()
         .get(300, TimeUnit.MILLISECONDS);
   }
@@ -154,7 +77,7 @@ class KVAsyncArcusCommandsTest extends AsyncArcusCommandsTest {
   @Test
   void cancelMultiGet() throws ExecutionException, InterruptedException, TimeoutException {
     // given
-    async.multiSet(keys, 0, VALUE)
+    async.multiSet(items, 0)
         .thenAccept(result -> {
           for (Boolean b : result.values()) {
             assertTrue(b);
@@ -371,7 +294,7 @@ class KVAsyncArcusCommandsTest extends AsyncArcusCommandsTest {
   @Test
   void multiGetsSuccess() throws ExecutionException, InterruptedException, TimeoutException {
     // given
-    async.multiSet(keys, 60, VALUE)
+    async.multiSet(items, 60)
             .thenAccept(result -> {
               for (Boolean b : result.values()) {
                 assertTrue(b);
@@ -426,16 +349,10 @@ class KVAsyncArcusCommandsTest extends AsyncArcusCommandsTest {
   }
 
   @Test
-  void multiSetMapSuccess() throws ExecutionException, InterruptedException, TimeoutException {
+  void multiSetSuccess() throws ExecutionException, InterruptedException, TimeoutException {
     // given
-    Map<String, Object> elements = new HashMap<>();
-
-    for (int i = 0; i < keys.size(); i++) {
-      elements.put(keys.get(i), VALUE + i);
-    }
-
     // when
-    async.multiSet(elements, 60)
+    async.multiSet(items, 60)
         .thenCompose(result -> {
           assertEquals(keys.size(), result.size());
           for (Boolean b : result.values()) {
@@ -446,8 +363,8 @@ class KVAsyncArcusCommandsTest extends AsyncArcusCommandsTest {
         // then
         .thenAccept(result -> {
           assertEquals(keys.size(), result.size());
-          for (int i = 0; i < keys.size(); i++) {
-            assertEquals(VALUE + i, result.get(keys.get(i)));
+          for (String key : keys) {
+            assertEquals(VALUE, result.get(key));
           }
         })
         .toCompletableFuture()
@@ -455,15 +372,10 @@ class KVAsyncArcusCommandsTest extends AsyncArcusCommandsTest {
   }
 
   @Test
-  void multiAddMapSuccess() throws ExecutionException, InterruptedException, TimeoutException {
+  void multiAddSuccess() throws ExecutionException, InterruptedException, TimeoutException {
     // given
-    Map<String, Object> elements = new HashMap<>();
-    for (int i = 0; i < keys.size(); i++) {
-      elements.put(keys.get(i), VALUE + i);
-    }
-
     // when
-    async.multiAdd(elements, 60)
+    async.multiAdd(items, 60)
         .thenCompose(result -> {
           assertEquals(keys.size(), result.size());
           for (Boolean b : result.values()) {
@@ -474,8 +386,8 @@ class KVAsyncArcusCommandsTest extends AsyncArcusCommandsTest {
         // then
         .thenAccept(result -> {
           assertEquals(keys.size(), result.size());
-          for (int i = 0; i < keys.size(); i++) {
-            assertEquals(VALUE + i, result.get(keys.get(i)));
+          for (String key : keys) {
+            assertEquals(VALUE, result.get(key));
           }
         })
         .toCompletableFuture()
@@ -483,15 +395,10 @@ class KVAsyncArcusCommandsTest extends AsyncArcusCommandsTest {
   }
 
   @Test
-  void multiAddMapPartialSuccess() throws ExecutionException, InterruptedException,
+  void multiAddPartialSuccess() throws ExecutionException, InterruptedException,
       TimeoutException {
 
     // given
-    Map<String, Object> elements = new HashMap<>();
-    for (int i = 0; i < keys.size(); i++) {
-      elements.put(keys.get(i), VALUE + i);
-    }
-
     /* 0th key is added before multiAdd, so it should fail. */
     async.set(keys.get(0), 60, VALUE + "-old")
         .thenAccept(Assertions::assertTrue)
@@ -499,7 +406,7 @@ class KVAsyncArcusCommandsTest extends AsyncArcusCommandsTest {
         .get(300L, TimeUnit.MILLISECONDS);
 
     // when
-    async.multiAdd(elements, 60)
+    async.multiAdd(items, 60)
         .thenCompose(result -> {
           assertEquals(keys.size(), result.size());
           assertFalse(result.get(keys.get(0)));
@@ -513,7 +420,7 @@ class KVAsyncArcusCommandsTest extends AsyncArcusCommandsTest {
           assertEquals(keys.size(), result.size());
           assertEquals(VALUE + "-old", result.get(keys.get(0)));
           for (int i = 1; i < keys.size(); i++) {
-            assertEquals(VALUE + i, result.get(keys.get(i)));
+            assertEquals(VALUE, result.get(keys.get(i)));
           }
         })
         .toCompletableFuture()
@@ -521,21 +428,16 @@ class KVAsyncArcusCommandsTest extends AsyncArcusCommandsTest {
   }
 
   @Test
-  void multiReplaceMapSuccess() throws ExecutionException, InterruptedException,
+  void multiReplaceSuccess() throws ExecutionException, InterruptedException,
       TimeoutException {
 
     // given
-    Map<String, Object> oldElements = new HashMap<>();
+    Map<String, Object> newItems = new HashMap<>();
     for (int i = 0; i < keys.size(); i++) {
-      oldElements.put(keys.get(i), VALUE + "-old-" + i);
+      newItems.put(keys.get(i), VALUE + "-new-" + i);
     }
 
-    Map<String, Object> newElements = new HashMap<>();
-    for (int i = 0; i < keys.size(); i++) {
-      newElements.put(keys.get(i), VALUE + "-new-" + i);
-    }
-
-    async.multiSet(oldElements, 60)
+    async.multiSet(items, 60)
         .thenAccept(result -> {
           assertEquals(keys.size(), result.size());
           for (Boolean b : result.values()) {
@@ -546,7 +448,7 @@ class KVAsyncArcusCommandsTest extends AsyncArcusCommandsTest {
         .get(300L, TimeUnit.MILLISECONDS);
 
     // when
-    async.multiReplace(newElements, 60)
+    async.multiReplace(newItems, 60)
         .thenCompose(result -> {
           assertEquals(keys.size(), result.size());
           for (Boolean b : result.values()) {
@@ -566,24 +468,24 @@ class KVAsyncArcusCommandsTest extends AsyncArcusCommandsTest {
   }
 
   @Test
-  void multiReplaceMapPartialSuccess() throws ExecutionException, InterruptedException,
+  void multiReplacePartialSuccess() throws ExecutionException, InterruptedException,
       TimeoutException {
 
     // given
-    Map<String, Object> oldElements = new HashMap<>();
+    Map<String, Object> oldItems = new HashMap<>();
     for (int i = 0; i < 2; i++) {
-      oldElements.put(keys.get(i), VALUE + "-old-" + i);
+      oldItems.put(keys.get(i), VALUE + "-old-" + i);
     }
 
-    Map<String, Object> newElements = new HashMap<>();
+    Map<String, Object> newItems = new HashMap<>();
     for (int i = 0; i < keys.size(); i++) {
-      newElements.put(keys.get(i), VALUE + "-new-" + i);
+      newItems.put(keys.get(i), VALUE + "-new-" + i);
     }
 
     /* 0, 1st keys are added before multiReplace, so only they should succeed. */
-    async.multiSet(oldElements, 60)
+    async.multiSet(oldItems, 60)
         .thenAccept(result -> {
-          assertEquals(oldElements.size(), result.size());
+          assertEquals(oldItems.size(), result.size());
           for (Boolean b : result.values()) {
             assertTrue(b);
           }
@@ -592,7 +494,7 @@ class KVAsyncArcusCommandsTest extends AsyncArcusCommandsTest {
         .get(300L, TimeUnit.MILLISECONDS);
 
     // when
-    async.multiReplace(newElements, 60)
+    async.multiReplace(newItems, 60)
         .thenCompose(result -> {
           assertEquals(keys.size(), result.size());
           for (int i = 0; i < 2; i++) {
@@ -656,7 +558,7 @@ class KVAsyncArcusCommandsTest extends AsyncArcusCommandsTest {
   @Test
   void multiDeleteSuccess() throws ExecutionException, InterruptedException, TimeoutException {
     // given
-    async.multiSet(keys, 0, VALUE)
+    async.multiSet(items, 0)
             .thenAccept(result -> {
               for (Boolean b : result.values()) {
                 assertTrue(b);


### PR DESCRIPTION
### 🔗 Related Issue

<!-- Please link related issue. ex) https://github.com/naver/arcus-java-client/issues/{issue_number} -->
- 

### ⌨️ What I did

<!-- Please describe this PR and what you've been working on. -->


- https://github.com/naver/arcus-java-client/pull/1056 에서의 Comment를 바탕으로 작업 진행했습니다.
- List 방식은 모든 Key에 동일한 Value를 저장하는 방식으로, 실용성이 낮다고 판단하여 제거합니다.
  - 이에 따라, 관련된 API 코드 및 테스트 코드를 제거하였습니다. 

**Multi-Store (set, add, replace)**                                                                                                                                                                                                    
   
_as-is_                                                                                                                                                                                                                                
- List, Map 2가지 방식의 `multiStore` API 제공            
  - List: 여러 Key에 동일한 Value를 저장
  - Map: 여러 Key-Value 쌍을 저장                                                                                                                                                                                                      
   
_to-be_                                                                                                                                                                                                                                
- Map 방식으로만 `multiStore` API 제공

