### PR TITLE
FEATURE: Add CompletableFuture Admin APIs

### DIFF
--- a/src/main/java/net/spy/memcached/MemcachedClient.java
+++ b/src/main/java/net/spy/memcached/MemcachedClient.java
@@ -2241,7 +2241,7 @@ public class MemcachedClient extends SpyThread
    *
    * @return all memcached nodes from node locator
    */
-  protected Collection<MemcachedNode> getAllNodes() {
+  public Collection<MemcachedNode> getAllNodes() {
     return conn.getLocator().getAll();
   }
 

--- a/src/main/java/net/spy/memcached/v2/AsyncArcusCommands.java
+++ b/src/main/java/net/spy/memcached/v2/AsyncArcusCommands.java
@@ -17,6 +17,7 @@
  */
 package net.spy.memcached.v2;
 
+import java.net.SocketAddress;
 import java.util.AbstractMap;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -98,6 +99,7 @@ import net.spy.memcached.ops.Mutator;
 import net.spy.memcached.ops.Operation;
 import net.spy.memcached.ops.OperationCallback;
 import net.spy.memcached.ops.OperationStatus;
+import net.spy.memcached.ops.StatsOperation;
 import net.spy.memcached.ops.StatusCode;
 import net.spy.memcached.ops.StoreType;
 import net.spy.memcached.transcoders.Transcoder;
@@ -627,34 +629,6 @@ public class AsyncArcusCommands<T> implements AsyncArcusCommandsIF<T> {
     return future;
   }
 
-  public ArcusFuture<Boolean> flush(int delay) {
-    ArcusClient client = arcusClientSupplier.get();
-    Collection<MemcachedNode> nodes = client.getFlushNodes();
-
-    Collection<CompletableFuture<?>> futures = new ArrayList<>();
-
-    for (MemcachedNode node : nodes) {
-      CompletableFuture<Boolean> future = flush(client, node, delay).toCompletableFuture();
-      futures.add(future);
-    }
-
-    /*
-     * Combine all futures. Returns true if all flush operations succeed.
-     * Returns false if any flush operation fails.
-     */
-    return new ArcusMultiFuture<>(futures, () -> {
-      for (CompletableFuture<?> future : futures) {
-        if (future.isCompletedExceptionally()) {
-          return false;
-        }
-        Boolean result = (Boolean) future.join();
-        if (result == null || !result) {
-          return false;
-        }
-      }
-      return true;
-    });
-  }
 
   public ArcusFuture<Boolean> delete(String key) {
     AbstractArcusResult<Boolean> result = new AbstractArcusResult<>(new AtomicReference<>());
@@ -712,41 +686,6 @@ public class AsyncArcusCommands<T> implements AsyncArcusCommandsIF<T> {
       });
       return results;
     });
