### PR TITLE
FEATURE: Replace BopGetArgs with operation-specific args classes

### DIFF
--- a/src/main/java/net/spy/memcached/v2/AsyncArcusCommands.java
+++ b/src/main/java/net/spy/memcached/v2/AsyncArcusCommands.java
@@ -111,7 +111,10 @@ import net.spy.memcached.v2.vo.BTreeSMGetResult;
 import net.spy.memcached.v2.vo.BTreeUpdateElement;
 import net.spy.memcached.v2.vo.BopDeleteArgs;
 import net.spy.memcached.v2.vo.BopGetArgs;
-import net.spy.memcached.v2.vo.GetOption;
+import net.spy.memcached.v2.vo.BopMultiGetArgs;
+import net.spy.memcached.v2.vo.BopRangeGetArgs;
+import net.spy.memcached.v2.vo.BopSMGetArgs;
+import net.spy.memcached.v2.vo.GetMode;
 
 public class AsyncArcusCommands<T> implements AsyncArcusCommandsIF<T> {
 
@@ -735,10 +738,10 @@ public class AsyncArcusCommands<T> implements AsyncArcusCommandsIF<T> {
   }
 
   @Override
-  public ArcusFuture<T> lopGet(String key, int index, GetOption option) {
+  public ArcusFuture<T> lopGet(String key, int index, GetMode mode) {
     AbstractArcusResult<T> result = new AbstractArcusResult<>(new AtomicReference<>());
     ArcusFutureImpl<T> future = new ArcusFutureImpl<>(result);
-    ListGet get = new ListGet(index, option.isWithDelete(), option.isDropIfEmpty());
+    ListGet get = new ListGet(index, mode.isWithDelete(), mode.isDropIfEmpty());
     ArcusClient client = arcusClientSupplier.get();
 
     CollectionGetOperation.Callback cb = new CollectionGetOperation.Callback() {
@@ -781,11 +784,11 @@ public class AsyncArcusCommands<T> implements AsyncArcusCommandsIF<T> {
   }
 
   @Override
-  public ArcusFuture<List<T>> lopGet(String key, int from, int to, GetOption option) {
+  public ArcusFuture<List<T>> lopGet(String key, int from, int to, GetMode mode) {
     AbstractArcusResult<List<T>> result =
         new AbstractArcusResult<>(new AtomicReference<>(new ArrayList<>()));
     ArcusFutureImpl<List<T>> future = new ArcusFutureImpl<>(result);
-    ListGet get = new ListGet(from, to, option.isWithDelete(), option.isDropIfEmpty());
+    ListGet get = new ListGet(from, to, mode.isWithDelete(), mode.isDropIfEmpty());
     ArcusClient client = arcusClientSupplier.get();
 
     CollectionGetOperation.Callback cb = new CollectionGetOperation.Callback() {
@@ -864,11 +867,11 @@ public class AsyncArcusCommands<T> implements AsyncArcusCommandsIF<T> {
   }
 
   @Override
-  public ArcusFuture<Set<T>> sopGet(String key, int count, GetOption option) {
+  public ArcusFuture<Set<T>> sopGet(String key, int count, GetMode mode) {
     AbstractArcusResult<Set<T>> result
         = new AbstractArcusResult<>(new AtomicReference<>(new HashSet<>()));
     ArcusFutureImpl<Set<T>> future = new ArcusFutureImpl<>(result);
-    SetGet get = new SetGet(count, option.isWithDelete(), option.isDropIfEmpty());
+    SetGet get = new SetGet(count, mode.isWithDelete(), mode.isDropIfEmpty());
     ArcusClient client = arcusClientSupplier.get();
 
     CollectionGetOperation.Callback cb = new CollectionGetOperation.Callback() {
@@ -1009,18 +1012,18 @@ public class AsyncArcusCommands<T> implements AsyncArcusCommandsIF<T> {
   }
 
   @Override
-  public ArcusFuture<Map<String, T>> mopGet(String key, GetOption option) {
-    return mopGet(key, new ArrayList<>(), option);
+  public ArcusFuture<Map<String, T>> mopGet(String key, GetMode mode) {
+    return mopGet(key, new ArrayList<>(), mode);
   }
 
   @Override
-  public ArcusFuture<T> mopGet(String key, String mKey, GetOption option) {
+  public ArcusFuture<T> mopGet(String key, String mKey, GetMode mode) {
     keyValidator.validateMKey(mKey);
 
     AbstractArcusResult<T> result = new AbstractArcusResult<>(new AtomicReference<>());
     ArcusFutureImpl<T> future = new ArcusFutureImpl<>(result);
     List<String> mKeys = Collections.singletonList(mKey);
-    MapGet get = new MapGet(mKeys, option.isWithDelete(), option.isDropIfEmpty());
+    MapGet get = new MapGet(mKeys, mode.isWithDelete(), mode.isDropIfEmpty());
     ArcusClient client = arcusClientSupplier.get();
 
     CollectionGetOperation.Callback cb = new CollectionGetOperation.Callback() {
@@ -1063,7 +1066,7 @@ public class AsyncArcusCommands<T> implements AsyncArcusCommandsIF<T> {
   }
 
   @Override
-  public ArcusFuture<Map<String, T>> mopGet(String key, List<String> mKeys, GetOption option) {
+  public ArcusFuture<Map<String, T>> mopGet(String key, List<String> mKeys, GetMode mode) {
     if (mKeys == null) {
       throw new IllegalArgumentException("mKeys cannot be null");
     }
@@ -1075,7 +1078,7 @@ public class AsyncArcusCommands<T> implements AsyncArcusCommandsIF<T> {
     AbstractArcusResult<Map<String, T>> result =
         new AbstractArcusResult<>(new AtomicReference<>(new HashMap<>()));
     ArcusFutureImpl<Map<String, T>> future = new ArcusFutureImpl<>(result);
-    MapGet get = new MapGet(mKeys, option.isWithDelete(), option.isDropIfEmpty());
+    MapGet get = new MapGet(mKeys, mode.isWithDelete(), mode.isDropIfEmpty());
     ArcusClient client = arcusClientSupplier.get();
 
     CollectionGetOperation.Callback cb = new CollectionGetOperation.Callback() {
@@ -1353,7 +1356,8 @@ public class AsyncArcusCommands<T> implements AsyncArcusCommandsIF<T> {
   }
 
   @Override
-  public ArcusFuture<BTreeGetResult<T>> bopGet(String key, BKey from, BKey to, BopGetArgs args) {
+  public ArcusFuture<BTreeGetResult<T>> bopGet(String key, BKey from, BKey to,
+                                               BopRangeGetArgs args) {
     verifyBKeyTypesMatch(from, to);
 
     AbstractArcusResult<BTreeGetResult<T>> result =
@@ -1405,34 +1409,33 @@ public class AsyncArcusCommands<T> implements AsyncArcusCommandsIF<T> {
 
   private static BTreeGet createBTreeGet(BKey bKey, BopGetArgs args) {
     if (bKey.getType() == BKey.BKeyType.LONG) {
-      return new BTreeGet((long) bKey.getData(), args.getElementFlagFilter(),
+      return new BTreeGet((long) bKey.getData(), args.getEFlagFilter(),
           args.isWithDelete(), args.isDropIfEmpty());
     }
 
-    return new BTreeGet((byte[]) bKey.getData(), args.getElementFlagFilter(),
+    return new BTreeGet((byte[]) bKey.getData(), args.getEFlagFilter(),
         args.isWithDelete(), args.isDropIfEmpty());
   }
 
-  private static BTreeGet createBTreeGet(BKey from, BKey to, BopGetArgs args) {
+  private static BTreeGet createBTreeGet(BKey from, BKey to, BopRangeGetArgs args) {
     if (from.getType() == BKey.BKeyType.LONG) {
       return new BTreeGet((long) from.getData(), (long) to.getData(),
-          args.getElementFlagFilter(), args.getOffset(), args.getCount(),
+          args.getEFlagFilter(), args.getOffset(), args.getCount(),
           args.isWithDelete(), args.isDropIfEmpty());
     }
 
     return new BTreeGet((byte[]) from.getData(), (byte[]) to.getData(),
-        args.getElementFlagFilter(), args.getOffset(), args.getCount(),
+        args.getEFlagFilter(), args.getOffset(), args.getCount(),
         args.isWithDelete(), args.isDropIfEmpty());
   }
 
   @Override
   public ArcusFuture<Map<String, BTreeGetResult<T>>> bopMultiGet(List<String> keys,
                                                                  BKey from, BKey to,
-                                                                 BopGetArgs args) {
+                                                                 BopMultiGetArgs args) {
     keyValidator.validateKey(keys);
     keyValidator.checkDupKey(keys);
     verifyBKeyTypesMatch(from, to);
-    verifyPositiveCountArg(args, ArcusClient.MAX_GETBULK_ELEMENT_COUNT);
 
     ArcusClient client = arcusClientSupplier.get();
     Collection<Map.Entry<MemcachedNode, List<String>>> arrangedKeys =
@@ -1542,25 +1545,24 @@ public class AsyncArcusCommands<T> implements AsyncArcusCommandsIF<T> {
   }
 
   private BTreeGetBulk<T> createBTreeGetBulk(MemcachedNode node, List<String> keys,
-                                             BKey from, BKey to, BopGetArgs args) {
+                                             BKey from, BKey to, BopMultiGetArgs args) {
     if (from.getType() == BKey.BKeyType.LONG) {
       return new BTreeGetBulkWithLongTypeBkey<>(node, keys,
-          (long) from.getData(), (long) to.getData(), args.getElementFlagFilter(),
+          (long) from.getData(), (long) to.getData(), args.getEFlagFilter(),
           args.getOffset(), args.getCount());
     }
 
     return new BTreeGetBulkWithByteTypeBkey<>(node, keys,
-        (byte[]) from.getData(), (byte[]) to.getData(), args.getElementFlagFilter(),
+        (byte[]) from.getData(), (byte[]) to.getData(), args.getEFlagFilter(),
         args.getOffset(), args.getCount());
   }
 
   @Override
   public ArcusFuture<BTreeSMGetResult<T>> bopSortMergeGet(List<String> keys, BKey from, BKey to,
-                                                          boolean unique, BopGetArgs args) {
+                                                          BopSMGetArgs args) {
     keyValidator.validateKey(keys);
     keyValidator.checkDupKey(keys);
     verifyBKeyTypesMatch(from, to);
-    verifyPositiveCountArg(args, ArcusClient.MAX_SMGET_COUNT);
 
     ArcusClient client = arcusClientSupplier.get();
     Collection<Map.Entry<MemcachedNode, List<String>>> arrangedKeys =
@@ -1569,7 +1571,7 @@ public class AsyncArcusCommands<T> implements AsyncArcusCommandsIF<T> {
     List<CompletableFuture<BTreeSMGetResult<T>>> smGetFutures = new ArrayList<>();
 
     for (Map.Entry<MemcachedNode, List<String>> entry : arrangedKeys) {
-      BTreeSMGet<T> smGet = createBTreeSMGet(from, to, args, unique, entry);
+      BTreeSMGet<T> smGet = createBTreeSMGet(from, to, args, entry);
       CompletableFuture<BTreeSMGetResult<T>> future =
           bopSortMergeGetPerNode(client, smGet).toCompletableFuture();
       smGetFutures.add(future);
@@ -1585,8 +1587,8 @@ public class AsyncArcusCommands<T> implements AsyncArcusCommandsIF<T> {
           results.add(future.join());
         }
       }
-      return BTreeSMGetResult.mergeSMGetElements(results, from.compareTo(to) <= 0, unique,
-          args.getCount());
+      return BTreeSMGetResult.mergeSMGetElements(results, from.compareTo(to) <= 0,
+          args.isUnique(), args.getCount());
     });
   }
 
@@ -1656,18 +1658,17 @@ public class AsyncArcusCommands<T> implements AsyncArcusCommandsIF<T> {
     return future;
   }
 
-  private BTreeSMGet<T> createBTreeSMGet(BKey from, BKey to, BopGetArgs args,
-                                         boolean unique,
+  private BTreeSMGet<T> createBTreeSMGet(BKey from, BKey to, BopSMGetArgs args,
                                          Map.Entry<MemcachedNode, List<String>> entry) {
     if (from.getType() == BKey.BKeyType.LONG) {
       return new BTreeSMGetWithLongTypeBkey<>(entry.getKey(), entry.getValue(),
-          (long) from.getData(), (long) to.getData(), args.getElementFlagFilter(),
-          args.getCount(), unique);
+          (long) from.getData(), (long) to.getData(),
+          args.getEFlagFilter(), args.getCount(), args.isUnique());
     }
 
     return new BTreeSMGetWithByteTypeBkey<>(entry.getKey(), entry.getValue(),
-        (byte[]) from.getData(), (byte[]) to.getData(), args.getElementFlagFilter(),
-        args.getCount(), unique);
+        (byte[]) from.getData(), (byte[]) to.getData(),
+        args.getEFlagFilter(), args.getCount(), args.isUnique());
   }
 
   @Override
@@ -1930,13 +1931,6 @@ public class AsyncArcusCommands<T> implements AsyncArcusCommandsIF<T> {
   private static void verifyBKeyTypesMatch(BKey from, BKey to) {
     if (from.getType() != to.getType()) {
       throw new IllegalArgumentException("Two BKey types(from, to) must be the same.");
-    }
-  }
-
-  private static void verifyPositiveCountArg(BopGetArgs args, int maxCount) {
-    int count = args.getCount();
-    if (count <= 0 || count > maxCount) {
-      throw new IllegalArgumentException("Count should be between 1 to " + maxCount);
     }
   }
 

--- a/src/main/java/net/spy/memcached/v2/AsyncArcusCommandsIF.java
+++ b/src/main/java/net/spy/memcached/v2/AsyncArcusCommandsIF.java
@@ -35,7 +35,10 @@ import net.spy.memcached.v2.vo.BTreeSMGetResult;
 import net.spy.memcached.v2.vo.BTreeUpdateElement;
 import net.spy.memcached.v2.vo.BopDeleteArgs;
 import net.spy.memcached.v2.vo.BopGetArgs;
-import net.spy.memcached.v2.vo.GetOption;
+import net.spy.memcached.v2.vo.BopMultiGetArgs;
+import net.spy.memcached.v2.vo.BopRangeGetArgs;
+import net.spy.memcached.v2.vo.BopSMGetArgs;
+import net.spy.memcached.v2.vo.GetMode;
 
 public interface AsyncArcusCommandsIF<T> {
 
@@ -260,10 +263,10 @@ public interface AsyncArcusCommandsIF<T> {
    *
    * @param key   key of the list
    * @param index index of the element to get
-   * @param option get option - {@link GetOption}
+   * @param mode  get mode - {@link net.spy.memcached.v2.vo.GetMode}
    * @return the element value, {@code null} if the key or element is not found
    */
-  ArcusFuture<T> lopGet(String key, int index, GetOption option);
+  ArcusFuture<T> lopGet(String key, int index, GetMode mode);
 
   /**
    * Get elements in an index range from a list.
@@ -271,11 +274,11 @@ public interface AsyncArcusCommandsIF<T> {
    * @param key  key of the list
    * @param from index range start (inclusive)
    * @param to   index range end (inclusive)
-   * @param option get option - {@link GetOption}
+   * @param mode get mode - {@link net.spy.memcached.v2.vo.GetMode}
    * @return list of element values in order, an empty list if no elements are found in the range,
    * {@code null} if the key is not found
    */
-  ArcusFuture<List<T>> lopGet(String key, int from, int to, GetOption option);
+  ArcusFuture<List<T>> lopGet(String key, int from, int to, GetMode mode);
 
   /**
    * Delete an element at the given index from a list.
@@ -342,11 +345,11 @@ public interface AsyncArcusCommandsIF<T> {
    *
    * @param key   key of the set
    * @param count number of elements to retrieve randomly (0 means all elements, max 1000)
-   * @param option get option - {@link GetOption}
+   * @param mode  get mode - {@link net.spy.memcached.v2.vo.GetMode}
    * @return set of element values, an empty set if no elements are found,
    * {@code null} if the key is not found
    */
-  ArcusFuture<Set<T>> sopGet(String key, int count, GetOption option);
+  ArcusFuture<Set<T>> sopGet(String key, int count, GetMode mode);
 
   /**
    * Check whether an element exists in a set.
@@ -448,35 +451,35 @@ public interface AsyncArcusCommandsIF<T> {
    * Get all elements from a map.
    *
    * @param key  key of the map
-   * @param option get option - {@link GetOption}
+   * @param mode get mode - {@link net.spy.memcached.v2.vo.GetMode}
    * @return map of MKey to value,
    * empty map if no elements exist,
    * {@code null} if the key is not found
    */
-  ArcusFuture<Map<String, T>> mopGet(String key, GetOption option);
+  ArcusFuture<Map<String, T>> mopGet(String key, GetMode mode);
 
   /**
    * Get an element with the given MKey from a map.
    *
    * @param key  key of the map
    * @param mKey MKey of the element to get
-   * @param option get option - {@link GetOption}
+   * @param mode get mode - {@link net.spy.memcached.v2.vo.GetMode}
    * @return the element value,
    * {@code null} if the key or MKey is not found
    */
-  ArcusFuture<T> mopGet(String key, String mKey, GetOption option);
+  ArcusFuture<T> mopGet(String key, String mKey, GetMode mode);
 
   /**
    * Get elements with the MKeys from a map.
    *
    * @param key   key of the map
    * @param mKeys list of MKeys to get
-   * @param option get option - {@link GetOption}
+   * @param mode  get mode - {@link net.spy.memcached.v2.vo.GetMode}
    * @return map of MKey to value for found elements,
    * empty map if no MKeys are found,
    * {@code null} if the key is not found
    */
-  ArcusFuture<Map<String, T>> mopGet(String key, List<String> mKeys, GetOption option);
+  ArcusFuture<Map<String, T>> mopGet(String key, List<String> mKeys, GetMode mode);
 
   /**
    * Delete all elements from a map.
@@ -694,7 +697,7 @@ public interface AsyncArcusCommandsIF<T> {
    * empty {@code BTreeGetResult} if no elements are found in the range but key exists,
    * {@code null} if key is not found
    */
-  ArcusFuture<BTreeGetResult<T>> bopGet(String key, BKey from, BKey to, BopGetArgs args);
+  ArcusFuture<BTreeGetResult<T>> bopGet(String key, BKey from, BKey to, BopRangeGetArgs args);
 
   /**
    * Get elements from multiple btree items.
@@ -708,21 +711,20 @@ public interface AsyncArcusCommandsIF<T> {
    * no {@code Map.Entry} in the map if the key is not found
    */
   ArcusFuture<Map<String, BTreeGetResult<T>>> bopMultiGet(
-      List<String> keys, BKey from, BKey to, BopGetArgs args);
+      List<String> keys, BKey from, BKey to, BopMultiGetArgs args);
 
   /**
    * Get sort-merged elements from multiple btree items.
    *
-   * @param keys   list of keys to get
-   * @param from   BKey range start
-   * @param to     BKey range end
-   * @param unique whether to return unique elements only
-   * @param args   arguments for get operation
+   * @param keys list of keys to get
+   * @param from BKey range start
+   * @param to   BKey range end
+   * @param args arguments for get operation {@link BopSMGetArgs}
    * @return {@code BTreeSMGetResult} containing sort-merged elements,
    * empty {@code BTreeSMGetResult} if no matching elements exist
    */
   ArcusFuture<BTreeSMGetResult<T>> bopSortMergeGet(
-      List<String> keys, BKey from, BKey to, boolean unique, BopGetArgs args);
+      List<String> keys, BKey from, BKey to, BopSMGetArgs args);
 
   /**
    * Get the position of an element with the given bKey in a btree item.

--- a/src/main/java/net/spy/memcached/v2/vo/BopGetArgs.java
+++ b/src/main/java/net/spy/memcached/v2/vo/BopGetArgs.java
@@ -4,97 +4,30 @@ import net.spy.memcached.collection.ElementFlagFilter;
 
 public final class BopGetArgs {
 
-  public static final BopGetArgs DEFAULT = new BopGetArgs.Builder().build();
+  public static final BopGetArgs DEFAULT
+      = new BopGetArgs(ElementFlagFilter.DO_NOT_FILTER, GetMode.NONE);
 
   private final ElementFlagFilter eFlagFilter;
-  private final int offset;
-  private final int count;
-  private final boolean withDelete;
-  private final boolean dropIfEmpty;
+  private final GetMode mode;
 
-  private BopGetArgs(ElementFlagFilter eFlagFilter, int offset, int count,
-                     boolean withDelete, boolean dropIfEmpty) {
+  public BopGetArgs(ElementFlagFilter eFlagFilter, GetMode mode) {
+    if (mode == null) {
+      throw new IllegalArgumentException("mode cannot be null");
+    }
+
     this.eFlagFilter = eFlagFilter;
-    this.offset = offset;
-    this.count = count;
-    this.withDelete = withDelete;
-    this.dropIfEmpty = dropIfEmpty;
+    this.mode = mode;
   }
 
-  public ElementFlagFilter getElementFlagFilter() {
+  public ElementFlagFilter getEFlagFilter() {
     return eFlagFilter;
   }
 
-  public int getOffset() {
-    return offset;
-  }
-
-  public int getCount() {
-    return count;
-  }
-
   public boolean isWithDelete() {
-    return withDelete;
+    return mode.isWithDelete();
   }
 
   public boolean isDropIfEmpty() {
-    return dropIfEmpty;
-  }
-
-  public static final class Builder {
-    private ElementFlagFilter eFlagFilter = null;
-    private int offset = 0;
-    private int count = 50;
-    private boolean withDelete = false;
-    private boolean dropIfEmpty = false;
-
-    public Builder eFlagFilter(ElementFlagFilter eFlagFilter) {
-      this.eFlagFilter = eFlagFilter;
-      return this;
-    }
-
-    /**
-     * Set the offset only for {@code AsyncArcusCommands#bopGet}
-     * or {@code AsyncArcusCommands#bopMultiGet}
-     *
-     * @param offset to skip elements that match condition from the 'from' BKey
-     */
-    public Builder offset(int offset) {
-      if (offset < 0) {
-        throw new IllegalArgumentException("offset cannot be negative");
-      }
-      this.offset = offset;
-      return this;
-    }
-
-    /**
-     * Set the count of elements to retrieve.
-     *
-     * @param count For bopGet or bopMultiGet method,
-     *              set the number of elements to retrieve from each BTree item.
-     *              For bopSortMergeGet method,
-     *              set the total number of elements to retrieve across all BTree items.
-     */
-    public Builder count(int count) {
-      if (count < 0) {
-        throw new IllegalArgumentException("count cannot be negative");
-      }
-      this.count = count;
-      return this;
-    }
-
-    public Builder withDelete() {
-      this.withDelete = true;
-      return this;
-    }
-
-    public Builder dropIfEmpty() {
-      this.dropIfEmpty = true;
-      return this;
-    }
-
-    public BopGetArgs build() {
-      return new BopGetArgs(eFlagFilter, offset, count, withDelete, dropIfEmpty);
-    }
+    return mode.isDropIfEmpty();
   }
 }

--- a/src/main/java/net/spy/memcached/v2/vo/BopMultiGetArgs.java
+++ b/src/main/java/net/spy/memcached/v2/vo/BopMultiGetArgs.java
@@ -1,0 +1,41 @@
+package net.spy.memcached.v2.vo;
+
+import net.spy.memcached.collection.ElementFlagFilter;
+
+public class BopMultiGetArgs {
+
+  private static final int MAX_MGET_COUNT = 50;
+
+  public static final BopMultiGetArgs DEFAULT
+      = new BopMultiGetArgs(ElementFlagFilter.DO_NOT_FILTER, 0, MAX_MGET_COUNT);
+
+  private final ElementFlagFilter eFlagFilter;
+  private final int offset;
+  private final int count;
+
+  public BopMultiGetArgs(ElementFlagFilter eFlagFilter, int offset, int count) {
+    if (offset < 0) {
+      throw new IllegalArgumentException("offset cannot be negative");
+    }
+
+    if (count < 1 || count > MAX_MGET_COUNT) {
+      throw new IllegalArgumentException("count must be between 1 and 50");
+    }
+
+    this.eFlagFilter = eFlagFilter;
+    this.offset = offset;
+    this.count = count;
+  }
+
+  public ElementFlagFilter getEFlagFilter() {
+    return eFlagFilter;
+  }
+
+  public int getOffset() {
+    return offset;
+  }
+
+  public int getCount() {
+    return count;
+  }
+}

--- a/src/main/java/net/spy/memcached/v2/vo/BopRangeGetArgs.java
+++ b/src/main/java/net/spy/memcached/v2/vo/BopRangeGetArgs.java
@@ -1,0 +1,53 @@
+package net.spy.memcached.v2.vo;
+
+import net.spy.memcached.collection.ElementFlagFilter;
+
+public class BopRangeGetArgs {
+
+  public static final BopRangeGetArgs DEFAULT
+      = new BopRangeGetArgs(ElementFlagFilter.DO_NOT_FILTER, 0, 0, GetMode.NONE);
+
+  private final ElementFlagFilter eFlagFilter;
+  private final int offset;
+  private final int count;
+  private final GetMode mode;
+
+  public BopRangeGetArgs(ElementFlagFilter eFlagFilter, int offset, int count, GetMode mode) {
+    if (offset < 0) {
+      throw new IllegalArgumentException("offset cannot be negative");
+    }
+
+    if (count < 0) {
+      throw new IllegalArgumentException("count cannot be negative");
+    }
+
+    if (mode == null) {
+      throw new IllegalArgumentException("mode cannot be null");
+    }
+
+    this.eFlagFilter = eFlagFilter;
+    this.offset = offset;
+    this.count = count;
+    this.mode = mode;
+  }
+
+  public ElementFlagFilter getEFlagFilter() {
+    return eFlagFilter;
+  }
+
+  public int getOffset() {
+    return offset;
+  }
+
+  public int getCount() {
+    return count;
+  }
+
+  public boolean isWithDelete() {
+    return mode.isWithDelete();
+  }
+
+  public boolean isDropIfEmpty() {
+    return mode.isDropIfEmpty();
+  }
+}

--- a/src/main/java/net/spy/memcached/v2/vo/BopSMGetArgs.java
+++ b/src/main/java/net/spy/memcached/v2/vo/BopSMGetArgs.java
@@ -1,0 +1,37 @@
+package net.spy.memcached.v2.vo;
+
+import net.spy.memcached.collection.ElementFlagFilter;
+
+public class BopSMGetArgs {
+
+  private static final int MAX_SMGET_COUNT = 1000;
+
+  public static final BopSMGetArgs DEFAULT
+      = new BopSMGetArgs(ElementFlagFilter.DO_NOT_FILTER, MAX_SMGET_COUNT, false);
+
+  private final ElementFlagFilter eFlagFilter;
+  private final int count;
+  private final boolean unique;
+
+  public BopSMGetArgs(ElementFlagFilter eFlagFilter, int count, boolean unique) {
+    if (count < 1 || count > MAX_SMGET_COUNT) {
+      throw new IllegalArgumentException("count must be between 1 and 1000");
+    }
+
+    this.eFlagFilter = eFlagFilter;
+    this.count = count;
+    this.unique = unique;
+  }
+
+  public ElementFlagFilter getEFlagFilter() {
+    return eFlagFilter;
+  }
+
+  public int getCount() {
+    return count;
+  }
+
+  public boolean isUnique() {
+    return unique;
+  }
+}

--- a/src/main/java/net/spy/memcached/v2/vo/GetMode.java
+++ b/src/main/java/net/spy/memcached/v2/vo/GetMode.java
@@ -1,6 +1,6 @@
 package net.spy.memcached.v2.vo;
 
-public enum GetOption {
+public enum GetMode {
   /**
    * Retrieves elements without deleting them.
    */
@@ -19,7 +19,7 @@ public enum GetOption {
   private final boolean withDelete;
   private final boolean dropIfEmpty;
 
-  GetOption(boolean withDelete, boolean dropIfEmpty) {
+  GetMode(boolean withDelete, boolean dropIfEmpty) {
     this.withDelete = withDelete;
     this.dropIfEmpty = dropIfEmpty;
   }

--- a/src/test/java/net/spy/memcached/v2/BTreeAsyncArcusCommandsTest.java
+++ b/src/test/java/net/spy/memcached/v2/BTreeAsyncArcusCommandsTest.java
@@ -22,6 +22,10 @@ import net.spy.memcached.v2.vo.BTreeSMGetResult;
 import net.spy.memcached.v2.vo.BTreeUpdateElement;
 import net.spy.memcached.v2.vo.BopDeleteArgs;
 import net.spy.memcached.v2.vo.BopGetArgs;
+import net.spy.memcached.v2.vo.BopMultiGetArgs;
+import net.spy.memcached.v2.vo.BopRangeGetArgs;
+import net.spy.memcached.v2.vo.BopSMGetArgs;
+import net.spy.memcached.v2.vo.GetMode;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -216,7 +220,7 @@ class BTreeAsyncArcusCommandsTest extends AsyncArcusCommandsTest {
     async.bopInsert(key, ELEMENTS.get(0), attrs)
         .thenCompose(result -> async.bopInsert(key, ELEMENTS.get(1)))
         .thenCompose(result -> async.bopInsert(key, ELEMENTS.get(2)))
-        .thenCompose(result -> async.bopGet(key, BKey.of(1L), BKey.of(3L), BopGetArgs.DEFAULT))
+        .thenCompose(result -> async.bopGet(key, BKey.of(1L), BKey.of(3L), BopRangeGetArgs.DEFAULT))
         // then
         .thenAccept(elements -> {
           assertEquals(3, elements.getElements().size());
@@ -235,10 +239,8 @@ class BTreeAsyncArcusCommandsTest extends AsyncArcusCommandsTest {
     // given
     String key = keys.get(0);
     CollectionAttributes attrs = new CollectionAttributes();
-    BopGetArgs getArgsWithDelete = new BopGetArgs.Builder()
-        .withDelete()
-        .count(10)
-        .build();
+    BopGetArgs getArgsWithDelete
+        = new BopGetArgs(ElementFlagFilter.DO_NOT_FILTER, GetMode.DELETE);
 
     // when
     async.bopInsert(key, ELEMENTS.get(0), attrs)
@@ -263,15 +265,11 @@ class BTreeAsyncArcusCommandsTest extends AsyncArcusCommandsTest {
   void bopGetWithDeleteAndDropIfEmpty() throws Exception {
     // given
     String key = keys.get(0);
-    BopGetArgs getArgsWithDeleteAndDrop = new BopGetArgs.Builder()
-        .withDelete()
-        .dropIfEmpty()
-        .count(10)
-        .build();
+    BopGetArgs getArgsWithDrop = new BopGetArgs(ElementFlagFilter.DO_NOT_FILTER, GetMode.DROP);
 
     // when
     async.bopInsert(key, ELEMENTS.get(0), new CollectionAttributes())
-        .thenCompose(result -> async.bopGet(key, BKey.of(1L), getArgsWithDeleteAndDrop))
+        .thenCompose(result -> async.bopGet(key, BKey.of(1L), getArgsWithDrop))
         // then
         .thenAccept(element -> assertEquals(ELEMENTS.get(0), element))
         .thenCompose(v -> async.bopInsert(key, ELEMENTS.get(1)))
@@ -286,7 +284,7 @@ class BTreeAsyncArcusCommandsTest extends AsyncArcusCommandsTest {
     String key = keys.get(0);
 
     // when
-    async.bopGet(key, BKey.of(1L), BKey.of(10L), BopGetArgs.DEFAULT)
+    async.bopGet(key, BKey.of(1L), BKey.of(10L), BopRangeGetArgs.DEFAULT)
         // then
         .thenAccept(Assertions::assertNull) // NOT FOUND (key miss)
         .toCompletableFuture()
@@ -303,7 +301,7 @@ class BTreeAsyncArcusCommandsTest extends AsyncArcusCommandsTest {
         .thenCompose(result -> async.bopInsert(key, ELEMENTS.get(1)))
         .thenCompose(result -> async.bopInsert(key, ELEMENTS.get(2)))
         .thenCompose(result -> async.bopGet(key,
-            BKey.of(10L), BKey.of(20L), BopGetArgs.DEFAULT))
+            BKey.of(10L), BKey.of(20L), BopRangeGetArgs.DEFAULT))
         // then
         .thenAccept(elements -> {
           // NOT FOUND ELEMENT
@@ -319,10 +317,8 @@ class BTreeAsyncArcusCommandsTest extends AsyncArcusCommandsTest {
     // given
     String key = keys.get(0);
     CollectionAttributes attrs = new CollectionAttributes();
-    BopGetArgs getArgsWithDelete = new BopGetArgs.Builder()
-        .withDelete()
-        .count(10)
-        .build();
+    BopRangeGetArgs getArgsWithDelete
+        = new BopRangeGetArgs(ElementFlagFilter.DO_NOT_FILTER, 0, 10, GetMode.DELETE);
 
     // when
     async.bopInsert(key, ELEMENTS.get(0), attrs)
@@ -337,7 +333,7 @@ class BTreeAsyncArcusCommandsTest extends AsyncArcusCommandsTest {
           assertEquals(ELEMENTS.get(1), elements.getElements().get(0));
           assertEquals(ELEMENTS.get(2), elements.getElements().get(1));
         })
-        .thenCompose(v -> async.bopGet(key, BKey.of(2L), BKey.of(3L), BopGetArgs.DEFAULT))
+        .thenCompose(v -> async.bopGet(key, BKey.of(2L), BKey.of(3L), BopRangeGetArgs.DEFAULT))
         .thenAccept(elements -> {
           assertNotNull(elements);
           assertTrue(elements.getElements().isEmpty());
@@ -356,7 +352,8 @@ class BTreeAsyncArcusCommandsTest extends AsyncArcusCommandsTest {
         .thenCompose(result -> async.bopInsert(key, ELEMENTS.get(1)))
         .thenCompose(result -> async.bopInsert(key, ELEMENTS.get(2)))
         .thenCompose(result -> async.bopInsert(key, ELEMENTS.get(3)))
-        .thenCompose(result -> async.bopGet(key, BKey.of(10L), BKey.of(1L), BopGetArgs.DEFAULT))
+        .thenCompose(result -> async.bopGet(key, BKey.of(10L), BKey.of(1L),
+            BopRangeGetArgs.DEFAULT))
         // then
         .thenAccept(elements -> {
           assertNotNull(elements);
@@ -383,7 +380,7 @@ class BTreeAsyncArcusCommandsTest extends AsyncArcusCommandsTest {
         .thenCompose(result -> async.bopInsert(testKeys.get(2), ELEMENTS.get(4), attr))
         // then
         .thenCompose(result -> async
-            .bopMultiGet(testKeys, BKey.of(1L), BKey.of(10L), BopGetArgs.DEFAULT))
+            .bopMultiGet(testKeys, BKey.of(1L), BKey.of(10L), BopMultiGetArgs.DEFAULT))
         .thenAccept(map -> {
           assertEquals(3, map.size());
 
@@ -419,7 +416,7 @@ class BTreeAsyncArcusCommandsTest extends AsyncArcusCommandsTest {
         .thenCompose(result -> async.bopInsert(testKeys.get(2), ELEMENTS.get(4), attr))
         // then
         .thenCompose(result -> async
-            .bopMultiGet(testKeys, BKey.of(10L), BKey.of(1L), BopGetArgs.DEFAULT))
+            .bopMultiGet(testKeys, BKey.of(10L), BKey.of(1L), BopMultiGetArgs.DEFAULT))
         .thenAccept(map -> {
           assertEquals(3, map.size());
 
@@ -455,7 +452,7 @@ class BTreeAsyncArcusCommandsTest extends AsyncArcusCommandsTest {
     // when
     async.bopInsert(testKeys.get(0), ELEMENTS.get(0), attrs)
         .thenCompose(result -> async
-            .bopMultiGet(testKeys, BKey.of(10L), BKey.of(20L), BopGetArgs.DEFAULT))
+            .bopMultiGet(testKeys, BKey.of(10L), BKey.of(20L), BopMultiGetArgs.DEFAULT))
         // then
         .thenAccept(map -> {
           assertEquals(1, map.size());
@@ -477,6 +474,7 @@ class BTreeAsyncArcusCommandsTest extends AsyncArcusCommandsTest {
     // given
     List<String> testKeys = Arrays.asList(keys.get(0), keys.get(1), keys.get(2));
     CollectionAttributes attrs = new CollectionAttributes();
+    BopSMGetArgs getArgs = new BopSMGetArgs(ElementFlagFilter.DO_NOT_FILTER, 1000, true);
 
     async.bopInsert(testKeys.get(0), ELEMENTS.get(0), attrs)
         .thenCompose(result -> async.bopInsert(testKeys.get(0), ELEMENTS.get(2)))
@@ -486,7 +484,7 @@ class BTreeAsyncArcusCommandsTest extends AsyncArcusCommandsTest {
         .thenCompose(result -> async.bopInsert(testKeys.get(2), ELEMENTS.get(3)))
         // when
         .thenCompose(result -> async.bopSortMergeGet(testKeys,
-            BKey.of(1L), BKey.of(10L), true, BopGetArgs.DEFAULT))
+            BKey.of(1L), BKey.of(10L), getArgs))
         // then
         .thenAccept(smGetElements -> {
           assertNotNull(smGetElements);
@@ -511,6 +509,7 @@ class BTreeAsyncArcusCommandsTest extends AsyncArcusCommandsTest {
     // given
     List<String> testKeys = Arrays.asList(keys.get(0), keys.get(1), keys.get(2));
     CollectionAttributes attrs = new CollectionAttributes();
+    BopSMGetArgs getArgs = new BopSMGetArgs(ElementFlagFilter.DO_NOT_FILTER, 1000, true);
 
     async.bopInsert(testKeys.get(0), ELEMENTS.get(0), attrs)
         .thenCompose(result -> async.bopInsert(testKeys.get(0), ELEMENTS.get(2)))
@@ -520,7 +519,7 @@ class BTreeAsyncArcusCommandsTest extends AsyncArcusCommandsTest {
         .thenCompose(result -> async.bopInsert(testKeys.get(2), ELEMENTS.get(3)))
         // when
         .thenCompose(result -> async.bopSortMergeGet(testKeys,
-            BKey.of(10L), BKey.of(1L), true, BopGetArgs.DEFAULT))
+            BKey.of(10L), BKey.of(1L), getArgs))
         // then
         .thenAccept(smGetElements -> {
           assertNotNull(smGetElements);
@@ -552,7 +551,7 @@ class BTreeAsyncArcusCommandsTest extends AsyncArcusCommandsTest {
         .thenCompose(result -> async.bopInsert(testKeys.get(1), ELEMENTS.get(1)))
         // when
         .thenCompose(result -> async.bopSortMergeGet(testKeys,
-            BKey.of(1L), BKey.of(2L), false, BopGetArgs.DEFAULT))
+            BKey.of(1L), BKey.of(2L), BopSMGetArgs.DEFAULT))
         // then
         .thenAccept(smGetElements -> {
           assertNotNull(smGetElements);
@@ -590,7 +589,7 @@ class BTreeAsyncArcusCommandsTest extends AsyncArcusCommandsTest {
         .thenCompose(result -> async.bopInsert(testKeys.get(1), ELEMENTS.get(1)))
         // when
         .thenCompose(result -> async.bopSortMergeGet(testKeys,
-            BKey.of(2L), BKey.of(1L), false, BopGetArgs.DEFAULT))
+            BKey.of(2L), BKey.of(1L), BopSMGetArgs.DEFAULT))
         // then
         .thenAccept(smGetElements -> {
           assertNotNull(smGetElements);
@@ -620,6 +619,7 @@ class BTreeAsyncArcusCommandsTest extends AsyncArcusCommandsTest {
   void bopSortMergeGetUnique() throws Exception {
     // given
     CollectionAttributes attrs = new CollectionAttributes();
+    BopSMGetArgs getArgs = new BopSMGetArgs(ElementFlagFilter.DO_NOT_FILTER, 1000, true);
 
     async.bopInsert(keys.get(0), ELEMENTS.get(0), attrs)
         .thenCompose(result -> async.bopInsert(keys.get(1), ELEMENTS.get(0), attrs))
@@ -627,7 +627,7 @@ class BTreeAsyncArcusCommandsTest extends AsyncArcusCommandsTest {
         .thenCompose(result -> async.bopInsert(keys.get(3), ELEMENTS.get(0), attrs))
         // when
         .thenCompose(result -> async.bopSortMergeGet(keys,
-            BKey.of(1L), BKey.of(3L), true, BopGetArgs.DEFAULT))
+            BKey.of(1L), BKey.of(3L), getArgs))
         // then
         .thenAccept(smGetElements -> {
           assertNotNull(smGetElements);
@@ -650,7 +650,7 @@ class BTreeAsyncArcusCommandsTest extends AsyncArcusCommandsTest {
     async.bopInsert(testKeys.get(0), ELEMENTS.get(0), attrs)
         // when
         .thenCompose(result -> async.bopSortMergeGet(testKeys,
-            BKey.of(1L), BKey.of(10L), false, BopGetArgs.DEFAULT))
+            BKey.of(1L), BKey.of(10L), BopSMGetArgs.DEFAULT))
         // then
         .thenAccept(smGetElements -> {
           assertNotNull(smGetElements);
@@ -676,7 +676,7 @@ class BTreeAsyncArcusCommandsTest extends AsyncArcusCommandsTest {
 
     // when
     async.bopSortMergeGet(testKeys,
-            BKey.of(10L), BKey.of(20L), false, BopGetArgs.DEFAULT)
+            BKey.of(10L), BKey.of(20L), BopSMGetArgs.DEFAULT)
         // then
         .thenAccept(smGetElements -> {
           assertNotNull(smGetElements);
@@ -701,7 +701,7 @@ class BTreeAsyncArcusCommandsTest extends AsyncArcusCommandsTest {
         .thenCompose(result -> async.bopInsert(testKeys.get(0), ELEMENTS.get(1), attrs))
         .thenCompose(result -> async.bopInsert(testKeys.get(1), ELEMENTS.get(2), attrs))
         .thenCompose(result -> async.bopSortMergeGet(testKeys,
-            BKey.of(10L), BKey.of(20L), false, BopGetArgs.DEFAULT))
+            BKey.of(10L), BKey.of(20L), BopSMGetArgs.DEFAULT))
         // then
         .thenAccept(smGetElements -> {
           assertNotNull(smGetElements);
@@ -732,7 +732,7 @@ class BTreeAsyncArcusCommandsTest extends AsyncArcusCommandsTest {
         .thenCompose(result -> async.bopInsert(testKeys.get(1), ELEMENTS.get(1), attrs))
         .thenCompose(result -> async.bopInsert(testKeys.get(1), ELEMENTS.get(2)))
         .thenCompose(result -> async.bopSortMergeGet(testKeys,
-            BKey.of(10L), BKey.of(1L), false, BopGetArgs.DEFAULT))
+            BKey.of(10L), BKey.of(1L), BopSMGetArgs.DEFAULT))
         // then
         .thenAccept(smGetElements -> {
           assertNotNull(smGetElements);
@@ -773,8 +773,7 @@ class BTreeAsyncArcusCommandsTest extends AsyncArcusCommandsTest {
         .thenCompose(result -> async.bopInsert(testKeys.get(1), ELEMENTS.get(2), attrs))
         .thenCompose(result -> async.bopInsert(testKeys.get(1), ELEMENTS.get(3)))
         .thenCompose(result -> async.bopSortMergeGet(testKeys,
-            BKey.of(10L), BKey.of(1L), false,
-            new BopGetArgs.Builder().build()))
+            BKey.of(10L), BKey.of(1L), BopSMGetArgs.DEFAULT))
         // then
         .thenAccept(smGetElements -> {
           assertNotNull(smGetElements);
@@ -812,8 +811,7 @@ class BTreeAsyncArcusCommandsTest extends AsyncArcusCommandsTest {
         .thenCompose(result -> async.bopInsert(testKeys.get(1), ELEMENTS.get(1), attrs))
         .thenCompose(result -> async.bopInsert(testKeys.get(1), ELEMENTS.get(0)))
         .thenCompose(result -> async.bopSortMergeGet(testKeys,
-            BKey.of(1L), BKey.of(10L), false,
-            new BopGetArgs.Builder().build()))
+            BKey.of(1L), BKey.of(10L), BopSMGetArgs.DEFAULT))
         // then
         .thenAccept(smGetElements -> {
           assertNotNull(smGetElements);
@@ -1837,7 +1835,7 @@ class BTreeAsyncArcusCommandsTest extends AsyncArcusCommandsTest {
     async.bopDelete(key, from, to, deleteArgs)
         .thenCompose(result -> {
           assertTrue(result);
-          return async.bopGet(key, from, to, BopGetArgs.DEFAULT);
+          return async.bopGet(key, from, to, BopRangeGetArgs.DEFAULT);
         })
         .thenAccept(result -> {
           List<BTreeElement<Object>> elements = result.getElements();
@@ -1876,7 +1874,7 @@ class BTreeAsyncArcusCommandsTest extends AsyncArcusCommandsTest {
     async.bopDelete(key, from, to, args)
         .thenCompose(result -> {
           assertTrue(result);
-          return async.bopGet(key, from, to, BopGetArgs.DEFAULT);
+          return async.bopGet(key, from, to, BopRangeGetArgs.DEFAULT);
         })
         .thenAccept(result -> {
           assertNotNull(result);
@@ -1916,7 +1914,7 @@ class BTreeAsyncArcusCommandsTest extends AsyncArcusCommandsTest {
         // then
         .thenCompose(result -> {
           assertTrue(result);
-          return async.bopGet(key, from, to, BopGetArgs.DEFAULT);
+          return async.bopGet(key, from, to, BopRangeGetArgs.DEFAULT);
         })
         .thenAccept(result -> {
           assertNotNull(result);

--- a/src/test/java/net/spy/memcached/v2/ListAsyncArcusCommandsTest.java
+++ b/src/test/java/net/spy/memcached/v2/ListAsyncArcusCommandsTest.java
@@ -7,7 +7,7 @@ import java.util.concurrent.TimeUnit;
 import net.spy.memcached.collection.CollectionAttributes;
 import net.spy.memcached.collection.ElementValueType;
 import net.spy.memcached.ops.OperationException;
-import net.spy.memcached.v2.vo.GetOption;
+import net.spy.memcached.v2.vo.GetMode;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -92,7 +92,7 @@ class ListAsyncArcusCommandsTest extends AsyncArcusCommandsTest {
         // then
         .thenCompose(result -> {
           assertTrue(result);
-          return async.lopGet(key, 0, GetOption.NONE);
+          return async.lopGet(key, 0, GetMode.NONE);
         })
         .thenAccept(result -> assertEquals(VALUES.get(0), result))
         .toCompletableFuture()
@@ -132,7 +132,7 @@ class ListAsyncArcusCommandsTest extends AsyncArcusCommandsTest {
         .get(300L, TimeUnit.MILLISECONDS);
 
     // when
-    async.lopGet(key, 0, GetOption.NONE)
+    async.lopGet(key, 0, GetMode.NONE)
         // then
         .thenAccept(result -> assertEquals(VALUES.get(0), result))
         .toCompletableFuture()
@@ -143,7 +143,7 @@ class ListAsyncArcusCommandsTest extends AsyncArcusCommandsTest {
   void lopGetSingleNotFound() throws Exception {
     // given
     // when
-    async.lopGet(keys.get(0), 0, GetOption.NONE)
+    async.lopGet(keys.get(0), 0, GetMode.NONE)
         // then
         .thenAccept(Assertions::assertNull)
         .toCompletableFuture()
@@ -161,7 +161,7 @@ class ListAsyncArcusCommandsTest extends AsyncArcusCommandsTest {
         .get(300L, TimeUnit.MILLISECONDS);
 
     // when
-    async.lopGet(key, 5, GetOption.NONE)
+    async.lopGet(key, 5, GetMode.NONE)
         // then
         .thenAccept(Assertions::assertNull)
         .toCompletableFuture()
@@ -179,11 +179,11 @@ class ListAsyncArcusCommandsTest extends AsyncArcusCommandsTest {
         .get(300L, TimeUnit.MILLISECONDS);
 
     // when
-    async.lopGet(key, 0, GetOption.DROP)
+    async.lopGet(key, 0, GetMode.DROP)
         // then
         .thenCompose(result -> {
           assertEquals(VALUES.get(0), result);
-          return async.lopGet(key, 0, GetOption.NONE);
+          return async.lopGet(key, 0, GetMode.NONE);
         })
         .thenAccept(Assertions::assertNull)
         .toCompletableFuture()
@@ -202,7 +202,7 @@ class ListAsyncArcusCommandsTest extends AsyncArcusCommandsTest {
         .get(300L, TimeUnit.MILLISECONDS);
 
     // when
-    async.lopGet(key, 0, 2, GetOption.NONE)
+    async.lopGet(key, 0, 2, GetMode.NONE)
         // then
         .thenAccept(result -> {
           result.forEach(Assertions::assertNotNull);
@@ -216,7 +216,7 @@ class ListAsyncArcusCommandsTest extends AsyncArcusCommandsTest {
   void lopGetRangeNotFound() throws Exception {
     // given
     // when
-    async.lopGet(keys.get(0), 0, 2, GetOption.NONE)
+    async.lopGet(keys.get(0), 0, 2, GetMode.NONE)
         // then
         .thenAccept(Assertions::assertNull)
         .toCompletableFuture()
@@ -234,7 +234,7 @@ class ListAsyncArcusCommandsTest extends AsyncArcusCommandsTest {
         .get(300L, TimeUnit.MILLISECONDS);
 
     // when
-    async.lopGet(key, 5, 10, GetOption.NONE)
+    async.lopGet(key, 5, 10, GetMode.NONE)
         // then
         .thenAccept(result -> assertTrue(result.isEmpty()))
         .toCompletableFuture()
@@ -253,11 +253,11 @@ class ListAsyncArcusCommandsTest extends AsyncArcusCommandsTest {
         .get(300L, TimeUnit.MILLISECONDS);
 
     // when
-    async.lopGet(key, 0, 2, GetOption.DROP)
+    async.lopGet(key, 0, 2, GetMode.DROP)
         .thenCompose(result -> {
           assertNotNull(result);
           assertIterableEquals(VALUES.subList(0, 3), result);
-          return async.lopGet(key, 0, 2, GetOption.NONE);
+          return async.lopGet(key, 0, 2, GetMode.NONE);
         })
         .thenAccept(Assertions::assertNull)
         .toCompletableFuture()
@@ -278,7 +278,7 @@ class ListAsyncArcusCommandsTest extends AsyncArcusCommandsTest {
         // then
         .thenCompose(result -> {
           assertTrue(result);
-          return async.lopGet(key, 0, GetOption.NONE);
+          return async.lopGet(key, 0, GetMode.NONE);
         })
         .thenAccept(Assertions::assertNull)
         .toCompletableFuture()
@@ -301,7 +301,7 @@ class ListAsyncArcusCommandsTest extends AsyncArcusCommandsTest {
         // then
         .thenCompose(result -> {
           assertTrue(result);
-          return async.lopGet(key, 0, 2, GetOption.NONE);
+          return async.lopGet(key, 0, 2, GetMode.NONE);
         })
         .thenAccept(result -> assertTrue(result.isEmpty()))
         .toCompletableFuture()

--- a/src/test/java/net/spy/memcached/v2/MapAsyncArcusCommandsTest.java
+++ b/src/test/java/net/spy/memcached/v2/MapAsyncArcusCommandsTest.java
@@ -9,7 +9,7 @@ import java.util.concurrent.TimeoutException;
 import net.spy.memcached.collection.CollectionAttributes;
 import net.spy.memcached.collection.ElementValueType;
 import net.spy.memcached.ops.OperationException;
-import net.spy.memcached.v2.vo.GetOption;
+import net.spy.memcached.v2.vo.GetMode;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -99,7 +99,7 @@ class MapAsyncArcusCommandsTest extends AsyncArcusCommandsTest {
             // then
             .thenCompose(result -> {
               assertTrue(result);
-              return async.mopGet(key, MKEY1, GetOption.NONE);
+              return async.mopGet(key, MKEY1, GetMode.NONE);
             })
             .thenAccept(result -> assertEquals(VALUE1, result))
             .toCompletableFuture()
@@ -161,7 +161,7 @@ class MapAsyncArcusCommandsTest extends AsyncArcusCommandsTest {
             // then
             .thenCompose(result -> {
               assertTrue(result);
-              return async.mopGet(key, MKEY1, GetOption.NONE);
+              return async.mopGet(key, MKEY1, GetMode.NONE);
             })
             .thenAccept(result -> assertEquals(VALUE1, result))
             .toCompletableFuture()
@@ -183,7 +183,7 @@ class MapAsyncArcusCommandsTest extends AsyncArcusCommandsTest {
             // then
             .thenCompose(result -> {
               assertTrue(result);
-              return async.mopGet(key, MKEY1, GetOption.NONE);
+              return async.mopGet(key, MKEY1, GetMode.NONE);
             })
             .thenAccept(result -> assertEquals(VALUE2, result))
             .toCompletableFuture()
@@ -215,7 +215,7 @@ class MapAsyncArcusCommandsTest extends AsyncArcusCommandsTest {
             // then
             .thenCompose(result -> {
               assertTrue(result);
-              return async.mopGet(key, MKEY1, GetOption.NONE);
+              return async.mopGet(key, MKEY1, GetMode.NONE);
             })
             .thenAccept(result -> assertEquals(VALUE2, result))
             .toCompletableFuture()
@@ -264,7 +264,7 @@ class MapAsyncArcusCommandsTest extends AsyncArcusCommandsTest {
             .get(300L, TimeUnit.MILLISECONDS);
 
     // when
-    async.mopGet(key, GetOption.NONE)
+    async.mopGet(key, GetMode.NONE)
             // then
             .thenAccept(result -> {
               assertNotNull(result);
@@ -281,7 +281,7 @@ class MapAsyncArcusCommandsTest extends AsyncArcusCommandsTest {
   void mopGetAllNotFound() throws ExecutionException, InterruptedException, TimeoutException {
     // given
     // when
-    async.mopGet(keys.get(0), GetOption.NONE)
+    async.mopGet(keys.get(0), GetMode.NONE)
             // then
             .thenAccept(Assertions::assertNull)
             .toCompletableFuture()
@@ -300,7 +300,7 @@ class MapAsyncArcusCommandsTest extends AsyncArcusCommandsTest {
             .get(300L, TimeUnit.MILLISECONDS);
 
     // when
-    async.mopGet(key, GetOption.NONE)
+    async.mopGet(key, GetMode.NONE)
             // then
             .thenAccept(result -> {
               assertNotNull(result);
@@ -321,7 +321,7 @@ class MapAsyncArcusCommandsTest extends AsyncArcusCommandsTest {
             .get(300L, TimeUnit.MILLISECONDS);
 
     // when
-    async.mopGet(key, MKEY1, GetOption.NONE)
+    async.mopGet(key, MKEY1, GetMode.NONE)
             // then
             .thenAccept(result -> assertEquals(VALUE1, result))
             .toCompletableFuture()
@@ -332,7 +332,7 @@ class MapAsyncArcusCommandsTest extends AsyncArcusCommandsTest {
   void mopGetSingleNotFound() throws ExecutionException, InterruptedException, TimeoutException {
     // given
     // when
-    async.mopGet(keys.get(0), MKEY1, GetOption.NONE)
+    async.mopGet(keys.get(0), MKEY1, GetMode.NONE)
             // then
             .thenAccept(Assertions::assertNull)
             .toCompletableFuture()
@@ -351,7 +351,7 @@ class MapAsyncArcusCommandsTest extends AsyncArcusCommandsTest {
             .get(300L, TimeUnit.MILLISECONDS);
 
     // when
-    async.mopGet(key, MKEY1, GetOption.NONE)
+    async.mopGet(key, MKEY1, GetMode.NONE)
             // then
             .thenAccept(Assertions::assertNull)
             .toCompletableFuture()
@@ -371,7 +371,7 @@ class MapAsyncArcusCommandsTest extends AsyncArcusCommandsTest {
             .get(300L, TimeUnit.MILLISECONDS);
 
     // when
-    async.mopGet(key, mKeys, GetOption.NONE)
+    async.mopGet(key, mKeys, GetMode.NONE)
             // then
             .thenAccept(result -> {
               assertNotNull(result);
@@ -395,7 +395,7 @@ class MapAsyncArcusCommandsTest extends AsyncArcusCommandsTest {
             .get(300L, TimeUnit.MILLISECONDS);
 
     // when
-    async.mopGet(key, Arrays.asList(MKEY1, MKEY2), GetOption.NONE)
+    async.mopGet(key, Arrays.asList(MKEY1, MKEY2), GetMode.NONE)
             // then
             .thenAccept(result -> {
               assertNotNull(result);
@@ -417,7 +417,7 @@ class MapAsyncArcusCommandsTest extends AsyncArcusCommandsTest {
             .get(300L, TimeUnit.MILLISECONDS);
 
     // when
-    async.mopGet(key, Arrays.asList(MKEY1, MKEY2, MKEY3), GetOption.NONE)
+    async.mopGet(key, Arrays.asList(MKEY1, MKEY2, MKEY3), GetMode.NONE)
             // then
             .thenAccept(result -> {
               assertNotNull(result);
@@ -440,11 +440,11 @@ class MapAsyncArcusCommandsTest extends AsyncArcusCommandsTest {
             .get(300L, TimeUnit.MILLISECONDS);
 
     // when
-    async.mopGet(key, GetOption.DROP)
+    async.mopGet(key, GetMode.DROP)
             .thenCompose(result -> {
               assertNotNull(result);
               assertEquals(1, result.size());
-              return async.mopGet(key, GetOption.NONE);
+              return async.mopGet(key, GetMode.NONE);
             })
             // then
             .thenAccept(Assertions::assertNull)
@@ -467,7 +467,7 @@ class MapAsyncArcusCommandsTest extends AsyncArcusCommandsTest {
             // then
             .thenCompose(result -> {
               assertTrue(result);
-              return async.mopGet(key, GetOption.NONE);
+              return async.mopGet(key, GetMode.NONE);
             })
             .thenAccept(result -> {
               assertNotNull(result);
@@ -491,7 +491,7 @@ class MapAsyncArcusCommandsTest extends AsyncArcusCommandsTest {
     async.mopDelete(key, true)
             .thenCompose(result -> {
               assertTrue(result);
-              return async.mopGet(key, GetOption.NONE);
+              return async.mopGet(key, GetMode.NONE);
             })
             // then
             .thenAccept(Assertions::assertNull)
@@ -524,7 +524,7 @@ class MapAsyncArcusCommandsTest extends AsyncArcusCommandsTest {
             // then
             .thenCompose(result -> {
               assertTrue(result);
-              return async.mopGet(key, GetOption.NONE);
+              return async.mopGet(key, GetMode.NONE);
             })
             .thenAccept(result -> {
               assertNotNull(result);
@@ -580,7 +580,7 @@ class MapAsyncArcusCommandsTest extends AsyncArcusCommandsTest {
     async.mopDelete(key, MKEY1, true)
             .thenCompose(result -> {
               assertTrue(result);
-              return async.mopGet(key, GetOption.NONE);
+              return async.mopGet(key, GetMode.NONE);
             })
             // then
             .thenAccept(Assertions::assertNull)
@@ -611,7 +611,7 @@ class MapAsyncArcusCommandsTest extends AsyncArcusCommandsTest {
             // then
             .thenCompose(result -> {
               assertTrue(result);
-              return async.mopGet(key, GetOption.NONE);
+              return async.mopGet(key, GetMode.NONE);
             })
             .thenAccept(result -> {
               assertNotNull(result);
@@ -663,7 +663,7 @@ class MapAsyncArcusCommandsTest extends AsyncArcusCommandsTest {
             // then
             .thenCompose(result -> {
               assertTrue(result);
-              return async.mopGet(key, GetOption.NONE);
+              return async.mopGet(key, GetMode.NONE);
             })
             .thenAccept(Assertions::assertNull)
             .toCompletableFuture()

--- a/src/test/java/net/spy/memcached/v2/SetAsyncArcusCommandsTest.java
+++ b/src/test/java/net/spy/memcached/v2/SetAsyncArcusCommandsTest.java
@@ -5,7 +5,7 @@ import java.util.concurrent.TimeUnit;
 import net.spy.memcached.collection.CollectionAttributes;
 import net.spy.memcached.collection.ElementValueType;
 import net.spy.memcached.ops.OperationException;
-import net.spy.memcached.v2.vo.GetOption;
+import net.spy.memcached.v2.vo.GetMode;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -214,7 +214,7 @@ class SetAsyncArcusCommandsTest extends AsyncArcusCommandsTest {
         .get(300L, TimeUnit.MILLISECONDS);
 
     // when
-    async.sopGet(key, 10, GetOption.NONE)
+    async.sopGet(key, 10, GetMode.NONE)
         // then
         .thenAccept(result -> {
           assertNotNull(result);
@@ -228,7 +228,7 @@ class SetAsyncArcusCommandsTest extends AsyncArcusCommandsTest {
   void sopGetNotFound() throws Exception {
     // given
     // when
-    async.sopGet(keys.get(0), 10, GetOption.NONE)
+    async.sopGet(keys.get(0), 10, GetMode.NONE)
         // then
         .thenAccept(Assertions::assertNull)
         .toCompletableFuture()
@@ -246,7 +246,7 @@ class SetAsyncArcusCommandsTest extends AsyncArcusCommandsTest {
         .get(300L, TimeUnit.MILLISECONDS);
 
     // when
-    async.sopGet(key, 10, GetOption.NONE)
+    async.sopGet(key, 10, GetMode.NONE)
         // then
         .thenAccept(result -> assertTrue(result.isEmpty()))
         .toCompletableFuture()
@@ -264,11 +264,11 @@ class SetAsyncArcusCommandsTest extends AsyncArcusCommandsTest {
         .get(300L, TimeUnit.MILLISECONDS);
 
     // when
-    async.sopGet(key, 10, GetOption.DROP)
+    async.sopGet(key, 10, GetMode.DROP)
         .thenCompose(result -> {
           assertNotNull(result);
           assertEquals(1, result.size());
-          return async.sopGet(key, 10, GetOption.NONE);
+          return async.sopGet(key, 10, GetMode.NONE);
         })
         .thenAccept(Assertions::assertNull)
         .toCompletableFuture()
@@ -340,7 +340,7 @@ class SetAsyncArcusCommandsTest extends AsyncArcusCommandsTest {
         // then: set 자체가 삭제되어 null
         .thenCompose(result -> {
           assertTrue(result);
-          return async.sopGet(key, 10, GetOption.NONE);
+          return async.sopGet(key, 10, GetMode.NONE);
         })
         .thenAccept(Assertions::assertNull)
         .toCompletableFuture()


### PR DESCRIPTION
### 🔗 Related Issue

<!-- Please link related issue. ex) https://github.com/naver/arcus-java-client/issues/{issue_number} -->
- https://github.com/jam2in/arcus-works/issues/832#issuecomment-4474012949

### ⌨️ What I did

<!-- Please describe this PR and what you've been working on. -->
- `BopGetArgs` 하나로 BTree의 get 연산의 인자를 받던 구조를 연산별 전용 클래스로 분리합니다.
  - `BopGetArgs`: 단일 BKey 조회 전용 (EFlagFilter, GetOption)
  - `BopRangeGetArgs`: 범위 조회 전용 (EFlagFilter, offset, count, GetOption)
  - `BopSMGetArgs`: sort-merge get 전용 (EFlagFilter, count, unique)
- 인터페이스 메서드 시그니처 반영 