### PR TITLE
CLEANUP: Unify BKey, EFlag naming

### DIFF
--- a/src/main/java/net/spy/memcached/v2/AsyncArcusCommands.java
+++ b/src/main/java/net/spy/memcached/v2/AsyncArcusCommands.java
@@ -803,7 +803,7 @@ public class AsyncArcusCommands<T> implements AsyncArcusCommandsIF<T> {
                                         CollectionAttributes attributes) {
     BTreeInsert<T> insert = new BTreeInsert<>(element.getValue(), element.getEFlag(),
         null, attributes);
-    return collectionInsert(key, element.getBkey().toString(), insert);
+    return collectionInsert(key, element.getBKey().toString(), insert);
   }
 
   public ArcusFuture<Boolean> bopInsert(String key, BTreeElement<T> element) {
@@ -815,7 +815,7 @@ public class AsyncArcusCommands<T> implements AsyncArcusCommandsIF<T> {
                                         CollectionAttributes attributes) {
     BTreeUpsert<T> upsert = new BTreeUpsert<>(element.getValue(), element.getEFlag(),
         null, attributes);
-    return collectionInsert(key, element.getBkey().toString(), upsert);
+    return collectionInsert(key, element.getBKey().toString(), upsert);
   }
 
   @Override
@@ -873,7 +873,7 @@ public class AsyncArcusCommands<T> implements AsyncArcusCommandsIF<T> {
 
   public ArcusFuture<Boolean> bopUpdate(String key, BTreeUpdateElement<T> element) {
     BTreeUpdate<T> update = new BTreeUpdate<>(element.getValue(), element.getEFlagUpdate(), false);
-    return collectionUpdate(key, element.getBkey().toString(), update);
+    return collectionUpdate(key, element.getBKey().toString(), update);
   }
 
   private ArcusFuture<Boolean> collectionUpdate(String key,
@@ -1006,11 +1006,11 @@ public class AsyncArcusCommands<T> implements AsyncArcusCommandsIF<T> {
                                                                   boolean isUpsert,
                                                                   CollectionAttributes attributes) {
     BTreeInsertAndGet<T> insertAndGet;
-    if (element.getBkey().getType() == BKey.BKeyType.LONG) {
-      insertAndGet = new BTreeInsertAndGet<>((Long) element.getBkey().getData(),
+    if (element.getBKey().getType() == BKey.BKeyType.LONG) {
+      insertAndGet = new BTreeInsertAndGet<>((Long) element.getBKey().getData(),
           element.getEFlag(), element.getValue(), isUpsert, attributes);
     } else {
-      insertAndGet = new BTreeInsertAndGet<>((byte[]) element.getBkey().getData(),
+      insertAndGet = new BTreeInsertAndGet<>((byte[]) element.getBKey().getData(),
           element.getEFlag(), element.getValue(), isUpsert, attributes);
     }
     return insertAndGet;
@@ -1050,11 +1050,11 @@ public class AsyncArcusCommands<T> implements AsyncArcusCommandsIF<T> {
         future.complete();
       }
 
-      public void gotData(String bKey, int flags, byte[] data, byte[] eflag) {
+      public void gotData(String bKey, int flags, byte[] data, byte[] eFlag) {
         result.set(new BTreeElement<>(
                 BKey.of(bKey),
                 tcForCollection.decode(new CachedData(flags, data, tcForCollection.getMaxSize())),
-                eflag));
+                eFlag));
       }
     };
     Operation op = client.getOpFact().collectionGet(key, get, cb);
@@ -1113,12 +1113,12 @@ public class AsyncArcusCommands<T> implements AsyncArcusCommandsIF<T> {
         future.complete();
       }
 
-      public void gotData(String bKey, int flags, byte[] data, byte[] eflag) {
+      public void gotData(String bKey, int flags, byte[] data, byte[] eFlag) {
         BTreeElements<T> elements = result.get();
         elements.addElement(new BTreeElement<>(
                 BKey.of(bKey),
                 tcForCollection.decode(new CachedData(flags, data, tcForCollection.getMaxSize())),
-                eflag));
+                eFlag));
       }
     };
     Operation op = client.getOpFact().collectionGet(key, get, cb);
@@ -1948,7 +1948,7 @@ public class AsyncArcusCommands<T> implements AsyncArcusCommandsIF<T> {
 
     CollectionGetOperation.Callback cb = new CollectionGetOperation.Callback() {
       @Override
-      public void gotData(String subkey, int flags, byte[] data, byte[] eflag) {
+      public void gotData(String subkey, int flags, byte[] data, byte[] eFlag) {
         CachedData cachedData = new CachedData(flags, data, tcForCollection.getMaxSize());
         result.get().add(tcForCollection.decode(cachedData));
       }

--- a/src/main/java/net/spy/memcached/v2/vo/BTreeElement.java
+++ b/src/main/java/net/spy/memcached/v2/vo/BTreeElement.java
@@ -4,21 +4,21 @@ import java.util.Arrays;
 import java.util.Objects;
 
 public final class BTreeElement<V> implements Comparable<BTreeElement<V>> {
-  private final BKey bkey;
+  private final BKey bKey;
   private final V value;
   private final byte[] eFlag;
 
-  public BTreeElement(BKey bkey, V value, byte[] eFlag) {
-    if (bkey == null) {
+  public BTreeElement(BKey bKey, V value, byte[] eFlag) {
+    if (bKey == null) {
       throw new IllegalArgumentException("BKey cannot be null");
     }
-    this.bkey = bkey;
+    this.bKey = bKey;
     this.value = value;
     this.eFlag = eFlag;
   }
 
-  public BKey getBkey() {
-    return bkey;
+  public BKey getBKey() {
+    return bKey;
   }
 
   public V getValue() {
@@ -31,7 +31,7 @@ public final class BTreeElement<V> implements Comparable<BTreeElement<V>> {
 
   @Override
   public int compareTo(BTreeElement<V> o) {
-    return this.bkey.compareTo(o.bkey);
+    return this.bKey.compareTo(o.bKey);
   }
 
   @Override
@@ -44,12 +44,12 @@ public final class BTreeElement<V> implements Comparable<BTreeElement<V>> {
       return false;
     }
     BTreeElement<?> that = (BTreeElement<?>) o;
-    return Objects.equals(bkey, that.bkey) &&
+    return Objects.equals(bKey, that.bKey) &&
         Objects.equals(value, that.value) && Objects.deepEquals(eFlag, that.eFlag);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(bkey, value, Arrays.hashCode(eFlag));
+    return Objects.hash(bKey, value, Arrays.hashCode(eFlag));
   }
 }

--- a/src/main/java/net/spy/memcached/v2/vo/BTreePositionElement.java
+++ b/src/main/java/net/spy/memcached/v2/vo/BTreePositionElement.java
@@ -6,13 +6,13 @@ public final class BTreePositionElement<V> implements Comparable<BTreePositionEl
   private final BTreeElement<V> element;
   private final int position;
 
-  public BTreePositionElement(BKey bkey, V value, byte[] eFlag, int position) {
-    this.element = new BTreeElement<>(bkey, value, eFlag);
+  public BTreePositionElement(BKey bKey, V value, byte[] eFlag, int position) {
+    this.element = new BTreeElement<>(bKey, value, eFlag);
     this.position = position;
   }
 
-  public BKey getBkey() {
-    return element.getBkey();
+  public BKey getBKey() {
+    return element.getBKey();
   }
 
   public V getValue() {

--- a/src/main/java/net/spy/memcached/v2/vo/BTreeUpdateElement.java
+++ b/src/main/java/net/spy/memcached/v2/vo/BTreeUpdateElement.java
@@ -3,46 +3,46 @@ package net.spy.memcached.v2.vo;
 import net.spy.memcached.collection.ElementFlagUpdate;
 
 public final class BTreeUpdateElement<V> {
-  private final BKey bkey;
+  private final BKey bKey;
   private final V value;
   private final ElementFlagUpdate eFlagUpdate;
 
-  private BTreeUpdateElement(BKey bkey, V value, ElementFlagUpdate eFlagUpdate) {
-    if (bkey == null) {
+  private BTreeUpdateElement(BKey bKey, V value, ElementFlagUpdate eFlagUpdate) {
+    if (bKey == null) {
       throw new IllegalArgumentException("BKey cannot be null.");
     }
 
-    this.bkey = bkey;
+    this.bKey = bKey;
     this.value = value;
     this.eFlagUpdate = eFlagUpdate;
   }
 
-  public static <V> BTreeUpdateElement<V> withValue(BKey bkey, V value) {
+  public static <V> BTreeUpdateElement<V> withValue(BKey bKey, V value) {
     if (value == null) {
       throw new IllegalArgumentException("Value cannot be null.");
     }
-    return new BTreeUpdateElement<>(bkey, value, null);
+    return new BTreeUpdateElement<>(bKey, value, null);
   }
 
-  public static <V> BTreeUpdateElement<V> withEFlagUpdate(BKey bkey,
+  public static <V> BTreeUpdateElement<V> withEFlagUpdate(BKey bKey,
                                                           ElementFlagUpdate eFlagUpdate) {
     if (eFlagUpdate == null) {
       throw new IllegalArgumentException("EFlagUpdate cannot be null.");
     }
-    return new BTreeUpdateElement<>(bkey, null, eFlagUpdate);
+    return new BTreeUpdateElement<>(bKey, null, eFlagUpdate);
   }
 
-  public static <V> BTreeUpdateElement<V> withValueAndEFlag(BKey bkey,
+  public static <V> BTreeUpdateElement<V> withValueAndEFlag(BKey bKey,
                                                             V value,
                                                             ElementFlagUpdate eFlagUpdate) {
     if (value == null || eFlagUpdate == null) {
       throw new IllegalArgumentException("Both value and eFlagUpdate cannot be null.");
     }
-    return new BTreeUpdateElement<>(bkey, value, eFlagUpdate);
+    return new BTreeUpdateElement<>(bKey, value, eFlagUpdate);
   }
 
-  public BKey getBkey() {
-    return bkey;
+  public BKey getBKey() {
+    return bKey;
   }
 
   public V getValue() {

--- a/src/main/java/net/spy/memcached/v2/vo/SMGetElements.java
+++ b/src/main/java/net/spy/memcached/v2/vo/SMGetElements.java
@@ -42,7 +42,7 @@ public final class SMGetElements<V> {
 
     // 3) Remove trimmed keys outside the final element range
     if (!elements.isEmpty()) {
-      BKey lastBKey = elements.get(elements.size() - 1).getbTreeElement().getBkey();
+      BKey lastBKey = elements.get(elements.size() - 1).getbTreeElement().getBKey();
       trimmedKeys.removeIf(trimmedKey -> {
         int comp = trimmedKey.getBKey().compareTo(lastBKey);
         return ascending ? comp >= 0 : comp <= 0;
@@ -79,10 +79,10 @@ public final class SMGetElements<V> {
     // 3) Merge elements until reach desired element count
     while (!pq.isEmpty() && elements.size() < count) {
       ElementWithIndex<T> current = pq.poll();
-      BKey bkey = current.element.getbTreeElement().getBkey();
-      // Deduplicate based on bkey if unique option is set
+      BKey bKey = current.element.getbTreeElement().getBKey();
+      // Deduplicate based on bKey if unique option is set
       if (unique && !elements.isEmpty()) {
-        if (!elements.get(elements.size() - 1).getbTreeElement().getBkey().equals(bkey)) {
+        if (!elements.get(elements.size() - 1).getbTreeElement().getBKey().equals(bKey)) {
           elements.add(current.element);
         }
       } else {

--- a/src/test/java/net/spy/memcached/v2/BTreeAsyncArcusCommandsTest.java
+++ b/src/test/java/net/spy/memcached/v2/BTreeAsyncArcusCommandsTest.java
@@ -77,7 +77,7 @@ class BTreeAsyncArcusCommandsTest extends AsyncArcusCommandsTest {
         })
         .thenCompose(result -> {
           assertTrue(result);
-          return async.bopGet(key, element.getBkey(), BopGetArgs.DEFAULT);
+          return async.bopGet(key, element.getBKey(), BopGetArgs.DEFAULT);
         })
         // then
         .thenAccept(result -> assertNotEquals(element, result))
@@ -251,7 +251,7 @@ class BTreeAsyncArcusCommandsTest extends AsyncArcusCommandsTest {
         .thenAccept(element -> {
           // ELEMENT NOT FOUND
           assertNotNull(element);
-          assertEquals(BKey.of(2L), element.getBkey());
+          assertEquals(BKey.of(2L), element.getBKey());
           assertNull(element.getValue());
           assertNull(element.getEFlag());
         })
@@ -742,7 +742,7 @@ class BTreeAsyncArcusCommandsTest extends AsyncArcusCommandsTest {
 
           SMGetElements.TrimmedKey trimmedKey = smGetElements.getTrimmedKeys().get(0);
           assertEquals(keys.get(0), trimmedKey.getKey());
-          assertEquals(ELEMENTS.get(2).getBkey(), trimmedKey.getBKey());
+          assertEquals(ELEMENTS.get(2).getBKey(), trimmedKey.getBKey());
 
           List<SMGetElements.Element<Object>> elements = smGetElements.getElements();
           assertEquals(testKeys.get(0), elements.get(0).getKey());
@@ -847,7 +847,7 @@ class BTreeAsyncArcusCommandsTest extends AsyncArcusCommandsTest {
             })
             .thenAccept(element -> {
               assertNotNull(element);
-              assertEquals(ELEMENTS.get(0).getBkey(), element.getBkey());
+              assertEquals(ELEMENTS.get(0).getBKey(), element.getBKey());
               assertEquals(ELEMENTS.get(0).getValue(), element.getValue());
               assertNull(element.getEFlag());
             })
@@ -867,7 +867,7 @@ class BTreeAsyncArcusCommandsTest extends AsyncArcusCommandsTest {
             })
             .thenAccept(result -> {
               assertNotNull(result);
-              assertEquals(updatedElement.getBkey(), result.getBkey());
+              assertEquals(updatedElement.getBKey(), result.getBKey());
               assertEquals(updatedElement.getValue(), result.getValue());
               assertArrayEquals(eFlagUpdate.getElementFlag(), result.getEFlag());
             })
@@ -897,7 +897,7 @@ class BTreeAsyncArcusCommandsTest extends AsyncArcusCommandsTest {
             })
             .thenAccept(result -> {
               assertNotNull(result);
-              assertEquals(updatedElement.getBkey(), result.getBkey());
+              assertEquals(updatedElement.getBKey(), result.getBKey());
               assertEquals(updatedElement.getValue(), result.getValue());
               assertNull(result.getEFlag());
             })
@@ -928,7 +928,7 @@ class BTreeAsyncArcusCommandsTest extends AsyncArcusCommandsTest {
             })
             .thenAccept(result -> {
               assertNotNull(result);
-              assertEquals(updatedElement.getBkey(), result.getBkey());
+              assertEquals(updatedElement.getBKey(), result.getBKey());
               assertEquals(ELEMENTS.get(0).getValue(), result.getValue());
               assertArrayEquals(eFlagUpdate.getElementFlag(), result.getEFlag());
             })
@@ -1050,7 +1050,7 @@ class BTreeAsyncArcusCommandsTest extends AsyncArcusCommandsTest {
               return async.bopGet(key, bKey, BopGetArgs.DEFAULT);
             })
             .thenAccept(result -> {
-              assertEquals(bKey, result.getBkey());
+              assertEquals(bKey, result.getBKey());
               assertEquals("100", result.getValue());
               assertNull(result.getEFlag());
             })
@@ -1288,7 +1288,7 @@ class BTreeAsyncArcusCommandsTest extends AsyncArcusCommandsTest {
           TimeoutException {
     // given
     String key = keys.get(0);
-    BKey bKey = ELEMENTS.get(1).getBkey();
+    BKey bKey = ELEMENTS.get(1).getBKey();
 
     async.bopCreate(key, ElementValueType.STRING, new CollectionAttributes())
             .thenCompose(result -> {
@@ -1553,7 +1553,7 @@ class BTreeAsyncArcusCommandsTest extends AsyncArcusCommandsTest {
           TimeoutException {
     // given
     String key = keys.get(0);
-    BKey bKey = ELEMENTS.get(1).getBkey();
+    BKey bKey = ELEMENTS.get(1).getBKey();
 
     async.bopCreate(key, ElementValueType.STRING, new CollectionAttributes())
             .thenCompose(result -> {
@@ -1578,15 +1578,15 @@ class BTreeAsyncArcusCommandsTest extends AsyncArcusCommandsTest {
             .thenAccept(result -> {
               assertNotNull(result);
               assertEquals(3, result.size());
-              assertEquals(ELEMENTS.get(0).getBkey(), result.get(0).getBkey());
+              assertEquals(ELEMENTS.get(0).getBKey(), result.get(0).getBKey());
               assertEquals(ELEMENTS.get(0).getValue(), result.get(0).getValue());
               assertEquals(ELEMENTS.get(0).getEFlag(), result.get(0).getEFlag());
               assertEquals(0, result.get(0).getPosition());
-              assertEquals(ELEMENTS.get(1).getBkey(), result.get(1).getBkey());
+              assertEquals(ELEMENTS.get(1).getBKey(), result.get(1).getBKey());
               assertEquals(ELEMENTS.get(1).getValue(), result.get(1).getValue());
               assertEquals(ELEMENTS.get(1).getEFlag(), result.get(1).getEFlag());
               assertEquals(1, result.get(1).getPosition());
-              assertEquals(ELEMENTS.get(2).getBkey(), result.get(2).getBkey());
+              assertEquals(ELEMENTS.get(2).getBKey(), result.get(2).getBKey());
               assertEquals(ELEMENTS.get(2).getValue(), result.get(2).getValue());
               assertEquals(ELEMENTS.get(2).getEFlag(), result.get(2).getEFlag());
               assertEquals(2, result.get(2).getPosition());
@@ -1687,7 +1687,7 @@ class BTreeAsyncArcusCommandsTest extends AsyncArcusCommandsTest {
   void bopDeleteSuccess() throws ExecutionException, InterruptedException, TimeoutException {
     // given
     String key = keys.get(0);
-    BKey bKey = ELEMENTS.get(0).getBkey();
+    BKey bKey = ELEMENTS.get(0).getBKey();
 
     async.bopInsert(key, ELEMENTS.get(0), new CollectionAttributes())
             .thenAccept(Assertions::assertTrue)
@@ -1713,7 +1713,7 @@ class BTreeAsyncArcusCommandsTest extends AsyncArcusCommandsTest {
   void bopDeleteDropIfEmpty() throws ExecutionException, InterruptedException, TimeoutException {
     // given
     String key = keys.get(0);
-    BKey bKey = ELEMENTS.get(0).getBkey();
+    BKey bKey = ELEMENTS.get(0).getBKey();
     BopDeleteArgs args = new BopDeleteArgs.Builder()
             .dropIfEmpty()
             .build();
@@ -1817,8 +1817,8 @@ class BTreeAsyncArcusCommandsTest extends AsyncArcusCommandsTest {
   void bopDeleteByRangeSuccess() throws ExecutionException, InterruptedException, TimeoutException {
     // given
     String key = keys.get(0);
-    BKey from = ELEMENTS.get(0).getBkey();
-    BKey to = ELEMENTS.get(2).getBkey();
+    BKey from = ELEMENTS.get(0).getBKey();
+    BKey to = ELEMENTS.get(2).getBKey();
     BopDeleteArgs deleteArgs = new BopDeleteArgs.Builder()
             .count(1)
             .build();
@@ -2033,8 +2033,8 @@ class BTreeAsyncArcusCommandsTest extends AsyncArcusCommandsTest {
             .get(300L, TimeUnit.MILLISECONDS);
 
     // when
-    BKey from = ELEMENTS.get(0).getBkey();
-    BKey to = ELEMENTS.get(2).getBkey();
+    BKey from = ELEMENTS.get(0).getBKey();
+    BKey to = ELEMENTS.get(2).getBKey();
 
     async.bopCount(key, from, to, ElementFlagFilter.DO_NOT_FILTER)
             // then


### PR DESCRIPTION
### 🔗 Related Issue

<!-- Please link related issue. ex) https://github.com/naver/arcus-java-client/issues/{issue_number} -->
- 

### ⌨️ What I did

<!-- Please describe this PR and what you've been working on. -->
- v2 패키지 내의 `BKey`, `EFlag` 에 관한 변수명을 모두 통일하였습니다. 
  - BKey 관련: `bKey`
  - EFlag 관련: `eFlag`