### PR TITLE
CLEANUP: Reorder and reformat v2 APIs

### DIFF
--- a/src/main/java/net/spy/memcached/v2/AsyncArcusCommands.java
+++ b/src/main/java/net/spy/memcached/v2/AsyncArcusCommands.java
@@ -40,9 +40,9 @@ import net.spy.memcached.MemcachedNode;
 import net.spy.memcached.collection.BKeyObject;
 import net.spy.memcached.collection.BTreeCount;
 import net.spy.memcached.collection.BTreeCreate;
+import net.spy.memcached.collection.BTreeDelete;
 import net.spy.memcached.collection.BTreeFindPosition;
 import net.spy.memcached.collection.BTreeFindPositionWithGet;
-import net.spy.memcached.collection.BTreeDelete;
 import net.spy.memcached.collection.BTreeGet;
 import net.spy.memcached.collection.BTreeGetBulk;
 import net.spy.memcached.collection.BTreeGetBulkWithByteTypeBkey;
@@ -70,17 +70,17 @@ import net.spy.memcached.collection.ListCreate;
 import net.spy.memcached.collection.ListDelete;
 import net.spy.memcached.collection.ListGet;
 import net.spy.memcached.collection.ListInsert;
-import net.spy.memcached.collection.SetCreate;
-import net.spy.memcached.collection.SetDelete;
-import net.spy.memcached.collection.SetExist;
-import net.spy.memcached.collection.SetGet;
-import net.spy.memcached.collection.SetInsert;
 import net.spy.memcached.collection.MapCreate;
 import net.spy.memcached.collection.MapDelete;
 import net.spy.memcached.collection.MapGet;
 import net.spy.memcached.collection.MapInsert;
 import net.spy.memcached.collection.MapUpdate;
 import net.spy.memcached.collection.MapUpsert;
+import net.spy.memcached.collection.SetCreate;
+import net.spy.memcached.collection.SetDelete;
+import net.spy.memcached.collection.SetExist;
+import net.spy.memcached.collection.SetGet;
+import net.spy.memcached.collection.SetInsert;
 import net.spy.memcached.internal.result.GetsResultImpl;
 import net.spy.memcached.ops.APIType;
 import net.spy.memcached.ops.BTreeFindPositionOperation;
@@ -105,8 +105,8 @@ import net.spy.memcached.transcoders.Transcoder;
 import net.spy.memcached.transcoders.TranscoderUtils;
 import net.spy.memcached.v2.vo.BKey;
 import net.spy.memcached.v2.vo.BTreeElement;
-import net.spy.memcached.v2.vo.BTreePositionElement;
 import net.spy.memcached.v2.vo.BTreeElements;
+import net.spy.memcached.v2.vo.BTreePositionElement;
 import net.spy.memcached.v2.vo.BTreeUpdateElement;
 import net.spy.memcached.v2.vo.BopDeleteArgs;
 import net.spy.memcached.v2.vo.BopGetArgs;
@@ -174,22 +174,57 @@ public class AsyncArcusCommands<T> implements AsyncArcusCommandsIF<T> {
       }
     };
     Operation op = client.getOpFact()
-            .store(type, key, co.getFlags(), exp, co.getData(), cb);
+        .store(type, key, co.getFlags(), exp, co.getData(), cb);
     future.setOp(op);
     client.addOp(key, op);
 
     return future;
   }
 
-  public ArcusFuture<Boolean> append(String key, T value) {
-    return concat(ConcatenationType.append, key, value);
+  public ArcusFuture<Map<String, Boolean>> multiSet(Map<String, T> items, int exp) {
+    return multiStore(StoreType.set, items, exp);
+  }
+
+  public ArcusFuture<Map<String, Boolean>> multiAdd(Map<String, T> items, int exp) {
+    return multiStore(StoreType.add, items, exp);
+  }
+
+  public ArcusFuture<Map<String, Boolean>> multiReplace(Map<String, T> items, int exp) {
+    return multiStore(StoreType.replace, items, exp);
+  }
+
+  private ArcusFuture<Map<String, Boolean>> multiStore(StoreType type,
+                                                       Map<String, T> items,
+                                                       int exp) {
+    Map<String, CompletableFuture<?>> keyToFuture = new HashMap<>(items.size());
+
+    items.forEach((key, value) -> {
+      CompletableFuture<Boolean> future = store(type, key, exp, value).toCompletableFuture();
+      keyToFuture.put(key, future);
+    });
+
+    return new ArcusMultiFuture<>(keyToFuture.values(), () -> {
+      Map<String, Boolean> results = new HashMap<>();
+      keyToFuture.forEach((key, future) -> {
+        if (future.isCompletedExceptionally()) {
+          results.put(key, null);
+        } else {
+          results.put(key, (Boolean) future.join());
+        }
+      });
+      return results;
+    });
   }
 
   public ArcusFuture<Boolean> prepend(String key, T value) {
     return concat(ConcatenationType.prepend, key, value);
   }
 
-  private ArcusFuture<Boolean> concat(ConcatenationType catType, String key, T value) {
+  public ArcusFuture<Boolean> append(String key, T value) {
+    return concat(ConcatenationType.append, key, value);
+  }
+
+  private ArcusFuture<Boolean> concat(ConcatenationType concatType, String key, T value) {
     AbstractArcusResult<Boolean> result = new AbstractArcusResult<>(new AtomicReference<>());
     ArcusFutureImpl<Boolean> future = new ArcusFutureImpl<>(result);
     CachedData co = tc.encode(value);
@@ -221,7 +256,7 @@ public class AsyncArcusCommands<T> implements AsyncArcusCommandsIF<T> {
         future.complete();
       }
     };
-    Operation op = client.getOpFact().cat(catType, 0L, key, co.getData(), cb);
+    Operation op = client.getOpFact().cat(concatType, 0L, key, co.getData(), cb);
     future.setOp(op);
     client.addOp(key, op);
 
@@ -262,46 +297,75 @@ public class AsyncArcusCommands<T> implements AsyncArcusCommandsIF<T> {
       }
     };
     Operation op = client.getOpFact()
-            .cas(StoreType.set, key, casId, co.getFlags(), exp, co.getData(), cb);
+        .cas(StoreType.set, key, casId, co.getFlags(), exp, co.getData(), cb);
     future.setOp(op);
     client.addOp(key, op);
 
     return future;
   }
 
