### PR TITLE
FIX: Correct limit validation for compValue

### DIFF
--- a/src/main/java/net/spy/memcached/collection/ElementMultiFlagsFilter.java
+++ b/src/main/java/net/spy/memcached/collection/ElementMultiFlagsFilter.java
@@ -22,8 +22,8 @@ import net.spy.memcached.util.BTreeUtil;
 
 public class ElementMultiFlagsFilter extends ElementFlagFilter {
 
-  final static int MAX_EFLAGS = 100;
-  private ArrayList<byte[]> compValue = new ArrayList<>();
+  private static final int MAX_COMP_VALUE_COUNT = 100;
+  private final ArrayList<byte[]> compValue = new ArrayList<>();
 
   public ElementMultiFlagsFilter() {
   }
@@ -61,10 +61,10 @@ public class ElementMultiFlagsFilter extends ElementFlagFilter {
                       + MAX_EFLAG_LENGTH);
     }
 
-    if (this.compValue.size() > MAX_EFLAGS) {
+    if (this.compValue.size() >= MAX_COMP_VALUE_COUNT) {
       throw new IllegalArgumentException(
-              "Count of comparison values must be less than "
-                      + MAX_EFLAGS);
+              "Count of comparison values must not exceed "
+                      + MAX_COMP_VALUE_COUNT);
     }
 
     if (!this.compValue.isEmpty()

--- a/src/test/java/net/spy/memcached/collection/ElementMultiFlagsFilterTest.java
+++ b/src/test/java/net/spy/memcached/collection/ElementMultiFlagsFilterTest.java
@@ -1,0 +1,19 @@
+package net.spy.memcached.collection;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class ElementMultiFlagsFilterTest {
+
+  @Test
+  void shouldRejectCompValueExceedingMaximumCount() {
+    ElementMultiFlagsFilter filter = new ElementMultiFlagsFilter();
+
+    for (int i = 0; i < 100; i++) {
+      filter.addCompValue(new byte[]{(byte) i});
+    }
+
+    assertThrows(IllegalArgumentException.class, () -> filter.addCompValue(new byte[]{0}));
+  }
+}


### PR DESCRIPTION
### 🔗 Related Issue

<!-- Please link related issue. ex) https://github.com/naver/arcus-java-client/issues/{issue_number} -->
- 

### ⌨️ What I did

<!-- Please describe this PR and what you've been working on. -->
- `ElementMultiFlagsFilter`의 comparison value 개수 제한 검증을 수정합니다.
- 최대 100개까지 허용하고, 101번째 추가 시 예외가 발생하는 경계값 테스트를 추가했습니다. 