-  }
-
-  /**
-   * Use only in flush method.
-   *
-   * @param client the ArcusClient instance to use
-   * @param node   the MemcachedNode to flush
-   * @param delay  flush delay
-   * @return ArcusFuture with flush result
-   */
-  private ArcusFuture<Boolean> flush(ArcusClient client, MemcachedNode node, int delay) {
-    AbstractArcusResult<Boolean> result = new AbstractArcusResult<>(new AtomicReference<>());
-    ArcusFutureImpl<Boolean> future = new ArcusFutureImpl<>(result);
-
-    OperationCallback cb = new OperationCallback() {
-      @Override
-      public void receivedStatus(OperationStatus status) {
-        if (status.getStatusCode() == StatusCode.CANCELLED) {
-          future.internalCancel();
-          return;
-        }
-        result.set(status.isSuccess());
-      }
-
-      @Override
-      public void complete() {
-        future.complete();
-      }
-    };
-
-    Operation op = client.getOpFact().flush(delay, cb);
-    future.setOp(op);
-    client.addOp(node, op);
-
-    return future;
   }
 
   public ArcusFuture<Boolean> bopCreate(String key, ElementValueType type,
@@ -1175,7 +1114,7 @@ public class AsyncArcusCommands<T> implements AsyncArcusCommandsIF<T> {
     return new ArcusMultiFuture<>(futures, () -> {
       Map<String, BTreeElements<T>> results = new HashMap<>();
       for (Map.Entry<CompletableFuture<Map<String, BTreeElements<T>>>, List<String>> entry
-          : futureToKeys.entrySet()) {
+              : futureToKeys.entrySet()) {
         if (entry.getKey().isCompletedExceptionally()) {
           for (String key : entry.getValue()) {
             results.put(key, null);
@@ -2124,5 +2063,219 @@ public class AsyncArcusCommands<T> implements AsyncArcusCommandsIF<T> {
   public ArcusFuture<Boolean> mopDelete(String key, List<String> mKeys, boolean dropIfEmpty) {
     MapDelete delete = new MapDelete(mKeys, dropIfEmpty, false);
     return collectionDelete(key, delete);
+  }
+
+  public ArcusFuture<Boolean> flush() {
+    return flush(-1);
+  }
+
+  public ArcusFuture<Boolean> flush(int delay) {
+    if (delay < -1) {
+      throw new IllegalArgumentException("Delay should be greater than or equal to -1");
+    }
+
+    ArcusClient client = arcusClientSupplier.get();
+    Collection<MemcachedNode> nodes = client.getFlushNodes();
+    Collection<CompletableFuture<?>> futures = new ArrayList<>(nodes.size());
+
+    for (MemcachedNode node : nodes) {
+      AbstractArcusResult<Boolean> result = new AbstractArcusResult<>(new AtomicReference<>());
+      ArcusFutureImpl<Boolean> future = new ArcusFutureImpl<>(result);
+
+      OperationCallback cb = new OperationCallback() {
+        @Override
+        public void receivedStatus(OperationStatus status) {
+          switch (status.getStatusCode()) {
+            case SUCCESS:
+              result.set(true);
+              break;
+            case CANCELLED:
+              future.internalCancel();
+              break;
+            default:
+              result.addError(node.getSocketAddress().toString(), status);
+              break;
+          }
+        }
+
+        @Override
+        public void complete() {
+          future.complete();
+        }
+      };
+
+      Operation op = client.getOpFact().flush(delay, cb);
+      future.setOp(op);
+      client.addOp(node, op);
+      futures.add(future);
+    }
+
+    return new ArcusMultiFuture<>(futures, () -> true);
+  }
+
+  public ArcusFuture<Boolean> flush(String prefix) {
+    return flush(prefix, -1);
+  }
+
+  public ArcusFuture<Boolean> flush(String prefix, int delay) {
+    if (prefix == null) {
+      throw new IllegalArgumentException("Prefix should not be null");
+    }
+
+    if (delay < -1) {
+      throw new IllegalArgumentException("Delay should be greater than or equal to -1");
+    }
+
+    ArcusClient client = arcusClientSupplier.get();
+    Collection<MemcachedNode> nodes = client.getFlushNodes();
+    Collection<CompletableFuture<?>> futures = new ArrayList<>(nodes.size());
+
+    for (MemcachedNode node : nodes) {
+      AbstractArcusResult<Boolean> result = new AbstractArcusResult<>(new AtomicReference<>());
+      ArcusFutureImpl<Boolean> future = new ArcusFutureImpl<>(result);
+
+      OperationCallback cb = new OperationCallback() {
+        @Override
+        public void receivedStatus(OperationStatus status) {
+          switch (status.getStatusCode()) {
+            case SUCCESS:
+              result.set(true);
+              break;
+            case ERR_NOT_FOUND:
+              result.set(false);
+              break;
+            case CANCELLED:
+              future.internalCancel();
+              break;
+            default:
+              result.addError(node.getSocketAddress().toString(), status);
+              break;
+          }
+        }
+
+        @Override
+        public void complete() {
+          future.complete();
+        }
+      };
+
+      Operation op = client.getOpFact()
+              .flush(prefix.isEmpty() ? "<null>" : prefix, delay, false, cb);
+      future.setOp(op);
+      client.addOp(node, op);
+      futures.add(future);
+    }
+
+
+    return new ArcusMultiFuture<>(futures, () -> {
+      for (CompletableFuture<?> future : futures) {
+        if (!future.isCompletedExceptionally() && Boolean.TRUE.equals(future.join())) {
+          return true;
+        }
+      }
+      return false;
+    });
+  }
+
+  public ArcusFuture<Map<SocketAddress, Map<String, String>>> stats() {
+    return stats(StatsArg.GENERAL);
+  }
+
+  public ArcusFuture<Map<SocketAddress, Map<String, String>>> stats(StatsArg arg) {
+    ArcusClient client = arcusClientSupplier.get();
+    Collection<MemcachedNode> nodes = client.getAllNodes();
+
+    Map<SocketAddress, CompletableFuture<?>> addressToFuture = new HashMap<>(nodes.size());
+
+    for (MemcachedNode node : nodes) {
+      SocketAddress address = node.getSocketAddress();
+      AbstractArcusResult<Map<String, String>> result
+              = new AbstractArcusResult<>(new AtomicReference<>(new HashMap<>()));
+      ArcusFutureImpl<Map<String, String>> future = new ArcusFutureImpl<>(result);
+
+      StatsOperation.Callback cb = new StatsOperation.Callback() {
+        @Override
+        public void gotStat(String name, String val) {
+          result.get().put(name, val);
+        }
+
+        @Override
+        public void receivedStatus(OperationStatus status) {
+          if (status.getStatusCode() == StatusCode.CANCELLED) {
+            future.internalCancel();
+          }
+        }
+
+        @Override
+        public void complete() {
+          future.complete();
+        }
+      };
+      Operation op = client.getOpFact().stats(arg.getArg(), cb);
+      future.setOp(op);
+      client.addOp(node, op);
+
+      addressToFuture.put(address, future);
+    }
+
+    return new ArcusMultiFuture<>(addressToFuture.values(), () -> {
+      Map<SocketAddress, Map<String, String>> resultMap = new HashMap<>(addressToFuture.size());
+      addressToFuture.forEach((address, future) -> {
+        if (future.isCompletedExceptionally()) {
+          resultMap.put(address, null);
+        } else {
+          @SuppressWarnings("unchecked")
+          Map<String, String> stats = (Map<String, String>) future.join();
+          resultMap.put(address, stats);
+        }
+      });
+      return resultMap;
+    });
+  }
+
+  public ArcusFuture<Map<SocketAddress, String>> versions() {
+    ArcusClient client = arcusClientSupplier.get();
+    Collection<MemcachedNode> nodes = client.getAllNodes();
+
+    Map<SocketAddress, CompletableFuture<?>> addressToFuture = new HashMap<>(nodes.size());
+
+    for (MemcachedNode node : nodes) {
+      SocketAddress address = node.getSocketAddress();
+      AbstractArcusResult<String> result = new AbstractArcusResult<>(new AtomicReference<>());
+      ArcusFutureImpl<String> future = new ArcusFutureImpl<>(result);
+
+      OperationCallback cb = new OperationCallback() {
+        @Override
+        public void receivedStatus(OperationStatus status) {
+          if (status.getStatusCode() == StatusCode.CANCELLED) {
+            future.internalCancel();
+            return;
+          }
+          result.set(status.getMessage());
+        }
+
+        @Override
+        public void complete() {
+          future.complete();
+        }
+      };
+      Operation op = client.getOpFact().version(cb);
+      future.setOp(op);
+      client.addOp(node, op);
+
+      addressToFuture.put(address, future);
+    }
+
+    return new ArcusMultiFuture<>(addressToFuture.values(), () -> {
+      Map<SocketAddress, String> resultMap = new HashMap<>(addressToFuture.size());
+      addressToFuture.forEach((address, future) -> {
+        if (future.isCompletedExceptionally()) {
+          resultMap.put(address, null);
+        } else {
+          resultMap.put(address, (String) future.join());
+        }
+      });
+      return resultMap;
+    });
   }
 }

--- a/src/main/java/net/spy/memcached/v2/AsyncArcusCommandsIF.java
+++ b/src/main/java/net/spy/memcached/v2/AsyncArcusCommandsIF.java
@@ -17,6 +17,7 @@
  */
 package net.spy.memcached.v2;
 
+import java.net.SocketAddress;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -220,14 +221,6 @@ public interface AsyncArcusCommandsIF<T> {
    * @return Map of key to Boolean result
    */
   ArcusFuture<Map<String, Boolean>> multiDelete(List<String> keys);
-
-  /**
-   * Flush all items from all servers.
-   *
-   * @param delay delay in seconds before flushing
-   * @return {@code Boolean.True} if flushed successfully, otherwise {@code Boolean.False}
-   */
-  ArcusFuture<Boolean> flush(int delay);
 
   /**
    * Create a btree item.
@@ -808,4 +801,60 @@ public interface AsyncArcusCommandsIF<T> {
    */
   ArcusFuture<Boolean> mopDelete(String key, List<String> mKeys, boolean dropIfEmpty);
 
+
+  /**
+   * Flush all items from all servers immediately.
+   *
+   * @return {@code true} if all servers flushed successfully, {@code false} otherwise
+   */
+  ArcusFuture<Boolean> flush();
+
+  /**
+   * Flush all items from all servers after a given delay.
+   *
+   * @param delay delay in seconds before flushing. (&ge; -1)
+   * @return {@code true} if all servers flushed successfully, {@code false} otherwise
+   */
+  ArcusFuture<Boolean> flush(int delay);
+
+  /**
+   * Flush all items with the given prefix from all servers immediately.
+   *
+   * @param prefix the prefix of the items to flush. Use {@code ""} for items with no prefix.
+   * @return {@code true} if flushed successfully,
+   * {@code false} if no items with the given prefix exist
+   */
+  ArcusFuture<Boolean> flush(String prefix);
+
+  /**
+   * Flush all items with the given prefix from all servers after a given delay.
+   *
+   * @param prefix the prefix of the items to flush. Use {@code ""} for items with no prefix.
+   * @param delay  delay in seconds before flushing. (&ge; -1)
+   * @return {@code true} if flushed successfully,
+   * {@code false} if no items with the given prefix exist
+   */
+  ArcusFuture<Boolean> flush(String prefix, int delay);
+
+  /**
+   * Get statistics from all connected servers.
+   *
+   * @return a map of each server's {@link java.net.SocketAddress} to its stats key-value pairs
+   */
+  ArcusFuture<Map<SocketAddress, Map<String, String>>> stats();
+
+  /**
+   * Get a specific set of statistics from all connected servers.
+   *
+   * @param arg the stats argument ({@link net.spy.memcached.v2.StatsArg})
+   * @return a map of each server's {@link java.net.SocketAddress} to its stats key-value pairs
+   */
+  ArcusFuture<Map<SocketAddress, Map<String, String>>> stats(StatsArg arg);
+
+  /**
+   * Get the version string from all connected servers.
+   *
+   * @return a map of each server's {@link java.net.SocketAddress} to its version string
+   */
+  ArcusFuture<Map<SocketAddress, String>> versions();
 }

--- a/src/main/java/net/spy/memcached/v2/StatsArg.java
+++ b/src/main/java/net/spy/memcached/v2/StatsArg.java
@@ -1,0 +1,20 @@
+package net.spy.memcached.v2;
+
+public enum StatsArg {
+  GENERAL(null),
+  SETTINGS("settings"),
+  ITEMS("items"),
+  SLABS("slabs"),
+  PREFIXES("prefixes");
+
+  private final String arg;
+
+  StatsArg(String arg) {
+    this.arg = arg;
+  }
+
+  public String getArg() {
+    return arg;
+  }
+
+}

--- a/src/test/java/net/spy/memcached/v2/AdminAsyncArcusCommandsTest.java
+++ b/src/test/java/net/spy/memcached/v2/AdminAsyncArcusCommandsTest.java
@@ -1,0 +1,194 @@
+package net.spy.memcached.v2;
+
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class AdminAsyncArcusCommandsTest extends AsyncArcusCommandsTest {
+
+  @Test
+  void flush() throws ExecutionException, InterruptedException, TimeoutException {
+    // given
+    String key = keys.get(0);
+    async.set(key, 0, VALUE)
+        .toCompletableFuture()
+        .get(300L, TimeUnit.MILLISECONDS);
+
+    // when
+    async.flush()
+        // then
+        .thenCompose(result -> {
+          assertTrue(result);
+          return async.get(key);
+        })
+        .thenAccept(Assertions::assertNull)
+        .toCompletableFuture()
+        .get(300L, TimeUnit.MILLISECONDS);
+  }
+
+  @Test
+  void flushWithDelay() throws ExecutionException, InterruptedException, TimeoutException {
+    // given
+    String key = keys.get(0);
+    async.set(key, 0, VALUE)
+        .toCompletableFuture()
+        .get(300L, TimeUnit.MILLISECONDS);
+
+    // when
+    async.flush(0)
+        // then
+        .thenCompose(result -> {
+          assertTrue(result);
+          return async.get(key);
+        })
+        .thenAccept(Assertions::assertNull)
+        .toCompletableFuture()
+        .get(300L, TimeUnit.MILLISECONDS);
+  }
+
+  @Test
+  void flushWithPrefix() throws ExecutionException, InterruptedException, TimeoutException {
+    // given
+    String keyA = "prefixA:key";
+    String keyB = "prefixB:key";
+    async.set(keyA, 0, VALUE)
+        .thenCompose(result -> async.set(keyB, 0, VALUE))
+        .toCompletableFuture()
+        .get(300L, TimeUnit.MILLISECONDS);
+
+    // when
+    async.flush("prefixA")
+        // then
+        .thenCompose(result -> {
+          assertTrue(result);
+          return async.get(keyA);
+        })
+        .thenCompose(result -> {
+          assertNull(result);
+          return async.get(keyB);
+        })
+        .thenAccept(result -> {
+          assertNotNull(result);
+          assertEquals(VALUE, result);
+        })
+        .toCompletableFuture()
+        .get(300L, TimeUnit.MILLISECONDS);
+  }
+
+  @Test
+  void flushWithPrefixNotFound() throws ExecutionException, InterruptedException, TimeoutException {
+    // given
+    // when
+    async.flush("nonExistentPrefix")
+        // then
+        .thenAccept(Assertions::assertFalse)
+        .toCompletableFuture()
+        .get(300L, TimeUnit.MILLISECONDS);
+  }
+
+  @Test
+  void flushWithPrefixAndDelay() throws ExecutionException, InterruptedException, TimeoutException {
+    // given
+    String key = "prefixA:key";
+    async.set(key, 0, VALUE)
+        .toCompletableFuture()
+        .get(300L, TimeUnit.MILLISECONDS);
+
+    // when
+    async.flush("prefixA", 0)
+        // then
+        .thenCompose(result -> {
+          assertTrue(result);
+          return async.get(key);
+        })
+        .thenAccept(Assertions::assertNull)
+        .toCompletableFuture()
+        .get(300L, TimeUnit.MILLISECONDS);
+  }
+
+  @Test
+  void flushNonPrefix() throws ExecutionException, InterruptedException, TimeoutException {
+    // given
+    String prefixKey = "prefixA:key";
+    String nonPrefixKey = "test-key";
+
+    async.set(prefixKey, 0, VALUE)
+        .thenCompose(result -> async.set(nonPrefixKey, 0, VALUE))
+        .toCompletableFuture()
+        .get(300L, TimeUnit.MILLISECONDS);
+
+    // when
+    async.flush("")
+            // then
+            .thenCompose(result -> {
+              assertTrue(result);
+              return async.get(prefixKey);
+            })
+            .thenCompose(result -> {
+              assertNotNull(result);
+              assertEquals(VALUE, result);
+              return async.get(nonPrefixKey);
+            })
+            .thenAccept(Assertions::assertNull)
+            .toCompletableFuture()
+            .get(300L, TimeUnit.MILLISECONDS);
+  }
+
+  @Test
+  void stats() throws ExecutionException, InterruptedException, TimeoutException {
+    // given
+    // when
+    async.stats()
+        // then
+        .thenAccept(result -> {
+          assertFalse(result.isEmpty());
+          result.forEach((address, stat) -> {
+            assertNotNull(address);
+            assertTrue(stat.containsKey("total_items"));
+          });
+        })
+        .toCompletableFuture()
+        .get(300L, TimeUnit.MILLISECONDS);
+  }
+
+  @Test
+  void statsAllArgs() throws ExecutionException, InterruptedException, TimeoutException {
+    // given
+    for (StatsArg arg : StatsArg.values()) {
+      // when
+      async.stats(arg)
+              // then
+              .thenAccept(Assertions::assertNotNull)
+              .toCompletableFuture()
+              .get(300L, TimeUnit.MILLISECONDS);
+    }
+  }
+
+  @Test
+  void versions() throws ExecutionException, InterruptedException, TimeoutException {
+    // given
+    // when
+    async.versions()
+        // then
+        .thenAccept(result -> {
+          assertFalse(result.isEmpty());
+          result.forEach((socketAddress, version) -> {
+            assertNotNull(socketAddress);
+            assertNotNull(version);
+            assertFalse(version.isEmpty());
+          });
+        })
+        .toCompletableFuture()
+        .get(300L, TimeUnit.MILLISECONDS);
+  }
+
+}


### PR DESCRIPTION
### 🔗 Related Issue

<!-- Please link related issue. ex) https://github.com/naver/arcus-java-client/issues/{issue_number} -->
- https://github.com/jam2in/arcus-works/issues/832#event-23130177064

### ⌨️ What I did

<!-- Please describe this PR and what you've been working on. -->
- v2 API에 Admin API (flush, stats, version)를 지원합니다. 
  - `flush()` / `flush(int delay)`: flush_all
  - `flush(String prefix)` / `flush(String prefix, int delay)`: flush_prefix
  - `stats()` / `stats(String arg)`: 서버 통계 조회
  - `versions()`: 서버 버전 조회