### PR TITLE
FIX: Return null for `ERR_NOT_FOUND` in collectionInsert receivedStatus

### DIFF
--- a/src/main/java/net/spy/memcached/v2/AsyncArcusCommands.java
+++ b/src/main/java/net/spy/memcached/v2/AsyncArcusCommands.java
@@ -808,24 +808,27 @@ public class AsyncArcusCommands<T> implements AsyncArcusCommandsIF<T> {
     OperationCallback cb = new OperationCallback() {
       @Override
       public void receivedStatus(OperationStatus status) {
-        if (!status.isSuccess()) {
-          switch (status.getStatusCode()) {
-            case ERR_ELEMENT_EXISTS:
-            case ERR_NOT_FOUND:
-              break;
-            case CANCELLED:
-              future.internalCancel();
-              return;
-            default:
-              /*
-               * TYPE_MISMATCH / BKEY_MISMATCH / OVERFLOWED / OUT_OF_RANGE / NOT_SUPPORTED
-               * or unknown statement
-               */
-              result.addError(key, status);
-              return;
-          }
+        switch (status.getStatusCode()) {
+          case SUCCESS:
+            result.set(true);
+            break;
+          case ERR_ELEMENT_EXISTS:
+            result.set(false);
+            break;
+          case ERR_NOT_FOUND:
+            result.set(null);
+            break;
+          case CANCELLED:
+            future.internalCancel();
+            break;
+          default:
+            /*
+             * TYPE_MISMATCH / BKEY_MISMATCH / OVERFLOWED / OUT_OF_RANGE / NOT_SUPPORTED
+             * or unknown statement
+             */
+            result.addError(key, status);
+            break;
         }
-        result.set(status.isSuccess());
       }
 
       @Override

--- a/src/test/java/net/spy/memcached/v2/BTreeAsyncArcusCommandsTest.java
+++ b/src/test/java/net/spy/memcached/v2/BTreeAsyncArcusCommandsTest.java
@@ -79,9 +79,7 @@ class BTreeAsyncArcusCommandsTest extends AsyncArcusCommandsTest {
           return async.bopGet(key, element.getBkey(), BopGetArgs.DEFAULT);
         })
         // then
-        .thenAccept(result -> {
-          assertNotEquals(element, result);
-        })
+        .thenAccept(result -> assertNotEquals(element, result))
         .toCompletableFuture()
         .get(300, TimeUnit.MILLISECONDS);
   }
@@ -91,7 +89,7 @@ class BTreeAsyncArcusCommandsTest extends AsyncArcusCommandsTest {
     // given & when
     async.bopInsert(keys.get(0), ELEMENTS.get(0))
         // then
-        .thenAccept(Assertions::assertFalse)
+        .thenAccept(Assertions::assertNull)
         .toCompletableFuture()
         .get(300, TimeUnit.MILLISECONDS);
   }
@@ -276,7 +274,7 @@ class BTreeAsyncArcusCommandsTest extends AsyncArcusCommandsTest {
         // then
         .thenAccept(element -> assertEquals(ELEMENTS.get(0), element))
         .thenCompose(v -> async.bopInsert(key, ELEMENTS.get(1)))
-        .thenAccept(Assertions::assertFalse) // NOT FOUND (key miss)
+        .thenAccept(Assertions::assertNull)
         .toCompletableFuture()
         .get(300, TimeUnit.MILLISECONDS);
   }
@@ -369,7 +367,6 @@ class BTreeAsyncArcusCommandsTest extends AsyncArcusCommandsTest {
         .toCompletableFuture()
         .get(300, TimeUnit.MILLISECONDS);
   }
-
 
   @Test
   void bopMultiGet() throws Exception {


### PR DESCRIPTION
### 🔗 Related Issue

<!-- Please link related issue. ex) https://github.com/naver/arcus-java-client/issues/{issue_number} -->
- 

### ⌨️ What I did

<!-- Please describe this PR and what you've been working on. -->
- `collectionInsert()` 에서 receivedStatus - `ERR_NOT_FOUND` 응답 시 스펙과 다르게 반환하던 문제를 수정합니다.
  - as-is: ERR_NOT_FOUND 발생 &rarr; return false
  - to-be: ERR_NOT_FOUND 발생 &rarr; return **null**