### PR TITLE
FEATURE: Rename BTree get result classes to use `Result` suffix

### DIFF
--- a/src/main/java/net/spy/memcached/v2/AsyncArcusCommands.java
+++ b/src/main/java/net/spy/memcached/v2/AsyncArcusCommands.java
@@ -105,13 +105,13 @@ import net.spy.memcached.transcoders.Transcoder;
 import net.spy.memcached.transcoders.TranscoderUtils;
 import net.spy.memcached.v2.vo.BKey;
 import net.spy.memcached.v2.vo.BTreeElement;
-import net.spy.memcached.v2.vo.BTreeElements;
+import net.spy.memcached.v2.vo.BTreeGetResult;
 import net.spy.memcached.v2.vo.BTreePositionElement;
+import net.spy.memcached.v2.vo.BTreeSMGetResult;
 import net.spy.memcached.v2.vo.BTreeUpdateElement;
 import net.spy.memcached.v2.vo.BopDeleteArgs;
 import net.spy.memcached.v2.vo.BopGetArgs;
 import net.spy.memcached.v2.vo.GetOption;
-import net.spy.memcached.v2.vo.SMGetElements;
 
 public class AsyncArcusCommands<T> implements AsyncArcusCommandsIF<T> {
 
@@ -1353,12 +1353,12 @@ public class AsyncArcusCommands<T> implements AsyncArcusCommandsIF<T> {
   }
 
   @Override
-  public ArcusFuture<BTreeElements<T>> bopGet(String key, BKey from, BKey to, BopGetArgs args) {
+  public ArcusFuture<BTreeGetResult<T>> bopGet(String key, BKey from, BKey to, BopGetArgs args) {
     verifyBKeyTypesMatch(from, to);
 
-    AbstractArcusResult<BTreeElements<T>> result =
-        new AbstractArcusResult<>(new AtomicReference<>(new BTreeElements<>(new ArrayList<>())));
-    ArcusFutureImpl<BTreeElements<T>> future = new ArcusFutureImpl<>(result);
+    AbstractArcusResult<BTreeGetResult<T>> result =
+        new AbstractArcusResult<>(new AtomicReference<>(new BTreeGetResult<>(new ArrayList<>())));
+    ArcusFutureImpl<BTreeGetResult<T>> future = new ArcusFutureImpl<>(result);
     BTreeGet get = createBTreeGet(from, to, args);
     ArcusClient client = arcusClientSupplier.get();
 
@@ -1426,9 +1426,9 @@ public class AsyncArcusCommands<T> implements AsyncArcusCommandsIF<T> {
   }
 
   @Override
-  public ArcusFuture<Map<String, BTreeElements<T>>> bopMultiGet(List<String> keys,
-                                                                BKey from, BKey to,
-                                                                BopGetArgs args) {
+  public ArcusFuture<Map<String, BTreeGetResult<T>>> bopMultiGet(List<String> keys,
+                                                                 BKey from, BKey to,
+                                                                 BopGetArgs args) {
     keyValidator.validateKey(keys);
     keyValidator.checkDupKey(keys);
     verifyBKeyTypesMatch(from, to);
@@ -1439,28 +1439,28 @@ public class AsyncArcusCommands<T> implements AsyncArcusCommandsIF<T> {
         client.groupingKeys(keys, ArcusClient.BOPGET_BULK_CHUNK_SIZE, APIType.BOP_GET);
 
     Collection<CompletableFuture<?>> futures = new ArrayList<>();
-    Map<CompletableFuture<Map<String, BTreeElements<T>>>, List<String>> futureToKeys =
+    Map<CompletableFuture<Map<String, BTreeGetResult<T>>>, List<String>> futureToKeys =
         new HashMap<>();
 
     for (Map.Entry<MemcachedNode, List<String>> entry : arrangedKeys) {
       BTreeGetBulk<T> getBulk =
           createBTreeGetBulk(entry.getKey(), entry.getValue(), from, to, args);
-      CompletableFuture<Map<String, BTreeElements<T>>> future =
+      CompletableFuture<Map<String, BTreeGetResult<T>>> future =
           bopMultiGetPerNode(client, getBulk).toCompletableFuture();
       futureToKeys.put(future, entry.getValue());
       futures.add(future);
     }
 
     return new ArcusMultiFuture<>(futures, () -> {
-      Map<String, BTreeElements<T>> results = new HashMap<>();
-      for (Map.Entry<CompletableFuture<Map<String, BTreeElements<T>>>, List<String>> entry
+      Map<String, BTreeGetResult<T>> results = new HashMap<>();
+      for (Map.Entry<CompletableFuture<Map<String, BTreeGetResult<T>>>, List<String>> entry
           : futureToKeys.entrySet()) {
         if (entry.getKey().isCompletedExceptionally()) {
           for (String key : entry.getValue()) {
             results.put(key, null);
           }
         } else {
-          Map<String, BTreeElements<T>> result = entry.getKey().join();
+          Map<String, BTreeGetResult<T>> result = entry.getKey().join();
           if (result != null) {
             results.putAll(result);
           }
@@ -1470,11 +1470,11 @@ public class AsyncArcusCommands<T> implements AsyncArcusCommandsIF<T> {
     });
   }
 
-  private ArcusFuture<Map<String, BTreeElements<T>>> bopMultiGetPerNode(ArcusClient client,
-                                                                        BTreeGetBulk<T> getBulk) {
-    AbstractArcusResult<Map<String, BTreeElements<T>>> result =
+  private ArcusFuture<Map<String, BTreeGetResult<T>>> bopMultiGetPerNode(ArcusClient client,
+                                                                         BTreeGetBulk<T> getBulk) {
+    AbstractArcusResult<Map<String, BTreeGetResult<T>>> result =
         new AbstractArcusResult<>(new AtomicReference<>(new HashMap<>()));
-    ArcusFutureImpl<Map<String, BTreeElements<T>>> future = new ArcusFutureImpl<>(result);
+    ArcusFutureImpl<Map<String, BTreeGetResult<T>>> future = new ArcusFutureImpl<>(result);
 
     BTreeGetBulkOperation.Callback cb = new BTreeGetBulkOperation.Callback() {
       @Override
@@ -1504,10 +1504,10 @@ public class AsyncArcusCommands<T> implements AsyncArcusCommandsIF<T> {
       public void gotKey(String key, int elementCount, OperationStatus status) {
         switch (status.getStatusCode()) {
           case SUCCESS:
-            result.get().put(key, new BTreeElements<>(new ArrayList<>()));
+            result.get().put(key, new BTreeGetResult<>(new ArrayList<>()));
             break;
           case TRIMMED:
-            BTreeElements<T> elements = new BTreeElements<>(new ArrayList<>());
+            BTreeGetResult<T> elements = new BTreeGetResult<>(new ArrayList<>());
             elements.trimmed();
             result.get().put(key, elements);
             break;
@@ -1515,7 +1515,7 @@ public class AsyncArcusCommands<T> implements AsyncArcusCommandsIF<T> {
             break;
           case ERR_NOT_FOUND_ELEMENT:
             // Put empty BTreeElements for the BTree item key
-            result.get().put(key, new BTreeElements<>(new ArrayList<>()));
+            result.get().put(key, new BTreeGetResult<>(new ArrayList<>()));
             break;
           default:
             /*
@@ -1529,7 +1529,7 @@ public class AsyncArcusCommands<T> implements AsyncArcusCommandsIF<T> {
       @Override
       public void gotElement(String key, int flags, Object bKey, byte[] eFlag, byte[] data) {
         CachedData cachedData = new CachedData(flags, data, tcForCollection.getMaxSize());
-        BTreeElements<T> elements = result.get().get(key);
+        BTreeGetResult<T> elements = result.get().get(key);
         elements.addElement(new BTreeElement<>(
             BKey.of(bKey), tcForCollection.decode(cachedData), eFlag));
       }
@@ -1555,8 +1555,8 @@ public class AsyncArcusCommands<T> implements AsyncArcusCommandsIF<T> {
   }
 
   @Override
-  public ArcusFuture<SMGetElements<T>> bopSortMergeGet(List<String> keys, BKey from, BKey to,
-                                                       boolean unique, BopGetArgs args) {
+  public ArcusFuture<BTreeSMGetResult<T>> bopSortMergeGet(List<String> keys, BKey from, BKey to,
+                                                          boolean unique, BopGetArgs args) {
     keyValidator.validateKey(keys);
     keyValidator.checkDupKey(keys);
     verifyBKeyTypesMatch(from, to);
@@ -1566,11 +1566,11 @@ public class AsyncArcusCommands<T> implements AsyncArcusCommandsIF<T> {
     Collection<Map.Entry<MemcachedNode, List<String>>> arrangedKeys =
         client.groupingKeys(keys, ArcusClient.SMGET_CHUNK_SIZE, APIType.BOP_SMGET);
 
-    List<CompletableFuture<SMGetElements<T>>> smGetFutures = new ArrayList<>();
+    List<CompletableFuture<BTreeSMGetResult<T>>> smGetFutures = new ArrayList<>();
 
     for (Map.Entry<MemcachedNode, List<String>> entry : arrangedKeys) {
       BTreeSMGet<T> smGet = createBTreeSMGet(from, to, args, unique, entry);
-      CompletableFuture<SMGetElements<T>> future =
+      CompletableFuture<BTreeSMGetResult<T>> future =
           bopSortMergeGetPerNode(client, smGet).toCompletableFuture();
       smGetFutures.add(future);
     }
@@ -1579,29 +1579,30 @@ public class AsyncArcusCommands<T> implements AsyncArcusCommandsIF<T> {
     Collection<CompletableFuture<?>> futures =
         (Collection<CompletableFuture<?>>) (Collection<?>) smGetFutures;
     return new ArcusMultiFuture<>(futures, () -> {
-      List<SMGetElements<T>> results = new ArrayList<>();
-      for (CompletableFuture<SMGetElements<T>> future : smGetFutures) {
+      List<BTreeSMGetResult<T>> results = new ArrayList<>();
+      for (CompletableFuture<BTreeSMGetResult<T>> future : smGetFutures) {
         if (!future.isCompletedExceptionally()) {
           results.add(future.join());
         }
       }
-      return SMGetElements.mergeSMGetElements(results, from.compareTo(to) <= 0, unique,
+      return BTreeSMGetResult.mergeSMGetElements(results, from.compareTo(to) <= 0, unique,
           args.getCount());
     });
   }
 
-  private ArcusFuture<SMGetElements<T>> bopSortMergeGetPerNode(ArcusClient client,
-                                                               BTreeSMGet<T> smGet) {
-    List<SMGetElements.Element<T>> elementList = new ArrayList<>();
-    List<SMGetElements.MissedKey> missedKeys = new ArrayList<>();
-    List<SMGetElements.TrimmedKey> trimmedKeys = new ArrayList<>();
-    SMGetElements<T> smGetElements = new SMGetElements<>(elementList, missedKeys, trimmedKeys);
+  private ArcusFuture<BTreeSMGetResult<T>> bopSortMergeGetPerNode(ArcusClient client,
+                                                                  BTreeSMGet<T> smGet) {
+    List<BTreeSMGetResult.Element<T>> elementList = new ArrayList<>();
+    List<BTreeSMGetResult.MissedKey> missedKeys = new ArrayList<>();
+    List<BTreeSMGetResult.TrimmedKey> trimmedKeys = new ArrayList<>();
+    BTreeSMGetResult<T> smGetElements = new BTreeSMGetResult<>(
+        elementList, missedKeys, trimmedKeys);
 
-    AtomicReference<SMGetElements<T>> atomicReference = new AtomicReference<>(smGetElements);
-    AbstractArcusResult<SMGetElements<T>> result =
+    AtomicReference<BTreeSMGetResult<T>> atomicReference = new AtomicReference<>(smGetElements);
+    AbstractArcusResult<BTreeSMGetResult<T>> result =
         new AbstractArcusResult<>(atomicReference);
 
-    ArcusFutureImpl<SMGetElements<T>> future = new ArcusFutureImpl<>(result);
+    ArcusFutureImpl<BTreeSMGetResult<T>> future = new ArcusFutureImpl<>(result);
 
     BTreeSortMergeGetOperation.Callback cb = new BTreeSortMergeGetOperation.Callback() {
       @Override
@@ -1635,17 +1636,17 @@ public class AsyncArcusCommands<T> implements AsyncArcusCommandsIF<T> {
         CachedData cachedData = new CachedData(flags, data, tcForCollection.getMaxSize());
         BTreeElement<T> btreeElement = new BTreeElement<>(
             BKey.of(bKey), tcForCollection.decode(cachedData), eFlag);
-        elementList.add(new SMGetElements.Element<>(key, btreeElement));
+        elementList.add(new BTreeSMGetResult.Element<>(key, btreeElement));
       }
 
       @Override
       public void gotMissedKey(String key, OperationStatus cause) {
-        missedKeys.add(new SMGetElements.MissedKey(key, cause.getStatusCode()));
+        missedKeys.add(new BTreeSMGetResult.MissedKey(key, cause.getStatusCode()));
       }
 
       @Override
       public void gotTrimmedKey(String key, Object bKey) {
-        trimmedKeys.add(new SMGetElements.TrimmedKey(key, BKey.of(bKey)));
+        trimmedKeys.add(new BTreeSMGetResult.TrimmedKey(key, BKey.of(bKey)));
       }
     };
     Operation op = client.getOpFact().bopsmget(smGet, cb);

--- a/src/main/java/net/spy/memcached/v2/AsyncArcusCommandsIF.java
+++ b/src/main/java/net/spy/memcached/v2/AsyncArcusCommandsIF.java
@@ -29,13 +29,13 @@ import net.spy.memcached.collection.ElementFlagFilter;
 import net.spy.memcached.collection.ElementValueType;
 import net.spy.memcached.v2.vo.BKey;
 import net.spy.memcached.v2.vo.BTreeElement;
-import net.spy.memcached.v2.vo.BTreeElements;
+import net.spy.memcached.v2.vo.BTreeGetResult;
 import net.spy.memcached.v2.vo.BTreePositionElement;
+import net.spy.memcached.v2.vo.BTreeSMGetResult;
 import net.spy.memcached.v2.vo.BTreeUpdateElement;
 import net.spy.memcached.v2.vo.BopDeleteArgs;
 import net.spy.memcached.v2.vo.BopGetArgs;
 import net.spy.memcached.v2.vo.GetOption;
-import net.spy.memcached.v2.vo.SMGetElements;
 
 public interface AsyncArcusCommandsIF<T> {
 
@@ -690,11 +690,11 @@ public interface AsyncArcusCommandsIF<T> {
    * @param from BKey range start
    * @param to   BKey range end
    * @param args arguments for get operation
-   * @return {@code BTreeElements} with found elements,
-   * empty {@code BTreeElements} if no elements are found in the range but key exists,
+   * @return {@code BTreeGetResult} with found elements,
+   * empty {@code BTreeGetResult} if no elements are found in the range but key exists,
    * {@code null} if key is not found
    */
-  ArcusFuture<BTreeElements<T>> bopGet(String key, BKey from, BKey to, BopGetArgs args);
+  ArcusFuture<BTreeGetResult<T>> bopGet(String key, BKey from, BKey to, BopGetArgs args);
 
   /**
    * Get elements from multiple btree items.
@@ -703,11 +703,11 @@ public interface AsyncArcusCommandsIF<T> {
    * @param from BKey range start
    * @param to   BKey range end
    * @param args arguments for get operation
-   * @return map of key to {@code BTreeElements} with found elements,
-   * empty {@code BTreeElements} if no elements are found in the range but key exists,
+   * @return map of key to {@code BTreeGetResult} with found elements,
+   * empty {@code BTreeGetResult} if no elements are found in the range but key exists,
    * no {@code Map.Entry} in the map if the key is not found
    */
-  ArcusFuture<Map<String, BTreeElements<T>>> bopMultiGet(
+  ArcusFuture<Map<String, BTreeGetResult<T>>> bopMultiGet(
       List<String> keys, BKey from, BKey to, BopGetArgs args);
 
   /**
@@ -718,10 +718,10 @@ public interface AsyncArcusCommandsIF<T> {
    * @param to     BKey range end
    * @param unique whether to return unique elements only
    * @param args   arguments for get operation
-   * @return {@code SMGetElements} containing sort-merged elements,
-   * empty {@code SMGetElements} if no matching elements exist
+   * @return {@code BTreeSMGetResult} containing sort-merged elements,
+   * empty {@code BTreeSMGetResult} if no matching elements exist
    */
-  ArcusFuture<SMGetElements<T>> bopSortMergeGet(
+  ArcusFuture<BTreeSMGetResult<T>> bopSortMergeGet(
       List<String> keys, BKey from, BKey to, boolean unique, BopGetArgs args);
 
   /**

--- a/src/main/java/net/spy/memcached/v2/vo/BTreeGetResult.java
+++ b/src/main/java/net/spy/memcached/v2/vo/BTreeGetResult.java
@@ -3,11 +3,11 @@ package net.spy.memcached.v2.vo;
 import java.util.Collections;
 import java.util.List;
 
-public final class BTreeElements<V> {
+public final class BTreeGetResult<V> {
   private boolean isTrimmed;
   private final List<BTreeElement<V>> elements;
 
-  public BTreeElements(List<BTreeElement<V>> elements) {
+  public BTreeGetResult(List<BTreeElement<V>> elements) {
     if (elements == null) {
       throw new IllegalArgumentException("Elements map cannot be null");
     }

--- a/src/main/java/net/spy/memcached/v2/vo/BTreeSMGetResult.java
+++ b/src/main/java/net/spy/memcached/v2/vo/BTreeSMGetResult.java
@@ -9,14 +9,14 @@ import java.util.PriorityQueue;
 
 import net.spy.memcached.ops.StatusCode;
 
-public final class SMGetElements<V> {
+public final class BTreeSMGetResult<V> {
   private final List<Element<V>> elements;
   private final List<MissedKey> missedKeys;
   private final List<TrimmedKey> trimmedKeys;
 
-  public SMGetElements(List<Element<V>> elements,
-                       List<MissedKey> missedKeys,
-                       List<TrimmedKey> trimmedKeys) {
+  public BTreeSMGetResult(List<Element<V>> elements,
+                          List<MissedKey> missedKeys,
+                          List<TrimmedKey> trimmedKeys) {
     if (elements == null || missedKeys == null || trimmedKeys == null) {
       throw new IllegalArgumentException("Arguments cannot be null");
     }
@@ -25,9 +25,9 @@ public final class SMGetElements<V> {
     this.trimmedKeys = trimmedKeys;
   }
 
-  public static <T> SMGetElements<T> mergeSMGetElements(List<SMGetElements<T>> smGetElementsList,
-                                                        boolean ascending,
-                                                        boolean unique, int count) {
+  public static <T> BTreeSMGetResult<T> mergeSMGetElements(
+      List<BTreeSMGetResult<T>> smGetElementsList,
+      boolean ascending, boolean unique, int count) {
     List<Element<T>> elements = new ArrayList<>();
     List<MissedKey> missedKeys = new ArrayList<>();
     List<TrimmedKey> trimmedKeys = new ArrayList<>();
@@ -49,11 +49,11 @@ public final class SMGetElements<V> {
       });
     }
 
-    return new SMGetElements<>(elements, missedKeys, trimmedKeys);
+    return new BTreeSMGetResult<>(elements, missedKeys, trimmedKeys);
   }
 
   private static <T> void mergeSMGetElements(
-      List<SMGetElements<T>> smGetElementsList,
+      List<BTreeSMGetResult<T>> smGetElementsList,
       List<Element<T>> elements,
       List<MissedKey> missedKeys,
       List<TrimmedKey> trimmedKeys,
@@ -67,7 +67,7 @@ public final class SMGetElements<V> {
     // 2) Initialize the priority queue with the first element from each list
     //    and collect missed keys and trimmed keys
     for (int i = 0; i < smGetElementsList.size(); i++) {
-      SMGetElements<T> smGetElements = smGetElementsList.get(i);
+      BTreeSMGetResult<T> smGetElements = smGetElementsList.get(i);
       List<Element<T>> eachElements = smGetElements.getElements();
       if (!eachElements.isEmpty()) {
         pq.offer(new ElementWithIndex<>(eachElements.get(0), i, 0));

--- a/src/test/java/net/spy/memcached/v2/BTreeAsyncArcusCommandsTest.java
+++ b/src/test/java/net/spy/memcached/v2/BTreeAsyncArcusCommandsTest.java
@@ -17,11 +17,11 @@ import net.spy.memcached.ops.OperationException;
 import net.spy.memcached.ops.StatusCode;
 import net.spy.memcached.v2.vo.BKey;
 import net.spy.memcached.v2.vo.BTreeElement;
-import net.spy.memcached.v2.vo.BTreeElements;
+import net.spy.memcached.v2.vo.BTreeGetResult;
+import net.spy.memcached.v2.vo.BTreeSMGetResult;
 import net.spy.memcached.v2.vo.BTreeUpdateElement;
 import net.spy.memcached.v2.vo.BopDeleteArgs;
 import net.spy.memcached.v2.vo.BopGetArgs;
-import net.spy.memcached.v2.vo.SMGetElements;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -387,17 +387,17 @@ class BTreeAsyncArcusCommandsTest extends AsyncArcusCommandsTest {
         .thenAccept(map -> {
           assertEquals(3, map.size());
 
-          BTreeElements<Object> elements0 = map.get(testKeys.get(0));
+          BTreeGetResult<Object> elements0 = map.get(testKeys.get(0));
           assertEquals(2, elements0.getElements().size());
           assertEquals(ELEMENTS.get(0), elements0.getElements().get(0));
           assertEquals(ELEMENTS.get(1), elements0.getElements().get(1));
 
-          BTreeElements<Object> elements1 = map.get(testKeys.get(1));
+          BTreeGetResult<Object> elements1 = map.get(testKeys.get(1));
           assertEquals(2, elements1.getElements().size());
           assertEquals(ELEMENTS.get(2), elements1.getElements().get(0));
           assertEquals(ELEMENTS.get(3), elements1.getElements().get(1));
 
-          BTreeElements<Object> elements2 = map.get(testKeys.get(2));
+          BTreeGetResult<Object> elements2 = map.get(testKeys.get(2));
           assertEquals(1, elements2.getElements().size());
           assertEquals(ELEMENTS.get(4), elements2.getElements().get(0));
         })
@@ -423,11 +423,11 @@ class BTreeAsyncArcusCommandsTest extends AsyncArcusCommandsTest {
         .thenAccept(map -> {
           assertEquals(3, map.size());
 
-          BTreeElements<Object> elements0 = map.get(testKeys.get(0));
+          BTreeGetResult<Object> elements0 = map.get(testKeys.get(0));
           assertEquals(2, elements0.getElements().size());
-          BTreeElements<Object> elements1 = map.get(testKeys.get(1));
+          BTreeGetResult<Object> elements1 = map.get(testKeys.get(1));
           assertEquals(2, elements1.getElements().size());
-          BTreeElements<Object> elements2 = map.get(testKeys.get(2));
+          BTreeGetResult<Object> elements2 = map.get(testKeys.get(2));
           assertEquals(1, elements2.getElements().size());
 
           // Make sure that the order is descending
@@ -461,7 +461,7 @@ class BTreeAsyncArcusCommandsTest extends AsyncArcusCommandsTest {
           assertEquals(1, map.size());
 
           // NOT FOUND ELEMENT
-          BTreeElements<Object> elements = map.get(testKeys.get(0));
+          BTreeGetResult<Object> elements = map.get(testKeys.get(0));
           assertNotNull(elements);
           assertEquals(0, elements.getElements().size());
 
@@ -492,7 +492,7 @@ class BTreeAsyncArcusCommandsTest extends AsyncArcusCommandsTest {
           assertNotNull(smGetElements);
           assertEquals(4, smGetElements.getElements().size());
 
-          List<SMGetElements.Element<Object>> elements = smGetElements.getElements();
+          List<BTreeSMGetResult.Element<Object>> elements = smGetElements.getElements();
           assertEquals(testKeys.get(0), elements.get(0).getKey());
           assertEquals(ELEMENTS.get(0), elements.get(0).getbTreeElement());
           assertEquals(testKeys.get(1), elements.get(1).getKey());
@@ -526,7 +526,7 @@ class BTreeAsyncArcusCommandsTest extends AsyncArcusCommandsTest {
           assertNotNull(smGetElements);
           assertEquals(4, smGetElements.getElements().size());
 
-          List<SMGetElements.Element<Object>> elements = smGetElements.getElements();
+          List<BTreeSMGetResult.Element<Object>> elements = smGetElements.getElements();
           assertEquals(testKeys.get(2), elements.get(0).getKey());
           assertEquals(ELEMENTS.get(3), elements.get(0).getbTreeElement());
           assertEquals(testKeys.get(0), elements.get(1).getKey());
@@ -558,19 +558,19 @@ class BTreeAsyncArcusCommandsTest extends AsyncArcusCommandsTest {
           assertNotNull(smGetElements);
           assertEquals(4, smGetElements.getElements().size());
 
-          SMGetElements.Element<Object> element1 = smGetElements.getElements().get(0);
+          BTreeSMGetResult.Element<Object> element1 = smGetElements.getElements().get(0);
           assertEquals(ELEMENTS.get(0), element1.getbTreeElement());
           assertEquals(testKeys.get(0), element1.getKey());
 
-          SMGetElements.Element<Object> element2 = smGetElements.getElements().get(1);
+          BTreeSMGetResult.Element<Object> element2 = smGetElements.getElements().get(1);
           assertEquals(ELEMENTS.get(0), element2.getbTreeElement());
           assertEquals(testKeys.get(1), element2.getKey());
 
-          SMGetElements.Element<Object> element3 = smGetElements.getElements().get(2);
+          BTreeSMGetResult.Element<Object> element3 = smGetElements.getElements().get(2);
           assertEquals(ELEMENTS.get(1), element3.getbTreeElement());
           assertEquals(testKeys.get(0), element3.getKey());
 
-          SMGetElements.Element<Object> element4 = smGetElements.getElements().get(3);
+          BTreeSMGetResult.Element<Object> element4 = smGetElements.getElements().get(3);
           assertEquals(ELEMENTS.get(1), element4.getbTreeElement());
           assertEquals(testKeys.get(1), element4.getKey());
         })
@@ -596,19 +596,19 @@ class BTreeAsyncArcusCommandsTest extends AsyncArcusCommandsTest {
           assertNotNull(smGetElements);
           assertEquals(4, smGetElements.getElements().size());
 
-          SMGetElements.Element<Object> element1 = smGetElements.getElements().get(0);
+          BTreeSMGetResult.Element<Object> element1 = smGetElements.getElements().get(0);
           assertEquals(ELEMENTS.get(1), element1.getbTreeElement());
           assertEquals(testKeys.get(1), element1.getKey());
 
-          SMGetElements.Element<Object> element2 = smGetElements.getElements().get(1);
+          BTreeSMGetResult.Element<Object> element2 = smGetElements.getElements().get(1);
           assertEquals(ELEMENTS.get(1), element2.getbTreeElement());
           assertEquals(testKeys.get(0), element2.getKey());
 
-          SMGetElements.Element<Object> element3 = smGetElements.getElements().get(2);
+          BTreeSMGetResult.Element<Object> element3 = smGetElements.getElements().get(2);
           assertEquals(ELEMENTS.get(0), element3.getbTreeElement());
           assertEquals(testKeys.get(1), element3.getKey());
 
-          SMGetElements.Element<Object> element4 = smGetElements.getElements().get(3);
+          BTreeSMGetResult.Element<Object> element4 = smGetElements.getElements().get(3);
           assertEquals(ELEMENTS.get(0), element4.getbTreeElement());
           assertEquals(testKeys.get(0), element4.getKey());
         })
@@ -633,7 +633,7 @@ class BTreeAsyncArcusCommandsTest extends AsyncArcusCommandsTest {
           assertNotNull(smGetElements);
           assertEquals(1, smGetElements.getElements().size());
 
-          SMGetElements.Element<Object> element = smGetElements.getElements().get(0);
+          BTreeSMGetResult.Element<Object> element = smGetElements.getElements().get(0);
           assertEquals(ELEMENTS.get(0), element.getbTreeElement());
           assertEquals(keys.get(0), element.getKey());
         })
@@ -656,12 +656,12 @@ class BTreeAsyncArcusCommandsTest extends AsyncArcusCommandsTest {
           assertNotNull(smGetElements);
 
           assertEquals(1, smGetElements.getElements().size());
-          List<SMGetElements.Element<Object>> elements = smGetElements.getElements();
+          List<BTreeSMGetResult.Element<Object>> elements = smGetElements.getElements();
           assertEquals(ELEMENTS.get(0), elements.get(0).getbTreeElement());
           assertEquals(testKeys.get(0), elements.get(0).getKey());
 
           assertEquals(1, smGetElements.getMissedKeys().size());
-          SMGetElements.MissedKey missedKey = smGetElements.getMissedKeys().get(0);
+          BTreeSMGetResult.MissedKey missedKey = smGetElements.getMissedKeys().get(0);
           assertEquals(testKeys.get(1), missedKey.getKey());
           assertEquals(StatusCode.ERR_NOT_FOUND, missedKey.getStatusCode());
         })
@@ -684,7 +684,7 @@ class BTreeAsyncArcusCommandsTest extends AsyncArcusCommandsTest {
           assertEquals(3, smGetElements.getMissedKeys().size());
           assertEquals(0, smGetElements.getTrimmedKeys().size());
           assertIterableEquals(testKeys, smGetElements.getMissedKeys().stream()
-              .map(SMGetElements.MissedKey::getKey).collect(Collectors.toList()));
+              .map(BTreeSMGetResult.MissedKey::getKey).collect(Collectors.toList()));
         })
         .toCompletableFuture()
         .get(300, TimeUnit.MILLISECONDS);
@@ -709,7 +709,7 @@ class BTreeAsyncArcusCommandsTest extends AsyncArcusCommandsTest {
           assertEquals(1, smGetElements.getMissedKeys().size());
           assertEquals(0, smGetElements.getTrimmedKeys().size());
 
-          SMGetElements.MissedKey missedKey = smGetElements.getMissedKeys().get(0);
+          BTreeSMGetResult.MissedKey missedKey = smGetElements.getMissedKeys().get(0);
           assertEquals(testKeys.get(2), missedKey.getKey());
           assertEquals(StatusCode.ERR_NOT_FOUND, missedKey.getStatusCode());
         })
@@ -740,11 +740,11 @@ class BTreeAsyncArcusCommandsTest extends AsyncArcusCommandsTest {
           assertEquals(1, smGetElements.getMissedKeys().size());
           assertEquals(1, smGetElements.getTrimmedKeys().size());
 
-          SMGetElements.TrimmedKey trimmedKey = smGetElements.getTrimmedKeys().get(0);
+          BTreeSMGetResult.TrimmedKey trimmedKey = smGetElements.getTrimmedKeys().get(0);
           assertEquals(keys.get(0), trimmedKey.getKey());
           assertEquals(ELEMENTS.get(2).getBKey(), trimmedKey.getBKey());
 
-          List<SMGetElements.Element<Object>> elements = smGetElements.getElements();
+          List<BTreeSMGetResult.Element<Object>> elements = smGetElements.getElements();
           assertEquals(testKeys.get(0), elements.get(0).getKey());
           assertEquals(ELEMENTS.get(3), elements.get(0).getbTreeElement());
           assertEquals(testKeys.get(1), elements.get(1).getKey());
@@ -782,7 +782,7 @@ class BTreeAsyncArcusCommandsTest extends AsyncArcusCommandsTest {
           assertTrue(smGetElements.getMissedKeys().isEmpty());
           assertTrue(smGetElements.getTrimmedKeys().isEmpty());
 
-          List<SMGetElements.Element<Object>> elements = smGetElements.getElements();
+          List<BTreeSMGetResult.Element<Object>> elements = smGetElements.getElements();
           assertEquals(testKeys.get(1), elements.get(0).getKey());
           assertEquals(ELEMENTS.get(3), elements.get(0).getbTreeElement());
           assertEquals(testKeys.get(0), elements.get(1).getKey());
@@ -821,7 +821,7 @@ class BTreeAsyncArcusCommandsTest extends AsyncArcusCommandsTest {
           assertTrue(smGetElements.getMissedKeys().isEmpty());
           assertTrue(smGetElements.getTrimmedKeys().isEmpty());
 
-          List<SMGetElements.Element<Object>> elements = smGetElements.getElements();
+          List<BTreeSMGetResult.Element<Object>> elements = smGetElements.getElements();
           assertEquals(testKeys.get(0), elements.get(0).getKey());
           assertEquals(ELEMENTS.get(0), elements.get(0).getbTreeElement());
           assertEquals(testKeys.get(1), elements.get(1).getKey());


### PR DESCRIPTION
### 🔗 Related Issue

<!-- Please link related issue. ex) https://github.com/naver/arcus-java-client/issues/{issue_number} -->
- https://github.com/jam2in/arcus-works/issues/832

### ⌨️ What I did

<!-- Please describe this PR and what you've been working on. -->
- BTree 조회(get) 응답 결과 클래스에 `Result` suffix를 사용하도록 변경하였습니다. 
  - `BTreeElements` &rarr; `BTreeGetResult` 로 변경
  - `SMGetElements` &rarr; `BTreeSMGetResult` 로 변경 