-  public ArcusFuture<Map<String, Boolean>> multiSet(Map<String, T> items, int exp) {
-    return multiStore(StoreType.set, items, exp);
+  public ArcusFuture<Long> incr(String key, int delta) {
+    return mutate(Mutator.incr, key, delta, -1L, 0);
   }
 
-  public ArcusFuture<Map<String, Boolean>> multiAdd(Map<String, T> items, int exp) {
-    return multiStore(StoreType.add, items, exp);
+  public ArcusFuture<Long> incr(String key, int delta, long initial, int exp) {
+    if (initial < 0) {
+      throw new IllegalArgumentException("Initial value must be 0 or greater.");
+    }
+    return mutate(Mutator.incr, key, delta, initial, exp);
   }
 
-  public ArcusFuture<Map<String, Boolean>> multiReplace(Map<String, T> items, int exp) {
-    return multiStore(StoreType.replace, items, exp);
+  public ArcusFuture<Long> decr(String key, int delta) {
+    return mutate(Mutator.decr, key, delta, -1L, 0);
   }
 
-  private ArcusFuture<Map<String, Boolean>> multiStore(StoreType type,
-                                                       Map<String, T> items,
-                                                       int exp) {
-    Map<String, CompletableFuture<?>> keyToFuture = new HashMap<>(items.size());
+  public ArcusFuture<Long> decr(String key, int delta, long initial, int exp) {
+    if (initial < 0) {
+      throw new IllegalArgumentException("Initial value must be 0 or greater.");
+    }
+    return mutate(Mutator.decr, key, delta, initial, exp);
+  }
 
-    items.forEach((key, value) -> {
-      CompletableFuture<Boolean> future = store(type, key, exp, value).toCompletableFuture();
-      keyToFuture.put(key, future);
-    });
+  private ArcusFuture<Long> mutate(Mutator mutator, String key, int delta, long initial, int exp) {
+    if (delta <= 0) {
+      throw new IllegalArgumentException("Delta must be greater than 0.");
+    }
 
-    return new ArcusMultiFuture<>(keyToFuture.values(), () -> {
-      Map<String, Boolean> results = new HashMap<>();
-      keyToFuture.forEach((key, future) -> {
-        if (future.isCompletedExceptionally()) {
-          results.put(key, null);
-        } else {
-          results.put(key, (Boolean) future.join());
+    AbstractArcusResult<Long> result = new AbstractArcusResult<>(new AtomicReference<>());
+    ArcusFutureImpl<Long> future = new ArcusFutureImpl<>(result);
+    ArcusClient client = arcusClientSupplier.get();
+
+    OperationCallback cb = new OperationCallback() {
+      @Override
+      public void receivedStatus(OperationStatus status) {
+        switch (status.getStatusCode()) {
+          case SUCCESS:
+            result.set(Long.parseLong(status.getMessage()));
+            break;
+          case ERR_NOT_FOUND:
+            result.set(-1L);
+            break;
+          case CANCELLED:
+            future.internalCancel();
+            break;
+          default:
+            /*
+             * TYPE_MISMATCH or unknown statement.
+             */
+            result.addError(key, status);
         }
-      });
-      return results;
-    });
+      }
+
+      @Override
+      public void complete() {
+        future.complete();
+      }
+    };
+    Operation op = client.getOpFact().mutate(mutator, key, delta, initial, exp, cb);
+    future.setOp(op);
+    client.addOp(key, op);
+
+    return future;
   }
 
   public ArcusFuture<T> get(String key) {
@@ -347,10 +411,10 @@ public class AsyncArcusCommands<T> implements AsyncArcusCommandsIF<T> {
 
   public ArcusFuture<CASValue<T>> gets(String key) {
     AbstractArcusResult<GetsResultImpl<T>> result
-            = new AbstractArcusResult<>(new AtomicReference<>());
+        = new AbstractArcusResult<>(new AtomicReference<>());
     @SuppressWarnings("unchecked")
     ArcusFutureImpl<CASValue<T>> future = new ArcusFutureImpl<>(
-            result, r -> r == null ? null : ((GetsResultImpl<T>) r).getDecodedValue());
+        result, r -> r == null ? null : ((GetsResultImpl<T>) r).getDecodedValue());
     ArcusClient client = arcusClientSupplier.get();
 
     GetsOperation.Callback cb = new GetsOperation.Callback() {
@@ -403,7 +467,7 @@ public class AsyncArcusCommands<T> implements AsyncArcusCommandsIF<T> {
       MemcachedNode node = entry.getKey();
       List<String> keyList = entry.getValue();
       CompletableFuture<Map<String, T>> future = getPerNode(client, node, keyList)
-              .toCompletableFuture();
+          .toCompletableFuture();
       futureToKeys.put(future, keyList);
       futures.add(future);
     }
@@ -478,77 +542,13 @@ public class AsyncArcusCommands<T> implements AsyncArcusCommandsIF<T> {
     return future;
   }
 
-  public ArcusFuture<Long> incr(String key, int delta) {
-    return mutate(Mutator.incr, key, delta, -1L, 0);
-  }
-
-  public ArcusFuture<Long> incr(String key, int delta, long initial, int exp) {
-    if (initial < 0) {
-      throw new IllegalArgumentException("Initial value must be 0 or greater.");
-    }
-    return mutate(Mutator.incr, key, delta, initial, exp);
-  }
-
-  public ArcusFuture<Long> decr(String key, int delta) {
-    return mutate(Mutator.decr, key, delta, -1L, 0);
-  }
-
-  public ArcusFuture<Long> decr(String key, int delta, long initial, int exp) {
-    if (initial < 0) {
-      throw new IllegalArgumentException("Initial value must be 0 or greater.");
-    }
-    return mutate(Mutator.decr, key, delta, initial, exp);
-  }
-
-  private ArcusFuture<Long> mutate(Mutator mutator, String key, int delta, long initial, int exp) {
-    if (delta <= 0) {
-      throw new IllegalArgumentException("Delta must be greater than 0.");
-    }
-
-    AbstractArcusResult<Long> result = new AbstractArcusResult<>(new AtomicReference<>());
-    ArcusFutureImpl<Long> future = new ArcusFutureImpl<>(result);
-    ArcusClient client = arcusClientSupplier.get();
-
-    OperationCallback cb = new OperationCallback() {
-      @Override
-      public void receivedStatus(OperationStatus status) {
-        switch (status.getStatusCode()) {
-          case SUCCESS:
-            result.set(Long.parseLong(status.getMessage()));
-            break;
-          case ERR_NOT_FOUND:
-            result.set(-1L);
-            break;
-          case CANCELLED:
-            future.internalCancel();
-            break;
-          default:
-            /*
-             * TYPE_MISMATCH or unknown statement.
-             */
-            result.addError(key, status);
-        }
-      }
-
-      @Override
-      public void complete() {
-        future.complete();
-      }
-    };
-    Operation op = client.getOpFact().mutate(mutator, key, delta, initial, exp, cb);
-    future.setOp(op);
-    client.addOp(key, op);
-
-    return future;
-  }
-
   public ArcusFuture<Map<String, CASValue<T>>> multiGets(List<String> keys) {
     keyValidator.validateKey(keys);
     keyValidator.checkDupKey(keys);
 
     ArcusClient client = arcusClientSupplier.get();
     Collection<Map.Entry<MemcachedNode, List<String>>> arrangedKeys
-            = client.groupingKeys(keys, MemcachedClient.GET_BULK_CHUNK_SIZE, APIType.GETS);
+        = client.groupingKeys(keys, MemcachedClient.GET_BULK_CHUNK_SIZE, APIType.GETS);
 
     Collection<CompletableFuture<?>> futures = new ArrayList<>();
     Map<CompletableFuture<Map<String, CASValue<T>>>, List<String>> futureToKeys = new HashMap<>();
@@ -557,7 +557,7 @@ public class AsyncArcusCommands<T> implements AsyncArcusCommandsIF<T> {
       MemcachedNode node = entry.getKey();
       List<String> keyList = entry.getValue();
       CompletableFuture<Map<String, CASValue<T>>> future
-              = getsPerNode(client, node, keyList).toCompletableFuture();
+          = getsPerNode(client, node, keyList).toCompletableFuture();
       futureToKeys.put(future, keyList);
       futures.add(future);
     }
@@ -581,13 +581,13 @@ public class AsyncArcusCommands<T> implements AsyncArcusCommandsIF<T> {
   private ArcusFuture<Map<String, CASValue<T>>> getsPerNode(ArcusClient client, MemcachedNode node,
                                                             List<String> keyList) {
     AbstractArcusResult<Map<String, GetsResultImpl<T>>> result
-            = new AbstractArcusResult<>(new AtomicReference<>(new HashMap<>()));
+        = new AbstractArcusResult<>(new AtomicReference<>(new HashMap<>()));
 
     @SuppressWarnings("unchecked")
     ArcusFutureImpl<Map<String, CASValue<T>>> future = new ArcusFutureImpl<>(result, r -> {
       Map<String, CASValue<T>> decodedMap = new HashMap<>();
       ((Map<String, GetsResultImpl<T>>) r).forEach((key, getsResult) ->
-              decodedMap.put(key, getsResult.getDecodedValue()));
+          decodedMap.put(key, getsResult.getDecodedValue()));
       return decodedMap;
     });
 
@@ -690,1026 +690,6 @@ public class AsyncArcusCommands<T> implements AsyncArcusCommandsIF<T> {
     });
   }
 
-  public ArcusFuture<Boolean> bopCreate(String key, ElementValueType type,
-                                        CollectionAttributes attributes) {
-    if (attributes == null) {
-      throw new IllegalArgumentException("CollectionAttributes cannot be null");
-    }
-
-    CollectionCreate create = new BTreeCreate(TranscoderUtils.examineFlags(type),
-        attributes.getExpireTime(), attributes.getMaxCount(),
-        attributes.getOverflowAction(), attributes.getReadable(), false);
-
-    return collectionCreate(key, create);
-  }
-
-  private ArcusFuture<Boolean> collectionCreate(String key, CollectionCreate collectionCreate) {
-    AbstractArcusResult<Boolean> result = new AbstractArcusResult<>(new AtomicReference<>());
-    ArcusFutureImpl<Boolean> future = new ArcusFutureImpl<>(result);
-    ArcusClient client = arcusClientSupplier.get();
-
-    OperationCallback cb = new OperationCallback() {
-      @Override
-      public void receivedStatus(OperationStatus status) {
-        switch (status.getStatusCode()) {
-          case SUCCESS:
-            result.set(true);
-            break;
-          case ERR_EXISTS:
-            result.set(false);
-            break;
-          case CANCELLED:
-            future.internalCancel();
-            break;
-          default:
-            /*
-             * NOT_SUPPORTED or unknown statement.
-             */
-            result.addError(key, status);
-        }
-      }
-
-      @Override
-      public void complete() {
-        future.complete();
-      }
-    };
-    CollectionCreateOperation op = client.getOpFact()
-        .collectionCreate(key, collectionCreate, cb);
-    future.setOp(op);
-    client.addOp(key, op);
-
-    return future;
-  }
-
-  public ArcusFuture<Boolean> bopInsert(String key, BTreeElement<T> element,
-                                        CollectionAttributes attributes) {
-    BTreeInsert<T> insert = new BTreeInsert<>(element.getValue(), element.getEFlag(),
-        null, attributes);
-    return collectionInsert(key, element.getBKey().toString(), insert);
-  }
-
-  public ArcusFuture<Boolean> bopInsert(String key, BTreeElement<T> element) {
-    return bopInsert(key, element, null);
-  }
-
-  @Override
-  public ArcusFuture<Boolean> bopUpsert(String key, BTreeElement<T> element,
-                                        CollectionAttributes attributes) {
-    BTreeUpsert<T> upsert = new BTreeUpsert<>(element.getValue(), element.getEFlag(),
-        null, attributes);
-    return collectionInsert(key, element.getBKey().toString(), upsert);
-  }
-
-  @Override
-  public ArcusFuture<Boolean> bopUpsert(String key, BTreeElement<T> element) {
-    return bopUpsert(key, element, null);
-  }
-
-  private ArcusFuture<Boolean> collectionInsert(String key,
-                                                String internalKey,
-                                                CollectionInsert<T> collectionInsert) {
-    AbstractArcusResult<Boolean> result = new AbstractArcusResult<>(new AtomicReference<>());
-    ArcusFutureImpl<Boolean> future = new ArcusFutureImpl<>(result);
-    CachedData co = tcForCollection.encode(collectionInsert.getValue());
-    collectionInsert.setFlags(co.getFlags());
-    ArcusClient client = arcusClientSupplier.get();
-
-    OperationCallback cb = new OperationCallback() {
-      @Override
-      public void receivedStatus(OperationStatus status) {
-        switch (status.getStatusCode()) {
-          case SUCCESS:
-            result.set(true);
-            break;
-          case ERR_ELEMENT_EXISTS:
-            result.set(false);
-            break;
-          case ERR_NOT_FOUND:
-            result.set(null);
-            break;
-          case CANCELLED:
-            future.internalCancel();
-            break;
-          default:
-            /*
-             * TYPE_MISMATCH / BKEY_MISMATCH / OVERFLOWED / OUT_OF_RANGE / NOT_SUPPORTED
-             * or unknown statement.
-             */
-            result.addError(key, status);
-        }
-      }
-
-      @Override
-      public void complete() {
-        future.complete();
-      }
-    };
-    CollectionInsertOperation op = client.getOpFact()
-        .collectionInsert(key, internalKey, collectionInsert, co.getData(), cb);
-    future.setOp(op);
-    client.addOp(key, op);
-
-    return future;
-  }
-
-  public ArcusFuture<Boolean> bopUpdate(String key, BTreeUpdateElement<T> element) {
-    BTreeUpdate<T> update = new BTreeUpdate<>(element.getValue(), element.getEFlagUpdate(), false);
-    return collectionUpdate(key, element.getBKey().toString(), update);
-  }
-
-  private ArcusFuture<Boolean> collectionUpdate(String key,
-                                                String internalKey,
-                                                CollectionUpdate<T> collectionUpdate) {
-    AbstractArcusResult<Boolean> result = new AbstractArcusResult<>(new AtomicReference<>());
-    ArcusFutureImpl<Boolean> future = new ArcusFutureImpl<>(result);
-    CachedData co = null;
-    if (collectionUpdate.getNewValue() != null) {
-      co = tcForCollection.encode(collectionUpdate.getNewValue());
-      collectionUpdate.setFlags(co.getFlags());
-    }
-    ArcusClient client = arcusClientSupplier.get();
-
-    OperationCallback cb = new OperationCallback() {
-      @Override
-      public void receivedStatus(OperationStatus status) {
-        switch (status.getStatusCode()) {
-          case SUCCESS:
-            result.set(true);
-            break;
-          case ERR_NOT_FOUND_ELEMENT:
-            result.set(false);
-            break;
-          case ERR_NOT_FOUND:
-            result.set(null);
-            break;
-          case CANCELLED:
-            future.internalCancel();
-            break;
-          default:
-            /*
-             * TYPE_MISMATCH / BKEY_MISMATCH / EFLAG_MISMATCH / NOTHING_TO_UPDATE /
-             * OVERFLOWED / OUT_OF_RANGE / NOT_SUPPORTED or unknown statement.
-             */
-            result.addError(key, status);
-        }
-      }
-
-      @Override
-      public void complete() {
-        future.complete();
-      }
-    };
-    Operation op = client.getOpFact()
-            .collectionUpdate(key, internalKey, collectionUpdate,
-                    (co == null) ? null : co.getData(), cb);
-    future.setOp(op);
-    client.addOp(key, op);
-
-    return future;
-  }
-
-  public ArcusFuture<Map.Entry<Boolean, BTreeElement<T>>> bopInsertAndGetTrimmed(
-      String key, BTreeElement<T> element, CollectionAttributes attributes) {
-    return bopInsertOrUpsertAndGetTrimmed(key, element, false, attributes);
-  }
-
-  public ArcusFuture<Map.Entry<Boolean, BTreeElement<T>>> bopInsertAndGetTrimmed(
-      String key, BTreeElement<T> element) {
-    return bopInsertOrUpsertAndGetTrimmed(key, element, false, null);
-  }
-
-  public ArcusFuture<Map.Entry<Boolean, BTreeElement<T>>> bopUpsertAndGetTrimmed(
-      String key, BTreeElement<T> element, CollectionAttributes attributes) {
-    return bopInsertOrUpsertAndGetTrimmed(key, element, true, attributes);
-  }
-
-  public ArcusFuture<Map.Entry<Boolean, BTreeElement<T>>> bopUpsertAndGetTrimmed(
-      String key, BTreeElement<T> element) {
-    return bopInsertOrUpsertAndGetTrimmed(key, element, true, null);
-  }
-
-  private ArcusFutureImpl<Map.Entry<Boolean, BTreeElement<T>>> bopInsertOrUpsertAndGetTrimmed(
-      String key, BTreeElement<T> element, boolean isUpsert, CollectionAttributes attributes) {
-    AbstractArcusResult<Map.Entry<Boolean, BTreeElement<T>>> result =
-        new AbstractArcusResult<>(new AtomicReference<>());
-    ArcusFutureImpl<Map.Entry<Boolean, BTreeElement<T>>> future = new ArcusFutureImpl<>(result);
-    BTreeInsertAndGet<T> insertAndGet = createBTreeInsertAndGet(element, isUpsert, attributes);
-    CachedData co = tcForCollection.encode(insertAndGet.getValue());
-    insertAndGet.setFlags(co.getFlags());
-    ArcusClient client = arcusClientSupplier.get();
-
-    BTreeInsertAndGetOperation.Callback cb = new BTreeInsertAndGetOperation.Callback() {
-      private BTreeElement<T> trimmedElement = null;
-
-      public void receivedStatus(OperationStatus status) {
-        switch (status.getStatusCode()) {
-          case SUCCESS:
-          case TRIMMED:
-            result.set(new AbstractMap.SimpleEntry<>(true, trimmedElement));
-            break;
-          case ERR_ELEMENT_EXISTS:
-            result.set(new AbstractMap.SimpleEntry<>(false, trimmedElement));
-            break;
-          case ERR_NOT_FOUND:
-            result.set(null);
-            break;
-          case CANCELLED:
-            future.internalCancel();
-            break;
-          default:
-            /*
-             * TYPE_MISMATCH / BKEY_MISMATCH / OVERFLOWED / OUT_OF_RANGE / NOT_SUPPORTED
-             * or unknown statement.
-             */
-            result.addError(key, status);
-        }
-      }
-
-      public void complete() {
-        future.complete();
-      }
-
-      @Override
-      public void gotData(int flags, BKeyObject bKeyObject, byte[] eFlag, byte[] data) {
-        CachedData cachedData = new CachedData(flags, data, tcForCollection.getMaxSize());
-        trimmedElement = new BTreeElement<>(
-                BKey.of(bKeyObject), tcForCollection.decode(cachedData), eFlag);
-      }
-    };
-    Operation op = client.getOpFact()
-        .bopInsertAndGet(key, insertAndGet, co.getData(), cb);
-    future.setOp(op);
-    client.addOp(key, op);
-
-    return future;
-  }
-
-  private static <T> BTreeInsertAndGet<T> createBTreeInsertAndGet(BTreeElement<T> element,
-                                                                  boolean isUpsert,
-                                                                  CollectionAttributes attributes) {
-    BTreeInsertAndGet<T> insertAndGet;
-    if (element.getBKey().getType() == BKey.BKeyType.LONG) {
-      insertAndGet = new BTreeInsertAndGet<>((Long) element.getBKey().getData(),
-          element.getEFlag(), element.getValue(), isUpsert, attributes);
-    } else {
-      insertAndGet = new BTreeInsertAndGet<>((byte[]) element.getBKey().getData(),
-          element.getEFlag(), element.getValue(), isUpsert, attributes);
-    }
-    return insertAndGet;
-  }
-
-  public ArcusFuture<BTreeElement<T>> bopGet(String key, BKey bKey, BopGetArgs args) {
-    AbstractArcusResult<BTreeElement<T>> result =
-        new AbstractArcusResult<>(new AtomicReference<>());
-    ArcusFutureImpl<BTreeElement<T>> future = new ArcusFutureImpl<>(result);
-    BTreeGet get = createBTreeGet(bKey, args);
-    ArcusClient client = arcusClientSupplier.get();
-
-    CollectionGetOperation.Callback cb = new CollectionGetOperation.Callback() {
-      public void receivedStatus(OperationStatus status) {
-        switch (status.getStatusCode()) {
-          case SUCCESS:
-            break;
-          case ERR_NOT_FOUND:
-            result.set(null);
-            break;
-          case ERR_NOT_FOUND_ELEMENT:
-            result.set(new BTreeElement<>(bKey, null, null));
-            break;
-          case CANCELLED:
-            future.internalCancel();
-            break;
-          default:
-            /*
-             * TYPE_MISMATCH / BKEY_MISMATCH / OUT_OF_RANGE / UNREADABLE / NOT_SUPPORTED
-             * or unknown statement.
-             */
-            result.addError(key, status);
-        }
-      }
-
-      public void complete() {
-        future.complete();
-      }
-
-      public void gotData(String bKey, int flags, byte[] data, byte[] eFlag) {
-        CachedData cachedData = new CachedData(flags, data, tcForCollection.getMaxSize());
-        result.set(new BTreeElement<>(BKey.of(bKey), tcForCollection.decode(cachedData), eFlag));
-      }
-    };
-    Operation op = client.getOpFact().collectionGet(key, get, cb);
-    future.setOp(op);
-    client.addOp(key, op);
-
-    return future;
-  }
-
-  private static BTreeGet createBTreeGet(BKey bKey, BopGetArgs args) {
-    BTreeGet get;
-    if (bKey.getType() == BKey.BKeyType.LONG) {
-      get = new BTreeGet((long) bKey.getData(), args.getElementFlagFilter(),
-          args.isWithDelete(), args.isDropIfEmpty());
-    } else {
-      get = new BTreeGet((byte[]) bKey.getData(), args.getElementFlagFilter(),
-          args.isWithDelete(), args.isDropIfEmpty());
-    }
-    return get;
-  }
-
-  public ArcusFuture<BTreeElements<T>> bopGet(String key, BKey from, BKey to, BopGetArgs args) {
-    verifyBKeyTypesMatch(from, to);
-
-    AbstractArcusResult<BTreeElements<T>> result =
-        new AbstractArcusResult<>(new AtomicReference<>(new BTreeElements<>(new ArrayList<>())));
-    ArcusFutureImpl<BTreeElements<T>> future = new ArcusFutureImpl<>(result);
-    BTreeGet get = createBTreeGet(from, to, args);
-    ArcusClient client = arcusClientSupplier.get();
-
-    CollectionGetOperation.Callback cb = new CollectionGetOperation.Callback() {
-      public void receivedStatus(OperationStatus status) {
-        switch (status.getStatusCode()) {
-          case SUCCESS:
-          case ERR_NOT_FOUND_ELEMENT:
-            break;
-          case TRIMMED:
-            result.get().trimmed();
-            break;
-          case ERR_NOT_FOUND:
-            result.set(null);
-            break;
-          case CANCELLED:
-            future.internalCancel();
-            break;
-          default:
-            /*
-             * TYPE_MISMATCH / BKEY_MISMATCH / OUT_OF_RANGE / UNREADABLE / NOT_SUPPORTED
-             * or unknown statement.
-             */
-            result.addError(key, status);
-        }
-      }
-
-      public void complete() {
-        future.complete();
-      }
-
-      public void gotData(String bKey, int flags, byte[] data, byte[] eFlag) {
-        CachedData cachedData = new CachedData(flags, data, tcForCollection.getMaxSize());
-        result.get().addElement(new BTreeElement<>(
-                BKey.of(bKey), tcForCollection.decode(cachedData), eFlag));
-      }
-    };
-    Operation op = client.getOpFact().collectionGet(key, get, cb);
-    future.setOp(op);
-    client.addOp(key, op);
-
-    return future;
-  }
-
-  private static BTreeGet createBTreeGet(BKey from, BKey to, BopGetArgs args) {
-    BTreeGet get;
-    if (from.getType() == BKey.BKeyType.LONG) {
-      get = new BTreeGet((Long) from.getData(), (Long) to.getData(),
-          args.getElementFlagFilter(), args.getOffset(), args.getCount(),
-          args.isWithDelete(), args.isDropIfEmpty());
-    } else {
-      get = new BTreeGet((byte[]) from.getData(), (byte[]) to.getData(),
-          args.getElementFlagFilter(), args.getOffset(), args.getCount(),
-          args.isWithDelete(), args.isDropIfEmpty());
-    }
-    return get;
-  }
-
-  public ArcusFuture<Map<String, BTreeElements<T>>> bopMultiGet(List<String> keys,
-                                                                BKey from, BKey to,
-                                                                BopGetArgs args) {
-    keyValidator.validateKey(keys);
-    keyValidator.checkDupKey(keys);
-    verifyBKeyTypesMatch(from, to);
-    verifyPositiveCountArg(args, ArcusClient.MAX_GETBULK_ELEMENT_COUNT);
-
-    ArcusClient client = arcusClientSupplier.get();
-    Collection<Map.Entry<MemcachedNode, List<String>>> arrangedKeys =
-        client.groupingKeys(keys, ArcusClient.BOPGET_BULK_CHUNK_SIZE, APIType.BOP_GET);
-
-    Collection<CompletableFuture<?>> futures = new ArrayList<>();
-    Map<CompletableFuture<Map<String, BTreeElements<T>>>, List<String>> futureToKeys =
-        new HashMap<>();
-
-    for (Map.Entry<MemcachedNode, List<String>> entry : arrangedKeys) {
-      BTreeGetBulk<T> getBulk =
-          createBTreeGetBulk(entry.getKey(), entry.getValue(), from, to, args);
-      CompletableFuture<Map<String, BTreeElements<T>>> future =
-          bopMultiGetPerNode(client, getBulk).toCompletableFuture();
-      futureToKeys.put(future, entry.getValue());
-      futures.add(future);
-    }
-
-    /*
-     * Combine all futures. If any future fails exceptionally,
-     * the corresponding keys will have null values in the result map.
-     * If key not found, the corresponding key will not be present in the result map.
-     */
-    return new ArcusMultiFuture<>(futures, () -> {
-      Map<String, BTreeElements<T>> results = new HashMap<>();
-      for (Map.Entry<CompletableFuture<Map<String, BTreeElements<T>>>, List<String>> entry
-              : futureToKeys.entrySet()) {
-        if (entry.getKey().isCompletedExceptionally()) {
-          for (String key : entry.getValue()) {
-            results.put(key, null);
-          }
-        } else {
-          Map<String, BTreeElements<T>> result = entry.getKey().join();
-          if (result != null) {
-            results.putAll(result);
-          }
-        }
-      }
-      return results;
-    });
-  }
-
-  private void verifyPositiveCountArg(BopGetArgs args, int maxCount) {
-    int count = args.getCount();
-    if (count <= 0 || count > maxCount) {
-      throw new IllegalArgumentException("Count should be between 1 to " + maxCount);
-    }
-  }
-
-  /**
-   * Use only in bopMultiGet method.
-   *
-   * @param getBulk get bulk parameters for single node
-   * @return ArcusFuture with results
-   */
-  private ArcusFuture<Map<String, BTreeElements<T>>> bopMultiGetPerNode(ArcusClient client,
-                                                                        BTreeGetBulk<T> getBulk) {
-    AbstractArcusResult<Map<String, BTreeElements<T>>> result =
-        new AbstractArcusResult<>(new AtomicReference<>(new HashMap<>()));
-    ArcusFutureImpl<Map<String, BTreeElements<T>>> future = new ArcusFutureImpl<>(result);
-
-    BTreeGetBulkOperation.Callback cb = new BTreeGetBulkOperation.Callback() {
-      @Override
-      public void receivedStatus(OperationStatus status) {
-        switch (status.getStatusCode()) {
-          case SUCCESS:
-            break;
-          case CANCELLED:
-            future.internalCancel();
-            break;
-          default:
-            /*
-             * NOT_SUPPORTED or unknown statement.
-             */
-            for (String key : getBulk.getKeyList()) {
-              result.addError(key, status);
-            }
-        }
-      }
-
-      @Override
-      public void complete() {
-        future.complete();
-      }
-
-      @Override
-      public void gotKey(String key, int elementCount, OperationStatus status) {
-        switch (status.getStatusCode()) {
-          case SUCCESS:
-            result.get().put(key, new BTreeElements<>(new ArrayList<>()));
-            break;
-          case TRIMMED:
-            BTreeElements<T> elements = new BTreeElements<>(new ArrayList<>());
-            elements.trimmed();
-            result.get().put(key, elements);
-            break;
-          case ERR_NOT_FOUND:
-            break;
-          case ERR_NOT_FOUND_ELEMENT:
-            // Put empty BTreeElements for the BTree item key
-            result.get().put(key, new BTreeElements<>(new ArrayList<>()));
-            break;
-          default:
-            /*
-             * TYPE_MISMATCH / BKEY_MISMATCH / OUT_OF_RANGE / UNREADABLE
-             * or unknown statement.
-             */
-            result.addError(key, status);
-        }
-      }
-
-      @Override
-      public void gotElement(String key, int flags, Object bKey, byte[] eFlag, byte[] data) {
-        CachedData cachedData = new CachedData(flags, data, tcForCollection.getMaxSize());
-        BTreeElements<T> elements = result.get().get(key);
-        elements.addElement(new BTreeElement<>(
-                BKey.of(bKey), tcForCollection.decode(cachedData), eFlag));
-      }
-    };
-    Operation op = client.getOpFact().bopGetBulk(getBulk, cb);
-    future.setOp(op);
-    client.addOp(getBulk.getMemcachedNode(), op);
-
-    return future;
-  }
-
-  private static void verifyBKeyTypesMatch(BKey from, BKey to) {
-    if (from.getType() != to.getType()) {
-      throw new IllegalArgumentException("Two BKey types(from, to) must be the same.");
-    }
-  }
-
-  private BTreeGetBulk<T> createBTreeGetBulk(MemcachedNode node, List<String> keys,
-                                             BKey from, BKey to, BopGetArgs args) {
-    if (from.getType() == BKey.BKeyType.LONG) {
-      return new BTreeGetBulkWithLongTypeBkey<>(node, keys,
-          (Long) from.getData(), (Long) to.getData(), args.getElementFlagFilter(),
-          args.getOffset(), args.getCount());
-    } else {
-      return new BTreeGetBulkWithByteTypeBkey<>(node, keys,
-          (byte[]) from.getData(), (byte[]) to.getData(), args.getElementFlagFilter(),
-          args.getOffset(), args.getCount());
-    }
-  }
-
-  public ArcusFuture<Integer> bopGetPosition(String key, BKey bKey, BTreeOrder order) {
-    AbstractArcusResult<Integer> result = new AbstractArcusResult<>(new AtomicReference<>());
-    ArcusFutureImpl<Integer> future = new ArcusFutureImpl<>(result);
-    BTreeFindPosition findPosition = new BTreeFindPosition(bKey.toString(), order);
-    ArcusClient client = arcusClientSupplier.get();
-
-    BTreeFindPositionOperation.Callback cb = new BTreeFindPositionOperation.Callback() {
-      @Override
-      public void gotData(int position) {
-        result.set(position);
-      }
-
-      @Override
-      public void receivedStatus(OperationStatus status) {
-        switch (status.getStatusCode()) {
-          case SUCCESS:
-            break;
-          case ERR_NOT_FOUND:
-          case ERR_NOT_FOUND_ELEMENT:
-            result.set(null);
-            break;
-          case CANCELLED:
-            future.internalCancel();
-            break;
-          default:
-            /*
-             * TYPE_MISMATCH / BKEY_MISMATCH / UNREADABLE / NOT_SUPPORTED or unknown statement.
-             */
-            result.addError(key, status);
-        }
-      }
-
-      @Override
-      public void complete() {
-        future.complete();
-      }
-    };
-    Operation op = client.getOpFact().bopFindPosition(key, findPosition, cb);
-    future.setOp(op);
-    client.addOp(key, op);
-
-    return future;
-  }
-
-  public ArcusFuture<BTreeElement<T>> bopGetByPosition(String key, int pos, BTreeOrder order) {
-    AbstractArcusResult<BTreeElement<T>> result
-            = new AbstractArcusResult<>(new AtomicReference<>());
-    ArcusFutureImpl<BTreeElement<T>> future = new ArcusFutureImpl<>(result);
-    BTreeGetByPosition getByPosition = new BTreeGetByPosition(order, pos);
-    ArcusClient client = arcusClientSupplier.get();
-
-    BTreeGetByPositionOperation.Callback cb = new BTreeGetByPositionOperation.Callback() {
-      @Override
-      public void gotData(int pos, int flags, BKeyObject bKey, byte[] eFlag, byte[] data) {
-        CachedData cachedData = new CachedData(flags, data, tcForCollection.getMaxSize());
-        result.set(new BTreeElement<>(BKey.of(bKey), tcForCollection.decode(cachedData), eFlag));
-      }
-
-      @Override
-      public void receivedStatus(OperationStatus status) {
-        switch (status.getStatusCode()) {
-          case SUCCESS:
-            break;
-          case ERR_NOT_FOUND:
-          case ERR_NOT_FOUND_ELEMENT:
-            result.set(null);
-            break;
-          case CANCELLED:
-            future.internalCancel();
-            break;
-          default:
-            /*
-             * TYPE_MISMATCH / UNREADABLE / NOT_SUPPORTED or unknown statement.
-             */
-            result.addError(key, status);
-        }
-      }
-
-      @Override
-      public void complete() {
-        future.complete();
-      }
-    };
-    Operation op = client.getOpFact().bopGetByPosition(key, getByPosition, cb);
-    future.setOp(op);
-    client.addOp(key, op);
-
-    return future;
-  }
-
-  public ArcusFuture<List<BTreeElement<T>>> bopGetByPosition(String key,
-                                                             int from, int to,
-                                                             BTreeOrder order) {
-    if (from > to) {
-      throw new IllegalArgumentException("from should be less than or equal to to.");
-    }
-
-    AbstractArcusResult<List<BTreeElement<T>>> result
-            = new AbstractArcusResult<>(new AtomicReference<>(new ArrayList<>()));
-    ArcusFutureImpl<List<BTreeElement<T>>> future = new ArcusFutureImpl<>(result);
-    BTreeGetByPosition getByPosition = new BTreeGetByPosition(order, from, to);
-    ArcusClient client = arcusClientSupplier.get();
-
-    BTreeGetByPositionOperation.Callback cb = new BTreeGetByPositionOperation.Callback() {
-      @Override
-      public void gotData(int pos, int flags, BKeyObject bKey, byte[] eFlag, byte[] data) {
-        CachedData cachedData = new CachedData(flags, data, tcForCollection.getMaxSize());
-        result.get().add(new BTreeElement<>(
-                BKey.of(bKey), tcForCollection.decode(cachedData), eFlag));
-      }
-
-      @Override
-      public void receivedStatus(OperationStatus status) {
-        switch (status.getStatusCode()) {
-          case SUCCESS:
-          case ERR_NOT_FOUND_ELEMENT:
-            break;
-          case ERR_NOT_FOUND:
-            result.set(null);
-            break;
-          case CANCELLED:
-            future.internalCancel();
-            break;
-          default:
-            /*
-             * TYPE_MISMATCH / UNREADABLE / NOT_SUPPORTED or unknown statement.
-             */
-            result.addError(key, status);
-        }
-      }
-
-      @Override
-      public void complete() {
-        future.complete();
-      }
-    };
-    Operation op = client.getOpFact().bopGetByPosition(key, getByPosition, cb);
-    future.setOp(op);
-    client.addOp(key, op);
-
-    return future;
-  }
-
-  public ArcusFuture<List<BTreePositionElement<T>>> bopPositionWithGet(String key,
-                                                                      BKey bKey,
-                                                                      int count,
-                                                                      BTreeOrder order) {
-    AbstractArcusResult<List<BTreePositionElement<T>>> result =
-            new AbstractArcusResult<>(new AtomicReference<>(new ArrayList<>()));
-    ArcusFutureImpl<List<BTreePositionElement<T>>> future = new ArcusFutureImpl<>(result);
-    BTreeFindPositionWithGet findPositionWithGet =
-            new BTreeFindPositionWithGet(bKey.toBKeyObject(), order, count);
-    ArcusClient client = arcusClientSupplier.get();
-
-    BTreeFindPositionWithGetOperation.Callback cb = new BTreeFindPositionWithGetOperation
-            .Callback() {
-
-      @Override
-      public void gotData(int pos, int flags, BKeyObject bKey, byte[] eFlag, byte[] data) {
-        CachedData cachedData = new CachedData(flags, data, tcForCollection.getMaxSize());
-        result.get().add(new BTreePositionElement<>(
-                BKey.of(bKey), tcForCollection.decode(cachedData), eFlag, pos));
-      }
-
-      @Override
-      public void receivedStatus(OperationStatus status) {
-        switch (status.getStatusCode()) {
-          case SUCCESS:
-          case ERR_NOT_FOUND_ELEMENT:
-            break;
-          case ERR_NOT_FOUND:
-            result.set(null);
-            break;
-          case CANCELLED:
-            future.internalCancel();
-            break;
-          default:
-            /*
-             * TYPE_MISMATCH / BKEY_MISMATCH / UNREADABLE / NOT_SUPPORTED or unknown statement.
-             */
-            result.addError(key, status);
-        }
-      }
-
-      @Override
-      public void complete() {
-        future.complete();
-      }
-    };
-    Operation op = client.getOpFact().bopFindPositionWithGet(key, findPositionWithGet, cb);
-    future.setOp(op);
-    client.addOp(key, op);
-
-    return future;
-  }
-
-  public ArcusFuture<SMGetElements<T>> bopSortMergeGet(List<String> keys, BKey from, BKey to,
-                                                       boolean unique, BopGetArgs args) {
-    keyValidator.validateKey(keys);
-    keyValidator.checkDupKey(keys);
-    verifyBKeyTypesMatch(from, to);
-    verifyPositiveCountArg(args, ArcusClient.MAX_SMGET_COUNT);
-
-    ArcusClient client = arcusClientSupplier.get();
-    Collection<Map.Entry<MemcachedNode, List<String>>> arrangedKeys =
-        client.groupingKeys(keys, ArcusClient.SMGET_CHUNK_SIZE, APIType.BOP_SMGET);
-
-    List<CompletableFuture<SMGetElements<T>>> smGetFutures = new ArrayList<>();
-
-    for (Map.Entry<MemcachedNode, List<String>> entry : arrangedKeys) {
-      BTreeSMGet<T> smGet = createBTreeSMGet(from, to, args, unique, entry);
-      CompletableFuture<SMGetElements<T>> future =
-          bopSortMergeGetPerNode(client, smGet).toCompletableFuture();
-      smGetFutures.add(future);
-    }
-
-    /*
-     * Combine all futures and merge results from multiple nodes.
-     */
-    @SuppressWarnings("unchecked")
-    Collection<CompletableFuture<?>> futures =
-        (Collection<CompletableFuture<?>>) (Collection<?>) smGetFutures;
-    return new ArcusMultiFuture<>(futures, () -> {
-      List<SMGetElements<T>> results = new ArrayList<>();
-      for (CompletableFuture<SMGetElements<T>> future : smGetFutures) {
-        if (!future.isCompletedExceptionally()) {
-          results.add(future.join());
-        }
-      }
-      return SMGetElements.mergeSMGetElements(results, from.compareTo(to) <= 0, unique,
-          args.getCount());
-    });
-  }
-
-  /**
-   * Use only in bopSortMergeGet method.
-   *
-   * @param smGet sort-merge get parameters for single node
-   * @return ArcusFuture with results
-   */
-  private ArcusFuture<SMGetElements<T>> bopSortMergeGetPerNode(ArcusClient client,
-                                                               BTreeSMGet<T> smGet) {
-    List<SMGetElements.Element<T>> elementList = new ArrayList<>();
-    List<SMGetElements.MissedKey> missedKeys = new ArrayList<>();
-    List<SMGetElements.TrimmedKey> trimmedKeys = new ArrayList<>();
-    SMGetElements<T> smGetElements = new SMGetElements<>(elementList, missedKeys, trimmedKeys);
-
-    AtomicReference<SMGetElements<T>> atomicReference = new AtomicReference<>(smGetElements);
-    AbstractArcusResult<SMGetElements<T>> result =
-        new AbstractArcusResult<>(atomicReference);
-
-    ArcusFutureImpl<SMGetElements<T>> future = new ArcusFutureImpl<>(result);
-
-    BTreeSortMergeGetOperation.Callback cb = new BTreeSortMergeGetOperation.Callback() {
-      @Override
-      public void receivedStatus(OperationStatus status) {
-        switch (status.getStatusCode()) {
-          case SUCCESS:
-          case TRIMMED:
-          case DUPLICATED:
-          case DUPLICATED_TRIMMED:
-            break;
-          case CANCELLED:
-            future.internalCancel();
-            break;
-          default:
-            /*
-             * TYPE_MISMATCH / BKEY_MISMATCH / OUT_OF_RANGE / NOT_SUPPORTED or unknown statement.
-             */
-            for (String key : smGet.getKeyList()) {
-              result.addError(key, status);
-            }
-        }
-      }
-
-      @Override
-      public void complete() {
-        future.complete();
-      }
-
-      @Override
-      public void gotData(String key, int flags, Object bKey, byte[] eFlag, byte[] data) {
-        CachedData cachedData = new CachedData(flags, data, tcForCollection.getMaxSize());
-        BTreeElement<T> btreeElement = new BTreeElement<>(
-                BKey.of(bKey), tcForCollection.decode(cachedData), eFlag);
-        elementList.add(new SMGetElements.Element<>(key, btreeElement));
-      }
-
-      @Override
-      public void gotMissedKey(String key, OperationStatus cause) {
-        missedKeys.add(new SMGetElements.MissedKey(key, cause.getStatusCode()));
-      }
-
-      @Override
-      public void gotTrimmedKey(String key, Object bKey) {
-        trimmedKeys.add(new SMGetElements.TrimmedKey(key, BKey.of(bKey)));
-      }
-    };
-    Operation op = client.getOpFact().bopsmget(smGet, cb);
-    future.setOp(op);
-    client.addOp(smGet.getMemcachedNode(), op);
-
-    return future;
-  }
-
-  private BTreeSMGet<T> createBTreeSMGet(BKey from, BKey to, BopGetArgs args,
-                                         boolean unique,
-                                         Map.Entry<MemcachedNode, List<String>> entry) {
-
-    if (from.getType() == BKey.BKeyType.LONG) {
-      return new BTreeSMGetWithLongTypeBkey<>(entry.getKey(), entry.getValue(),
-          (Long) from.getData(), (Long) to.getData(), args.getElementFlagFilter(),
-          args.getCount(), unique);
-    } else {
-      return new BTreeSMGetWithByteTypeBkey<>(entry.getKey(), entry.getValue(),
-          (byte[]) from.getData(), (byte[]) to.getData(), args.getElementFlagFilter(),
-          args.getCount(), unique);
-    }
-  }
-
-  public ArcusFuture<Long> bopIncr(String key, BKey bKey, int delta) {
-    CollectionMutate mutate = new BTreeMutate(Mutator.incr, delta);
-    return collectionMutate(key, bKey.toString(), mutate);
-  }
-
-  public ArcusFuture<Long> bopIncr(String key, BKey bKey, int delta, long initial, byte[] eFlag) {
-    CollectionMutate mutate = new BTreeMutate(Mutator.incr, delta, initial, eFlag);
-    return collectionMutate(key, bKey.toString(), mutate);
-  }
-
-  public ArcusFuture<Long> bopDecr(String key, BKey bKey, int delta) {
-    CollectionMutate mutate = new BTreeMutate(Mutator.decr, delta);
-    return collectionMutate(key, bKey.toString(), mutate);
-  }
-
-  public ArcusFuture<Long> bopDecr(String key, BKey bKey, int delta, long initial, byte[] eFlag) {
-    CollectionMutate mutate = new BTreeMutate(Mutator.decr, delta, initial, eFlag);
-    return collectionMutate(key, bKey.toString(), mutate);
-  }
-
-  private ArcusFuture<Long> collectionMutate(String key, String internalKey,
-                                             CollectionMutate mutate) {
-    AbstractArcusResult<Long> result = new AbstractArcusResult<>(new AtomicReference<>());
-    ArcusFutureImpl<Long> future = new ArcusFutureImpl<>(result);
-    ArcusClient client = arcusClientSupplier.get();
-
-    OperationCallback cb = new OperationCallback() {
-      @Override
-      public void receivedStatus(OperationStatus status) {
-        switch (status.getStatusCode()) {
-          case SUCCESS:
-            result.set(Long.parseLong(status.getMessage()));
-            break;
-          case ERR_NOT_FOUND:
-          case ERR_NOT_FOUND_ELEMENT:
-            result.set(null);
-            break;
-          case CANCELLED:
-            future.internalCancel();
-            break;
-          default:
-            /*
-             * TYPE_MISMATCH / BKEY_MISMATCH / OUT_OF_RANGE /
-             * OVERFLOWED / NOT_SUPPORTED or unknown statement.
-             */
-            result.addError(key, status);
-        }
-      }
-
-      @Override
-      public void complete() {
-        future.complete();
-      }
-    };
-    Operation op = client.getOpFact().collectionMutate(key, internalKey, mutate, cb);
-    future.setOp(op);
-    client.addOp(key, op);
-
-    return future;
-  }
-
-  public ArcusFuture<Boolean> bopDelete(String key, BKey bKey, BopDeleteArgs args) {
-    BTreeDelete delete = new BTreeDelete(bKey.toString(),
-            args.getEFlagFilter(), args.isDropIfEmpty(), false);
-    return collectionDelete(key, delete);
-  }
-
-  public ArcusFuture<Boolean> bopDelete(String key, BKey from, BKey to, BopDeleteArgs args) {
-    verifyBKeyTypesMatch(from, to);
-    BTreeDelete delete = new BTreeDelete(from.toString(), to.toString(),
-            args.getCount(), args.getEFlagFilter(), args.isDropIfEmpty(), false);
-    return collectionDelete(key, delete);
-  }
-
-  private ArcusFuture<Boolean> collectionDelete(String key, CollectionDelete delete) {
-    AbstractArcusResult<Boolean> result = new AbstractArcusResult<>(new AtomicReference<>());
-    ArcusFutureImpl<Boolean> future = new ArcusFutureImpl<>(result);
-    ArcusClient client = arcusClientSupplier.get();
-
-    OperationCallback cb = new OperationCallback() {
-      @Override
-      public void receivedStatus(OperationStatus status) {
-        switch (status.getStatusCode()) {
-          case SUCCESS:
-            result.set(true);
-            break;
-          case ERR_NOT_FOUND:
-            result.set(null);
-            break;
-          case ERR_NOT_FOUND_ELEMENT:
-            result.set(false);
-            break;
-          case CANCELLED:
-            future.internalCancel();
-            break;
-          default:
-            /*
-             * TYPE_MISMATCH / BKEY_MISMATCH / NOT_SUPPORTED or unknown statement.
-             */
-            result.addError(key, status);
-        }
-      }
-
-      @Override
-      public void complete() {
-        future.complete();
-      }
-    };
-    Operation op = client.getOpFact().collectionDelete(key, delete, cb);
-    future.setOp(op);
-    client.addOp(key, op);
-
-    return future;
-  }
-
-  public ArcusFuture<Long> bopCount(String key, BKey from, BKey to, ElementFlagFilter eFlagFilter) {
-    verifyBKeyTypesMatch(from, to);
-
-    AbstractArcusResult<Long> result = new AbstractArcusResult<>(new AtomicReference<>());
-    ArcusFutureImpl<Long> future = new ArcusFutureImpl<>(result);
-    CollectionCount collectionCount = new BTreeCount(from.toString(), to.toString(), eFlagFilter);
-    ArcusClient client = arcusClientSupplier.get();
-
-    OperationCallback cb = new OperationCallback() {
-      @Override
-      public void receivedStatus(OperationStatus status) {
-        switch (status.getStatusCode()) {
-          case SUCCESS:
-            long count = Long.parseLong(status.getMessage());
-            result.set(count);
-            break;
-          case ERR_NOT_FOUND:
-            result.set(null);
-            break;
-          case CANCELLED:
-            future.internalCancel();
-            break;
-          default:
-            /*
-             * TYPE_MISMATCH / BKEY_MISMATCH / UNREADABLE / NOT_SUPPORTED or unknown statement.
-             */
-            result.addError(key, status);
-        }
-      }
-
-      @Override
-      public void complete() {
-        future.complete();
-      }
-    };
-    Operation op = client.getOpFact().collectionCount(key, collectionCount, cb);
-    future.setOp(op);
-    client.addOp(key, op);
-
-    return future;
-  }
-
   public ArcusFuture<Boolean> lopCreate(String key, ElementValueType type,
                                         CollectionAttributes attributes) {
     if (attributes == null) {
@@ -1717,8 +697,8 @@ public class AsyncArcusCommands<T> implements AsyncArcusCommandsIF<T> {
     }
 
     ListCreate create = new ListCreate(TranscoderUtils.examineFlags(type),
-            attributes.getExpireTime(), attributes.getMaxCount(),
-            attributes.getOverflowAction(), attributes.getReadable(), false);
+        attributes.getExpireTime(), attributes.getMaxCount(),
+        attributes.getOverflowAction(), attributes.getReadable(), false);
     return collectionCreate(key, create);
   }
 
@@ -1840,8 +820,8 @@ public class AsyncArcusCommands<T> implements AsyncArcusCommandsIF<T> {
     }
 
     SetCreate create = new SetCreate(
-            TranscoderUtils.examineFlags(type), attributes.getExpireTime(),
-            attributes.getMaxCount(), attributes.getReadable(), false);
+        TranscoderUtils.examineFlags(type), attributes.getExpireTime(),
+        attributes.getMaxCount(), attributes.getReadable(), false);
     return collectionCreate(key, create);
   }
 
@@ -1854,52 +834,9 @@ public class AsyncArcusCommands<T> implements AsyncArcusCommandsIF<T> {
     return collectionInsert(key, "", insert);
   }
 
-  public ArcusFuture<Boolean> sopExist(String key, T value) {
-    AbstractArcusResult<Boolean> result = new AbstractArcusResult<>(new AtomicReference<>());
-    ArcusFutureImpl<Boolean> future = new ArcusFutureImpl<>(result);
-    SetExist<T> exist = new SetExist<>(value, tcForCollection);
-    ArcusClient client = arcusClientSupplier.get();
-
-    OperationCallback cb = new OperationCallback() {
-      @Override
-      public void receivedStatus(OperationStatus status) {
-        switch (status.getStatusCode()) {
-          case EXIST:
-            result.set(true);
-            break;
-          case NOT_EXIST:
-            result.set(false);
-            break;
-          case ERR_NOT_FOUND:
-            result.set(null);
-            break;
-          case CANCELLED:
-            future.internalCancel();
-            break;
-          default:
-            /*
-             * TYPE_MISMATCH / UNREADABLE / NOT_SUPPORTED or unknown statement.
-             */
-            result.addError(key, status);
-            break;
-        }
-      }
-
-      @Override
-      public void complete() {
-        future.complete();
-      }
-    };
-    Operation op = client.getOpFact().collectionExist(key, "", exist, cb);
-    future.setOp(op);
-    client.addOp(key, op);
-
-    return future;
-  }
-
   public ArcusFuture<Set<T>> sopGet(String key, int count, GetArgs args) {
     AbstractArcusResult<Set<T>> result
-            = new AbstractArcusResult<>(new AtomicReference<>(new HashSet<>()));
+        = new AbstractArcusResult<>(new AtomicReference<>(new HashSet<>()));
     ArcusFutureImpl<Set<T>> future = new ArcusFutureImpl<>(result);
     SetGet get = new SetGet(count, args.isWithDelete(), args.isDropIfEmpty());
     ArcusClient client = arcusClientSupplier.get();
@@ -1943,6 +880,48 @@ public class AsyncArcusCommands<T> implements AsyncArcusCommandsIF<T> {
     return future;
   }
 
+  public ArcusFuture<Boolean> sopExist(String key, T value) {
+    AbstractArcusResult<Boolean> result = new AbstractArcusResult<>(new AtomicReference<>());
+    ArcusFutureImpl<Boolean> future = new ArcusFutureImpl<>(result);
+    SetExist<T> exist = new SetExist<>(value, tcForCollection);
+    ArcusClient client = arcusClientSupplier.get();
+
+    OperationCallback cb = new OperationCallback() {
+      @Override
+      public void receivedStatus(OperationStatus status) {
+        switch (status.getStatusCode()) {
+          case EXIST:
+            result.set(true);
+            break;
+          case NOT_EXIST:
+            result.set(false);
+            break;
+          case ERR_NOT_FOUND:
+            result.set(null);
+            break;
+          case CANCELLED:
+            future.internalCancel();
+            break;
+          default:
+            /*
+             * TYPE_MISMATCH / UNREADABLE / NOT_SUPPORTED or unknown statement.
+             */
+            result.addError(key, status);
+        }
+      }
+
+      @Override
+      public void complete() {
+        future.complete();
+      }
+    };
+    Operation op = client.getOpFact().collectionExist(key, "", exist, cb);
+    future.setOp(op);
+    client.addOp(key, op);
+
+    return future;
+  }
+
   public ArcusFuture<Boolean> sopDelete(String key, T value, boolean dropIfEmpty) {
     SetDelete<T> delete = new SetDelete<>(value, dropIfEmpty, false, tcForCollection);
     return collectionDelete(key, delete);
@@ -1955,8 +934,8 @@ public class AsyncArcusCommands<T> implements AsyncArcusCommandsIF<T> {
     }
 
     MapCreate create = new MapCreate(TranscoderUtils.examineFlags(type),
-            attributes.getExpireTime(), attributes.getMaxCount(),
-            attributes.getReadable(), false);
+        attributes.getExpireTime(), attributes.getMaxCount(),
+        attributes.getReadable(), false);
     return collectionCreate(key, create);
   }
 
@@ -2053,7 +1032,7 @@ public class AsyncArcusCommands<T> implements AsyncArcusCommandsIF<T> {
     }
 
     AbstractArcusResult<Map<String, T>> result =
-            new AbstractArcusResult<>(new AtomicReference<>(new HashMap<>()));
+        new AbstractArcusResult<>(new AtomicReference<>(new HashMap<>()));
     ArcusFutureImpl<Map<String, T>> future = new ArcusFutureImpl<>(result);
     MapGet get = new MapGet(mKeys, args.isWithDelete(), args.isDropIfEmpty());
     ArcusClient client = arcusClientSupplier.get();
@@ -2118,6 +1097,998 @@ public class AsyncArcusCommands<T> implements AsyncArcusCommandsIF<T> {
     return collectionDelete(key, delete);
   }
 
+  public ArcusFuture<Boolean> bopCreate(String key, ElementValueType type,
+                                        CollectionAttributes attributes) {
+    if (attributes == null) {
+      throw new IllegalArgumentException("CollectionAttributes cannot be null");
+    }
+
+    CollectionCreate create = new BTreeCreate(TranscoderUtils.examineFlags(type),
+        attributes.getExpireTime(), attributes.getMaxCount(),
+        attributes.getOverflowAction(), attributes.getReadable(), false);
+
+    return collectionCreate(key, create);
+  }
+
+  public ArcusFuture<Boolean> bopInsert(String key, BTreeElement<T> element) {
+    return bopInsert(key, element, null);
+  }
+
+  public ArcusFuture<Boolean> bopInsert(String key, BTreeElement<T> element,
+                                        CollectionAttributes attributes) {
+    BTreeInsert<T> insert = new BTreeInsert<>(element.getValue(), element.getEFlag(),
+        null, attributes);
+    return collectionInsert(key, element.getBKey().toString(), insert);
+  }
+
+  public ArcusFuture<Map.Entry<Boolean, BTreeElement<T>>> bopInsertAndGetTrimmed(
+      String key, BTreeElement<T> element) {
+    return bopInsertOrUpsertAndGetTrimmed(key, element, false, null);
+  }
+
+  public ArcusFuture<Map.Entry<Boolean, BTreeElement<T>>> bopInsertAndGetTrimmed(
+      String key, BTreeElement<T> element, CollectionAttributes attributes) {
+    return bopInsertOrUpsertAndGetTrimmed(key, element, false, attributes);
+  }
+
+  @Override
+  public ArcusFuture<Boolean> bopUpsert(String key, BTreeElement<T> element) {
+    return bopUpsert(key, element, null);
+  }
+
+  @Override
+  public ArcusFuture<Boolean> bopUpsert(String key, BTreeElement<T> element,
+                                        CollectionAttributes attributes) {
+    BTreeUpsert<T> upsert = new BTreeUpsert<>(element.getValue(), element.getEFlag(),
+        null, attributes);
+    return collectionInsert(key, element.getBKey().toString(), upsert);
+  }
+
+  public ArcusFuture<Map.Entry<Boolean, BTreeElement<T>>> bopUpsertAndGetTrimmed(
+      String key, BTreeElement<T> element) {
+    return bopInsertOrUpsertAndGetTrimmed(key, element, true, null);
+  }
+
+  public ArcusFuture<Map.Entry<Boolean, BTreeElement<T>>> bopUpsertAndGetTrimmed(
+      String key, BTreeElement<T> element, CollectionAttributes attributes) {
+    return bopInsertOrUpsertAndGetTrimmed(key, element, true, attributes);
+  }
+
+  private ArcusFutureImpl<Map.Entry<Boolean, BTreeElement<T>>> bopInsertOrUpsertAndGetTrimmed(
+      String key, BTreeElement<T> element, boolean isUpsert, CollectionAttributes attributes) {
+    AbstractArcusResult<Map.Entry<Boolean, BTreeElement<T>>> result =
+        new AbstractArcusResult<>(new AtomicReference<>());
+    ArcusFutureImpl<Map.Entry<Boolean, BTreeElement<T>>> future = new ArcusFutureImpl<>(result);
+    BTreeInsertAndGet<T> insertAndGet = createBTreeInsertAndGet(element, isUpsert, attributes);
+    CachedData co = tcForCollection.encode(insertAndGet.getValue());
+    insertAndGet.setFlags(co.getFlags());
+    ArcusClient client = arcusClientSupplier.get();
+
+    BTreeInsertAndGetOperation.Callback cb = new BTreeInsertAndGetOperation.Callback() {
+      private BTreeElement<T> trimmedElement = null;
+
+      public void receivedStatus(OperationStatus status) {
+        switch (status.getStatusCode()) {
+          case SUCCESS:
+          case TRIMMED:
+            result.set(new AbstractMap.SimpleEntry<>(true, trimmedElement));
+            break;
+          case ERR_ELEMENT_EXISTS:
+            result.set(new AbstractMap.SimpleEntry<>(false, trimmedElement));
+            break;
+          case ERR_NOT_FOUND:
+            result.set(null);
+            break;
+          case CANCELLED:
+            future.internalCancel();
+            break;
+          default:
+            /*
+             * TYPE_MISMATCH / BKEY_MISMATCH / OVERFLOWED / OUT_OF_RANGE / NOT_SUPPORTED
+             * or unknown statement.
+             */
+            result.addError(key, status);
+        }
+      }
+
+      public void complete() {
+        future.complete();
+      }
+
+      @Override
+      public void gotData(int flags, BKeyObject bKeyObject, byte[] eFlag, byte[] data) {
+        CachedData cachedData = new CachedData(flags, data, tcForCollection.getMaxSize());
+        trimmedElement = new BTreeElement<>(
+            BKey.of(bKeyObject), tcForCollection.decode(cachedData), eFlag);
+      }
+    };
+    Operation op = client.getOpFact()
+        .bopInsertAndGet(key, insertAndGet, co.getData(), cb);
+    future.setOp(op);
+    client.addOp(key, op);
+
+    return future;
+  }
+
+  private static <T> BTreeInsertAndGet<T> createBTreeInsertAndGet(BTreeElement<T> element,
+                                                                  boolean isUpsert,
+                                                                  CollectionAttributes attributes) {
+    if (element.getBKey().getType() == BKey.BKeyType.LONG) {
+      return new BTreeInsertAndGet<>((long) element.getBKey().getData(),
+          element.getEFlag(), element.getValue(), isUpsert, attributes);
+    }
+
+    return new BTreeInsertAndGet<>((byte[]) element.getBKey().getData(),
+        element.getEFlag(), element.getValue(), isUpsert, attributes);
+  }
+
+  public ArcusFuture<Boolean> bopUpdate(String key, BTreeUpdateElement<T> element) {
+    BTreeUpdate<T> update = new BTreeUpdate<>(element.getValue(), element.getEFlagUpdate(), false);
+    return collectionUpdate(key, element.getBKey().toString(), update);
+  }
+
+  public ArcusFuture<Long> bopIncr(String key, BKey bKey, int delta) {
+    CollectionMutate mutate = new BTreeMutate(Mutator.incr, delta);
+    return collectionMutate(key, bKey.toString(), mutate);
+  }
+
+  public ArcusFuture<Long> bopIncr(String key, BKey bKey, int delta, long initial, byte[] eFlag) {
+    CollectionMutate mutate = new BTreeMutate(Mutator.incr, delta, initial, eFlag);
+    return collectionMutate(key, bKey.toString(), mutate);
+  }
+
+  public ArcusFuture<Long> bopDecr(String key, BKey bKey, int delta) {
+    CollectionMutate mutate = new BTreeMutate(Mutator.decr, delta);
+    return collectionMutate(key, bKey.toString(), mutate);
+  }
+
+  public ArcusFuture<Long> bopDecr(String key, BKey bKey, int delta, long initial, byte[] eFlag) {
+    CollectionMutate mutate = new BTreeMutate(Mutator.decr, delta, initial, eFlag);
+    return collectionMutate(key, bKey.toString(), mutate);
+  }
+
+  public ArcusFuture<BTreeElement<T>> bopGet(String key, BKey bKey, BopGetArgs args) {
+    AbstractArcusResult<BTreeElement<T>> result =
+        new AbstractArcusResult<>(new AtomicReference<>());
+    ArcusFutureImpl<BTreeElement<T>> future = new ArcusFutureImpl<>(result);
+    BTreeGet get = createBTreeGet(bKey, args);
+    ArcusClient client = arcusClientSupplier.get();
+
+    CollectionGetOperation.Callback cb = new CollectionGetOperation.Callback() {
+      public void receivedStatus(OperationStatus status) {
+        switch (status.getStatusCode()) {
+          case SUCCESS:
+            break;
+          case ERR_NOT_FOUND:
+            result.set(null);
+            break;
+          case ERR_NOT_FOUND_ELEMENT:
+            result.set(new BTreeElement<>(bKey, null, null));
+            break;
+          case CANCELLED:
+            future.internalCancel();
+            break;
+          default:
+            /*
+             * TYPE_MISMATCH / BKEY_MISMATCH / OUT_OF_RANGE / UNREADABLE / NOT_SUPPORTED
+             * or unknown statement.
+             */
+            result.addError(key, status);
+        }
+      }
+
+      public void complete() {
+        future.complete();
+      }
+
+      public void gotData(String bKey, int flags, byte[] data, byte[] eFlag) {
+        CachedData cachedData = new CachedData(flags, data, tcForCollection.getMaxSize());
+        result.set(new BTreeElement<>(BKey.of(bKey), tcForCollection.decode(cachedData), eFlag));
+      }
+    };
+    Operation op = client.getOpFact().collectionGet(key, get, cb);
+    future.setOp(op);
+    client.addOp(key, op);
+
+    return future;
+  }
+
+  public ArcusFuture<BTreeElements<T>> bopGet(String key, BKey from, BKey to, BopGetArgs args) {
+    verifyBKeyTypesMatch(from, to);
+
+    AbstractArcusResult<BTreeElements<T>> result =
+        new AbstractArcusResult<>(new AtomicReference<>(new BTreeElements<>(new ArrayList<>())));
+    ArcusFutureImpl<BTreeElements<T>> future = new ArcusFutureImpl<>(result);
+    BTreeGet get = createBTreeGet(from, to, args);
+    ArcusClient client = arcusClientSupplier.get();
+
+    CollectionGetOperation.Callback cb = new CollectionGetOperation.Callback() {
+      public void receivedStatus(OperationStatus status) {
+        switch (status.getStatusCode()) {
+          case SUCCESS:
+          case ERR_NOT_FOUND_ELEMENT:
+            break;
+          case TRIMMED:
+            result.get().trimmed();
+            break;
+          case ERR_NOT_FOUND:
+            result.set(null);
+            break;
+          case CANCELLED:
+            future.internalCancel();
+            break;
+          default:
+            /*
+             * TYPE_MISMATCH / BKEY_MISMATCH / OUT_OF_RANGE / UNREADABLE / NOT_SUPPORTED
+             * or unknown statement.
+             */
+            result.addError(key, status);
+        }
+      }
+
+      public void complete() {
+        future.complete();
+      }
+
+      public void gotData(String bKey, int flags, byte[] data, byte[] eFlag) {
+        CachedData cachedData = new CachedData(flags, data, tcForCollection.getMaxSize());
+        result.get().addElement(new BTreeElement<>(
+            BKey.of(bKey), tcForCollection.decode(cachedData), eFlag));
+      }
+    };
+    Operation op = client.getOpFact().collectionGet(key, get, cb);
+    future.setOp(op);
+    client.addOp(key, op);
+
+    return future;
+  }
+
+  private static BTreeGet createBTreeGet(BKey bKey, BopGetArgs args) {
+    if (bKey.getType() == BKey.BKeyType.LONG) {
+      return new BTreeGet((long) bKey.getData(), args.getElementFlagFilter(),
+          args.isWithDelete(), args.isDropIfEmpty());
+    }
+
+    return new BTreeGet((byte[]) bKey.getData(), args.getElementFlagFilter(),
+        args.isWithDelete(), args.isDropIfEmpty());
+  }
+
+  private static BTreeGet createBTreeGet(BKey from, BKey to, BopGetArgs args) {
+    if (from.getType() == BKey.BKeyType.LONG) {
+      return new BTreeGet((long) from.getData(), (long) to.getData(),
+          args.getElementFlagFilter(), args.getOffset(), args.getCount(),
+          args.isWithDelete(), args.isDropIfEmpty());
+    }
+
+    return new BTreeGet((byte[]) from.getData(), (byte[]) to.getData(),
+        args.getElementFlagFilter(), args.getOffset(), args.getCount(),
+        args.isWithDelete(), args.isDropIfEmpty());
+  }
+
+  public ArcusFuture<Map<String, BTreeElements<T>>> bopMultiGet(List<String> keys,
+                                                                BKey from, BKey to,
+                                                                BopGetArgs args) {
+    keyValidator.validateKey(keys);
+    keyValidator.checkDupKey(keys);
+    verifyBKeyTypesMatch(from, to);
+    verifyPositiveCountArg(args, ArcusClient.MAX_GETBULK_ELEMENT_COUNT);
+
+    ArcusClient client = arcusClientSupplier.get();
+    Collection<Map.Entry<MemcachedNode, List<String>>> arrangedKeys =
+        client.groupingKeys(keys, ArcusClient.BOPGET_BULK_CHUNK_SIZE, APIType.BOP_GET);
+
+    Collection<CompletableFuture<?>> futures = new ArrayList<>();
+    Map<CompletableFuture<Map<String, BTreeElements<T>>>, List<String>> futureToKeys =
+        new HashMap<>();
+
+    for (Map.Entry<MemcachedNode, List<String>> entry : arrangedKeys) {
+      BTreeGetBulk<T> getBulk =
+          createBTreeGetBulk(entry.getKey(), entry.getValue(), from, to, args);
+      CompletableFuture<Map<String, BTreeElements<T>>> future =
+          bopMultiGetPerNode(client, getBulk).toCompletableFuture();
+      futureToKeys.put(future, entry.getValue());
+      futures.add(future);
+    }
+
+    return new ArcusMultiFuture<>(futures, () -> {
+      Map<String, BTreeElements<T>> results = new HashMap<>();
+      for (Map.Entry<CompletableFuture<Map<String, BTreeElements<T>>>, List<String>> entry
+          : futureToKeys.entrySet()) {
+        if (entry.getKey().isCompletedExceptionally()) {
+          for (String key : entry.getValue()) {
+            results.put(key, null);
+          }
+        } else {
+          Map<String, BTreeElements<T>> result = entry.getKey().join();
+          if (result != null) {
+            results.putAll(result);
+          }
+        }
+      }
+      return results;
+    });
+  }
+
+  private ArcusFuture<Map<String, BTreeElements<T>>> bopMultiGetPerNode(ArcusClient client,
+                                                                        BTreeGetBulk<T> getBulk) {
+    AbstractArcusResult<Map<String, BTreeElements<T>>> result =
+        new AbstractArcusResult<>(new AtomicReference<>(new HashMap<>()));
+    ArcusFutureImpl<Map<String, BTreeElements<T>>> future = new ArcusFutureImpl<>(result);
+
+    BTreeGetBulkOperation.Callback cb = new BTreeGetBulkOperation.Callback() {
+      @Override
+      public void receivedStatus(OperationStatus status) {
+        switch (status.getStatusCode()) {
+          case SUCCESS:
+            break;
+          case CANCELLED:
+            future.internalCancel();
+            break;
+          default:
+            /*
+             * NOT_SUPPORTED or unknown statement.
+             */
+            for (String key : getBulk.getKeyList()) {
+              result.addError(key, status);
+            }
+        }
+      }
+
+      @Override
+      public void complete() {
+        future.complete();
+      }
+
+      @Override
+      public void gotKey(String key, int elementCount, OperationStatus status) {
+        switch (status.getStatusCode()) {
+          case SUCCESS:
+            result.get().put(key, new BTreeElements<>(new ArrayList<>()));
+            break;
+          case TRIMMED:
+            BTreeElements<T> elements = new BTreeElements<>(new ArrayList<>());
+            elements.trimmed();
+            result.get().put(key, elements);
+            break;
+          case ERR_NOT_FOUND:
+            break;
+          case ERR_NOT_FOUND_ELEMENT:
+            // Put empty BTreeElements for the BTree item key
+            result.get().put(key, new BTreeElements<>(new ArrayList<>()));
+            break;
+          default:
+            /*
+             * TYPE_MISMATCH / BKEY_MISMATCH / OUT_OF_RANGE / UNREADABLE
+             * or unknown statement.
+             */
+            result.addError(key, status);
+        }
+      }
+
+      @Override
+      public void gotElement(String key, int flags, Object bKey, byte[] eFlag, byte[] data) {
+        CachedData cachedData = new CachedData(flags, data, tcForCollection.getMaxSize());
+        BTreeElements<T> elements = result.get().get(key);
+        elements.addElement(new BTreeElement<>(
+            BKey.of(bKey), tcForCollection.decode(cachedData), eFlag));
+      }
+    };
+    Operation op = client.getOpFact().bopGetBulk(getBulk, cb);
+    future.setOp(op);
+    client.addOp(getBulk.getMemcachedNode(), op);
+
+    return future;
+  }
+
+  private BTreeGetBulk<T> createBTreeGetBulk(MemcachedNode node, List<String> keys,
+                                             BKey from, BKey to, BopGetArgs args) {
+    if (from.getType() == BKey.BKeyType.LONG) {
+      return new BTreeGetBulkWithLongTypeBkey<>(node, keys,
+          (long) from.getData(), (long) to.getData(), args.getElementFlagFilter(),
+          args.getOffset(), args.getCount());
+    }
+
+    return new BTreeGetBulkWithByteTypeBkey<>(node, keys,
+        (byte[]) from.getData(), (byte[]) to.getData(), args.getElementFlagFilter(),
+        args.getOffset(), args.getCount());
+  }
+
+  public ArcusFuture<SMGetElements<T>> bopSortMergeGet(List<String> keys, BKey from, BKey to,
+                                                       boolean unique, BopGetArgs args) {
+    keyValidator.validateKey(keys);
+    keyValidator.checkDupKey(keys);
+    verifyBKeyTypesMatch(from, to);
+    verifyPositiveCountArg(args, ArcusClient.MAX_SMGET_COUNT);
+
+    ArcusClient client = arcusClientSupplier.get();
+    Collection<Map.Entry<MemcachedNode, List<String>>> arrangedKeys =
+        client.groupingKeys(keys, ArcusClient.SMGET_CHUNK_SIZE, APIType.BOP_SMGET);
+
+    List<CompletableFuture<SMGetElements<T>>> smGetFutures = new ArrayList<>();
+
+    for (Map.Entry<MemcachedNode, List<String>> entry : arrangedKeys) {
+      BTreeSMGet<T> smGet = createBTreeSMGet(from, to, args, unique, entry);
+      CompletableFuture<SMGetElements<T>> future =
+          bopSortMergeGetPerNode(client, smGet).toCompletableFuture();
+      smGetFutures.add(future);
+    }
+
+    @SuppressWarnings("unchecked")
+    Collection<CompletableFuture<?>> futures =
+        (Collection<CompletableFuture<?>>) (Collection<?>) smGetFutures;
+    return new ArcusMultiFuture<>(futures, () -> {
+      List<SMGetElements<T>> results = new ArrayList<>();
+      for (CompletableFuture<SMGetElements<T>> future : smGetFutures) {
+        if (!future.isCompletedExceptionally()) {
+          results.add(future.join());
+        }
+      }
+      return SMGetElements.mergeSMGetElements(results, from.compareTo(to) <= 0, unique,
+          args.getCount());
+    });
+  }
+
+  private ArcusFuture<SMGetElements<T>> bopSortMergeGetPerNode(ArcusClient client,
+                                                               BTreeSMGet<T> smGet) {
+    List<SMGetElements.Element<T>> elementList = new ArrayList<>();
+    List<SMGetElements.MissedKey> missedKeys = new ArrayList<>();
+    List<SMGetElements.TrimmedKey> trimmedKeys = new ArrayList<>();
+    SMGetElements<T> smGetElements = new SMGetElements<>(elementList, missedKeys, trimmedKeys);
+
+    AtomicReference<SMGetElements<T>> atomicReference = new AtomicReference<>(smGetElements);
+    AbstractArcusResult<SMGetElements<T>> result =
+        new AbstractArcusResult<>(atomicReference);
+
+    ArcusFutureImpl<SMGetElements<T>> future = new ArcusFutureImpl<>(result);
+
+    BTreeSortMergeGetOperation.Callback cb = new BTreeSortMergeGetOperation.Callback() {
+      @Override
+      public void receivedStatus(OperationStatus status) {
+        switch (status.getStatusCode()) {
+          case SUCCESS:
+          case TRIMMED:
+          case DUPLICATED:
+          case DUPLICATED_TRIMMED:
+            break;
+          case CANCELLED:
+            future.internalCancel();
+            break;
+          default:
+            /*
+             * TYPE_MISMATCH / BKEY_MISMATCH / OUT_OF_RANGE / NOT_SUPPORTED or unknown statement.
+             */
+            for (String key : smGet.getKeyList()) {
+              result.addError(key, status);
+            }
+        }
+      }
+
+      @Override
+      public void complete() {
+        future.complete();
+      }
+
+      @Override
+      public void gotData(String key, int flags, Object bKey, byte[] eFlag, byte[] data) {
+        CachedData cachedData = new CachedData(flags, data, tcForCollection.getMaxSize());
+        BTreeElement<T> btreeElement = new BTreeElement<>(
+            BKey.of(bKey), tcForCollection.decode(cachedData), eFlag);
+        elementList.add(new SMGetElements.Element<>(key, btreeElement));
+      }
+
+      @Override
+      public void gotMissedKey(String key, OperationStatus cause) {
+        missedKeys.add(new SMGetElements.MissedKey(key, cause.getStatusCode()));
+      }
+
+      @Override
+      public void gotTrimmedKey(String key, Object bKey) {
+        trimmedKeys.add(new SMGetElements.TrimmedKey(key, BKey.of(bKey)));
+      }
+    };
+    Operation op = client.getOpFact().bopsmget(smGet, cb);
+    future.setOp(op);
+    client.addOp(smGet.getMemcachedNode(), op);
+
+    return future;
+  }
+
+  private BTreeSMGet<T> createBTreeSMGet(BKey from, BKey to, BopGetArgs args,
+                                         boolean unique,
+                                         Map.Entry<MemcachedNode, List<String>> entry) {
+    if (from.getType() == BKey.BKeyType.LONG) {
+      return new BTreeSMGetWithLongTypeBkey<>(entry.getKey(), entry.getValue(),
+          (long) from.getData(), (long) to.getData(), args.getElementFlagFilter(),
+          args.getCount(), unique);
+    }
+
+    return new BTreeSMGetWithByteTypeBkey<>(entry.getKey(), entry.getValue(),
+        (byte[]) from.getData(), (byte[]) to.getData(), args.getElementFlagFilter(),
+        args.getCount(), unique);
+  }
+
+  public ArcusFuture<Integer> bopGetPosition(String key, BKey bKey, BTreeOrder order) {
+    AbstractArcusResult<Integer> result = new AbstractArcusResult<>(new AtomicReference<>());
+    ArcusFutureImpl<Integer> future = new ArcusFutureImpl<>(result);
+    BTreeFindPosition findPosition = new BTreeFindPosition(bKey.toString(), order);
+    ArcusClient client = arcusClientSupplier.get();
+
+    BTreeFindPositionOperation.Callback cb = new BTreeFindPositionOperation.Callback() {
+      @Override
+      public void gotData(int position) {
+        result.set(position);
+      }
+
+      @Override
+      public void receivedStatus(OperationStatus status) {
+        switch (status.getStatusCode()) {
+          case SUCCESS:
+            break;
+          case ERR_NOT_FOUND:
+          case ERR_NOT_FOUND_ELEMENT:
+            result.set(null);
+            break;
+          case CANCELLED:
+            future.internalCancel();
+            break;
+          default:
+            /*
+             * TYPE_MISMATCH / BKEY_MISMATCH / UNREADABLE / NOT_SUPPORTED or unknown statement.
+             */
+            result.addError(key, status);
+        }
+      }
+
+      @Override
+      public void complete() {
+        future.complete();
+      }
+    };
+    Operation op = client.getOpFact().bopFindPosition(key, findPosition, cb);
+    future.setOp(op);
+    client.addOp(key, op);
+
+    return future;
+  }
+
+  public ArcusFuture<BTreeElement<T>> bopGetByPosition(String key, int pos, BTreeOrder order) {
+    AbstractArcusResult<BTreeElement<T>> result
+        = new AbstractArcusResult<>(new AtomicReference<>());
+    ArcusFutureImpl<BTreeElement<T>> future = new ArcusFutureImpl<>(result);
+    BTreeGetByPosition getByPosition = new BTreeGetByPosition(order, pos);
+    ArcusClient client = arcusClientSupplier.get();
+
+    BTreeGetByPositionOperation.Callback cb = new BTreeGetByPositionOperation.Callback() {
+      @Override
+      public void gotData(int pos, int flags, BKeyObject bKey, byte[] eFlag, byte[] data) {
+        CachedData cachedData = new CachedData(flags, data, tcForCollection.getMaxSize());
+        result.set(new BTreeElement<>(BKey.of(bKey), tcForCollection.decode(cachedData), eFlag));
+      }
+
+      @Override
+      public void receivedStatus(OperationStatus status) {
+        switch (status.getStatusCode()) {
+          case SUCCESS:
+            break;
+          case ERR_NOT_FOUND:
+          case ERR_NOT_FOUND_ELEMENT:
+            result.set(null);
+            break;
+          case CANCELLED:
+            future.internalCancel();
+            break;
+          default:
+            /*
+             * TYPE_MISMATCH / UNREADABLE / NOT_SUPPORTED or unknown statement.
+             */
+            result.addError(key, status);
+        }
+      }
+
+      @Override
+      public void complete() {
+        future.complete();
+      }
+    };
+    Operation op = client.getOpFact().bopGetByPosition(key, getByPosition, cb);
+    future.setOp(op);
+    client.addOp(key, op);
+
+    return future;
+  }
+
+  public ArcusFuture<List<BTreeElement<T>>> bopGetByPosition(String key,
+                                                             int from, int to,
+                                                             BTreeOrder order) {
+    if (from > to) {
+      throw new IllegalArgumentException("from should be less than or equal to to.");
+    }
+
+    AbstractArcusResult<List<BTreeElement<T>>> result
+        = new AbstractArcusResult<>(new AtomicReference<>(new ArrayList<>()));
+    ArcusFutureImpl<List<BTreeElement<T>>> future = new ArcusFutureImpl<>(result);
+    BTreeGetByPosition getByPosition = new BTreeGetByPosition(order, from, to);
+    ArcusClient client = arcusClientSupplier.get();
+
+    BTreeGetByPositionOperation.Callback cb = new BTreeGetByPositionOperation.Callback() {
+      @Override
+      public void gotData(int pos, int flags, BKeyObject bKey, byte[] eFlag, byte[] data) {
+        CachedData cachedData = new CachedData(flags, data, tcForCollection.getMaxSize());
+        result.get().add(new BTreeElement<>(
+            BKey.of(bKey), tcForCollection.decode(cachedData), eFlag));
+      }
+
+      @Override
+      public void receivedStatus(OperationStatus status) {
+        switch (status.getStatusCode()) {
+          case SUCCESS:
+          case ERR_NOT_FOUND_ELEMENT:
+            break;
+          case ERR_NOT_FOUND:
+            result.set(null);
+            break;
+          case CANCELLED:
+            future.internalCancel();
+            break;
+          default:
+            /*
+             * TYPE_MISMATCH / UNREADABLE / NOT_SUPPORTED or unknown statement.
+             */
+            result.addError(key, status);
+        }
+      }
+
+      @Override
+      public void complete() {
+        future.complete();
+      }
+    };
+    Operation op = client.getOpFact().bopGetByPosition(key, getByPosition, cb);
+    future.setOp(op);
+    client.addOp(key, op);
+
+    return future;
+  }
+
+  public ArcusFuture<List<BTreePositionElement<T>>> bopPositionWithGet(String key,
+                                                                       BKey bKey,
+                                                                       int count,
+                                                                       BTreeOrder order) {
+    AbstractArcusResult<List<BTreePositionElement<T>>> result =
+        new AbstractArcusResult<>(new AtomicReference<>(new ArrayList<>()));
+    ArcusFutureImpl<List<BTreePositionElement<T>>> future = new ArcusFutureImpl<>(result);
+    BTreeFindPositionWithGet findPositionWithGet =
+        new BTreeFindPositionWithGet(bKey.toBKeyObject(), order, count);
+    ArcusClient client = arcusClientSupplier.get();
+
+    BTreeFindPositionWithGetOperation.Callback cb = new BTreeFindPositionWithGetOperation
+        .Callback() {
+      @Override
+      public void gotData(int pos, int flags, BKeyObject bKey, byte[] eFlag, byte[] data) {
+        CachedData cachedData = new CachedData(flags, data, tcForCollection.getMaxSize());
+        result.get().add(new BTreePositionElement<>(
+            BKey.of(bKey), tcForCollection.decode(cachedData), eFlag, pos));
+      }
+
+      @Override
+      public void receivedStatus(OperationStatus status) {
+        switch (status.getStatusCode()) {
+          case SUCCESS:
+          case ERR_NOT_FOUND_ELEMENT:
+            break;
+          case ERR_NOT_FOUND:
+            result.set(null);
+            break;
+          case CANCELLED:
+            future.internalCancel();
+            break;
+          default:
+            /*
+             * TYPE_MISMATCH / BKEY_MISMATCH / UNREADABLE / NOT_SUPPORTED or unknown statement.
+             */
+            result.addError(key, status);
+        }
+      }
+
+      @Override
+      public void complete() {
+        future.complete();
+      }
+    };
+    Operation op = client.getOpFact().bopFindPositionWithGet(key, findPositionWithGet, cb);
+    future.setOp(op);
+    client.addOp(key, op);
+
+    return future;
+  }
+
+  public ArcusFuture<Long> bopCount(String key, BKey from, BKey to, ElementFlagFilter eFlagFilter) {
+    verifyBKeyTypesMatch(from, to);
+
+    AbstractArcusResult<Long> result = new AbstractArcusResult<>(new AtomicReference<>());
+    ArcusFutureImpl<Long> future = new ArcusFutureImpl<>(result);
+    CollectionCount collectionCount = new BTreeCount(from.toString(), to.toString(), eFlagFilter);
+    ArcusClient client = arcusClientSupplier.get();
+
+    OperationCallback cb = new OperationCallback() {
+      @Override
+      public void receivedStatus(OperationStatus status) {
+        switch (status.getStatusCode()) {
+          case SUCCESS:
+            long count = Long.parseLong(status.getMessage());
+            result.set(count);
+            break;
+          case ERR_NOT_FOUND:
+            result.set(null);
+            break;
+          case CANCELLED:
+            future.internalCancel();
+            break;
+          default:
+            /*
+             * TYPE_MISMATCH / BKEY_MISMATCH / UNREADABLE / NOT_SUPPORTED or unknown statement.
+             */
+            result.addError(key, status);
+        }
+      }
+
+      @Override
+      public void complete() {
+        future.complete();
+      }
+    };
+    Operation op = client.getOpFact().collectionCount(key, collectionCount, cb);
+    future.setOp(op);
+    client.addOp(key, op);
+
+    return future;
+  }
+
+  public ArcusFuture<Boolean> bopDelete(String key, BKey bKey, BopDeleteArgs args) {
+    BTreeDelete delete = new BTreeDelete(bKey.toString(),
+        args.getEFlagFilter(), args.isDropIfEmpty(), false);
+    return collectionDelete(key, delete);
+  }
+
+  public ArcusFuture<Boolean> bopDelete(String key, BKey from, BKey to, BopDeleteArgs args) {
+    verifyBKeyTypesMatch(from, to);
+    BTreeDelete delete = new BTreeDelete(from.toString(), to.toString(),
+        args.getCount(), args.getEFlagFilter(), args.isDropIfEmpty(), false);
+    return collectionDelete(key, delete);
+  }
+
+  private static void verifyBKeyTypesMatch(BKey from, BKey to) {
+    if (from.getType() != to.getType()) {
+      throw new IllegalArgumentException("Two BKey types(from, to) must be the same.");
+    }
+  }
+
+  private static void verifyPositiveCountArg(BopGetArgs args, int maxCount) {
+    int count = args.getCount();
+    if (count <= 0 || count > maxCount) {
+      throw new IllegalArgumentException("Count should be between 1 to " + maxCount);
+    }
+  }
+
+  private ArcusFuture<Boolean> collectionCreate(String key, CollectionCreate collectionCreate) {
+    AbstractArcusResult<Boolean> result = new AbstractArcusResult<>(new AtomicReference<>());
+    ArcusFutureImpl<Boolean> future = new ArcusFutureImpl<>(result);
+    ArcusClient client = arcusClientSupplier.get();
+
+    OperationCallback cb = new OperationCallback() {
+      @Override
+      public void receivedStatus(OperationStatus status) {
+        switch (status.getStatusCode()) {
+          case SUCCESS:
+            result.set(true);
+            break;
+          case ERR_EXISTS:
+            result.set(false);
+            break;
+          case CANCELLED:
+            future.internalCancel();
+            break;
+          default:
+            /*
+             * NOT_SUPPORTED or unknown statement.
+             */
+            result.addError(key, status);
+        }
+      }
+
+      @Override
+      public void complete() {
+        future.complete();
+      }
+    };
+    CollectionCreateOperation op = client.getOpFact()
+        .collectionCreate(key, collectionCreate, cb);
+    future.setOp(op);
+    client.addOp(key, op);
+
+    return future;
+  }
+
+  private ArcusFuture<Boolean> collectionInsert(String key,
+                                                String internalKey,
+                                                CollectionInsert<T> collectionInsert) {
+    AbstractArcusResult<Boolean> result = new AbstractArcusResult<>(new AtomicReference<>());
+    ArcusFutureImpl<Boolean> future = new ArcusFutureImpl<>(result);
+    CachedData co = tcForCollection.encode(collectionInsert.getValue());
+    collectionInsert.setFlags(co.getFlags());
+    ArcusClient client = arcusClientSupplier.get();
+
+    OperationCallback cb = new OperationCallback() {
+      @Override
+      public void receivedStatus(OperationStatus status) {
+        switch (status.getStatusCode()) {
+          case SUCCESS:
+            result.set(true);
+            break;
+          case ERR_ELEMENT_EXISTS:
+            result.set(false);
+            break;
+          case ERR_NOT_FOUND:
+            result.set(null);
+            break;
+          case CANCELLED:
+            future.internalCancel();
+            break;
+          default:
+            /*
+             * TYPE_MISMATCH / BKEY_MISMATCH / OVERFLOWED / OUT_OF_RANGE / NOT_SUPPORTED
+             * or unknown statement.
+             */
+            result.addError(key, status);
+        }
+      }
+
+      @Override
+      public void complete() {
+        future.complete();
+      }
+    };
+    CollectionInsertOperation op = client.getOpFact()
+        .collectionInsert(key, internalKey, collectionInsert, co.getData(), cb);
+    future.setOp(op);
+    client.addOp(key, op);
+
+    return future;
+  }
+
+  private ArcusFuture<Boolean> collectionUpdate(String key,
+                                                String internalKey,
+                                                CollectionUpdate<T> collectionUpdate) {
+    AbstractArcusResult<Boolean> result = new AbstractArcusResult<>(new AtomicReference<>());
+    ArcusFutureImpl<Boolean> future = new ArcusFutureImpl<>(result);
+    CachedData co = null;
+    if (collectionUpdate.getNewValue() != null) {
+      co = tcForCollection.encode(collectionUpdate.getNewValue());
+      collectionUpdate.setFlags(co.getFlags());
+    }
+    ArcusClient client = arcusClientSupplier.get();
+
+    OperationCallback cb = new OperationCallback() {
+      @Override
+      public void receivedStatus(OperationStatus status) {
+        switch (status.getStatusCode()) {
+          case SUCCESS:
+            result.set(true);
+            break;
+          case ERR_NOT_FOUND_ELEMENT:
+            result.set(false);
+            break;
+          case ERR_NOT_FOUND:
+            result.set(null);
+            break;
+          case CANCELLED:
+            future.internalCancel();
+            break;
+          default:
+            /*
+             * TYPE_MISMATCH / BKEY_MISMATCH / EFLAG_MISMATCH / NOTHING_TO_UPDATE /
+             * OVERFLOWED / OUT_OF_RANGE / NOT_SUPPORTED or unknown statement.
+             */
+            result.addError(key, status);
+        }
+      }
+
+      @Override
+      public void complete() {
+        future.complete();
+      }
+    };
+    Operation op = client.getOpFact()
+        .collectionUpdate(key, internalKey, collectionUpdate,
+            (co == null) ? null : co.getData(), cb);
+    future.setOp(op);
+    client.addOp(key, op);
+
+    return future;
+  }
+
+  private ArcusFuture<Long> collectionMutate(String key, String internalKey,
+                                             CollectionMutate mutate) {
+    AbstractArcusResult<Long> result = new AbstractArcusResult<>(new AtomicReference<>());
+    ArcusFutureImpl<Long> future = new ArcusFutureImpl<>(result);
+    ArcusClient client = arcusClientSupplier.get();
+
+    OperationCallback cb = new OperationCallback() {
+      @Override
+      public void receivedStatus(OperationStatus status) {
+        switch (status.getStatusCode()) {
+          case SUCCESS:
+            result.set(Long.parseLong(status.getMessage()));
+            break;
+          case ERR_NOT_FOUND:
+          case ERR_NOT_FOUND_ELEMENT:
+            result.set(null);
+            break;
+          case CANCELLED:
+            future.internalCancel();
+            break;
+          default:
+            /*
+             * TYPE_MISMATCH / BKEY_MISMATCH / OUT_OF_RANGE /
+             * OVERFLOWED / NOT_SUPPORTED or unknown statement.
+             */
+            result.addError(key, status);
+        }
+      }
+
+      @Override
+      public void complete() {
+        future.complete();
+      }
+    };
+    Operation op = client.getOpFact().collectionMutate(key, internalKey, mutate, cb);
+    future.setOp(op);
+    client.addOp(key, op);
+
+    return future;
+  }
+
+  private ArcusFuture<Boolean> collectionDelete(String key, CollectionDelete delete) {
+    AbstractArcusResult<Boolean> result = new AbstractArcusResult<>(new AtomicReference<>());
+    ArcusFutureImpl<Boolean> future = new ArcusFutureImpl<>(result);
+    ArcusClient client = arcusClientSupplier.get();
+
+    OperationCallback cb = new OperationCallback() {
+      @Override
+      public void receivedStatus(OperationStatus status) {
+        switch (status.getStatusCode()) {
+          case SUCCESS:
+            result.set(true);
+            break;
+          case ERR_NOT_FOUND:
+            result.set(null);
+            break;
+          case ERR_NOT_FOUND_ELEMENT:
+            result.set(false);
+            break;
+          case CANCELLED:
+            future.internalCancel();
+            break;
+          default:
+            /*
+             * TYPE_MISMATCH / BKEY_MISMATCH / NOT_SUPPORTED or unknown statement.
+             */
+            result.addError(key, status);
+        }
+      }
+
+      @Override
+      public void complete() {
+        future.complete();
+      }
+    };
+    Operation op = client.getOpFact().collectionDelete(key, delete, cb);
+    future.setOp(op);
+    client.addOp(key, op);
+
+    return future;
+  }
+
   public ArcusFuture<Boolean> flush() {
     return flush(-1);
   }
@@ -2146,7 +2117,6 @@ public class AsyncArcusCommands<T> implements AsyncArcusCommandsIF<T> {
               break;
             default:
               result.addError(node.getSocketAddress().toString(), status);
-              break;
           }
         }
 
@@ -2201,7 +2171,6 @@ public class AsyncArcusCommands<T> implements AsyncArcusCommandsIF<T> {
               break;
             default:
               result.addError(node.getSocketAddress().toString(), status);
-              break;
           }
         }
 
@@ -2212,7 +2181,7 @@ public class AsyncArcusCommands<T> implements AsyncArcusCommandsIF<T> {
       };
 
       Operation op = client.getOpFact()
-              .flush(prefix.isEmpty() ? "<null>" : prefix, delay, false, cb);
+          .flush(prefix.isEmpty() ? "<null>" : prefix, delay, false, cb);
       future.setOp(op);
       client.addOp(node, op);
       futures.add(future);
@@ -2241,7 +2210,7 @@ public class AsyncArcusCommands<T> implements AsyncArcusCommandsIF<T> {
     for (MemcachedNode node : nodes) {
       SocketAddress address = node.getSocketAddress();
       AbstractArcusResult<Map<String, String>> result
-              = new AbstractArcusResult<>(new AtomicReference<>(new HashMap<>()));
+          = new AbstractArcusResult<>(new AtomicReference<>(new HashMap<>()));
       ArcusFutureImpl<Map<String, String>> future = new ArcusFutureImpl<>(result);
 
       StatsOperation.Callback cb = new StatsOperation.Callback() {

--- a/src/main/java/net/spy/memcached/v2/AsyncArcusCommandsIF.java
+++ b/src/main/java/net/spy/memcached/v2/AsyncArcusCommandsIF.java
@@ -69,37 +69,6 @@ public interface AsyncArcusCommandsIF<T> {
    */
   ArcusFuture<Boolean> replace(String key, int exp, T value);
 
-
-  /**
-   * Perform a compare-and-set operation for the given key.
-   *
-   * @param key   the key to set
-   * @param exp   expiration time in seconds
-   * @param value the new value to set if the CAS ID matches
-   * @param casId the CAS ID obtained from {@link #gets(String)}
-   * @return {@code true} if compared and set successfully,
-   * {@code false} if the key does not exist or CAS ID does not match
-   */
-  ArcusFuture<Boolean> cas(String key, int exp, T value, long casId);
-
-  /**
-   * Append String or byte[] to an existing same type of value.
-   *
-   * @param key   the key
-   * @param value the value to append
-   * @return {@code true} if appended, otherwise {@code false}
-   */
-  ArcusFuture<Boolean> append(String key, T value);
-
-  /**
-   * Prepend String or byte[] to an existing same type of value.
-   *
-   * @param key   the key
-   * @param value the value to prepend
-   * @return {@code true} if prepended, otherwise {@code false}
-   */
-  ArcusFuture<Boolean> prepend(String key, T value);
-
   /**
    * Sets multiple key-value pairs.
    *
@@ -128,28 +97,34 @@ public interface AsyncArcusCommandsIF<T> {
   ArcusFuture<Map<String, Boolean>> multiReplace(Map<String, T> items, int exp);
 
   /**
-   * Get a value for the given key.
+   * Prepend String or byte[] to an existing same type of value.
    *
-   * @param key the key
-   * @return the value, or {@code null} if not found
+   * @param key   the key
+   * @param value the value to prepend
+   * @return {@code true} if prepended, otherwise {@code false}
    */
-  ArcusFuture<T> get(String key);
+  ArcusFuture<Boolean> prepend(String key, T value);
 
   /**
-   * Get a value and its CAS ID for the given key.
+   * Append String or byte[] to an existing same type of value.
    *
-   * @param key the key
-   * @return {@link CASValue}, {@code null} if not found
+   * @param key   the key
+   * @param value the value to append
+   * @return {@code true} if appended, otherwise {@code false}
    */
-  ArcusFuture<CASValue<T>> gets(String key);
+  ArcusFuture<Boolean> append(String key, T value);
 
   /**
-   * Get values for multiple keys.
+   * Perform a compare-and-set operation for the given key.
    *
-   * @param keys list of keys to get
-   * @return Map of key to value
+   * @param key   the key to set
+   * @param exp   expiration time in seconds
+   * @param value the new value to set if the CAS ID matches
+   * @param casId the CAS ID obtained from {@link #gets(String)}
+   * @return {@code true} if compared and set successfully,
+   * {@code false} if the key does not exist or CAS ID does not match
    */
-  ArcusFuture<Map<String, T>> multiGet(List<String> keys);
+  ArcusFuture<Boolean> cas(String key, int exp, T value, long casId);
 
   /**
    * Increments a numeric value stored at the given key by {@code delta}.
@@ -198,6 +173,31 @@ public interface AsyncArcusCommandsIF<T> {
   ArcusFuture<Long> decr(String key, int delta, long initial, int exp);
 
   /**
+   * Get a value for the given key.
+   *
+   * @param key the key
+   * @return the value, or {@code null} if not found
+   */
+  ArcusFuture<T> get(String key);
+
+  /**
+   * Get a value and its CAS ID for the given key.
+   *
+   * @param key the key
+   * @return {@link CASValue}, {@code null} if not found
+   */
+  ArcusFuture<CASValue<T>> gets(String key);
+
+  /**
+   * Get values for multiple keys.
+   *
+   * @param keys list of keys to get
+   * @return Map of key to value
+   */
+  ArcusFuture<Map<String, T>> multiGet(List<String> keys);
+
+
+  /**
    * Get values with CAS for multiple keys.
    *
    * @param keys list of keys to get
@@ -221,310 +221,6 @@ public interface AsyncArcusCommandsIF<T> {
    * @return Map of key to Boolean result
    */
   ArcusFuture<Map<String, Boolean>> multiDelete(List<String> keys);
-
-  /**
-   * Create a btree item.
-   *
-   * @param key        key to create
-   * @param type       btree element value type
-   * @param attributes collection attributes (must not be null)
-   * @return {@code true} if created, otherwise {@code false}
-   */
-  ArcusFuture<Boolean> bopCreate(String key, ElementValueType type,
-                                 CollectionAttributes attributes);
-
-  /**
-   * Insert an element into a btree item.
-   *
-   * @param key        key to insert
-   * @param element    btree element to insert
-   * @param attributes collection attributes for creation when the btree does not exist
-   * @return {@code true} if inserted,
-   * {@code false} if element exists,
-   * {@code null} if key is not found
-   */
-  ArcusFuture<Boolean> bopInsert(String key, BTreeElement<T> element,
-                                 CollectionAttributes attributes);
-
-  /**
-   * Insert an element into a btree item.
-   *
-   * @param key     key to insert
-   * @param element btree element to insert
-   * @return {@code true} if inserted,
-   * {@code false} if element exists,
-   * {@code null} if key is not found
-   */
-  ArcusFuture<Boolean> bopInsert(String key, BTreeElement<T> element);
-
-  /**
-   * Upsert an element into a btree item.
-   *
-   * @param key        key to upsert
-   * @param element    btree element to upsert
-   * @param attributes collection attributes for creation when the btree does not exist
-   * @return {@code true} if upserted, {@code null} if the key is not found
-   */
-  ArcusFuture<Boolean> bopUpsert(String key, BTreeElement<T> element,
-                                 CollectionAttributes attributes);
-
-  /**
-   * Upsert an element into a btree item.
-   *
-   * @param key     key to upsert
-   * @param element btree element to upsert
-   * @return {@code true} if upserted, {@code null} if the key is not found
-   */
-  ArcusFuture<Boolean> bopUpsert(String key, BTreeElement<T> element);
-
-  /**
-   * Update an element in a btree item
-   *
-   * @param key     key to update
-   * @param element btree element to update
-   * @return {@code true} if updated,
-   * {@code false} if element does not exist,
-   * {@code null} if key is not found
-   */
-  ArcusFuture<Boolean> bopUpdate(String key, BTreeUpdateElement<T> element);
-
-  /**
-   * Insert an element into a btree item and get trimmed element if overflow trim occurs.
-   *
-   * @param key        key to insert
-   * @param element    btree element to insert
-   * @param attributes collection attributes for creation when the btree does not exist
-   * @return {@code Map.Entry} with insertion result and trimmed element
-   */
-  ArcusFuture<Map.Entry<Boolean, BTreeElement<T>>> bopInsertAndGetTrimmed(
-          String key, BTreeElement<T> element, CollectionAttributes attributes);
-
-  /**
-   * Insert an element into a btree item and get trimmed element if overflow trim occurs.
-   *
-   * @param key     key to insert
-   * @param element btree element to insert
-   * @return {@code Map.Entry} with insertion result and trimmed element
-   */
-  ArcusFuture<Map.Entry<Boolean, BTreeElement<T>>> bopInsertAndGetTrimmed(String key,
-                                                                          BTreeElement<T> element);
-
-  /**
-   * Upsert an element into a btree item and get trimmed element if overflow trim occurs.
-   *
-   * @param key        key to upsert
-   * @param element    btree element to upsert
-   * @param attributes collection attributes for creation when the btree does not exist
-   * @return {@code Map.Entry} with upsertion result and trimmed element
-   */
-  ArcusFuture<Map.Entry<Boolean, BTreeElement<T>>> bopUpsertAndGetTrimmed(
-          String key, BTreeElement<T> element, CollectionAttributes attributes);
-
-  /**
-   * Upsert an element into a btree item and get trimmed element if overflow trim occurs.
-   *
-   * @param key     key to upsert
-   * @param element btree element to upsert
-   * @return {@code Map.Entry} with upsertion result and trimmed element
-   */
-  ArcusFuture<Map.Entry<Boolean, BTreeElement<T>>> bopUpsertAndGetTrimmed(String key,
-                                                                          BTreeElement<T> element);
-
-  /**
-   * Get an element from a btree item.
-   *
-   * @param key  key to get
-   * @param bKey BKey of the element to get
-   * @param args arguments for get operation
-   * @return the {@code BTreeElement} if found,
-   * {@code BTreeElement} with null value and null eFlag if element is not found but key exists,
-   * {@code null} if key is not found
-   */
-  ArcusFuture<BTreeElement<T>> bopGet(String key, BKey bKey, BopGetArgs args);
-
-  /**
-   * Get elements from a btree item.
-   *
-   * @param key  key to get
-   * @param from BKey range start
-   * @param to   BKey range end
-   * @param args arguments for get operation
-   * @return {@code BTreeElements} with found elements,
-   * empty {@code BTreeElements} if no elements are found in the range but key exists,
-   * {@code null} if key is not found
-   */
-  ArcusFuture<BTreeElements<T>> bopGet(String key, BKey from, BKey to, BopGetArgs args);
-
-  /**
-   * Get elements from multiple btree items.
-   *
-   * @param keys list of keys to get
-   * @param from BKey range start
-   * @param to   BKey range end
-   * @param args arguments for get operation
-   * @return map of key to {@code BTreeElements} with found elements,
-   * empty {@code BTreeElements} if no elements are found in the range but key exists,
-   * no {@code Map.Entry} in the map if the key is not found
-   */
-  ArcusFuture<Map<String, BTreeElements<T>>> bopMultiGet(List<String> keys,
-                                                         BKey from, BKey to,
-                                                         BopGetArgs args);
-
-  /**
-   * Get the position of an element with the given bKey in a btree item.
-   *
-   * @param key   key of the btree item
-   * @param bKey  BKey of the element to find
-   * @param order the order of the btree to determine position
-   * @return the 0-based position of the element,
-   * {@code null} if the key or element is not found
-   */
-  ArcusFuture<Integer> bopGetPosition(String key, BKey bKey, BTreeOrder order);
-
-  /**
-   * Get an element at the given position in a btree item.
-   *
-   * @param key   key of the btree item
-   * @param pos   0-based position of the element to get
-   * @param order the order of the btree to determine position
-   * @return the {@code BTreeElement} at the given position,
-   * {@code null} if the key or element is not found
-   */
-  ArcusFuture<BTreeElement<T>> bopGetByPosition(String key, int pos, BTreeOrder order);
-
-  /**
-   * Get elements in a position range from a btree item.
-   *
-   * @param key   key of the btree item
-   * @param from  start position (inclusive)
-   * @param to    end position (inclusive); must be greater than or equal to {@code from}
-   * @param order the order of the btree to determine position
-   * @return list of {@code BTreeElement} in the given position range, in traversal order,
-   * empty list if no elements exist in the range,
-   * {@code null} if the key is not found
-   */
-  ArcusFuture<List<BTreeElement<T>>> bopGetByPosition(String key,
-                                                      int from, int to, BTreeOrder order);
-
-  /**
-   * Get an element by bKey and its neighboring elements with position information.
-   *
-   * @param key   key of the btree item
-   * @param bKey  BKey of the element to find
-   * @param count the number of neighboring elements to retrieve on each side
-   *              (0 &le; count &le; 100)
-   * @param order the order of the btree to determine position
-   * @return list of {@code BTreePositionElement} in traversal order,
-   * empty list if the element is not found,
-   * {@code null} if the key is not found
-   */
-  ArcusFuture<List<BTreePositionElement<T>>> bopPositionWithGet(String key, BKey bKey,
-                                                                int count, BTreeOrder order);
-
-  /**
-   * Get sort-merged elements from multiple btree items.
-   *
-   * @param keys   list of keys to get
-   * @param from   BKey range start
-   * @param to     BKey range end
-   * @param unique whether to return unique elements only
-   * @param args   arguments for get operation
-   * @return {@code SMGetElements} containing sort-merged elements,
-   * empty {@code SMGetElements} if no matching elements exist
-   */
-  ArcusFuture<SMGetElements<T>> bopSortMergeGet(List<String> keys, BKey from, BKey to,
-                                                boolean unique, BopGetArgs args);
-
-  /**
-   * Increments a numeric value of an element with the given bKey in a btree item by {@code delta}
-   *
-   * @param key   key of the btree item
-   * @param bKey  BKey of the element to increment
-   * @param delta the amount to increment (&gt; 0)
-   * @return the new value after increment, or {@code null} if the key or element is not found
-   */
-  ArcusFuture<Long> bopIncr(String key, BKey bKey, int delta);
-
-  /**
-   * Increments a numeric value of an element with the given bKey in a btree item by {@code delta}.
-   * If the element does not exist, it is created with {@code initial} value and {@code eFlag}.
-   *
-   * @param key     key of the btree item
-   * @param bKey    BKey of the element to increment
-   * @param delta   the amount to increment (&gt; 0)
-   * @param initial the value to store if the element does not exist
-   *                ({@code delta} is ignored) (&ge; 0)
-   * @param eFlag   eFlag of the element to create, or {@code null} if not needed
-   * @return the new value after increment, or {@code initial} if the element did not exist
-   */
-  ArcusFuture<Long> bopIncr(String key, BKey bKey, int delta, long initial, byte[] eFlag);
-
-  /**
-   * Decrements a numeric value of an element with the given bKey in a btree item by {@code delta}.
-   * <p>If the value is decremented below 0, it will be set to 0.</p>
-   *
-   * @param key   key of the btree item
-   * @param bKey  BKey of the element to decrement
-   * @param delta the amount to decrement (&gt; 0)
-   * @return the new value after decrement, or {@code null} if the key or element is not found
-   */
-  ArcusFuture<Long> bopDecr(String key, BKey bKey, int delta);
-
-  /**
-   * Decrements a numeric value of an element with the given bKey in a btree item by {@code delta}.
-   * If the element does not exist, it is created with {@code initial} value and {@code eFlag}.
-   * <p>If the value is decremented below 0, it will be set to 0.</p>
-   *
-   * @param key     key of the btree item
-   * @param bKey    BKey of the element to decrement
-   * @param delta   the amount to decrement (&gt; 0)
-   * @param initial the value to store if the element does not exist
-   *                ({@code delta} is ignored) (&ge; 0)
-   * @param eFlag   eFlag of the element to create, or {@code null} if not needed
-   * @return the new value after decrement, or {@code initial} if the element did not exist
-   */
-  ArcusFuture<Long> bopDecr(String key, BKey bKey, int delta, long initial, byte[] eFlag);
-
-  /**
-   * Delete an element with the given bKey from a btree item.
-   *
-   * @param key  key of the btree item
-   * @param bKey BKey of the element to delete
-   * @param args delete arguments (eFlagFilter, dropIfEmpty)
-   * @return {@code true} if the element was deleted,
-   * {@code false} if the element is not found,
-   * {@code null} if the key is not found
-   */
-  ArcusFuture<Boolean> bopDelete(String key, BKey bKey, BopDeleteArgs args);
-
-  /**
-   * Delete elements in a bKey range from a btree item.
-   * Elements are deleted in order from {@code from} to {@code to}.
-   * <p>If {@code args.count} is 0 (default), all elements in the range are deleted. </p>
-   * Otherwise, only the first {@code args.count} elements (in {@code from}-to-{@code to} order)
-   * are deleted.
-   *
-   * @param key  key of the btree item
-   * @param from BKey range start (inclusive)
-   * @param to   BKey range end (inclusive)
-   * @param args delete arguments (count, eFlagFilter, dropIfEmpty)
-   * @return {@code true} if at least one element was deleted,
-   * {@code false} if no elements are found in the range,
-   * {@code null} if the key is not found
-   */
-  ArcusFuture<Boolean> bopDelete(String key, BKey from, BKey to, BopDeleteArgs args);
-
-  /**
-   * Count elements in a bKey range from a btree item.
-   *
-   * @param key         key of the btree item
-   * @param from        BKey range start (inclusive)
-   * @param to          BKey range end (inclusive)
-   * @param eFlagFilter eFlag filter condition, or {@code null} to count all elements in the range
-   * @return the number of elements in the range (0 if none exist),
-   * {@code null} if the key is not found
-   */
-  ArcusFuture<Long> bopCount(String key, BKey from, BKey to, ElementFlagFilter eFlagFilter);
 
   /**
    * Create a list with the given attributes.
@@ -642,17 +338,6 @@ public interface AsyncArcusCommandsIF<T> {
   ArcusFuture<Boolean> sopInsert(String key, T value, CollectionAttributes attributes);
 
   /**
-   * Check whether an element exists in a set.
-   *
-   * @param key   key of the set
-   * @param value the value to check
-   * @return {@code true} if the element exists,
-   * {@code false} if the element is not found,
-   * {@code null} if the key is not found
-   */
-  ArcusFuture<Boolean> sopExist(String key, T value);
-
-  /**
    * Get elements randomly from a set.
    *
    * @param key   key of the set
@@ -662,6 +347,17 @@ public interface AsyncArcusCommandsIF<T> {
    * {@code null} if the key is not found
    */
   ArcusFuture<Set<T>> sopGet(String key, int count, GetArgs args);
+
+  /**
+   * Check whether an element exists in a set.
+   *
+   * @param key   key of the set
+   * @param value the value to check
+   * @return {@code true} if the element exists,
+   * {@code false} if the element is not found,
+   * {@code null} if the key is not found
+   */
+  ArcusFuture<Boolean> sopExist(String key, T value);
 
   /**
    * Delete an element from a set.
@@ -817,6 +513,309 @@ public interface AsyncArcusCommandsIF<T> {
    */
   ArcusFuture<Boolean> mopDelete(String key, List<String> mKeys, boolean dropIfEmpty);
 
+  /**
+   * Create a btree item.
+   *
+   * @param key        key to create
+   * @param type       btree element value type
+   * @param attributes collection attributes (must not be null)
+   * @return {@code true} if created, otherwise {@code false}
+   */
+  ArcusFuture<Boolean> bopCreate(String key, ElementValueType type,
+                                 CollectionAttributes attributes);
+
+  /**
+   * Insert an element into a btree item.
+   *
+   * @param key     key to insert
+   * @param element btree element to insert
+   * @return {@code true} if inserted,
+   * {@code false} if element exists,
+   * {@code null} if key is not found
+   */
+  ArcusFuture<Boolean> bopInsert(String key, BTreeElement<T> element);
+
+  /**
+   * Insert an element into a btree item.
+   *
+   * @param key        key to insert
+   * @param element    btree element to insert
+   * @param attributes collection attributes for creation when the btree does not exist
+   * @return {@code true} if inserted,
+   * {@code false} if element exists,
+   * {@code null} if key is not found
+   */
+  ArcusFuture<Boolean> bopInsert(String key, BTreeElement<T> element,
+                                 CollectionAttributes attributes);
+
+  /**
+   * Insert an element into a btree item and get trimmed element if overflow trim occurs.
+   *
+   * @param key     key to insert
+   * @param element btree element to insert
+   * @return {@code Map.Entry} with insertion result and trimmed element
+   */
+  ArcusFuture<Map.Entry<Boolean, BTreeElement<T>>> bopInsertAndGetTrimmed(
+      String key, BTreeElement<T> element);
+
+  /**
+   * Insert an element into a btree item and get trimmed element if overflow trim occurs.
+   *
+   * @param key        key to insert
+   * @param element    btree element to insert
+   * @param attributes collection attributes for creation when the btree does not exist
+   * @return {@code Map.Entry} with insertion result and trimmed element
+   */
+  ArcusFuture<Map.Entry<Boolean, BTreeElement<T>>> bopInsertAndGetTrimmed(
+      String key, BTreeElement<T> element, CollectionAttributes attributes);
+
+  /**
+   * Upsert an element into a btree item.
+   *
+   * @param key     key to upsert
+   * @param element btree element to upsert
+   * @return {@code true} if upserted, {@code null} if the key is not found
+   */
+  ArcusFuture<Boolean> bopUpsert(String key, BTreeElement<T> element);
+
+  /**
+   * Upsert an element into a btree item.
+   *
+   * @param key        key to upsert
+   * @param element    btree element to upsert
+   * @param attributes collection attributes for creation when the btree does not exist
+   * @return {@code true} if upserted, {@code null} if the key is not found
+   */
+  ArcusFuture<Boolean> bopUpsert(String key, BTreeElement<T> element,
+                                 CollectionAttributes attributes);
+
+  /**
+   * Upsert an element into a btree item and get trimmed element if overflow trim occurs.
+   *
+   * @param key     key to upsert
+   * @param element btree element to upsert
+   * @return {@code Map.Entry} with upsertion result and trimmed element
+   */
+  ArcusFuture<Map.Entry<Boolean, BTreeElement<T>>> bopUpsertAndGetTrimmed(
+      String key, BTreeElement<T> element);
+
+  /**
+   * Upsert an element into a btree item and get trimmed element if overflow trim occurs.
+   *
+   * @param key        key to upsert
+   * @param element    btree element to upsert
+   * @param attributes collection attributes for creation when the btree does not exist
+   * @return {@code Map.Entry} with upsertion result and trimmed element
+   */
+  ArcusFuture<Map.Entry<Boolean, BTreeElement<T>>> bopUpsertAndGetTrimmed(
+      String key, BTreeElement<T> element, CollectionAttributes attributes);
+
+  /**
+   * Update an element in a btree item
+   *
+   * @param key     key to update
+   * @param element btree element to update
+   * @return {@code true} if updated,
+   * {@code false} if element does not exist,
+   * {@code null} if key is not found
+   */
+  ArcusFuture<Boolean> bopUpdate(String key, BTreeUpdateElement<T> element);
+
+  /**
+   * Increments a numeric value of an element with the given bKey in a btree item by {@code delta}
+   *
+   * @param key   key of the btree item
+   * @param bKey  BKey of the element to increment
+   * @param delta the amount to increment (&gt; 0)
+   * @return the new value after increment, or {@code null} if the key or element is not found
+   */
+  ArcusFuture<Long> bopIncr(String key, BKey bKey, int delta);
+
+  /**
+   * Increments a numeric value of an element with the given bKey in a btree item by {@code delta}.
+   * If the element does not exist, it is created with {@code initial} value and {@code eFlag}.
+   *
+   * @param key     key of the btree item
+   * @param bKey    BKey of the element to increment
+   * @param delta   the amount to increment (&gt; 0)
+   * @param initial the value to store if the element does not exist
+   *                ({@code delta} is ignored) (&ge; 0)
+   * @param eFlag   eFlag of the element to create, or {@code null} if not needed
+   * @return the new value after increment, or {@code initial} if the element did not exist
+   */
+  ArcusFuture<Long> bopIncr(String key, BKey bKey, int delta, long initial, byte[] eFlag);
+
+  /**
+   * Decrements a numeric value of an element with the given bKey in a btree item by {@code delta}.
+   * <p>If the value is decremented below 0, it will be set to 0.</p>
+   *
+   * @param key   key of the btree item
+   * @param bKey  BKey of the element to decrement
+   * @param delta the amount to decrement (&gt; 0)
+   * @return the new value after decrement, or {@code null} if the key or element is not found
+   */
+  ArcusFuture<Long> bopDecr(String key, BKey bKey, int delta);
+
+  /**
+   * Decrements a numeric value of an element with the given bKey in a btree item by {@code delta}.
+   * If the element does not exist, it is created with {@code initial} value and {@code eFlag}.
+   * <p>If the value is decremented below 0, it will be set to 0.</p>
+   *
+   * @param key     key of the btree item
+   * @param bKey    BKey of the element to decrement
+   * @param delta   the amount to decrement (&gt; 0)
+   * @param initial the value to store if the element does not exist
+   *                ({@code delta} is ignored) (&ge; 0)
+   * @param eFlag   eFlag of the element to create, or {@code null} if not needed
+   * @return the new value after decrement, or {@code initial} if the element did not exist
+   */
+  ArcusFuture<Long> bopDecr(String key, BKey bKey, int delta, long initial, byte[] eFlag);
+
+  /**
+   * Get an element from a btree item.
+   *
+   * @param key  key to get
+   * @param bKey BKey of the element to get
+   * @param args arguments for get operation
+   * @return the {@code BTreeElement} if found,
+   * {@code BTreeElement} with null value and null eFlag if element is not found but key exists,
+   * {@code null} if key is not found
+   */
+  ArcusFuture<BTreeElement<T>> bopGet(String key, BKey bKey, BopGetArgs args);
+
+  /**
+   * Get elements from a btree item.
+   *
+   * @param key  key to get
+   * @param from BKey range start
+   * @param to   BKey range end
+   * @param args arguments for get operation
+   * @return {@code BTreeElements} with found elements,
+   * empty {@code BTreeElements} if no elements are found in the range but key exists,
+   * {@code null} if key is not found
+   */
+  ArcusFuture<BTreeElements<T>> bopGet(String key, BKey from, BKey to, BopGetArgs args);
+
+  /**
+   * Get elements from multiple btree items.
+   *
+   * @param keys list of keys to get
+   * @param from BKey range start
+   * @param to   BKey range end
+   * @param args arguments for get operation
+   * @return map of key to {@code BTreeElements} with found elements,
+   * empty {@code BTreeElements} if no elements are found in the range but key exists,
+   * no {@code Map.Entry} in the map if the key is not found
+   */
+  ArcusFuture<Map<String, BTreeElements<T>>> bopMultiGet(
+      List<String> keys, BKey from, BKey to, BopGetArgs args);
+
+  /**
+   * Get sort-merged elements from multiple btree items.
+   *
+   * @param keys   list of keys to get
+   * @param from   BKey range start
+   * @param to     BKey range end
+   * @param unique whether to return unique elements only
+   * @param args   arguments for get operation
+   * @return {@code SMGetElements} containing sort-merged elements,
+   * empty {@code SMGetElements} if no matching elements exist
+   */
+  ArcusFuture<SMGetElements<T>> bopSortMergeGet(
+      List<String> keys, BKey from, BKey to, boolean unique, BopGetArgs args);
+
+  /**
+   * Get the position of an element with the given bKey in a btree item.
+   *
+   * @param key   key of the btree item
+   * @param bKey  BKey of the element to find
+   * @param order the order of the btree to determine position
+   * @return the 0-based position of the element,
+   * {@code null} if the key or element is not found
+   */
+  ArcusFuture<Integer> bopGetPosition(String key, BKey bKey, BTreeOrder order);
+
+  /**
+   * Get an element at the given position in a btree item.
+   *
+   * @param key   key of the btree item
+   * @param pos   0-based position of the element to get
+   * @param order the order of the btree to determine position
+   * @return the {@code BTreeElement} at the given position,
+   * {@code null} if the key or element is not found
+   */
+  ArcusFuture<BTreeElement<T>> bopGetByPosition(
+      String key, int pos, BTreeOrder order);
+
+  /**
+   * Get elements in a position range from a btree item.
+   *
+   * @param key   key of the btree item
+   * @param from  start position (inclusive)
+   * @param to    end position (inclusive); must be greater than or equal to {@code from}
+   * @param order the order of the btree to determine position
+   * @return list of {@code BTreeElement} in the given position range, in traversal order,
+   * empty list if no elements exist in the range,
+   * {@code null} if the key is not found
+   */
+  ArcusFuture<List<BTreeElement<T>>> bopGetByPosition(
+      String key, int from, int to, BTreeOrder order);
+
+  /**
+   * Get an element by bKey and its neighboring elements with position information.
+   *
+   * @param key   key of the btree item
+   * @param bKey  BKey of the element to find
+   * @param count the number of neighboring elements to retrieve on each side
+   *              (0 &le; count &le; 100)
+   * @param order the order of the btree to determine position
+   * @return list of {@code BTreePositionElement} in traversal order,
+   * empty list if the element is not found,
+   * {@code null} if the key is not found
+   */
+  ArcusFuture<List<BTreePositionElement<T>>> bopPositionWithGet(
+      String key, BKey bKey, int count, BTreeOrder order);
+
+  /**
+   * Count elements in a bKey range from a btree item.
+   *
+   * @param key         key of the btree item
+   * @param from        BKey range start (inclusive)
+   * @param to          BKey range end (inclusive)
+   * @param eFlagFilter eFlag filter condition, or {@code null} to count all elements in the range
+   * @return the number of elements in the range (0 if none exist),
+   * {@code null} if the key is not found
+   */
+  ArcusFuture<Long> bopCount(String key, BKey from, BKey to, ElementFlagFilter eFlagFilter);
+
+  /**
+   * Delete an element with the given bKey from a btree item.
+   *
+   * @param key  key of the btree item
+   * @param bKey BKey of the element to delete
+   * @param args delete arguments (eFlagFilter, dropIfEmpty)
+   * @return {@code true} if the element was deleted,
+   * {@code false} if the element is not found,
+   * {@code null} if the key is not found
+   */
+  ArcusFuture<Boolean> bopDelete(String key, BKey bKey, BopDeleteArgs args);
+
+  /**
+   * Delete elements in a bKey range from a btree item.
+   * Elements are deleted in order from {@code from} to {@code to}.
+   * <p>If {@code args.count} is 0 (default), all elements in the range are deleted. </p>
+   * Otherwise, only the first {@code args.count} elements (in {@code from}-to-{@code to} order)
+   * are deleted.
+   *
+   * @param key  key of the btree item
+   * @param from BKey range start (inclusive)
+   * @param to   BKey range end (inclusive)
+   * @param args delete arguments (count, eFlagFilter, dropIfEmpty)
+   * @return {@code true} if at least one element was deleted,
+   * {@code false} if no elements are found in the range,
+   * {@code null} if the key is not found
+   */
+  ArcusFuture<Boolean> bopDelete(String key, BKey from, BKey to, BopDeleteArgs args);
 
   /**
    * Flush all items from all servers immediately.


### PR DESCRIPTION
### 🔗 Related Issue

<!-- Please link related issue. ex) https://github.com/naver/arcus-java-client/issues/{issue_number} -->
- https://github.com/jam2in/arcus-works/issues/832#issuecomment-4349747200

### ⌨️ What I did

<!-- Please describe this PR and what you've been working on. -->

> API의 순서를 바꾸다보니 변경사항이 많습니다. 

- 인터페이스(`AsyncArcusCommandsIF`)를 이슈에 정의한 순서와 일치하도록 수정합니다.
- 구현 클래스(`AsyncArcusCommands`)의 메서드를 아래 원칙에 따라 재배치합니다.
  - public method
    - 인터페이스와 동일하게 KV / List / Set / Map / BTree / Admin 순으로 구성합니다.
  - private method
    - 헬퍼 메서드는 단일 호출자 바로 뒤에 배치
    - BTree 내 공유 헬퍼 메서드는 BTree 섹션 최하단
    - 컬렉션 공통 헬퍼 메서드는 Admin 직전에 배치