### PR TITLE
CLEANUP: Replace assert statements with proper exception handling

### DIFF
--- a/src/main/java/net/spy/memcached/AddrUtil.java
+++ b/src/main/java/net/spy/memcached/AddrUtil.java
@@ -21,29 +21,21 @@ public final class AddrUtil {
    *
    * Note that colon-delimited IPv6 is also supported.
    * For example:  ::1:11211
-   * @param s The {@link java.util.List} of {@link java.lang.String}
+   * @param hosts The {@link java.util.List} of {@link java.lang.String}
    *          containing {@code host:port}
    * @return The {@link java.util.List} of {@link java.net.InetSocketAddress}
    */
-  public static List<InetSocketAddress> getAddresses(List<String> s) {
-    if (s == null) {
-      throw new NullPointerException("Null host list");
-    }
-    ArrayList<InetSocketAddress> addrs =
-            new ArrayList<>();
-
-    if (s.isEmpty()) {
-      return addrs;
+  public static List<InetSocketAddress> getAddresses(List<String> hosts) {
+    if (hosts == null) {
+      throw new IllegalArgumentException("Hosts must not be null");
     }
 
-    for (String hoststuff : s) {
-      hoststuff = hoststuff.trim();
-      if (hoststuff.equals("")) {
-        continue;
+    ArrayList<InetSocketAddress> addrs = new ArrayList<>();
+    for (String host : hosts) {
+      if (!host.trim().isEmpty()) {
+        addrs.add(getAddress(host));
       }
-      addrs.add(getAddress(hoststuff));
     }
-    assert !addrs.isEmpty() : "No addrs found";
     return Collections.unmodifiableList(addrs);
   }
 

--- a/src/main/java/net/spy/memcached/protocol/ascii/BTreeFindPositionWithGetOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/BTreeFindPositionWithGetOperationImpl.java
@@ -105,14 +105,12 @@ public final class BTreeFindPositionWithGetOperationImpl extends OperationImpl i
      */
     if (line.startsWith("VALUE ")) {
       String[] stuff = line.split(" ");
-      assert stuff.length == 5;
 
       position = Integer.parseInt(stuff[1]);
       flags = Integer.parseInt(stuff[2]);
       count = Integer.parseInt(stuff[3]);
       index = Integer.parseInt(stuff[4]);
 
-      assert count > 0;
       // position counter
       pos = position - index;
       posDiff = 1;
@@ -171,13 +169,6 @@ public final class BTreeFindPositionWithGetOperationImpl extends OperationImpl i
       return;
     }
 
-    // Read data
-    assert key != null;
-    assert data != null;
-    // This will be the case, because we'll clear them when it's not.
-    assert readOffset <= data.length
-            : "readOffset is " + readOffset + " data.length is " + data.length;
-
     getLogger().debug("readOffset: %d, length: %d", readOffset, data.length);
 
     if (lookingFor == '\0') {
@@ -205,19 +196,14 @@ public final class BTreeFindPositionWithGetOperationImpl extends OperationImpl i
     if (lookingFor != '\0' && bb.hasRemaining()) {
       do {
         byte tmp = bb.get();
-        assert tmp == lookingFor : "Expecting " + lookingFor + ", got "
-                + (char) tmp;
+        if (tmp != lookingFor) {
+          throw new IllegalStateException("Expecting " + lookingFor + ", got " + (char) tmp);
+        }
 
-        switch (lookingFor) {
-          case '\r':
-            lookingFor = '\n';
-            break;
-          case '\n':
-            lookingFor = '\0';
-            break;
-          default:
-            assert false : "Looking for unexpected char: "
-                    + (char) lookingFor;
+        if (lookingFor == '\r') {
+          lookingFor = '\n';
+        } else { // lookingFor == '\n';
+          lookingFor = '\0';
         }
       } while (lookingFor != '\0' && bb.hasRemaining());
 

--- a/src/main/java/net/spy/memcached/protocol/ascii/BTreeGetBulkOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/BTreeGetBulkOperationImpl.java
@@ -161,14 +161,6 @@ public final class BTreeGetBulkOperationImpl extends OperationImpl implements
       return;
     }
 
-    // Read data
-    // assert key != null;
-    assert data != null;
-
-    // This will be the case, because we'll clear them when it's not.
-    assert readOffset <= data.length : "readOffset is " + readOffset
-            + " data.length is " + data.length;
-
     getLogger().debug("readOffset: %d, length: %d", readOffset, data.length);
 
     if (lookingFor == '\0') {
@@ -191,19 +183,14 @@ public final class BTreeGetBulkOperationImpl extends OperationImpl implements
     if (lookingFor != '\0' && bb.hasRemaining()) {
       do {
         byte tmp = bb.get();
-        assert tmp == lookingFor : "Expecting " + lookingFor + ", got "
-                + (char) tmp;
+        if (tmp != lookingFor) {
+          throw new IllegalStateException("Expecting " + lookingFor + ", got " + (char) tmp);
+        }
 
-        switch (lookingFor) {
-          case '\r':
-            lookingFor = '\n';
-            break;
-          case '\n':
-            lookingFor = '\0';
-            break;
-          default:
-            assert false : "Looking for unexpected char: "
-                    + (char) lookingFor;
+        if (lookingFor == '\r') {
+          lookingFor = '\n';
+        } else { // lookingFor == '\n';
+          lookingFor = '\0';
         }
       } while (lookingFor != '\0' && bb.hasRemaining());
 

--- a/src/main/java/net/spy/memcached/protocol/ascii/BTreeGetByPositionOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/BTreeGetByPositionOperationImpl.java
@@ -102,8 +102,6 @@ public final class BTreeGetByPositionOperationImpl extends OperationImpl impleme
      */
     if (line.startsWith("VALUE ")) {
       String[] stuff = line.split(" ");
-      assert stuff.length == 3;
-      assert "VALUE".equals(stuff[0]);
 
       flags = Integer.parseInt(stuff[1]);
       count = Integer.parseInt(stuff[2]);
@@ -173,13 +171,6 @@ public final class BTreeGetByPositionOperationImpl extends OperationImpl impleme
       return;
     }
 
-    // Read data
-    assert key != null;
-    assert data != null;
-    // This will be the case, because we'll clear them when it's not.
-    assert readOffset <= data.length
-            : "readOffset is " + readOffset + " data.length is " + data.length;
-
     getLogger().debug("readOffset: %d, length: %d", readOffset, data.length);
 
     if (lookingFor == '\0') {
@@ -207,19 +198,14 @@ public final class BTreeGetByPositionOperationImpl extends OperationImpl impleme
     if (lookingFor != '\0' && bb.hasRemaining()) {
       do {
         byte tmp = bb.get();
-        assert tmp == lookingFor : "Expecting " + lookingFor + ", got "
-                + (char) tmp;
+        if (tmp != lookingFor) {
+          throw new IllegalStateException("Expecting " + lookingFor + ", got " + (char) tmp);
+        }
 
-        switch (lookingFor) {
-          case '\r':
-            lookingFor = '\n';
-            break;
-          case '\n':
-            lookingFor = '\0';
-            break;
-          default:
-            assert false : "Looking for unexpected char: "
-                    + (char) lookingFor;
+        if (lookingFor == '\r') {
+          lookingFor = '\n';
+        } else { // lookingFor == '\n';
+          lookingFor = '\0';
         }
       } while (lookingFor != '\0' && bb.hasRemaining());
 

--- a/src/main/java/net/spy/memcached/protocol/ascii/BTreeInsertAndGetOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/BTreeInsertAndGetOperationImpl.java
@@ -135,8 +135,6 @@ public final class BTreeInsertAndGetOperationImpl extends OperationImpl implemen
     */
     if (line.startsWith("VALUE ")) {
       String[] stuff = line.split(" ");
-      assert stuff.length == 3;
-      assert "VALUE".equals(stuff[0]);
 
       flags = Integer.parseInt(stuff[1]);
       count = Integer.parseInt(stuff[2]);
@@ -200,13 +198,6 @@ public final class BTreeInsertAndGetOperationImpl extends OperationImpl implemen
       return;
     }
 
-    // Read data
-    assert key != null;
-    assert data != null;
-    // This will be the case, because we'll clear them when it's not.
-    assert readOffset <= data.length
-            : "readOffset is " + readOffset + " data.length is " + data.length;
-
     getLogger().debug("readOffset: %d, length: %d", readOffset, data.length);
 
     if (lookingFor == '\0') {
@@ -231,19 +222,14 @@ public final class BTreeInsertAndGetOperationImpl extends OperationImpl implemen
     if (lookingFor != '\0' && bb.hasRemaining()) {
       do {
         byte tmp = bb.get();
-        assert tmp == lookingFor : "Expecting " + lookingFor + ", got "
-                + (char) tmp;
+        if (tmp != lookingFor) {
+          throw new IllegalStateException("Expecting " + lookingFor + ", got " + (char) tmp);
+        }
 
-        switch (lookingFor) {
-          case '\r':
-            lookingFor = '\n';
-            break;
-          case '\n':
-            lookingFor = '\0';
-            break;
-          default:
-            assert false : "Looking for unexpected char: "
-                    + (char) lookingFor;
+        if (lookingFor == '\r') {
+          lookingFor = '\n';
+        } else { // lookingFor == '\n';
+          lookingFor = '\0';
         }
       } while (lookingFor != '\0' && bb.hasRemaining());
 

--- a/src/main/java/net/spy/memcached/protocol/ascii/BTreeSortMergeGetOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/BTreeSortMergeGetOperationImpl.java
@@ -105,7 +105,6 @@ public final class BTreeSortMergeGetOperationImpl extends OperationImpl implemen
       readState = ReadState.ELEMENTS;
 
       String[] stuff = line.split(" ");
-      assert "ELEMENTS".equals(stuff[0]) || "VALUE".equals(stuff[0]);
 
       lineCount = Integer.parseInt(stuff[1]);
       if (lineCount > 0) {
@@ -125,8 +124,6 @@ public final class BTreeSortMergeGetOperationImpl extends OperationImpl implemen
       readState = ReadState.TRIMMED_KEYS;
 
       String[] stuff = line.split(" ");
-      assert "TRIMMED_KEYS".equals(stuff[0]);
-
       lineCount = Integer.parseInt(stuff[1]);
       if (lineCount > 0) {
         setReadType(OperationReadType.DATA);
@@ -220,14 +217,6 @@ public final class BTreeSortMergeGetOperationImpl extends OperationImpl implemen
       return;
     }
 
-    // Read data
-    // assert key != null;
-    assert data != null;
-
-    // This will be the case, because we'll clear them when it's not.
-    assert readOffset <= data.length : "readOffset is " + readOffset
-            + " data.length is " + data.length;
-
     getLogger()
             .debug("readOffset: %d, length: %d", readOffset, data.length);
 
@@ -251,19 +240,14 @@ public final class BTreeSortMergeGetOperationImpl extends OperationImpl implemen
     if (lookingFor != '\0' && bb.hasRemaining()) {
       do {
         byte tmp = bb.get();
-        assert tmp == lookingFor : "Expecting " + lookingFor + ", got "
-                + (char) tmp;
+        if (tmp != lookingFor) {
+          throw new IllegalStateException("Expecting " + lookingFor + ", got " + (char) tmp);
+        }
 
-        switch (lookingFor) {
-          case '\r':
-            lookingFor = '\n';
-            break;
-          case '\n':
-            lookingFor = '\0';
-            break;
-          default:
-            assert false : "Looking for unexpected char: "
-                    + (char) lookingFor;
+        if (lookingFor == '\r') {
+          lookingFor = '\n';
+        } else { // lookingFor == '\n';
+          lookingFor = '\0';
         }
       } while (lookingFor != '\0' && bb.hasRemaining());
 

--- a/src/main/java/net/spy/memcached/protocol/ascii/BaseGetOpImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/BaseGetOpImpl.java
@@ -106,7 +106,6 @@ abstract class BaseGetOpImpl extends OperationImpl {
     } else if (line.startsWith("VALUE ")) {
       getLogger().debug("Got line %s", line);
       String[] stuff = line.split(" ");
-      assert stuff[0].equals("VALUE");
       currentKey = stuff[1];
       currentFlags = Integer.parseInt(stuff[2]);
       data = new byte[Integer.parseInt(stuff[3])];
@@ -129,12 +128,6 @@ abstract class BaseGetOpImpl extends OperationImpl {
 
   @Override
   public final void handleRead(ByteBuffer bb) {
-    assert currentKey != null;
-    assert data != null;
-    // This will be the case, because we'll clear them when it's not.
-    assert readOffset <= data.length : "readOffset is " + readOffset
-        + " data.length is " + data.length;
-
     getLogger().debug("readOffset: %d, length: %d", readOffset, data.length);
     // If we're not looking for termination, we're still looking for data
     if (lookingFor == '\0') {
@@ -163,17 +156,14 @@ abstract class BaseGetOpImpl extends OperationImpl {
     if (lookingFor != '\0' && bb.hasRemaining()) {
       do {
         byte tmp = bb.get();
-        assert tmp == lookingFor : "Expecting " + lookingFor + ", got "
-                + (char) tmp;
-        switch (lookingFor) {
-          case '\r':
-            lookingFor = '\n';
-            break;
-          case '\n':
-            lookingFor = '\0';
-            break;
-          default:
-            assert false : "Looking for unexpected char: " + (char) lookingFor;
+        if (tmp != lookingFor) {
+          throw new IllegalStateException("Expecting " + lookingFor + ", got " + (char) tmp);
+        }
+
+        if (lookingFor == '\r') {
+          lookingFor = '\n';
+        } else { // lookingFor == '\n';
+          lookingFor = '\0';
         }
       } while (lookingFor != '\0' && bb.hasRemaining());
       // Completed the read, reset stuff.
@@ -197,34 +187,39 @@ abstract class BaseGetOpImpl extends OperationImpl {
 
     String keysString = generateKeysString();
 
-    if (cmd.equals("get") || cmd.equals("gets")) {
-      // syntax: get <keys...>\r\n
-      commandBuilder.append(cmd);
-      commandBuilder.append(' ');
-      commandBuilder.append(keysString);
-      commandBuilder.append(RN_STRING);
-    } else if (cmd.equals("gat") || cmd.equals("gats")) {
-      // syntax: gat || gats <exp> <key>\r\n
-      commandBuilder.append(cmd);
-      commandBuilder.append(' ');
-      commandBuilder.append(exp);
-      commandBuilder.append(' ');
-      commandBuilder.append(keysString);
-      commandBuilder.append(RN_STRING);
-    } else {
-      assert (cmd.equals("mget") || cmd.equals("mgets"))
-          : "Unknown Command " + cmd;
-      // syntax: mget <lenKeys> <numkeys>\r\n<keys>\r\n
-      int lenKeys = keysString.getBytes().length;
-      int numKeys = keys.size();
-      commandBuilder.append(cmd);
-      commandBuilder.append(' ');
-      commandBuilder.append(lenKeys);
-      commandBuilder.append(' ');
-      commandBuilder.append(numKeys);
-      commandBuilder.append(RN_STRING);
-      commandBuilder.append(keysString);
-      commandBuilder.append(RN_STRING);
+    switch (cmd) {
+      case "get":
+      case "gets":
+        // syntax: get || gets <keys...>\r\n
+        commandBuilder.append(cmd);
+        commandBuilder.append(' ');
+        commandBuilder.append(keysString);
+        commandBuilder.append(RN_STRING);
+        break;
+      case "gat":
+      case "gats":
+        // syntax: gat || gats <exp> <key>\r\n
+        commandBuilder.append(cmd);
+        commandBuilder.append(' ');
+        commandBuilder.append(exp);
+        commandBuilder.append(' ');
+        commandBuilder.append(keysString);
+        commandBuilder.append(RN_STRING);
+        break;
+      case "mget":
+      case "mgets":
+        // syntax: mget || mgets <lenKeys> <numkeys>\r\n<keys>\r\n
+        commandBuilder.append(cmd);
+        commandBuilder.append(' ');
+        commandBuilder.append(keysString.getBytes().length);
+        commandBuilder.append(' ');
+        commandBuilder.append(keys.size());
+        commandBuilder.append(RN_STRING);
+        commandBuilder.append(keysString);
+        commandBuilder.append(RN_STRING);
+        break;
+      default:
+        assert false : "Unknown command: " + cmd;
     }
 
     commandLine = commandBuilder.toString().getBytes();

--- a/src/main/java/net/spy/memcached/protocol/ascii/CollectionGetOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/CollectionGetOperationImpl.java
@@ -129,7 +129,6 @@ public final class CollectionGetOperationImpl extends OperationImpl
       getLogger().debug("Got line %s", line);
 
       String[] stuff = line.split(" ");
-      assert "VALUE".equals(stuff[0]);
 
       flags = Integer.parseInt(stuff[1]);
       count = Integer.parseInt(stuff[2]);
@@ -198,13 +197,6 @@ public final class CollectionGetOperationImpl extends OperationImpl
       return;
     }
 
-    // Read data
-    assert key != null;
-    assert data != null;
-    // This will be the case, because we'll clear them when it's not.
-    assert readOffset <= data.length
-            : "readOffset is " + readOffset + " data.length is " + data.length;
-
     getLogger().debug("readOffset: %d, length: %d", readOffset, data.length);
 
     if (lookingFor == '\0') {
@@ -228,19 +220,14 @@ public final class CollectionGetOperationImpl extends OperationImpl
     if (lookingFor != '\0' && bb.hasRemaining()) {
       do {
         byte tmp = bb.get();
-        assert tmp == lookingFor : "Expecting " + lookingFor + ", got "
-                + (char) tmp;
+        if (tmp != lookingFor) {
+          throw new IllegalStateException("Expecting " + lookingFor + ", got " + (char) tmp);
+        }
 
-        switch (lookingFor) {
-          case '\r':
-            lookingFor = '\n';
-            break;
-          case '\n':
-            lookingFor = '\0';
-            break;
-          default:
-            assert false : "Looking for unexpected char: "
-                    + (char) lookingFor;
+        if (lookingFor == '\r') {
+          lookingFor = '\n';
+        } else { // lookingFor == '\n';
+          lookingFor = '\0';
         }
       } while (lookingFor != '\0' && bb.hasRemaining());
 

--- a/src/main/java/net/spy/memcached/transcoders/TranscoderUtils.java
+++ b/src/main/java/net/spy/memcached/transcoders/TranscoderUtils.java
@@ -107,6 +107,10 @@ public final class TranscoderUtils {
   }
 
   public long decodeLong(byte[] b) {
+    if (b.length > 8) {
+      throw new IllegalStateException("Too long to be an long (" + b.length + ") bytes");
+    }
+
     long rv = 0;
     for (byte i : b) {
       rv = (rv << 8) | (i < 0 ? 256 + i : i);
@@ -119,8 +123,9 @@ public final class TranscoderUtils {
   }
 
   public int decodeInt(byte[] in) {
-    assert in.length <= 4
-            : "Too long to be an int (" + in.length + ") bytes";
+    if (in.length > 4) {
+      throw new IllegalStateException("Too long to be an int (" + in.length + ") bytes");
+    }
     return (int) decodeLong(in);
   }
 
@@ -129,12 +134,10 @@ public final class TranscoderUtils {
   }
 
   public byte decodeByte(byte[] in) {
-    assert in.length <= 1 : "Too long for a byte";
-    byte rv = 0;
-    if (in.length == 1) {
-      rv = in[0];
+    if (in.length != 1) {
+      throw new IllegalStateException("Wrong length for a byte");
     }
-    return rv;
+    return in[0];
   }
 
   public byte[] encodeBoolean(boolean b) {
@@ -144,7 +147,9 @@ public final class TranscoderUtils {
   }
 
   public boolean decodeBoolean(byte[] in) {
-    assert in.length == 1 : "Wrong length for a boolean";
+    if (in.length != 1) {
+      throw new IllegalStateException("Wrong length for a boolean");
+    }
     return in[0] == '1';
   }
 

--- a/src/main/java/net/spy/memcached/transcoders/WhalinTranscoder.java
+++ b/src/main/java/net/spy/memcached/transcoders/WhalinTranscoder.java
@@ -177,7 +177,9 @@ public class WhalinTranscoder extends BaseSerializingTranscoder
   }
 
   public boolean decodeBoolean(byte[] in) {
-    assert in.length == 1 : "Wrong length for a boolean";
+    if (in.length != 1) {
+      throw new IllegalStateException("Wrong length for a boolean");
+    }
     return in[0] == 1;
   }
 

--- a/src/main/java/net/spy/memcached/transcoders/WhalinV1Transcoder.java
+++ b/src/main/java/net/spy/memcached/transcoders/WhalinV1Transcoder.java
@@ -141,32 +141,40 @@ public class WhalinV1Transcoder extends BaseSerializingTranscoder
   }
 
   private Byte decodeByte(byte[] in) {
-    assert in.length == 2 : "Wrong length for a byte";
+    if (in.length != 2) {
+      throw new IllegalStateException("Wrong length for a byte");
+    }
     byte value = in[1];
     return Byte.valueOf(value);
-
   }
 
   private Integer decodeInteger(byte[] in) {
-    assert in.length == 5 : "Wrong length for an int";
+    if (in.length != 5) {
+      throw new IllegalStateException("Wrong length for an int");
+    }
     return Integer.valueOf((int) decodeLong(in).longValue());
-
   }
 
   private Float decodeFloat(byte[] in) {
-    assert in.length == 5 : "Wrong length for a float";
+    if (in.length != 5) {
+      throw new IllegalStateException("Wrong length for a float");
+    }
     Integer l = decodeInteger(in);
     return Float.valueOf(Float.intBitsToFloat(l.intValue()));
   }
 
   private Double decodeDouble(byte[] in) {
-    assert in.length == 9 : "Wrong length for a double";
+    if (in.length != 9) {
+      throw new IllegalStateException("Wrong length for a double");
+    }
     Long l = decodeLong(in);
     return Double.valueOf(Double.longBitsToDouble(l.longValue()));
   }
 
   private Boolean decodeBoolean(byte[] in) {
-    assert in.length == 2 : "Wrong length for a boolean";
+    if (in.length != 2) {
+      throw new IllegalStateException("Wrong length for a boolean");
+    }
     return Boolean.valueOf(in[1] == 1);
   }
 

--- a/src/test/java/net/spy/memcached/AddrUtilTest.java
+++ b/src/test/java/net/spy/memcached/AddrUtilTest.java
@@ -94,8 +94,8 @@ class AddrUtilTest {
     try {
       List<InetSocketAddress> addrs = AddrUtil.getAddresses(s);
       fail("Expected failure, got " + addrs);
-    } catch (NullPointerException e) {
-      assertEquals("Null host list", e.getMessage());
+    } catch (IllegalArgumentException e) {
+      assertEquals("Hosts must not be null", e.getMessage());
     }
   }
 

--- a/src/test/java/net/spy/memcached/transcoders/TranscoderUtilsTest.java
+++ b/src/test/java/net/spy/memcached/transcoders/TranscoderUtilsTest.java
@@ -27,7 +27,7 @@ class TranscoderUtilsTest {
     try {
       boolean b = tu.decodeBoolean(oversizeBytes);
       fail("Got " + b + " expected assertion.");
-    } catch (AssertionError e) {
+    } catch (IllegalStateException e) {
       // pass
     }
   }
@@ -37,7 +37,7 @@ class TranscoderUtilsTest {
     try {
       byte b = tu.decodeByte(oversizeBytes);
       fail("Got " + b + " expected assertion.");
-    } catch (AssertionError e) {
+    } catch (IllegalStateException e) {
       // pass
     }
   }
@@ -47,7 +47,7 @@ class TranscoderUtilsTest {
     try {
       int b = tu.decodeInt(oversizeBytes);
       fail("Got " + b + " expected assertion.");
-    } catch (AssertionError e) {
+    } catch (IllegalStateException e) {
       // pass
     }
   }
@@ -57,7 +57,7 @@ class TranscoderUtilsTest {
     try {
       long b = tu.decodeLong(oversizeBytes);
       fail("Got " + b + " expected assertion.");
-    } catch (AssertionError e) {
+    } catch (IllegalStateException e) {
       // pass
     }
   }

--- a/src/test/java/net/spy/memcached/v2/KVAsyncArcusCommandsTest.java
+++ b/src/test/java/net/spy/memcached/v2/KVAsyncArcusCommandsTest.java
@@ -172,9 +172,7 @@ class KVAsyncArcusCommandsTest extends AsyncArcusCommandsTest {
             })
             .toCompletableFuture();
     // then
-    // AssertionError in the Transcoder causes the I/O thread to terminate abruptly.
-    // The future is never completed, leading to a TimeoutException in the main thread.
-    assertThrows(TimeoutException.class, () -> future.get(300L, TimeUnit.MILLISECONDS));
+    assertThrows(ExecutionException.class, () -> future.get(300L, TimeUnit.MILLISECONDS));
   }
 
   @Test


### PR DESCRIPTION
### 🔗 Related Issue

<!-- Please link related issue. ex) https://github.com/naver/arcus-java-client/issues/{issue_number} -->
- https://github.com/jam2in/arcus-works/issues/576

### ⌨️ What I did

<!-- Please describe this PR and what you've been working on. -->
- `assert` 문을 중요도에 따라 분류하고, 중요도 높음 항목을 우선 처리합니다.

**처리 기준**
- I/O Thread 내 서버 응답 검증 &rarr; `IllegalStateException` 으로 대체
- null, 범위 검증 `assert` 제거 &rarr; RuntimeException(NPE, IndexOutOfBoundsException 등) 발생하므로 불필요 
- 상위 조건으로 이미 보장된 `assert` 제거
