### PR TITLE
DOC: Fix typo in asyncLopInsertBulk Javadoc parameter description

### DIFF
--- a/src/main/java/net/spy/memcached/ArcusClientIF.java
+++ b/src/main/java/net/spy/memcached/ArcusClientIF.java
@@ -335,7 +335,7 @@ public interface ArcusClientIF extends MemcachedClientIF {
    * @param index               list index
    *                            (the item will be inserted before the element with the given index)
    * @param value               a value to insert into each list
-   * @param attributesForCreate if not true, a list should be created when key does not exist
+   * @param attributesForCreate if not null, a list should be created when key does not exist
    * @param tc                  transcoder to encode value
    * @return a future that will indicate the failure list of each operation
    */


### PR DESCRIPTION
## Related Issue

N/A

## What I did

Fixed typo in `ArcusClientIF.asyncLopInsertBulk()` Javadoc: `if not true` → `if not null`

The parameter type is `CollectionAttributes`, not boolean, so `true` is incorrect. All other overloads of this method correctly use `if not null`.