### PR TITLE
FIX: Fix incorrect status code handling in BTree

### DIFF
--- a/src/main/java/net/spy/memcached/v2/AsyncArcusCommands.java
+++ b/src/main/java/net/spy/memcached/v2/AsyncArcusCommands.java
@@ -927,8 +927,10 @@ public class AsyncArcusCommands<T> implements AsyncArcusCommandsIF<T> {
             result.set(new AbstractMap.SimpleEntry<>(true, trimmedElement));
             break;
           case ERR_ELEMENT_EXISTS:
-          case ERR_NOT_FOUND:
             result.set(new AbstractMap.SimpleEntry<>(false, trimmedElement));
+            break;
+          case ERR_NOT_FOUND:
+            result.set(null);
             break;
           case CANCELLED:
             future.internalCancel();
@@ -1046,14 +1048,13 @@ public class AsyncArcusCommands<T> implements AsyncArcusCommandsIF<T> {
       public void receivedStatus(OperationStatus status) {
         switch (status.getStatusCode()) {
           case SUCCESS:
+          case ERR_NOT_FOUND_ELEMENT:
             break;
           case TRIMMED:
             result.get().trimmed();
             break;
           case ERR_NOT_FOUND:
             result.set(null);
-            break;
-          case ERR_NOT_FOUND_ELEMENT:
             break;
           case CANCELLED:
             future.internalCancel();


### PR DESCRIPTION
### 🔗 Related Issue

<!-- Please link related issue. ex) https://github.com/naver/arcus-java-client/issues/{issue_number} -->
- https://github.com/jam2in/arcus-works/issues/832#issuecomment-4326060585

### ⌨️ What I did

<!-- Please describe this PR and what you've been working on. -->
- bop(`bopGet` / `bopInsertOrAndGetTrimmed`)의 receivedStatus 메서드를 수정합니다.
  - `bopGet`: case `ERR_NOT_FOUND_ELEMENT` 를 `SUCCESS` 와 합쳐서 처리 (다른 코드와 통일을 위해)
  - `bopInsertOrAndGetTrimmed`: `ERR_NOT_FOUND` 시 null 을 반환하도록 수정 