### PR TITLE
FEATURE: Add pluggable compression codec support with Snappy algorithm

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,6 +20,7 @@
         <bolyartech.version>2.0.2</bolyartech.version>
         <jackson.version>2.19.0</jackson.version>
         <findbugs-jsr305.version>3.0.2</findbugs-jsr305.version>
+        <snappy-java.version>1.1.10.8</snappy-java.version>
     </properties>
     <licenses>
         <license>
@@ -158,6 +159,14 @@
             <artifactId>jsr305</artifactId>
             <version>${findbugs-jsr305.version}</version>
             <scope>provided</scope>
+        </dependency>
+
+        <!-- Snappy -->
+        <dependency>
+            <groupId>org.xerial.snappy</groupId>
+            <artifactId>snappy-java</artifactId>
+            <version>${snappy-java.version}</version>
+            <scope>compile</scope>
         </dependency>
     </dependencies>
 

--- a/src/main/java/net/spy/memcached/transcoders/BaseSerializingTranscoder.java
+++ b/src/main/java/net/spy/memcached/transcoders/BaseSerializingTranscoder.java
@@ -26,6 +26,8 @@ import java.io.ObjectStreamClass;
 import java.lang.reflect.Proxy;
 
 import net.spy.memcached.compat.SpyObject;
+import net.spy.memcached.transcoders.compression.CompressionCodec;
+import net.spy.memcached.transcoders.compression.GZIPCompressionCodec;
 
 /**
  * Base class for any transcoders that may want to work with serialized or
@@ -42,7 +44,7 @@ public abstract class BaseSerializingTranscoder extends SpyObject {
    */
   private final ClassLoader classLoader;
 
