### PR TITLE
FEATURE: Add overloaded constructor to BTreeElement

### DIFF
--- a/src/main/java/net/spy/memcached/v2/vo/BTreeElement.java
+++ b/src/main/java/net/spy/memcached/v2/vo/BTreeElement.java
@@ -17,6 +17,10 @@ public final class BTreeElement<V> implements Comparable<BTreeElement<V>> {
     this.eFlag = eFlag;
   }
 
+  public BTreeElement(BKey bKey, V value) {
+    this(bKey, value, null);
+  }
+
   public BKey getBKey() {
     return bKey;
   }


### PR DESCRIPTION
### 🔗 Related Issue

<!-- Please link related issue. ex) https://github.com/naver/arcus-java-client/issues/{issue_number} -->
- https://github.com/jam2in/arcus-works/issues/848#issuecomment-4459027565

### ⌨️ What I did

<!-- Please describe this PR and what you've been working on. -->
- v2의 `BTreeElement` 생성자에서 `eFlag`를 생략하는 생성자를 추가합니다.   