### PR TITLE
FEATURE: Add CompletableFuture BTree delete API

### DIFF
--- a/src/main/java/net/spy/memcached/collection/BTreeDelete.java
+++ b/src/main/java/net/spy/memcached/collection/BTreeDelete.java
@@ -27,38 +27,42 @@ public class BTreeDelete extends CollectionDelete {
 
   protected ElementFlagFilter elementFlagFilter;
 
-  public BTreeDelete(long bkey, ElementFlagFilter elementFlagFilter,
+  public BTreeDelete(String bKey, ElementFlagFilter elementFlagFilter,
                      boolean dropIfEmpty, boolean noreply) {
-    this.range = String.valueOf(bkey);
+    this.range = bKey;
     this.elementFlagFilter = elementFlagFilter;
     this.dropIfEmpty = dropIfEmpty;
     this.noreply = noreply;
+  }
+
+  public BTreeDelete(String from, String to, int count, ElementFlagFilter elementFlagFilter,
+                     boolean dropIfEmpty, boolean noreply) {
+    this.range = from + ".." + to;
+    this.count = count;
+    this.elementFlagFilter = elementFlagFilter;
+    this.dropIfEmpty = dropIfEmpty;
+    this.noreply = noreply;
+  }
+
+  public BTreeDelete(long bKey, ElementFlagFilter elementFlagFilter,
+                     boolean dropIfEmpty, boolean noreply) {
+    this(String.valueOf(bKey), elementFlagFilter, dropIfEmpty, noreply);
   }
 
   public BTreeDelete(long from, long to, int count, ElementFlagFilter elementFlagFilter,
                      boolean dropIfEmpty, boolean noreply) {
-    this.range = from + ".." + to;
-    this.count = count;
-    this.dropIfEmpty = dropIfEmpty;
-    this.noreply = noreply;
-    this.elementFlagFilter = elementFlagFilter;
+    this(String.valueOf(from), String.valueOf(to), count, elementFlagFilter, dropIfEmpty, noreply);
   }
 
-  public BTreeDelete(byte[] bkey, ElementFlagFilter elementFlagFilter,
+  public BTreeDelete(byte[] bKey, ElementFlagFilter elementFlagFilter,
                      boolean dropIfEmpty, boolean noreply) {
-    this.range = BTreeUtil.toHex(bkey);
-    this.noreply = noreply;
-    this.dropIfEmpty = dropIfEmpty;
-    this.elementFlagFilter = elementFlagFilter;
+    this(BTreeUtil.toHex(bKey), elementFlagFilter, dropIfEmpty, noreply);
   }
 
   public BTreeDelete(byte[] from, byte[] to, int count, ElementFlagFilter elementFlagFilter,
                      boolean dropIfEmpty, boolean noreply) {
-    this.range = BTreeUtil.toHex(from) + ".." + BTreeUtil.toHex(to);
-    this.count = count;
-    this.noreply = noreply;
-    this.dropIfEmpty = dropIfEmpty;
-    this.elementFlagFilter = elementFlagFilter;
+    this(BTreeUtil.toHex(from), BTreeUtil.toHex(to),
+            count, elementFlagFilter, dropIfEmpty, noreply);
   }
 
   @Nullable

--- a/src/main/java/net/spy/memcached/v2/AsyncArcusCommands.java
+++ b/src/main/java/net/spy/memcached/v2/AsyncArcusCommands.java
@@ -36,6 +36,7 @@ import net.spy.memcached.MemcachedNode;
 import net.spy.memcached.collection.BKeyObject;
 import net.spy.memcached.collection.BTreeCount;
 import net.spy.memcached.collection.BTreeCreate;
+import net.spy.memcached.collection.BTreeDelete;
 import net.spy.memcached.collection.BTreeGet;
 import net.spy.memcached.collection.BTreeGetBulk;
 import net.spy.memcached.collection.BTreeGetBulkWithByteTypeBkey;
@@ -51,6 +52,7 @@ import net.spy.memcached.collection.BTreeUpsert;
 import net.spy.memcached.collection.CollectionAttributes;
 import net.spy.memcached.collection.CollectionCount;
 import net.spy.memcached.collection.CollectionCreate;
+import net.spy.memcached.collection.CollectionDelete;
 import net.spy.memcached.collection.CollectionInsert;
 import net.spy.memcached.collection.CollectionMutate;
 import net.spy.memcached.collection.CollectionUpdate;
@@ -79,6 +81,7 @@ import net.spy.memcached.v2.vo.BKey;
 import net.spy.memcached.v2.vo.BTreeElement;
 import net.spy.memcached.v2.vo.BTreeElements;
 import net.spy.memcached.v2.vo.BTreeUpdateElement;
+import net.spy.memcached.v2.vo.BopDeleteArgs;
 import net.spy.memcached.v2.vo.BopGetArgs;
 import net.spy.memcached.v2.vo.SMGetElements;
 
@@ -1421,6 +1424,59 @@ public class AsyncArcusCommands<T> implements AsyncArcusCommandsIF<T> {
       }
     };
     Operation op = client.getOpFact().collectionMutate(key, internalKey, mutate, cb);
+    future.setOp(op);
+    client.addOp(key, op);
+
+    return future;
+  }
+
+  public ArcusFuture<Boolean> bopDelete(String key, BKey bKey, BopDeleteArgs args) {
+    BTreeDelete delete = new BTreeDelete(bKey.toString(),
+            args.getEFlagFilter(), args.isDropIfEmpty(), false);
+    return collectionDelete(key, delete);
+  }
+
+  public ArcusFuture<Boolean> bopDelete(String key, BKey from, BKey to, BopDeleteArgs args) {
+    verifyBKeyRange(from, to);
+    BTreeDelete delete = new BTreeDelete(from.toString(), to.toString(),
+            args.getCount(), args.getEFlagFilter(), args.isDropIfEmpty(), false);
+    return collectionDelete(key, delete);
+  }
+
+  private ArcusFuture<Boolean> collectionDelete(String key, CollectionDelete delete) {
+    AbstractArcusResult<Boolean> result = new AbstractArcusResult<>(new AtomicReference<>());
+    ArcusFutureImpl<Boolean> future = new ArcusFutureImpl<>(result);
+    ArcusClient client = arcusClientSupplier.get();
+
+    OperationCallback cb = new OperationCallback() {
+      @Override
+      public void receivedStatus(OperationStatus status) {
+        switch (status.getStatusCode()) {
+          case SUCCESS:
+            result.set(true);
+            break;
+          case ERR_NOT_FOUND:
+            result.set(null);
+            break;
+          case ERR_NOT_FOUND_ELEMENT:
+            result.set(false);
+            break;
+          case CANCELLED:
+            future.internalCancel();
+            break;
+          default:
+            /* TYPE_MISMATCH / BKEY_MISMATCH / NOT_SUPPORTED or unknown statement */
+            result.addError(key, status);
+            break;
+        }
+      }
+
+      @Override
+      public void complete() {
+        future.complete();
+      }
+    };
+    Operation op = client.getOpFact().collectionDelete(key, delete, cb);
     future.setOp(op);
     client.addOp(key, op);
 

--- a/src/main/java/net/spy/memcached/v2/AsyncArcusCommandsIF.java
+++ b/src/main/java/net/spy/memcached/v2/AsyncArcusCommandsIF.java
@@ -28,6 +28,7 @@ import net.spy.memcached.v2.vo.BKey;
 import net.spy.memcached.v2.vo.BTreeElement;
 import net.spy.memcached.v2.vo.BTreeElements;
 import net.spy.memcached.v2.vo.BTreeUpdateElement;
+import net.spy.memcached.v2.vo.BopDeleteArgs;
 import net.spy.memcached.v2.vo.BopGetArgs;
 import net.spy.memcached.v2.vo.SMGetElements;
 
@@ -433,6 +434,35 @@ public interface AsyncArcusCommandsIF<T> {
    *         or {@code initial} if the element did not exist.
    */
   ArcusFuture<Long> bopDecr(String key, BKey bKey, int delta, long initial, byte[] eFlag);
+
+  /**
+   * Delete an element with the given bKey from a btree item.
+   *
+   * @param key  key of the btree item
+   * @param bKey BKey of the element to delete
+   * @param args delete arguments (eFlagFilter, dropIfEmpty)
+   * @return {@code true} if the element was deleted,
+   * {@code null} if the key is not found,
+   * {@code false} if the element is not found.
+   */
+  ArcusFuture<Boolean> bopDelete(String key, BKey bKey, BopDeleteArgs args);
+
+  /**
+   * Delete elements in a bKey range from a btree item.
+   * Elements are deleted in order from {@code from} to {@code to}.
+   * <p>If {@code args.count} is 0 (default), all elements in the range are deleted. </p>
+   * Otherwise, only the first {@code args.count} elements (in {@code from}-to-{@code to} order)
+   * are deleted.
+   *
+   * @param key  key of the btree item
+   * @param from BKey range start (inclusive)
+   * @param to   BKey range end (inclusive)
+   * @param args delete arguments (count, eFlagFilter, dropIfEmpty)
+   * @return {@code true} if at least one element was deleted,
+   * {@code null} if the key is not found,
+   * {@code false} if no elements are found in the range.
+   */
+  ArcusFuture<Boolean> bopDelete(String key, BKey from, BKey to, BopDeleteArgs args);
 
   /**
    * Count elements in a bKey range from a btree item.

--- a/src/main/java/net/spy/memcached/v2/vo/BopDeleteArgs.java
+++ b/src/main/java/net/spy/memcached/v2/vo/BopDeleteArgs.java
@@ -1,0 +1,58 @@
+package net.spy.memcached.v2.vo;
+
+import net.spy.memcached.collection.ElementFlagFilter;
+
+public final class BopDeleteArgs {
+
+  public static final BopDeleteArgs DEFAULT = new BopDeleteArgs.Builder().build();
+
+  private final ElementFlagFilter eFlagFilter;
+  private final int count;
+  private final boolean dropIfEmpty;
+
+  private BopDeleteArgs(ElementFlagFilter eFlagFilter, int count, boolean dropIfEmpty) {
+    this.eFlagFilter = eFlagFilter;
+    this.count = count;
+    this.dropIfEmpty = dropIfEmpty;
+  }
+
+  public ElementFlagFilter getEFlagFilter() {
+    return eFlagFilter;
+  }
+
+  public int getCount() {
+    return count;
+  }
+
+  public boolean isDropIfEmpty() {
+    return dropIfEmpty;
+  }
+
+  public static class Builder {
+    private ElementFlagFilter eFlagFilter = ElementFlagFilter.DO_NOT_FILTER;
+    private int count = 0;
+    private boolean dropIfEmpty = false;
+
+    public Builder eFlagFilter(ElementFlagFilter eFlagFilter) {
+      this.eFlagFilter = eFlagFilter;
+      return this;
+    }
+
+    public Builder count(int count) {
+      if (count < 0) {
+        throw new IllegalArgumentException("Count must be non-negative.");
+      }
+      this.count = count;
+      return this;
+    }
+
+    public Builder dropIfEmpty() {
+      this.dropIfEmpty = true;
+      return this;
+    }
+
+    public BopDeleteArgs build() {
+      return new BopDeleteArgs(eFlagFilter, count, dropIfEmpty);
+    }
+  }
+}

--- a/src/test/java/net/spy/memcached/v2/BTreeAsyncArcusCommandsTest.java
+++ b/src/test/java/net/spy/memcached/v2/BTreeAsyncArcusCommandsTest.java
@@ -18,6 +18,7 @@ import net.spy.memcached.v2.vo.BKey;
 import net.spy.memcached.v2.vo.BTreeElement;
 import net.spy.memcached.v2.vo.BTreeElements;
 import net.spy.memcached.v2.vo.BTreeUpdateElement;
+import net.spy.memcached.v2.vo.BopDeleteArgs;
 import net.spy.memcached.v2.vo.BopGetArgs;
 import net.spy.memcached.v2.vo.SMGetElements;
 
@@ -1275,6 +1276,337 @@ class BTreeAsyncArcusCommandsTest extends AsyncArcusCommandsTest {
     // when
     async.bopDecr(key, BKey.of(new byte[]{0x01}), 10)
             // then
+            .handle((result, ex) -> {
+              assertInstanceOf(OperationException.class, ex);
+              assertTrue(ex.getMessage().contains("BKEY_MISMATCH"));
+              return result;
+            })
+            .toCompletableFuture()
+            .get(300L, TimeUnit.MILLISECONDS);
+  }
+
+  @Test
+  void bopDeleteSuccess() throws ExecutionException, InterruptedException, TimeoutException {
+    // given
+    String key = keys.get(0);
+    BKey bKey = ELEMENTS.get(0).getBkey();
+
+    async.bopInsert(key, ELEMENTS.get(0), new CollectionAttributes())
+            .thenAccept(Assertions::assertTrue)
+            .toCompletableFuture()
+            .get(300L, TimeUnit.MILLISECONDS);
+
+    // when
+    async.bopDelete(key, bKey, BopDeleteArgs.DEFAULT)
+            // then
+            .thenCompose(result -> {
+              assertTrue(result);
+              return async.bopGet(key, bKey, BopGetArgs.DEFAULT);
+            })
+            .thenAccept(result -> {
+              assertNotNull(result);
+              assertNull(result.getValue());
+            })
+            .toCompletableFuture()
+            .get(300L, TimeUnit.MILLISECONDS);
+  }
+
+  @Test
+  void bopDeleteDropIfEmpty() throws ExecutionException, InterruptedException, TimeoutException {
+    // given
+    String key = keys.get(0);
+    BKey bKey = ELEMENTS.get(0).getBkey();
+    BopDeleteArgs args = new BopDeleteArgs.Builder()
+            .dropIfEmpty()
+            .build();
+
+    async.bopInsert(key, ELEMENTS.get(0), new CollectionAttributes())
+            .thenAccept(Assertions::assertTrue)
+            .toCompletableFuture()
+            .get(300L, TimeUnit.MILLISECONDS);
+
+    // when
+    async.bopDelete(key, bKey, args)
+            // then
+            .thenCompose(result -> {
+              assertTrue(result);
+              return async.bopGet(key, bKey, BopGetArgs.DEFAULT);
+            })
+            .thenAccept(Assertions::assertNull)
+            .toCompletableFuture()
+            .get(300L, TimeUnit.MILLISECONDS);
+  }
+
+  @Test
+  void bopDeleteNotFound() throws ExecutionException, InterruptedException, TimeoutException {
+    // given
+    String key = keys.get(0);
+    BKey bKey = BKey.of(1L);
+
+    // when
+    async.bopDelete(key, bKey, BopDeleteArgs.DEFAULT)
+            // then
+            .thenAccept(Assertions::assertNull)
+            .toCompletableFuture()
+            .get(300L, TimeUnit.MILLISECONDS);
+  }
+
+  @Test
+  void bopDeleteNotFoundElement() throws ExecutionException, InterruptedException,
+          TimeoutException {
+    // given
+    String key = keys.get(0);
+    BKey bKey = BKey.of(999L);
+
+    async.bopCreate(key, ElementValueType.STRING, new CollectionAttributes())
+            .thenAccept(Assertions::assertTrue)
+            .toCompletableFuture()
+            .get(300L, TimeUnit.MILLISECONDS);
+
+    // when
+    async.bopDelete(key, bKey, BopDeleteArgs.DEFAULT)
+            // then
+            .thenAccept(Assertions::assertFalse)
+            .toCompletableFuture()
+            .get(300L, TimeUnit.MILLISECONDS);
+  }
+
+  @Test
+  void bopDeleteTypeMismatch() throws ExecutionException, InterruptedException, TimeoutException {
+    // given
+    String key = keys.get(0);
+    BKey bKey = BKey.of(1L);
+
+    async.set(key, 60, "invalid-type-value")
+            .thenAccept(Assertions::assertTrue)
+            .toCompletableFuture()
+            .get(300L, TimeUnit.MILLISECONDS);
+
+    // when
+    async.bopDelete(key, bKey, BopDeleteArgs.DEFAULT)
+            .handle((result, ex) -> {
+              assertInstanceOf(OperationException.class, ex);
+              assertTrue(ex.getMessage().contains("TYPE_MISMATCH"));
+              return result;
+            })
+            .toCompletableFuture()
+            .get(300L, TimeUnit.MILLISECONDS);
+  }
+
+  @Test
+  void bopDeleteBKeyMismatch() throws ExecutionException, InterruptedException, TimeoutException {
+    // given
+    String key = keys.get(0);
+    BKey bKey = BKey.of(new byte[]{0x01});
+
+    async.bopInsert(key, ELEMENTS.get(0) /* long BKey */, new CollectionAttributes())
+            .thenAccept(Assertions::assertTrue)
+            .toCompletableFuture()
+            .get(300L, TimeUnit.MILLISECONDS);
+
+    // when
+    async.bopDelete(key, bKey, BopDeleteArgs.DEFAULT)
+            .handle((result, ex) -> {
+              assertInstanceOf(OperationException.class, ex);
+              assertTrue(ex.getMessage().contains("BKEY_MISMATCH"));
+              return result;
+            })
+            .toCompletableFuture()
+            .get(300L, TimeUnit.MILLISECONDS);
+  }
+
+  @Test
+  void bopDeleteByRangeSuccess() throws ExecutionException, InterruptedException, TimeoutException {
+    // given
+    String key = keys.get(0);
+    BKey from = ELEMENTS.get(0).getBkey();
+    BKey to = ELEMENTS.get(2).getBkey();
+    BopDeleteArgs deleteArgs = new BopDeleteArgs.Builder()
+            .count(1)
+            .build();
+
+    async.bopInsert(key, ELEMENTS.get(0), new CollectionAttributes())
+            .thenCompose(result -> {
+              assertTrue(result);
+              return async.bopInsert(key, ELEMENTS.get(1));
+            })
+            .thenCompose(result -> {
+              assertTrue(result);
+              return async.bopInsert(key, ELEMENTS.get(2));
+            })
+            .toCompletableFuture()
+            .get(300L, TimeUnit.MILLISECONDS);
+
+    // when
+    async.bopDelete(key, from, to, deleteArgs)
+            .thenCompose(result -> {
+              assertTrue(result);
+              return async.bopGet(key, from, to, BopGetArgs.DEFAULT);
+            })
+            .thenAccept(result -> {
+              List<BTreeElement<Object>> elements = result.getElements();
+              assertEquals(2, elements.size());
+            })
+            .toCompletableFuture()
+            .get(300L, TimeUnit.MILLISECONDS);
+  }
+
+  @Test
+  void bopDeleteByRangeCountZero() throws ExecutionException, InterruptedException,
+          TimeoutException {
+    // given
+    String key = keys.get(0);
+    BKey from = BKey.of(0L);
+    BKey to = BKey.of(10L);
+    BopDeleteArgs args = BopDeleteArgs.DEFAULT;
+
+    async.bopInsert(key, ELEMENTS.get(0), new CollectionAttributes())
+            .thenCompose(result -> {
+              assertTrue(result);
+              return async.bopInsert(key, ELEMENTS.get(1));
+            })
+            .thenCompose(result -> {
+              assertTrue(result);
+              return async.bopInsert(key, ELEMENTS.get(2));
+            })
+            .thenCompose(result -> {
+              assertTrue(result);
+              return async.bopInsert(key, ELEMENTS.get(3));
+            })
+            .toCompletableFuture()
+            .get(300L, TimeUnit.MILLISECONDS);
+
+    // when
+    async.bopDelete(key, from, to, args)
+            .thenCompose(result -> {
+              assertTrue(result);
+              return async.bopGet(key, from, to, BopGetArgs.DEFAULT);
+            })
+            .thenAccept(result -> {
+              assertNotNull(result);
+              assertTrue(result.getElements().isEmpty());
+            })
+            .toCompletableFuture()
+            .get(300L, TimeUnit.MILLISECONDS);
+  }
+
+  @Test
+  void bopDeleteByRangeEFlag() throws ExecutionException, InterruptedException, TimeoutException {
+    // given
+    String key = keys.get(0);
+    byte[] eFlag = new byte[]{0x01};
+    BTreeElement<Object> elementWithFlag = new BTreeElement<>(BKey.of(1L), "value1", eFlag);
+    BTreeElement<Object> elementWithoutFlag = new BTreeElement<>(BKey.of(2L), "value2", null);
+
+    ElementFlagFilter filter = new ElementFlagFilter(ElementFlagFilter.CompOperands.Equal, eFlag);
+    BopDeleteArgs args = new BopDeleteArgs.Builder()
+            .eFlagFilter(filter)
+            .build();
+
+    BKey from = BKey.of(0L);
+    BKey to = BKey.of(10L);
+
+    async.bopInsert(key, elementWithFlag, new CollectionAttributes())
+            .thenCompose(result -> {
+              assertTrue(result);
+              return async.bopInsert(key, elementWithoutFlag);
+            })
+            .thenAccept(Assertions::assertTrue)
+            .toCompletableFuture()
+            .get(300L, TimeUnit.MILLISECONDS);
+
+    // when
+    async.bopDelete(key, from, to, args)
+            // then
+            .thenCompose(result -> {
+              assertTrue(result);
+              return async.bopGet(key, from, to, BopGetArgs.DEFAULT);
+            })
+            .thenAccept(result -> {
+              assertNotNull(result);
+              assertEquals(1, result.getElements().size());
+              assertEquals(elementWithoutFlag.getBkey(), result.getElements().get(0).getBkey());
+            })
+            .toCompletableFuture()
+            .get(300L, TimeUnit.MILLISECONDS);
+  }
+
+  @Test
+  void bopDeleteByRangeNotFound() throws ExecutionException, InterruptedException,
+          TimeoutException {
+    // given
+    String key = keys.get(0);
+    BKey from = BKey.of(0L);
+    BKey to = BKey.of(10L);
+
+    // when
+    async.bopDelete(key, from, to, BopDeleteArgs.DEFAULT)
+            // then
+            .thenAccept(Assertions::assertNull)
+            .toCompletableFuture()
+            .get(300L, TimeUnit.MILLISECONDS);
+  }
+
+  @Test
+  void bopDeleteByRangeNotFoundElement() throws ExecutionException, InterruptedException,
+          TimeoutException {
+    // given
+    String key = keys.get(0);
+    BKey from = BKey.of(100L);
+    BKey to = BKey.of(200L);
+
+    async.bopInsert(key, ELEMENTS.get(0), new CollectionAttributes())
+            .thenAccept(Assertions::assertTrue)
+            .toCompletableFuture()
+            .get(300L, TimeUnit.MILLISECONDS);
+
+    // when
+    async.bopDelete(key, from, to, BopDeleteArgs.DEFAULT)
+            // then
+            .thenAccept(Assertions::assertFalse)
+            .toCompletableFuture()
+            .get(300L, TimeUnit.MILLISECONDS);
+  }
+
+  @Test
+  void bopDeleteByRangeTypeMismatch() throws ExecutionException, InterruptedException,
+          TimeoutException {
+    // given
+    String key = keys.get(0);
+    BKey from = BKey.of(0L);
+    BKey to = BKey.of(10L);
+
+    async.set(key, 60, "invalid-type-value")
+            .thenAccept(Assertions::assertTrue)
+            .toCompletableFuture()
+            .get(300L, TimeUnit.MILLISECONDS);
+
+    // when
+    async.bopDelete(key, from, to, BopDeleteArgs.DEFAULT)
+            .handle((result, ex) -> {
+              assertInstanceOf(OperationException.class, ex);
+              assertTrue(ex.getMessage().contains("TYPE_MISMATCH"));
+              return result;
+            })
+            .toCompletableFuture()
+            .get(300L, TimeUnit.MILLISECONDS);
+  }
+
+  @Test
+  void bopDeleteByRangeBKeyMismatch() throws ExecutionException, InterruptedException,
+          TimeoutException {
+    // given
+    String key = keys.get(0);
+    BKey from = BKey.of(new byte[]{0x00});
+    BKey to = BKey.of(new byte[]{0x10});
+
+    async.bopInsert(key, ELEMENTS.get(0), new CollectionAttributes())
+            .thenAccept(Assertions::assertTrue)
+            .toCompletableFuture()
+            .get(300L, TimeUnit.MILLISECONDS);
+
+    // when
+    async.bopDelete(key, from, to, BopDeleteArgs.DEFAULT)
             .handle((result, ex) -> {
               assertInstanceOf(OperationException.class, ex);
               assertTrue(ex.getMessage().contains("BKEY_MISMATCH"));


### PR DESCRIPTION
### 🔗 Related Issue

<!-- Please link related issue. ex) https://github.com/naver/arcus-java-client/issues/{issue_number} -->
- https://github.com/jam2in/arcus-works/issues/832#event-23130177064

### ⌨️ What I did

<!-- Please describe this PR and what you've been working on. -->
- B+Tree의 삭제 연산인 `bopDelete`, `bopDeleteByRange` API를 구현하였습니다.
- v2에서 BKey 클래스 호환성을 위해 BTreeDelete 클래스에서 String 형태의 BKey를 받을 수 있는 생성자를 추가하였습니다.

**참고사항**

- BopDeleteArgs의 count 값이 0 이하인 음수를 사용하더라도 서버에서는 **전체 삭제로 동작** 합니다.
  - 하지만, 의도하지 않은 동작으로 판단하고 예외가 발생하도록 구성하였습니다. 