-  private final CompressionUtils cu = new CompressionUtils();
+  private final CompressionCodec compressionCodec;
   protected final TranscoderUtils tu;
 
   /**
@@ -57,9 +59,15 @@ public abstract class BaseSerializingTranscoder extends SpyObject {
   }
 
   public BaseSerializingTranscoder(int max, ClassLoader cl, boolean pack) {
+    this(max, cl, pack, new GZIPCompressionCodec());
+  }
+
+  public BaseSerializingTranscoder(int max, ClassLoader cl, boolean pack,
+                                   CompressionCodec codec) {
     super();
     this.maxSize = max;
     this.classLoader = cl;
+    this.compressionCodec = codec;
     this.tu = new TranscoderUtils(pack);
   }
 
@@ -71,7 +79,7 @@ public abstract class BaseSerializingTranscoder extends SpyObject {
    * @param threshold the number of bytes
    */
   public void setCompressionThreshold(int threshold) {
-    cu.setCompressionThreshold(threshold);
+    compressionCodec.setCompressionThreshold(threshold);
   }
 
   public String getCharset() {
@@ -127,7 +135,7 @@ public abstract class BaseSerializingTranscoder extends SpyObject {
    * @throws NullPointerException if the input is null
    */
   protected byte[] compress(byte[] in) {
-    return cu.compress(in);
+    return compressionCodec.compress(in);
   }
 
   /**
@@ -137,7 +145,7 @@ public abstract class BaseSerializingTranscoder extends SpyObject {
    * @return the decompressed byte array, or null if input is null or decompression fails
    */
   protected byte[] decompress(byte[] in) {
-    return cu.decompress(in);
+    return compressionCodec.decompress(in);
   }
 
   /**
@@ -147,7 +155,7 @@ public abstract class BaseSerializingTranscoder extends SpyObject {
    * @return true if the data should be compressed, false otherwise
    */
   protected boolean isCompressionCandidate(byte[] data) {
-    return cu.isCompressionCandidate(data);
+    return compressionCodec.isCompressionCandidate(data);
   }
 
   public int getMaxSize() {

--- a/src/main/java/net/spy/memcached/transcoders/CompressionUtils.java
+++ b/src/main/java/net/spy/memcached/transcoders/CompressionUtils.java
@@ -12,6 +12,7 @@ import net.spy.memcached.compat.SpyObject;
 /**
  * Utility class for compression and decompression operations.
  */
+@Deprecated
 public class CompressionUtils extends SpyObject {
 
   public static final int DEFAULT_COMPRESSION_THRESHOLD = 16384;

--- a/src/main/java/net/spy/memcached/transcoders/GenericJsonSerializingTranscoder.java
+++ b/src/main/java/net/spy/memcached/transcoders/GenericJsonSerializingTranscoder.java
@@ -10,6 +10,8 @@ import java.util.Date;
 
 import net.spy.memcached.CachedData;
 import net.spy.memcached.compat.SpyObject;
+import net.spy.memcached.transcoders.compression.CompressionCodec;
+import net.spy.memcached.transcoders.compression.GZIPCompressionCodec;
 
 import static net.spy.memcached.transcoders.TranscoderUtils.COMPRESSED;
 import static net.spy.memcached.transcoders.TranscoderUtils.SERIALIZED;
@@ -30,7 +32,7 @@ public class GenericJsonSerializingTranscoder extends SpyObject implements Trans
 
   private final ObjectMapper objectMapper;
   private final int maxSize;
-  private final CompressionUtils cu;
+  private final CompressionCodec compressionCodec;
   private final TranscoderUtils tu;
   private final boolean isCollection;
   private final boolean forceJsonSerializeForCollection;
@@ -53,15 +55,7 @@ public class GenericJsonSerializingTranscoder extends SpyObject implements Trans
 
   @Deprecated
   public GenericJsonSerializingTranscoder(ObjectMapper objectMapper, int max) {
-    if (objectMapper == null) {
-      throw new IllegalArgumentException("ObjectMapper must not be null");
-    }
-    this.objectMapper = objectMapper;
-    this.maxSize = max;
-    this.cu = new CompressionUtils();
-    this.tu = new TranscoderUtils(true);
-    this.isCollection = false;
-    this.forceJsonSerializeForCollection = false;
+    this(objectMapper, max, false, false, new GZIPCompressionCodec());
   }
 
   /**
@@ -71,13 +65,14 @@ public class GenericJsonSerializingTranscoder extends SpyObject implements Trans
    */
   private GenericJsonSerializingTranscoder(ObjectMapper objectMapper, int max,
                                            boolean isCollection,
-                                           boolean forceJsonSerializeForCollection) {
+                                           boolean forceJsonSerializeForCollection,
+                                           CompressionCodec codec) {
     if (objectMapper == null) {
       throw new IllegalArgumentException("ObjectMapper must not be null");
     }
     this.objectMapper = objectMapper;
     this.maxSize = max;
-    this.cu = new CompressionUtils();
+    this.compressionCodec = codec;
     this.tu = new TranscoderUtils(true);
     this.isCollection = isCollection;
     this.forceJsonSerializeForCollection = forceJsonSerializeForCollection;
@@ -131,7 +126,7 @@ public class GenericJsonSerializingTranscoder extends SpyObject implements Trans
    * @param threshold the number of bytes
    */
   public void setCompressionThreshold(int threshold) {
-    cu.setCompressionThreshold(threshold);
+    compressionCodec.setCompressionThreshold(threshold);
   }
 
   /**
@@ -153,7 +148,7 @@ public class GenericJsonSerializingTranscoder extends SpyObject implements Trans
     }
 
     if ((d.getFlags() & COMPRESSED) != 0) {
-      data = cu.decompress(data);
+      data = compressionCodec.decompress(data);
     }
 
     Object rv = null;
@@ -241,8 +236,8 @@ public class GenericJsonSerializingTranscoder extends SpyObject implements Trans
       flags |= SERIALIZED;
     }
     assert b != null;
-    if (!isCollection && cu.isCompressionCandidate(b)) {
-      byte[] compressed = cu.compress(b);
+    if (!isCollection && compressionCodec.isCompressionCandidate(b)) {
+      byte[] compressed = compressionCodec.compress(b);
       if (compressed.length < b.length) {
         getLogger().debug("Compressed %s from %d to %d",
             o.getClass().getName(), b.length, compressed.length);
@@ -287,6 +282,7 @@ public class GenericJsonSerializingTranscoder extends SpyObject implements Trans
     private int max;
     private boolean isCollection;
     private boolean forceJsonSerializeForCollection;
+    private CompressionCodec compressionCodec = new GZIPCompressionCodec();
 
     private Builder(ObjectMapper objectMapper) {
       this.objectMapper = objectMapper;
@@ -326,6 +322,11 @@ public class GenericJsonSerializingTranscoder extends SpyObject implements Trans
       return this;
     }
 
+    public Builder compressionCodec(CompressionCodec codec) {
+      this.compressionCodec = codec;
+      return this;
+    }
+
     public Builder forceJsonSerializeForCollection() {
       if (!isCollection) {
         throw new IllegalStateException("forceJsonSerializationForCollection can only be " +
@@ -346,7 +347,7 @@ public class GenericJsonSerializingTranscoder extends SpyObject implements Trans
         objectMapper.setDefaultTyping(typer);
       }
       return new GenericJsonSerializingTranscoder(objectMapper, max,
-          isCollection, forceJsonSerializeForCollection);
+          isCollection, forceJsonSerializeForCollection, compressionCodec);
     }
   }
 }

--- a/src/main/java/net/spy/memcached/transcoders/JsonSerializingTranscoder.java
+++ b/src/main/java/net/spy/memcached/transcoders/JsonSerializingTranscoder.java
@@ -26,6 +26,8 @@ import java.util.Objects;
 
 import net.spy.memcached.CachedData;
 import net.spy.memcached.compat.SpyObject;
+import net.spy.memcached.transcoders.compression.CompressionCodec;
+import net.spy.memcached.transcoders.compression.GZIPCompressionCodec;
 
 import static net.spy.memcached.transcoders.TranscoderUtils.COMPRESSED;
 import static net.spy.memcached.transcoders.TranscoderUtils.SERIALIZED;
@@ -48,7 +50,7 @@ public class JsonSerializingTranscoder<T> extends SpyObject implements Transcode
   private final ObjectMapper objectMapper;
   private final JavaType javaType;
   private final int maxSize;
-  private final CompressionUtils cu;
+  private final CompressionCodec compressionCodec;
   private final TranscoderUtils tu;
 
   public JsonSerializingTranscoder(Class<T> clazz) {
@@ -60,18 +62,26 @@ public class JsonSerializingTranscoder<T> extends SpyObject implements Transcode
   }
 
   public JsonSerializingTranscoder(int max, Class<T> clazz) {
-    this.maxSize = max;
-    this.objectMapper = new ObjectMapper();
-    this.javaType = objectMapper.getTypeFactory().constructType(clazz);
-    this.cu = new CompressionUtils();
-    this.tu = new TranscoderUtils(true);
+    this(max, clazz, new GZIPCompressionCodec());
   }
 
   public JsonSerializingTranscoder(int max, JavaType javaType) {
+    this(max, javaType, new GZIPCompressionCodec());
+  }
+
+  public JsonSerializingTranscoder(int max, Class<T> clazz, CompressionCodec codec) {
+    this.maxSize = max;
+    this.objectMapper = new ObjectMapper();
+    this.javaType = objectMapper.getTypeFactory().constructType(clazz);
+    this.compressionCodec = codec;
+    this.tu = new TranscoderUtils(true);
+  }
+
+  public JsonSerializingTranscoder(int max, JavaType javaType, CompressionCodec codec) {
     this.maxSize = max;
     this.objectMapper = new ObjectMapper();
     this.javaType = Objects.requireNonNull(javaType, "JavaType must not be null");
-    this.cu = new CompressionUtils();
+    this.compressionCodec = codec;
     this.tu = new TranscoderUtils(true);
   }
 
@@ -88,7 +98,7 @@ public class JsonSerializingTranscoder<T> extends SpyObject implements Transcode
    * @param threshold the number of bytes
    */
   public void setCompressionThreshold(int threshold) {
-    cu.setCompressionThreshold(threshold);
+    this.compressionCodec.setCompressionThreshold(threshold);
   }
 
   /**
@@ -110,7 +120,7 @@ public class JsonSerializingTranscoder<T> extends SpyObject implements Transcode
     }
 
     if ((d.getFlags() & COMPRESSED) != 0) {
-      data = cu.decompress(data);
+      data = compressionCodec.decompress(data);
     }
 
     Object rv = null;
@@ -192,8 +202,8 @@ public class JsonSerializingTranscoder<T> extends SpyObject implements Transcode
       flags |= SERIALIZED;
     }
     assert b != null;
-    if (cu.isCompressionCandidate(b)) {
-      byte[] compressed = cu.compress(b);
+    if (compressionCodec.isCompressionCandidate(b)) {
+      byte[] compressed = compressionCodec.compress(b);
       if (compressed.length < b.length) {
         getLogger().debug("Compressed %s from %d to %d",
                 o.getClass().getName(), b.length, compressed.length);

--- a/src/main/java/net/spy/memcached/transcoders/SerializingTranscoder.java
+++ b/src/main/java/net/spy/memcached/transcoders/SerializingTranscoder.java
@@ -21,6 +21,8 @@ package net.spy.memcached.transcoders;
 import java.util.Date;
 
 import net.spy.memcached.CachedData;
+import net.spy.memcached.transcoders.compression.CompressionCodec;
+import net.spy.memcached.transcoders.compression.GZIPCompressionCodec;
 
 import static net.spy.memcached.transcoders.TranscoderUtils.COMPRESSED;
 import static net.spy.memcached.transcoders.TranscoderUtils.SERIALIZED;
@@ -54,15 +56,20 @@ public class SerializingTranscoder extends BaseSerializingTranscoder
    * Get a serializing transcoder with the default max data size.
    */
   public SerializingTranscoder() {
-    this(CachedData.MAX_SIZE, null, false, false);
+    this(CachedData.MAX_SIZE, null, false, false, new GZIPCompressionCodec());
   }
 
   public SerializingTranscoder(int max) {
-    this(max, null, false, false);
+    this(max, null, false, false, new GZIPCompressionCodec());
   }
 
   public SerializingTranscoder(int max, ClassLoader cl) {
-    this(max, cl, false, false);
+    this(max, cl, false, false, new GZIPCompressionCodec());
+  }
+
+  protected SerializingTranscoder(int max, ClassLoader cl, boolean isCollection,
+                               boolean forceJDKSerializeForCollection) {
+    this(max, cl, isCollection, forceJDKSerializeForCollection, new GZIPCompressionCodec());
   }
 
   /**
@@ -71,8 +78,9 @@ public class SerializingTranscoder extends BaseSerializingTranscoder
    * or Builder for custom configurations.
    */
   protected SerializingTranscoder(int max, ClassLoader cl, boolean isCollection,
-                               boolean forceJDKSerializeForCollection) {
-    super(max, cl);
+                               boolean forceJDKSerializeForCollection,
+                               CompressionCodec codec) {
+    super(max, cl, true, codec);
     this.isCollection = isCollection;
     this.forceJDKSerializeForCollection = forceJDKSerializeForCollection;
   }
@@ -207,6 +215,7 @@ public class SerializingTranscoder extends BaseSerializingTranscoder
     private ClassLoader cl;
     private boolean isCollection;
     private boolean forceJDKSerializeForCollection;
+    private CompressionCodec compressionCodec = new GZIPCompressionCodec();
 
     private Builder() {}
 
@@ -236,6 +245,11 @@ public class SerializingTranscoder extends BaseSerializingTranscoder
       return this;
     }
 
+    public Builder compressionCodec(CompressionCodec codec) {
+      this.compressionCodec = codec;
+      return this;
+    }
+
     /**
      * By default, this transcoder uses Java serialization only if the type is a user-defined class.
      * This mechanism may cause malfunction if you store Object type values
@@ -255,7 +269,8 @@ public class SerializingTranscoder extends BaseSerializingTranscoder
     }
 
     public SerializingTranscoder build() {
-      return new SerializingTranscoder(max, cl, isCollection, forceJDKSerializeForCollection);
+      return new SerializingTranscoder(max, cl, isCollection,
+              forceJDKSerializeForCollection, compressionCodec);
     }
   }
 }

--- a/src/main/java/net/spy/memcached/transcoders/compression/CompressionCodec.java
+++ b/src/main/java/net/spy/memcached/transcoders/compression/CompressionCodec.java
@@ -1,0 +1,12 @@
+package net.spy.memcached.transcoders.compression;
+
+public interface CompressionCodec {
+
+  byte[] compress(byte[] data);
+
+  byte[] decompress(byte[] data);
+
+  boolean isCompressionCandidate(byte[] data);
+
+  void setCompressionThreshold(int threshold);
+}

--- a/src/main/java/net/spy/memcached/transcoders/compression/GZIPCompressionCodec.java
+++ b/src/main/java/net/spy/memcached/transcoders/compression/GZIPCompressionCodec.java
@@ -1,0 +1,69 @@
+package net.spy.memcached.transcoders.compression;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.zip.GZIPInputStream;
+import java.util.zip.GZIPOutputStream;
+
+import net.spy.memcached.compat.SpyObject;
+
+
+public class GZIPCompressionCodec extends SpyObject implements CompressionCodec {
+
+  private static final int DECOMPRESSION_BUF_SIZE = 8192;
+
+  private volatile int compressionThreshold = 16_384;
+
+  @Override
+  public byte[] compress(byte[] in) {
+    if (in == null) {
+      throw new IllegalArgumentException("Can't compress null");
+    }
+
+    ByteArrayOutputStream bos = new ByteArrayOutputStream();
+    try (GZIPOutputStream gz = new GZIPOutputStream(bos)) {
+      gz.write(in);
+    } catch (IOException e) {
+      throw new RuntimeException("IO exception compressing data", e);
+    }
+
+    byte[] result = bos.toByteArray();
+    getLogger().debug("Compressed %d bytes to %d", in.length, result.length);
+    return result;
+  }
+
+  @Override
+  public byte[] decompress(byte[] in) {
+    if (in == null) {
+      return null;
+    }
+
+    try (ByteArrayInputStream bis = new ByteArrayInputStream(in);
+         GZIPInputStream gis = new GZIPInputStream(bis);
+         ByteArrayOutputStream bos = new ByteArrayOutputStream()) {
+
+      byte[] buf = new byte[DECOMPRESSION_BUF_SIZE];
+      int read;
+      while ((read = gis.read(buf)) > 0) {
+        bos.write(buf, 0, read);
+      }
+
+      return bos.toByteArray();
+    } catch (IOException e) {
+      getLogger().warn("Failed to decompress data", e);
+      return null;
+    }
+  }
+
+  @Override
+  public boolean isCompressionCandidate(byte[] data) {
+    return data != null && data.length > compressionThreshold;
+  }
+
+  @Override
+  public void setCompressionThreshold(int threshold) {
+    this.compressionThreshold = threshold;
+  }
+
+}

--- a/src/main/java/net/spy/memcached/transcoders/compression/SnappyCompressionCodec.java
+++ b/src/main/java/net/spy/memcached/transcoders/compression/SnappyCompressionCodec.java
@@ -1,0 +1,55 @@
+package net.spy.memcached.transcoders.compression;
+
+
+import java.io.IOException;
+
+import net.spy.memcached.compat.SpyObject;
+
+import org.xerial.snappy.Snappy;
+
+public class SnappyCompressionCodec extends SpyObject implements CompressionCodec {
+
+  private volatile int compressionThreshold = 16_384;
+
+  @Override
+  public byte[] compress(byte[] data) {
+    if (data == null) {
+      throw new IllegalArgumentException("Can't compress null");
+    }
+
+    try {
+      byte[] compressed = Snappy.compress(data);
+      getLogger().debug("Compressed %d bytes to %d", data.length, compressed.length);
+      return compressed;
+    } catch (IOException e) {
+      throw new RuntimeException("IO exception compressing data", e);
+    }
+  }
+
+  @Override
+  public byte[] decompress(byte[] data) {
+    if (data == null) {
+      return null;
+    }
+
+    try {
+      byte[] decompress = Snappy.uncompress(data);
+      getLogger().debug("Decompressed %d bytes to %d", data.length, decompress.length);
+      return decompress;
+    } catch (IOException e) {
+      getLogger().warn("Failed to decompress data, returning null", e);
+      return null;
+    }
+  }
+
+  @Override
+  public boolean isCompressionCandidate(byte[] data) {
+    return data != null && data.length > compressionThreshold;
+  }
+
+  @Override
+  public void setCompressionThreshold(int threshold) {
+    this.compressionThreshold = threshold;
+  }
+
+}

--- a/src/test/java/net/spy/memcached/transcoders/BaseSerializingTranscoderTest.java
+++ b/src/test/java/net/spy/memcached/transcoders/BaseSerializingTranscoderTest.java
@@ -49,7 +49,7 @@ class BaseSerializingTranscoderTest {
     try {
       ex.compress(null);
       fail("Expected an assertion error");
-    } catch (NullPointerException e) {
+    } catch (IllegalArgumentException e) {
       // pass
     }
   }

--- a/src/test/java/net/spy/memcached/transcoders/compression/CompressionCodecTest.java
+++ b/src/test/java/net/spy/memcached/transcoders/compression/CompressionCodecTest.java
@@ -1,0 +1,118 @@
+package net.spy.memcached.transcoders.compression;
+
+import java.nio.charset.StandardCharsets;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class CompressionCodecTest {
+
+  private static final byte[] LARGE_DATA =
+      repeat("hello arcus ", 2000).getBytes(StandardCharsets.UTF_8);
+
+
+  private static String repeat(String s, int times) {
+    StringBuilder sb = new StringBuilder(s.length() * times);
+    for (int i = 0; i < times; i++) {
+      sb.append(s);
+    }
+    return sb.toString();
+  }
+
+  // ---- GZIP ----
+
+  @Test
+  void GZIPCompressAndDecompress() {
+    GZIPCompressionCodec codec = new GZIPCompressionCodec();
+    byte[] compressed = codec.compress(LARGE_DATA);
+    byte[] decompressed = codec.decompress(compressed);
+
+    assertNotNull(compressed);
+    assertTrue(compressed.length < LARGE_DATA.length);
+    assertArrayEquals(LARGE_DATA, decompressed);
+  }
+
+  @Test
+  void GZIPCompressNullThrows() {
+    assertThrows(IllegalArgumentException.class, () -> new GZIPCompressionCodec().compress(null));
+  }
+
+  @Test
+  void GZIPDecompressNullReturnsNull() {
+    assertNull(new GZIPCompressionCodec().decompress(null));
+  }
+
+  @Test
+  void GZIPDecompressInvalidDataReturnsNull() {
+    byte[] invalid = "not gzip data".getBytes(StandardCharsets.UTF_8);
+    assertNull(new GZIPCompressionCodec().decompress(invalid));
+  }
+
+  @Test
+  void GZIPIsCompressionCandidateDefaultThreshold() {
+    GZIPCompressionCodec codec = new GZIPCompressionCodec();
+    assertFalse(codec.isCompressionCandidate(new byte[100]));
+    assertTrue(codec.isCompressionCandidate(new byte[16385]));
+    assertFalse(codec.isCompressionCandidate(null));
+  }
+
+  @Test
+  void GZIPSetCompressionThreshold() {
+    GZIPCompressionCodec codec = new GZIPCompressionCodec();
+    codec.setCompressionThreshold(100);
+    assertFalse(codec.isCompressionCandidate(new byte[50]));
+    assertTrue(codec.isCompressionCandidate(new byte[101]));
+  }
+
+  // ---- Snappy ----
+
+  @Test
+  void SnappyCompressAndDecompress() {
+    SnappyCompressionCodec codec = new SnappyCompressionCodec();
+    byte[] compressed = codec.compress(LARGE_DATA);
+    byte[] decompressed = codec.decompress(compressed);
+
+    assertNotNull(compressed);
+    assertTrue(compressed.length < LARGE_DATA.length, "압축 후 크기가 원본보다 작아야 한다");
+    assertArrayEquals(LARGE_DATA, decompressed);
+  }
+
+  @Test
+  void SnappyCompressNullThrows() {
+    assertThrows(IllegalArgumentException.class, () -> new SnappyCompressionCodec().compress(null));
+  }
+
+  @Test
+  void SnappyDecompressNullReturnsNull() {
+    assertNull(new SnappyCompressionCodec().decompress(null));
+  }
+
+  @Test
+  void SnappyDecompressInvalidDataReturnsNull() {
+    byte[] invalid = "not snappy data".getBytes(StandardCharsets.UTF_8);
+    assertNull(new SnappyCompressionCodec().decompress(invalid));
+  }
+
+  @Test
+  void SnappyIsCompressionCandidateDefaultThreshold() {
+    SnappyCompressionCodec codec = new SnappyCompressionCodec();
+    assertFalse(codec.isCompressionCandidate(new byte[100]));
+    assertTrue(codec.isCompressionCandidate(new byte[16385]));
+    assertFalse(codec.isCompressionCandidate(null));
+  }
+
+  @Test
+  void SnappySetCompressionThreshold() {
+    SnappyCompressionCodec codec = new SnappyCompressionCodec();
+    codec.setCompressionThreshold(100);
+    assertFalse(codec.isCompressionCandidate(new byte[50]));
+    assertTrue(codec.isCompressionCandidate(new byte[101]));
+  }
+
+}


### PR DESCRIPTION
### 🔗 Related Issue

<!-- Please link related issue. ex) https://github.com/naver/arcus-java-client/issues/{issue_number} -->
- https://github.com/jam2in/arcus-works/issues/828#issuecomment-4151688410

### ⌨️ What I did

<!-- Please describe this PR and what you've been working on. -->

압축 인터페이스 도입 및 Snappy 알고리즘을 추가합니다.

- 기존 `CompressionUtils.java` 에 하드코딩된 GZIP 압축 방식을 `CompressionCodecIF` 인터페이스 기반으로 변경합니다.
  - GZIPCompressionCodec: 기존 GZIP 로직을 구현체로 분리 (기본값)
  - SnappyCompressionCodec: [snappy-java](https://github.com/xerial/snappy-java) 기반의 구현체 추가 
- `BaseSerializingTranscoder`, `GenericJsonSerializingTranscoder`, `JsonSerializingTranscoder` 에서 생성자(Builder)를 통해 압축 코덱을 주입받도록 변경합니다.
- 기존 클라이언트에서 별도 설정 없이도 기본값인 GZIP을 사용하도록 하위 호환성을 보장합니다.