### PR TITLE
FIX: Forcefully use ScramSaslClientFactory instead of others

### DIFF
--- a/src/main/java/net/spy/memcached/MemcachedConnection.java
+++ b/src/main/java/net/spy/memcached/MemcachedConnection.java
@@ -47,7 +47,6 @@ import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
-import javax.security.sasl.Sasl;
 import javax.security.sasl.SaslClient;
 
 import net.spy.memcached.auth.AuthDescriptor;
@@ -64,6 +63,8 @@ import net.spy.memcached.ops.OperationException;
 import net.spy.memcached.ops.OperationState;
 import net.spy.memcached.ops.OperationStatus;
 import net.spy.memcached.ops.OperationType;
+
+import static net.spy.memcached.auth.ScramSaslClient.ScramSaslClientFactory;
 
 /**
  * Connection to a cluster of memcached servers.
@@ -618,7 +619,7 @@ public final class MemcachedConnection extends SpyObject {
 
     final SaslClient sc;
     try {
-      sc = Sasl.createSaslClient(authDescriptor.getMechs(), null,
+      sc = new ScramSaslClientFactory().createSaslClient(authDescriptor.getMechs(), null,
               "memcached", node.getSocketAddress().toString(), null, authDescriptor.getCallback());
     } catch (Exception e) {
       throw new IllegalStateException("Can't create SaslClient", e);


### PR DESCRIPTION
### 🔗 Related Issue

<!-- Please link related issue. ex) https://github.com/naver/arcus-java-client/issues/{issue_number} -->
- ScramSaslClient가 아닌 다른 SaslClient 구현체가 사용될 경우, 인증 과정이 정상적으로 동작하지 않을 수 있다.

### ⌨️ What I did

<!-- Please describe this PR and what you've been working on. -->
- 항상 ScramSaslClientFactory를 사용하여, ScramSaslClient를 반드시 사용하도록 합니다.