### PR TITLE
INTERNAL: Fix expire time parameter type from int to long

### DIFF
--- a/src/main/java/net/spy/memcached/OperationFactory.java
+++ b/src/main/java/net/spy/memcached/OperationFactory.java
@@ -160,7 +160,7 @@ public interface OperationFactory {
    * @param cb the callback that will contain the result
    * @return a new GetAndTouchOperation
    */
-  GetOperation getAndTouch(String key, int expiration, GetOperation.Callback cb);
+  GetOperation getAndTouch(String key, long expiration, GetOperation.Callback cb);
 
   /**
    * Gets (with CAS support) the key and resets its timeout.
@@ -170,7 +170,7 @@ public interface OperationFactory {
    * @param cb the callback that will contain the result
    * @return a new GetsAndTouchOperation
    */
-  GetsOperation getsAndTouch(String key, int expiration, GetsOperation.Callback cb);
+  GetsOperation getsAndTouch(String key, long expiration, GetsOperation.Callback cb);
 
   /**
    * Create a mutator operation.
@@ -184,7 +184,7 @@ public interface OperationFactory {
    * @return the new mutator operation
    */
   MutatorOperation mutate(Mutator m, String key, int by,
-                          long def, int exp, OperationCallback cb);
+                          long def, long exp, OperationCallback cb);
 
   /**
    * Get a new StatsOperation.
@@ -206,7 +206,7 @@ public interface OperationFactory {
    * @param cb        the status callback
    * @return the new store operation
    */
-  StoreOperation store(StoreType storeType, String key, int flags, int exp,
+  StoreOperation store(StoreType storeType, String key, int flags, long exp,
                        byte[] data, OperationCallback cb);
 
   /**
@@ -217,7 +217,7 @@ public interface OperationFactory {
    * @param cb          the status callback
    * @return the new touch operation
    */
-  TouchOperation touch(String key, int expiration, OperationCallback cb);
+  TouchOperation touch(String key, long expiration, OperationCallback cb);
 
   /**
    * Get a concatenation operation.
@@ -244,7 +244,7 @@ public interface OperationFactory {
    * @return the new store operation
    */
   CASOperation cas(StoreType t, String key, long casId, int flags,
-                   int exp, byte[] data, OperationCallback cb);
+                   long exp, byte[] data, OperationCallback cb);
 
   /**
    * Create a new version operation.

--- a/src/main/java/net/spy/memcached/collection/Attributes.java
+++ b/src/main/java/net/spy/memcached/collection/Attributes.java
@@ -20,10 +20,10 @@ import net.spy.memcached.compat.SpyObject;
 
 public class Attributes extends SpyObject {
   public static final Integer DEFAULT_FLAGS = 0;
-  public static final Integer DEFAULT_EXPIRETIME = 0;
+  public static final Long DEFAULT_EXPIRETIME = 0L;
 
   protected Integer flags;
-  protected Integer expireTime;
+  protected Long expireTime;
   protected CollectionType type;
 
   private String str;
@@ -31,7 +31,7 @@ public class Attributes extends SpyObject {
   public Attributes() {
   }
 
-  public Attributes(Integer expireTime) {
+  public Attributes(long expireTime) {
     this.expireTime = expireTime;
   }
 
@@ -79,7 +79,7 @@ public class Attributes extends SpyObject {
       if ("flags".equals(name)) {
         flags = Integer.parseInt(value);
       } else if ("expiretime".equals(name)) {
-        expireTime = Integer.parseInt(value);
+        expireTime = Long.parseLong(value);
       } else if ("type".equals(name)) {
         type = CollectionType.find(value);
       }
@@ -89,7 +89,7 @@ public class Attributes extends SpyObject {
     }
   }
 
-  public void setExpireTime(Integer expireTime) {
+  public void setExpireTime(long expireTime) {
     this.expireTime = expireTime;
   }
 
@@ -97,7 +97,7 @@ public class Attributes extends SpyObject {
     return flags;
   }
 
-  public Integer getExpireTime() {
+  public Long getExpireTime() {
     return expireTime;
   }
 

--- a/src/main/java/net/spy/memcached/collection/BTreeCreate.java
+++ b/src/main/java/net/spy/memcached/collection/BTreeCreate.java
@@ -20,7 +20,7 @@ public class BTreeCreate extends CollectionCreate {
 
   private static final String COMMAND = "bop create";
 
-  public BTreeCreate(int flags, Integer expTime, Long maxCount,
+  public BTreeCreate(int flags, Long expTime, Long maxCount,
                      CollectionOverflowAction overflowAction, Boolean readable, boolean noreply) {
     super(CollectionType.btree, flags, expTime, maxCount, overflowAction, readable, noreply);
   }

--- a/src/main/java/net/spy/memcached/collection/CollectionAttributes.java
+++ b/src/main/java/net/spy/memcached/collection/CollectionAttributes.java
@@ -41,7 +41,7 @@ public class CollectionAttributes extends Attributes {
   public CollectionAttributes() {
   }
 
-  public CollectionAttributes(Integer expireTime,
+  public CollectionAttributes(long expireTime,
                               Long maxCount, CollectionOverflowAction overflowAction) {
     this.expireTime = expireTime;
     this.maxCount = maxCount;
@@ -100,7 +100,7 @@ public class CollectionAttributes extends Attributes {
       if ("flags".equals(name)) {
         flags = Integer.parseInt(value);
       } else if ("expiretime".equals(name)) {
-        expireTime = Integer.parseInt(value);
+        expireTime = Long.parseLong(value);
       } else if ("type".equals(name)) {
         type = CollectionType.find(value);
       } else if ("count".equals(name)) {

--- a/src/main/java/net/spy/memcached/collection/CollectionCreate.java
+++ b/src/main/java/net/spy/memcached/collection/CollectionCreate.java
@@ -18,7 +18,7 @@ package net.spy.memcached.collection;
 
 public abstract class CollectionCreate {
   protected int flags;
-  protected int expTime;
+  protected long expTime;
   protected long maxCount;
   protected CollectionOverflowAction overflowAction;
   protected Boolean readable;
@@ -26,7 +26,7 @@ public abstract class CollectionCreate {
 
   protected String str;
 
-  protected CollectionCreate(CollectionType type, int flags, Integer expTime, Long maxCount,
+  protected CollectionCreate(CollectionType type, int flags, Long expTime, Long maxCount,
                           CollectionOverflowAction overflowAction, Boolean readable,
                           boolean noreply) {
     checkOverflowAction(type, overflowAction);

--- a/src/main/java/net/spy/memcached/collection/ListCreate.java
+++ b/src/main/java/net/spy/memcached/collection/ListCreate.java
@@ -20,7 +20,7 @@ public class ListCreate extends CollectionCreate {
 
   private static final String COMMAND = "lop create";
 
-  public ListCreate(int flags, Integer expTime, Long maxCount,
+  public ListCreate(int flags, Long expTime, Long maxCount,
                     CollectionOverflowAction overflowAction, Boolean readable, boolean noreply) {
     super(CollectionType.list, flags, expTime, maxCount, overflowAction, readable, noreply);
   }

--- a/src/main/java/net/spy/memcached/collection/MapCreate.java
+++ b/src/main/java/net/spy/memcached/collection/MapCreate.java
@@ -20,7 +20,7 @@ public class MapCreate extends CollectionCreate {
 
   private static final String COMMAND = "mop create";
 
-  public MapCreate(int flags, Integer expTime, Long maxCount, Boolean readable, boolean noreply) {
+  public MapCreate(int flags, Long expTime, Long maxCount, Boolean readable, boolean noreply) {
     super(CollectionType.map, flags, expTime, maxCount, null, readable, noreply);
   }
 

--- a/src/main/java/net/spy/memcached/collection/SetCreate.java
+++ b/src/main/java/net/spy/memcached/collection/SetCreate.java
@@ -20,7 +20,7 @@ public class SetCreate extends CollectionCreate {
 
   private static final String COMMAND = "sop create";
 
-  public SetCreate(int flags, Integer expTime, Long maxCount, Boolean readable, boolean noreply) {
+  public SetCreate(int flags, Long expTime, Long maxCount, Boolean readable, boolean noreply) {
     super(CollectionType.set, flags, expTime, maxCount, null, readable, noreply);
   }
 

--- a/src/main/java/net/spy/memcached/ops/CASOperation.java
+++ b/src/main/java/net/spy/memcached/ops/CASOperation.java
@@ -23,7 +23,7 @@ public interface CASOperation extends KeyedOperation {
   /**
    * Get the expiration to be set for this operation.
    */
-  int getExpiration();
+  long getExpiration();
 
   /**
    * Get the bytes to be set during this operation.

--- a/src/main/java/net/spy/memcached/ops/MutatorOperation.java
+++ b/src/main/java/net/spy/memcached/ops/MutatorOperation.java
@@ -23,5 +23,5 @@ public interface MutatorOperation extends KeyedOperation {
   /**
    * Get the expiration to set in case of a new entry.
    */
-  int getExpiration();
+  long getExpiration();
 }

--- a/src/main/java/net/spy/memcached/ops/StoreOperation.java
+++ b/src/main/java/net/spy/memcached/ops/StoreOperation.java
@@ -18,7 +18,7 @@ public interface StoreOperation extends KeyedOperation {
   /**
    * Get the expiration value to be set.
    */
-  int getExpiration();
+  long getExpiration();
 
   /**
    * Get the bytes to be set during this operation.

--- a/src/main/java/net/spy/memcached/ops/TouchOperation.java
+++ b/src/main/java/net/spy/memcached/ops/TouchOperation.java
@@ -26,5 +26,5 @@ public interface TouchOperation extends KeyedOperation {
   /**
    * Get the expiration to set in case of a new entry.
    */
-  int getExpiration();
+  long getExpiration();
 }

--- a/src/main/java/net/spy/memcached/protocol/ascii/AsciiOperationFactory.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/AsciiOperationFactory.java
@@ -85,143 +85,173 @@ import net.spy.memcached.ops.VersionOperation;
  */
 public class AsciiOperationFactory extends BaseOperationFactory {
 
+  @Override
   public DeleteOperation delete(String key, OperationCallback cb) {
     return new DeleteOperationImpl(key, cb);
   }
 
+  @Override
   public FlushOperation flush(int delay, OperationCallback cb) {
     return new FlushOperationImpl(delay, cb);
   }
 
+  @Override
   public GetOperation get(String key, GetOperation.Callback cb) {
     return new GetOperationImpl(key, cb);
   }
 
+  @Override
   public GetOperation get(Collection<String> keys, GetOperation.Callback cb, boolean isMGet) {
     return new GetOperationImpl(keys, cb, isMGet);
   }
 
+  @Override
   public GetsOperation gets(String key, GetsOperation.Callback cb) {
     return new GetsOperationImpl(key, cb);
   }
 
+  @Override
   public GetsOperation gets(Collection<String> keys, GetsOperation.Callback cb, boolean isMGet) {
     return new GetsOperationImpl(keys, cb, isMGet);
   }
 
-  public GetOperation getAndTouch(String key, int expiration, GetOperation.Callback cb) {
-    return new GetAndTouchOperationImpl(key, expiration, cb);
+  @Override
+  public GetOperation getAndTouch(String key, long exp, GetOperation.Callback cb) {
+    return new GetAndTouchOperationImpl(key, exp, cb);
   }
 
-  public GetsOperation getsAndTouch(String key, int expiration, GetsOperation.Callback cb) {
-    return new GetsAndTouchOperationImpl(key, expiration, cb);
+  @Override
+  public GetsOperation getsAndTouch(String key, long exp, GetsOperation.Callback cb) {
+    return new GetsAndTouchOperationImpl(key, exp, cb);
   }
 
+  @Override
   public MutatorOperation mutate(Mutator m, String key, int by,
-                                 long def, int exp, OperationCallback cb) {
+                                 long def, long exp, OperationCallback cb) {
     return new MutatorOperationImpl(m, key, by, def, exp, cb);
   }
 
+  @Override
   public StatsOperation stats(String arg, StatsOperation.Callback cb) {
     return new StatsOperationImpl(arg, cb);
   }
 
+  @Override
   public StoreOperation store(StoreType storeType, String key, int flags,
-                              int exp, byte[] data, OperationCallback cb) {
+                              long exp, byte[] data, OperationCallback cb) {
     return new StoreOperationImpl(storeType, key, flags, exp, data, cb);
   }
 
-  public TouchOperation touch(String key, int expiration, OperationCallback cb) {
-    return new TouchOperationImpl(key, expiration, cb);
+  @Override
+  public TouchOperation touch(String key, long exp, OperationCallback cb) {
+    return new TouchOperationImpl(key, exp, cb);
   }
 
+  @Override
   public VersionOperation version(OperationCallback cb) {
     return new VersionOperationImpl(cb);
   }
 
+  @Override
   public NoopOperation noop(OperationCallback cb) {
     return new VersionOperationImpl(cb);
   }
 
+  @Override
   public CASOperation cas(StoreType type, String key, long casId, int flags,
-                          int exp, byte[] data, OperationCallback cb) {
+                          long exp, byte[] data, OperationCallback cb) {
     return new CASOperationImpl(key, casId, flags, exp, data, cb);
   }
 
+  @Override
   public ConcatenationOperation cat(ConcatenationType catType,
                                     long casId,
                                     String key, byte[] data, OperationCallback cb) {
     return new ConcatenationOperationImpl(catType, key, data, cb);
   }
 
+  @Override
   public SASLMechsOperation saslMechs(boolean isInternal, OperationCallback cb) {
     return new SASLMechsOperationImpl(isInternal, cb);
   }
 
+  @Override
   public SASLStepOperation saslStep(SaslClient sc, byte[] challenge, OperationCallback cb) {
     return new SASLStepOperationImpl(sc, challenge, cb);
   }
 
+  @Override
   public SASLAuthOperation saslAuth(SaslClient sc, OperationCallback cb) {
     return new SASLAuthOperationImpl(sc, cb);
   }
 
+  @Override
   public SetAttrOperation setAttr(String key, Attributes attrs,
                                   OperationCallback cb) {
     return new SetAttrOperationImpl(key, attrs, cb);
   }
 
+  @Override
   public GetAttrOperation getAttr(String key, GetAttrOperation.Callback cb) {
     return new GetAttrOperationImpl(key, cb);
   }
 
+  @Override
   public CollectionInsertOperation collectionInsert(String key, String subkey,
                                                     CollectionInsert<?> collectionInsert,
                                                     byte[] data, OperationCallback cb) {
     return new CollectionInsertOperationImpl(key, subkey,
-            collectionInsert, data, cb);
+        collectionInsert, data, cb);
   }
 
+  @Override
   public CollectionPipedInsertOperation collectionPipedInsert(String key,
                                                               CollectionPipedInsert<?> insert,
                                                               OperationCallback cb) {
     return new CollectionPipedInsertOperationImpl(key, insert, cb);
   }
 
+  @Override
   public CollectionGetOperation collectionGet(String key,
                                               CollectionGet collectionGet,
                                               CollectionGetOperation.Callback cb) {
     return new CollectionGetOperationImpl(key, collectionGet, cb);
   }
 
+  @Override
   public CollectionDeleteOperation collectionDelete(String key,
                                                     CollectionDelete collectionDelete,
                                                     OperationCallback cb) {
     return new CollectionDeleteOperationImpl(key, collectionDelete, cb);
   }
 
+  @Override
   public CollectionExistOperation collectionExist(String key, String subkey,
                                                   CollectionExist collectionExist,
                                                   OperationCallback cb) {
     return new CollectionExistOperationImpl(key, subkey, collectionExist, cb);
   }
 
+  @Override
   public CollectionCreateOperation collectionCreate(String key,
                                                     CollectionCreate collectionCreate,
                                                     OperationCallback cb) {
     return new CollectionCreateOperationImpl(key, collectionCreate, cb);
   }
 
+  @Override
   public CollectionCountOperation collectionCount(String key,
                                                   CollectionCount collectionCount,
                                                   OperationCallback cb) {
     return new CollectionCountOperationImpl(key, collectionCount, cb);
   }
 
+  @Override
   public FlushOperation flush(String prefix, int delay, boolean noreply, OperationCallback cb) {
     return new FlushByPrefixOperationImpl(prefix, delay, noreply, cb);
   }
 
+  @Override
   public BTreeSortMergeGetOperation bopsmget(BTreeSMGet<?> smGet,
                                              BTreeSortMergeGetOperation.Callback cb) {
     return new BTreeSortMergeGetOperationImpl(smGet, cb);
@@ -234,7 +264,7 @@ public class AsciiOperationFactory extends BaseOperationFactory {
                                                     byte[] data,
                                                     OperationCallback cb) {
     return new CollectionUpdateOperationImpl(key, subkey, collectionUpdate,
-            data, cb);
+        data, cb);
   }
 
   @Override

--- a/src/main/java/net/spy/memcached/protocol/ascii/BaseGetOpImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/BaseGetOpImpl.java
@@ -40,7 +40,7 @@ abstract class BaseGetOpImpl extends OperationImpl {
   private final String cmd;
   private final Collection<String> keys;
   private String currentKey = null;
-  private final int exp;
+  private final long exp;
   private long casValue = 0;
   private int currentFlags = 0;
   private byte[] data = null;
@@ -62,7 +62,7 @@ abstract class BaseGetOpImpl extends OperationImpl {
   /**
    * For GetAndTouchOperationImpl,  GetsAndTouchOperationImpl Only
    */
-  public BaseGetOpImpl(String c, int e,
+  public BaseGetOpImpl(String c, long e,
                        OperationCallback cb, Collection<String> k) {
     super(cb);
     cmd = c;
@@ -240,7 +240,7 @@ abstract class BaseGetOpImpl extends OperationImpl {
     return keys.size() > 1;
   }
 
-  public int getExpiration() {
+  public long getExpiration() {
     return exp;
   }
 }

--- a/src/main/java/net/spy/memcached/protocol/ascii/BaseStoreOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/BaseStoreOperationImpl.java
@@ -50,10 +50,10 @@ abstract class BaseStoreOperationImpl extends OperationImpl {
   protected final String type;
   protected final String key;
   protected final int flags;
-  protected final int exp;
+  protected final long exp;
   protected final byte[] data;
 
-  public BaseStoreOperationImpl(String t, String k, int f, int e,
+  public BaseStoreOperationImpl(String t, String k, int f, long e,
                                 byte[] d, OperationCallback cb) {
     super(cb);
     type = t;
@@ -111,7 +111,7 @@ abstract class BaseStoreOperationImpl extends OperationImpl {
     return flags;
   }
 
-  public int getExpiration() {
+  public long getExpiration() {
     return exp;
   }
 

--- a/src/main/java/net/spy/memcached/protocol/ascii/CASOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/CASOperationImpl.java
@@ -57,10 +57,10 @@ class CASOperationImpl extends OperationImpl implements CASOperation {
   private final String key;
   private final long casValue;
   private final int flags;
-  private final int exp;
+  private final long exp;
   private final byte[] data;
 
-  public CASOperationImpl(String k, long c, int f, int e,
+  public CASOperationImpl(String k, long c, int f, long e,
                           byte[] d, OperationCallback cb) {
     super(cb);
     key = k;
@@ -118,7 +118,7 @@ class CASOperationImpl extends OperationImpl implements CASOperation {
     return casValue;
   }
 
-  public int getExpiration() {
+  public long getExpiration() {
     return exp;
   }
 

--- a/src/main/java/net/spy/memcached/protocol/ascii/GetAndTouchOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/GetAndTouchOperationImpl.java
@@ -29,7 +29,7 @@ import net.spy.memcached.ops.GetOperation;
 class GetAndTouchOperationImpl extends BaseGetOpImpl implements GetOperation {
   private static final String CMD = "gat";
 
-  public GetAndTouchOperationImpl(String k, int e, GetOperation.Callback cb) {
+  public GetAndTouchOperationImpl(String k, long e, GetOperation.Callback cb) {
     super(CMD, e, cb, Collections.singleton(k));
     setAPIType(APIType.GAT);
   }

--- a/src/main/java/net/spy/memcached/protocol/ascii/GetsAndTouchOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/GetsAndTouchOperationImpl.java
@@ -29,7 +29,7 @@ import net.spy.memcached.ops.GetsOperation;
 class GetsAndTouchOperationImpl extends BaseGetOpImpl implements GetsOperation {
   private static final String CMD = "gats";
 
-  public GetsAndTouchOperationImpl(String k, int e, GetsOperation.Callback cb) {
+  public GetsAndTouchOperationImpl(String k, long e, GetsOperation.Callback cb) {
     super(CMD, e, cb, Collections.singleton(k));
     setAPIType(APIType.GATS);
   }

--- a/src/main/java/net/spy/memcached/protocol/ascii/MutatorOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/MutatorOperationImpl.java
@@ -51,9 +51,9 @@ final class MutatorOperationImpl extends OperationImpl
   private final String key;
   private final int amount;
   private final long def;
-  private final int exp;
+  private final long exp;
 
-  public MutatorOperationImpl(Mutator m, String k, int amt, long d, int e,
+  public MutatorOperationImpl(Mutator m, String k, int amt, long d, long e,
                               OperationCallback c) {
     super(c);
     mutator = m;
@@ -121,7 +121,7 @@ final class MutatorOperationImpl extends OperationImpl
     return -1;
   }
 
-  public int getExpiration() {
+  public long getExpiration() {
     return -1;
   }
 

--- a/src/main/java/net/spy/memcached/protocol/ascii/StoreOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/StoreOperationImpl.java
@@ -32,7 +32,7 @@ final class StoreOperationImpl extends BaseStoreOperationImpl
 
   private final StoreType storeType;
 
-  public StoreOperationImpl(StoreType t, String k, int f, int e,
+  public StoreOperationImpl(StoreType t, String k, int f, long e,
                             byte[] d, OperationCallback cb) {
     super(t.name(), k, f, e, d, cb);
     storeType = t;

--- a/src/main/java/net/spy/memcached/protocol/ascii/TouchOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/TouchOperationImpl.java
@@ -42,12 +42,12 @@ final class TouchOperationImpl extends OperationImpl implements TouchOperation {
           StatusCode.ERR_NOT_FOUND);
 
   private final String key;
-  private final int exp;
+  private final long exp;
 
-  public TouchOperationImpl(String k, int t, OperationCallback cb) {
+  public TouchOperationImpl(String k, long e, OperationCallback cb) {
     super(cb);
     key = k;
-    exp = t;
+    exp = e;
   }
 
   public Collection<String> getKeys() {
@@ -83,7 +83,7 @@ final class TouchOperationImpl extends OperationImpl implements TouchOperation {
   }
 
   @Override
-  public int getExpiration() {
+  public long getExpiration() {
     return exp;
   }
 

--- a/src/main/java/net/spy/memcached/protocol/binary/BinaryOperationFactory.java
+++ b/src/main/java/net/spy/memcached/protocol/binary/BinaryOperationFactory.java
@@ -86,107 +86,137 @@ import net.spy.memcached.ops.VersionOperation;
  */
 public class BinaryOperationFactory extends BaseOperationFactory {
 
+  @Override
   public DeleteOperation delete(String key,
                                 OperationCallback operationCallback) {
     return new DeleteOperationImpl(key, operationCallback);
   }
 
+  @Override
   public FlushOperation flush(int delay, OperationCallback cb) {
     return new FlushOperationImpl(cb);
   }
 
+  @Override
   public GetOperation get(String key, Callback callback) {
     return new GetOperationImpl(key, callback);
   }
 
+  @Override
   public GetOperation get(Collection<String> keys, Callback cb, boolean isMGet) {
     return new MultiGetOperationImpl(keys, cb);
   }
 
+  @Override
   public GetsOperation gets(String key, GetsOperation.Callback cb) {
     return new GetOperationImpl(key, cb);
   }
 
+  @Override
   public GetsOperation gets(Collection<String> keys, GetsOperation.Callback cb, boolean isMGet) {
     throw new RuntimeException(
             "multiple key gets is not supported in binary protocol yet.");
   }
 
-  public GetOperation getAndTouch(String key, int expiration, GetOperation.Callback cb) {
+  @Override
+  public GetOperation getAndTouch(String key, long expiration, GetOperation.Callback cb) {
     throw new RuntimeException(
             "GetAndTouchOperation is not supported in binary protocol yet.");
   }
 
-  public GetsOperation getsAndTouch(String key, int expiration, GetsOperation.Callback cb) {
+  @Override
+  public GetsOperation getsAndTouch(String key, long expiration, GetsOperation.Callback cb) {
     throw new RuntimeException(
             "GetsAndTouchOperation is not supported in binary protocol yet.");
   }
 
+  @Override
   public MutatorOperation mutate(Mutator m, String key, int by,
-                                 long def, int exp, OperationCallback cb) {
+                                 long def, long exp, OperationCallback cb) {
+    if (exp > Integer.MAX_VALUE) {
+      throw new IllegalArgumentException("Binary protocol not support long type expiration.");
+    }
     return new MutatorOperationImpl(m, key, by, def, exp, cb);
   }
 
+  @Override
   public StatsOperation stats(String arg,
                               net.spy.memcached.ops.StatsOperation.Callback cb) {
     return new StatsOperationImpl(arg, cb);
   }
 
+  @Override
   public StoreOperation store(StoreType storeType, String key, int flags,
-                              int exp, byte[] data, OperationCallback cb) {
+                              long exp, byte[] data, OperationCallback cb) {
+    if (exp > Integer.MAX_VALUE) {
+      throw new IllegalArgumentException("Binary protocol not support long type expiration.");
+    }
     return new StoreOperationImpl(storeType, key, flags, exp, data, 0, cb);
   }
 
-  public TouchOperation touch(String key, int expiration, OperationCallback cb) {
+  @Override
+  public TouchOperation touch(String key, long expiration, OperationCallback cb) {
     throw new RuntimeException(
             "TouchOperation is not supported in binary protocol yet.");
   }
 
+  @Override
   public VersionOperation version(OperationCallback cb) {
     return new VersionOperationImpl(cb);
   }
 
+  @Override
   public NoopOperation noop(OperationCallback cb) {
     return new NoopOperationImpl(cb);
   }
 
+  @Override
   public CASOperation cas(StoreType type, String key, long casId, int flags,
-                          int exp, byte[] data, OperationCallback cb) {
+                          long exp, byte[] data, OperationCallback cb) {
+    if (exp > Integer.MAX_VALUE) {
+      throw new IllegalArgumentException("Binary protocol not support long type expiration.");
+    }
     return new StoreOperationImpl(type, key, flags, exp, data,
             casId, cb);
   }
 
+  @Override
   public ConcatenationOperation cat(ConcatenationType catType, long casId,
                                     String key, byte[] data, OperationCallback cb) {
     return new ConcatenationOperationImpl(catType, key, data, casId, cb);
   }
 
+  @Override
   public SASLAuthOperation saslAuth(SaslClient sc, OperationCallback cb) {
     return new SASLAuthOperationImpl(sc, cb);
   }
 
+  @Override
   public SASLMechsOperation saslMechs(boolean isInternal, OperationCallback cb) {
     return new SASLMechsOperationImpl(isInternal, cb);
   }
 
+  @Override
   public SASLStepOperation saslStep(SaslClient sc, byte[] challenge, OperationCallback cb) {
     return new SASLStepOperationImpl(sc, challenge, cb);
   }
 
   //// UNSUPPORTED ////
-
+  @Override
   public SetAttrOperation setAttr(String key, Attributes attrs,
                                   OperationCallback cb) {
     throw new RuntimeException(
             "SetAttrOperation is not supported in binary protocol yet.");
   }
 
+  @Override
   public GetAttrOperation getAttr(String key,
                                   net.spy.memcached.ops.GetAttrOperation.Callback cb) {
     throw new RuntimeException(
             "GetAttrOperation is not supported in binary protocol yet.");
   }
 
+  @Override
   public CollectionInsertOperation collectionInsert(String key, String subkey,
                                                     CollectionInsert<?> collectionInsert,
                                                     byte[] data,
@@ -195,6 +225,7 @@ public class BinaryOperationFactory extends BaseOperationFactory {
             "CollectionInsertOperation is not supported in binary protocol yet.");
   }
 
+  @Override
   public CollectionPipedInsertOperation collectionPipedInsert(String key,
                                                               CollectionPipedInsert<?> insert,
                                                               OperationCallback cb) {
@@ -202,6 +233,7 @@ public class BinaryOperationFactory extends BaseOperationFactory {
             "CollectionPipedInsertOperation is not supported in binary protocol yet.");
   }
 
+  @Override
   public CollectionGetOperation collectionGet(String key,
                                               CollectionGet collectionGet,
                                               CollectionGetOperation.Callback cb) {
@@ -209,6 +241,7 @@ public class BinaryOperationFactory extends BaseOperationFactory {
             "CollectionGetOperation is not supported in binary protocol yet.");
   }
 
+  @Override
   public CollectionDeleteOperation collectionDelete(String key,
                                                     CollectionDelete collectionDelete,
                                                     OperationCallback cb) {
@@ -216,27 +249,31 @@ public class BinaryOperationFactory extends BaseOperationFactory {
             "CollectionDeleteOperation is not supported in binary protocol yet.");
   }
 
+  @Override
   public CollectionExistOperation collectionExist(String key, String subkey,
                                                   CollectionExist collectionExist,
                                                   OperationCallback cb) {
     throw new RuntimeException(
-            "CollectionExistOperation is not supported in binary protocol yet.");
+        "CollectionExistOperation is not supported in binary protocol yet.");
   }
 
+  @Override
   public CollectionCreateOperation collectionCreate(String key,
                                                     CollectionCreate collectionCreate,
                                                     OperationCallback cb) {
     throw new RuntimeException(
-            "CollectionCreateOperation is not supported in binary protocol yet.");
+        "CollectionCreateOperation is not supported in binary protocol yet.");
   }
 
+  @Override
   public CollectionCountOperation collectionCount(String key,
                                                   CollectionCount collectionCount,
                                                   OperationCallback cb) {
     throw new RuntimeException(
-            "CollectionCountOperation is not supported in binary protocol yet.");
+        "CollectionCountOperation is not supported in binary protocol yet.");
   }
 
+  @Override
   public FlushOperation flush(String prefix, int delay, boolean noreply, OperationCallback cb) {
     throw new RuntimeException(
             "Flush by prefix operation is not supported in binary protocol yet.");

--- a/src/main/java/net/spy/memcached/protocol/binary/MutatorOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/binary/MutatorOperationImpl.java
@@ -35,11 +35,11 @@ class MutatorOperationImpl extends OperationImpl implements
   private final Mutator mutator;
   private final String key;
   private final long by;
-  private final int exp;
+  private final long exp;
   private final long def;
 
   public MutatorOperationImpl(Mutator m, String k, long b,
-                              long d, int e, OperationCallback cb) {
+                              long d, long e, OperationCallback cb) {
     super(m == Mutator.incr ? CMD_INCR : CMD_DECR, generateOpaque(), cb);
     assert d >= 0 : "Default value is below zero";
     mutator = m;
@@ -87,7 +87,7 @@ class MutatorOperationImpl extends OperationImpl implements
     return def;
   }
 
-  public int getExpiration() {
+  public long getExpiration() {
     return exp;
   }
 

--- a/src/main/java/net/spy/memcached/protocol/binary/OptimizedSetImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/binary/OptimizedSetImpl.java
@@ -99,7 +99,7 @@ public final class OptimizedSetImpl extends OperationImpl {
       bb.putLong(so.getCasValue()); // cas
       // Extras
       bb.putInt(so.getFlags());
-      bb.putInt(so.getExpiration());
+      bb.putInt((int) so.getExpiration());
       // the actual key
       bb.put(keyBytes);
       // And the value

--- a/src/main/java/net/spy/memcached/protocol/binary/StoreOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/binary/StoreOperationImpl.java
@@ -43,7 +43,7 @@ class StoreOperationImpl extends OperationImpl
   private final String key;
   private final StoreType storeType;
   private final int flags;
-  private final int exp;
+  private final long exp;
   private final long cas;
   private final byte[] data;
 
@@ -65,7 +65,7 @@ class StoreOperationImpl extends OperationImpl
     return rv;
   }
 
-  public StoreOperationImpl(StoreType t, String k, int f, int e,
+  public StoreOperationImpl(StoreType t, String k, int f, long e,
                             byte[] d, long c, OperationCallback cb) {
     super(cmdMap(t), generateOpaque(), cb);
     key = k;
@@ -107,7 +107,7 @@ class StoreOperationImpl extends OperationImpl
     return cas;
   }
 
-  public int getExpiration() {
+  public long getExpiration() {
     return exp;
   }
 

--- a/src/main/java/net/spy/memcached/v2/AsyncArcusCommands.java
+++ b/src/main/java/net/spy/memcached/v2/AsyncArcusCommands.java
@@ -132,21 +132,21 @@ public class AsyncArcusCommands<T> implements AsyncArcusCommandsIF<T> {
   }
 
   @Override
-  public ArcusFuture<Boolean> set(String key, int exp, T value) {
+  public ArcusFuture<Boolean> set(String key, long exp, T value) {
     return store(StoreType.set, key, exp, value);
   }
 
   @Override
-  public ArcusFuture<Boolean> add(String key, int exp, T value) {
+  public ArcusFuture<Boolean> add(String key, long exp, T value) {
     return store(StoreType.add, key, exp, value);
   }
 
   @Override
-  public ArcusFuture<Boolean> replace(String key, int exp, T value) {
+  public ArcusFuture<Boolean> replace(String key, long exp, T value) {
     return store(StoreType.replace, key, exp, value);
   }
 
-  private ArcusFuture<Boolean> store(StoreType type, String key, int exp, T value) {
+  private ArcusFuture<Boolean> store(StoreType type, String key, long exp, T value) {
     AbstractArcusResult<Boolean> result = new AbstractArcusResult<>(new AtomicReference<>());
     ArcusFutureImpl<Boolean> future = new ArcusFutureImpl<>(result);
     CachedData co = tc.encode(value);
@@ -187,23 +187,23 @@ public class AsyncArcusCommands<T> implements AsyncArcusCommandsIF<T> {
   }
 
   @Override
-  public ArcusFuture<Map<String, Boolean>> multiSet(Map<String, T> items, int exp) {
+  public ArcusFuture<Map<String, Boolean>> multiSet(Map<String, T> items, long exp) {
     return multiStore(StoreType.set, items, exp);
   }
 
   @Override
-  public ArcusFuture<Map<String, Boolean>> multiAdd(Map<String, T> items, int exp) {
+  public ArcusFuture<Map<String, Boolean>> multiAdd(Map<String, T> items, long exp) {
     return multiStore(StoreType.add, items, exp);
   }
 
   @Override
-  public ArcusFuture<Map<String, Boolean>> multiReplace(Map<String, T> items, int exp) {
+  public ArcusFuture<Map<String, Boolean>> multiReplace(Map<String, T> items, long exp) {
     return multiStore(StoreType.replace, items, exp);
   }
 
   private ArcusFuture<Map<String, Boolean>> multiStore(StoreType type,
                                                        Map<String, T> items,
-                                                       int exp) {
+                                                       long exp) {
     Map<String, CompletableFuture<?>> keyToFuture = new HashMap<>(items.size());
 
     items.forEach((key, value) -> {
@@ -274,7 +274,7 @@ public class AsyncArcusCommands<T> implements AsyncArcusCommandsIF<T> {
   }
 
   @Override
-  public ArcusFuture<Boolean> cas(String key, int exp, T value, long casId) {
+  public ArcusFuture<Boolean> cas(String key, long exp, T value, long casId) {
     AbstractArcusResult<Boolean> result = new AbstractArcusResult<>(new AtomicReference<>());
     ArcusFutureImpl<Boolean> future = new ArcusFutureImpl<>(result);
     CachedData co = tc.encode(value);
@@ -321,7 +321,7 @@ public class AsyncArcusCommands<T> implements AsyncArcusCommandsIF<T> {
   }
 
   @Override
-  public ArcusFuture<Long> incr(String key, int delta, long initial, int exp) {
+  public ArcusFuture<Long> incr(String key, int delta, long initial, long exp) {
     if (initial < 0) {
       throw new IllegalArgumentException("Initial value must be 0 or greater.");
     }
@@ -334,14 +334,14 @@ public class AsyncArcusCommands<T> implements AsyncArcusCommandsIF<T> {
   }
 
   @Override
-  public ArcusFuture<Long> decr(String key, int delta, long initial, int exp) {
+  public ArcusFuture<Long> decr(String key, int delta, long initial, long exp) {
     if (initial < 0) {
       throw new IllegalArgumentException("Initial value must be 0 or greater.");
     }
     return mutate(Mutator.decr, key, delta, initial, exp);
   }
 
-  private ArcusFuture<Long> mutate(Mutator mutator, String key, int delta, long initial, int exp) {
+  private ArcusFuture<Long> mutate(Mutator mutator, String key, int delta, long initial, long exp) {
     if (delta <= 0) {
       throw new IllegalArgumentException("Delta must be greater than 0.");
     }

--- a/src/main/java/net/spy/memcached/v2/AsyncArcusCommandsIF.java
+++ b/src/main/java/net/spy/memcached/v2/AsyncArcusCommandsIF.java
@@ -49,7 +49,7 @@ public interface AsyncArcusCommandsIF<T> {
    * @param value the value to store
    * @return {@code true} if stored, otherwise {@code false}
    */
-  ArcusFuture<Boolean> set(String key, int exp, T value);
+  ArcusFuture<Boolean> set(String key, long exp, T value);
 
   /**
    * Add a value for the given key if it does not exist.
@@ -59,7 +59,7 @@ public interface AsyncArcusCommandsIF<T> {
    * @param value the value to store
    * @return {@code true} if stored, otherwise {@code false}
    */
-  ArcusFuture<Boolean> add(String key, int exp, T value);
+  ArcusFuture<Boolean> add(String key, long exp, T value);
 
   /**
    * Replace a value for the given key if it exists.
@@ -69,7 +69,7 @@ public interface AsyncArcusCommandsIF<T> {
    * @param value the value to store
    * @return {@code true} if stored, otherwise {@code false}
    */
-  ArcusFuture<Boolean> replace(String key, int exp, T value);
+  ArcusFuture<Boolean> replace(String key, long exp, T value);
 
   /**
    * Sets multiple key-value pairs.
@@ -78,7 +78,7 @@ public interface AsyncArcusCommandsIF<T> {
    * @param exp   expiration time in seconds
    * @return Map of key to Boolean result
    */
-  ArcusFuture<Map<String, Boolean>> multiSet(Map<String, T> items, int exp);
+  ArcusFuture<Map<String, Boolean>> multiSet(Map<String, T> items, long exp);
 
   /**
    * Add multiple key-value pairs if they do not exist.
@@ -87,7 +87,7 @@ public interface AsyncArcusCommandsIF<T> {
    * @param exp   expiration time in seconds
    * @return Map of key to Boolean result
    */
-  ArcusFuture<Map<String, Boolean>> multiAdd(Map<String, T> items, int exp);
+  ArcusFuture<Map<String, Boolean>> multiAdd(Map<String, T> items, long exp);
 
   /**
    * Replace multiple key-value pairs if they exist.
@@ -96,7 +96,7 @@ public interface AsyncArcusCommandsIF<T> {
    * @param exp   expiration time in seconds
    * @return Map of key to Boolean result
    */
-  ArcusFuture<Map<String, Boolean>> multiReplace(Map<String, T> items, int exp);
+  ArcusFuture<Map<String, Boolean>> multiReplace(Map<String, T> items, long exp);
 
   /**
    * Prepend String or byte[] to an existing same type of value.
@@ -126,7 +126,7 @@ public interface AsyncArcusCommandsIF<T> {
    * @return {@code true} if compared and set successfully,
    * {@code false} if the key does not exist or CAS ID does not match
    */
-  ArcusFuture<Boolean> cas(String key, int exp, T value, long casId);
+  ArcusFuture<Boolean> cas(String key, long exp, T value, long casId);
 
   /**
    * Increments a numeric value stored at the given key by {@code delta}.
@@ -148,7 +148,7 @@ public interface AsyncArcusCommandsIF<T> {
    * @param exp     expiration time in seconds, applied only when a new key is created
    * @return the new value after increment, or {@code initial} if the key did not exist
    */
-  ArcusFuture<Long> incr(String key, int delta, long initial, int exp);
+  ArcusFuture<Long> incr(String key, int delta, long initial, long exp);
 
   /**
    * Decrements a numeric value stored at the given key by {@code delta}.
@@ -172,7 +172,7 @@ public interface AsyncArcusCommandsIF<T> {
    * @param exp     expiration time in seconds, applied only when a new key is created
    * @return the new value after decrement, or {@code initial} if the key did not exist
    */
-  ArcusFuture<Long> decr(String key, int delta, long initial, int exp);
+  ArcusFuture<Long> decr(String key, int delta, long initial, long exp);
 
   /**
    * Get a value for the given key.

--- a/src/test/manual/net/spy/memcached/MultibyteKeyTest.java
+++ b/src/test/manual/net/spy/memcached/MultibyteKeyTest.java
@@ -574,7 +574,7 @@ class MultibyteKeyTest {
   void CollectionCreateOperationImplTest() {
     try {
       opFact.collectionCreate(MULTIBYTE_KEY,
-              new BTreeCreate(0, 0, 10000L, CollectionOverflowAction.error, true, false),
+              new BTreeCreate(0, 0L, 10000L, CollectionOverflowAction.error, true, false),
               genericCallback).initialize();
     } catch (java.nio.BufferOverflowException e) {
       fail();

--- a/src/test/manual/net/spy/memcached/collection/attribute/UnReadableBTreeTest.java
+++ b/src/test/manual/net/spy/memcached/collection/attribute/UnReadableBTreeTest.java
@@ -73,7 +73,7 @@ class UnReadableBTreeTest extends BaseIntegrationTest {
 
       assertEquals(Long.valueOf(0), attr.getCount());
       assertEquals(Long.valueOf(4000), attr.getMaxCount());
-      assertEquals(Integer.valueOf(0), attr.getExpireTime());
+      assertEquals(Long.valueOf(0), attr.getExpireTime());
       assertFalse(attr.getReadable());
 
       // insert an item
@@ -121,7 +121,7 @@ class UnReadableBTreeTest extends BaseIntegrationTest {
 
       assertEquals(Long.valueOf(0), attr.getCount());
       assertEquals(Long.valueOf(4000), attr.getMaxCount());
-      assertEquals(Integer.valueOf(0), attr.getExpireTime());
+      assertEquals(Long.valueOf(0), attr.getExpireTime());
       assertTrue(attr.getReadable());
 
       // insert an item

--- a/src/test/manual/net/spy/memcached/collection/attribute/UnReadableExtendedBTreeTest.java
+++ b/src/test/manual/net/spy/memcached/collection/attribute/UnReadableExtendedBTreeTest.java
@@ -74,7 +74,7 @@ class UnReadableExtendedBTreeTest extends BaseIntegrationTest {
 
       assertEquals(Long.valueOf(0), attr.getCount());
       assertEquals(Long.valueOf(4000), attr.getMaxCount());
-      assertEquals(Integer.valueOf(0), attr.getExpireTime());
+      assertEquals(Long.valueOf(0), attr.getExpireTime());
       assertFalse(attr.getReadable());
 
       // insert an item
@@ -125,7 +125,7 @@ class UnReadableExtendedBTreeTest extends BaseIntegrationTest {
 
       assertEquals(Long.valueOf(0), attr.getCount());
       assertEquals(Long.valueOf(4000), attr.getMaxCount());
-      assertEquals(Integer.valueOf(0), attr.getExpireTime());
+      assertEquals(Long.valueOf(0), attr.getExpireTime());
       assertTrue(attr.getReadable());
 
       // insert an item

--- a/src/test/manual/net/spy/memcached/collection/attribute/UnReadableListTest.java
+++ b/src/test/manual/net/spy/memcached/collection/attribute/UnReadableListTest.java
@@ -71,7 +71,7 @@ class UnReadableListTest extends BaseIntegrationTest {
 
       assertEquals(Long.valueOf(0), attr.getCount());
       assertEquals(Long.valueOf(4000), attr.getMaxCount());
-      assertEquals(Integer.valueOf(0), attr.getExpireTime());
+      assertEquals(Long.valueOf(0), attr.getExpireTime());
       assertFalse(attr.getReadable());
 
       // insert an item
@@ -117,7 +117,7 @@ class UnReadableListTest extends BaseIntegrationTest {
 
       assertEquals(Long.valueOf(0), attr.getCount());
       assertEquals(Long.valueOf(4000), attr.getMaxCount());
-      assertEquals(Integer.valueOf(0), attr.getExpireTime());
+      assertEquals(Long.valueOf(0), attr.getExpireTime());
       assertTrue(attr.getReadable());
 
       // insert an item

--- a/src/test/manual/net/spy/memcached/collection/attribute/UnReadableMapTest.java
+++ b/src/test/manual/net/spy/memcached/collection/attribute/UnReadableMapTest.java
@@ -71,7 +71,7 @@ class UnReadableMapTest extends BaseIntegrationTest {
 
       assertEquals(Long.valueOf(0), attr.getCount());
       assertEquals(Long.valueOf(4000), attr.getMaxCount());
-      assertEquals(Integer.valueOf(0), attr.getExpireTime());
+      assertEquals(Long.valueOf(0), attr.getExpireTime());
       assertFalse(attr.getReadable());
 
       // insert an item
@@ -118,7 +118,7 @@ class UnReadableMapTest extends BaseIntegrationTest {
 
       assertEquals(Long.valueOf(0), attr.getCount());
       assertEquals(Long.valueOf(4000), attr.getMaxCount());
-      assertEquals(Integer.valueOf(0), attr.getExpireTime());
+      assertEquals(Long.valueOf(0), attr.getExpireTime());
       assertTrue(attr.getReadable());
 
       // insert an item

--- a/src/test/manual/net/spy/memcached/collection/attribute/UnReadableSetTest.java
+++ b/src/test/manual/net/spy/memcached/collection/attribute/UnReadableSetTest.java
@@ -71,7 +71,7 @@ class UnReadableSetTest extends BaseIntegrationTest {
 
       assertEquals(Long.valueOf(0), attr.getCount());
       assertEquals(Long.valueOf(4000), attr.getMaxCount());
-      assertEquals(Integer.valueOf(0), attr.getExpireTime());
+      assertEquals(Long.valueOf(0), attr.getExpireTime());
       assertFalse(attr.getReadable());
 
       // insert an item
@@ -118,7 +118,7 @@ class UnReadableSetTest extends BaseIntegrationTest {
 
       assertEquals(Long.valueOf(0), attr.getCount());
       assertEquals(Long.valueOf(4000), attr.getMaxCount());
-      assertEquals(Integer.valueOf(0), attr.getExpireTime());
+      assertEquals(Long.valueOf(0), attr.getExpireTime());
       assertTrue(attr.getReadable());
 
       // insert an item

--- a/src/test/manual/net/spy/memcached/collection/btree/BopOverflowActionTest.java
+++ b/src/test/manual/net/spy/memcached/collection/btree/BopOverflowActionTest.java
@@ -196,7 +196,7 @@ class BopOverflowActionTest extends BaseIntegrationTest {
 
     // smallest_trim
     assertTrue(mc.asyncSetAttr(key,
-            new CollectionAttributes(null, 1L, CollectionOverflowAction.smallest_trim)).get(1000,
+            new CollectionAttributes(30, 1L, CollectionOverflowAction.smallest_trim)).get(1000,
             TimeUnit.MILLISECONDS));
 
     // test
@@ -214,7 +214,7 @@ class BopOverflowActionTest extends BaseIntegrationTest {
 
     // largest_trim
     assertTrue(mc.asyncSetAttr(key,
-            new CollectionAttributes(null, 1L, CollectionOverflowAction.largest_trim)).get(1000,
+            new CollectionAttributes(30, 1L, CollectionOverflowAction.largest_trim)).get(1000,
             TimeUnit.MILLISECONDS));
 
     // test
@@ -233,27 +233,27 @@ class BopOverflowActionTest extends BaseIntegrationTest {
     // Set OverflowAction
     // error
     assertTrue(mc.asyncSetAttr(key,
-            new CollectionAttributes(null, null, CollectionOverflowAction.error))
+            new CollectionAttributes(30, null, CollectionOverflowAction.error))
             .get(1000, TimeUnit.MILLISECONDS));
 
     // head_trim
     assertFalse(mc.asyncSetAttr(key,
-            new CollectionAttributes(null, null, CollectionOverflowAction.head_trim)).get(1000,
+            new CollectionAttributes(30, null, CollectionOverflowAction.head_trim)).get(1000,
             TimeUnit.MILLISECONDS));
 
     // tail_trim
     assertFalse(mc.asyncSetAttr(key,
-            new CollectionAttributes(null, null, CollectionOverflowAction.tail_trim)).get(1000,
+            new CollectionAttributes(30, null, CollectionOverflowAction.tail_trim)).get(1000,
             TimeUnit.MILLISECONDS));
 
     // smallest_trim
     assertTrue(mc.asyncSetAttr(key,
-            new CollectionAttributes(null, null, CollectionOverflowAction.smallest_trim)).get(1000,
+            new CollectionAttributes(30, null, CollectionOverflowAction.smallest_trim)).get(1000,
             TimeUnit.MILLISECONDS));
 
     // largest_trim
     assertTrue(mc.asyncSetAttr(key,
-            new CollectionAttributes(null, null, CollectionOverflowAction.largest_trim)).get(1000,
+            new CollectionAttributes(30, null, CollectionOverflowAction.largest_trim)).get(1000,
             TimeUnit.MILLISECONDS));
 
     mc.asyncBopDelete(key, 0, ElementFlagFilter.DO_NOT_FILTER, false).get(

--- a/src/test/manual/net/spy/memcached/collection/btree/BopServerMessageTest.java
+++ b/src/test/manual/net/spy/memcached/collection/btree/BopServerMessageTest.java
@@ -113,7 +113,7 @@ class BopServerMessageTest extends BaseIntegrationTest {
     assertTrue(future.get(1000, TimeUnit.MILLISECONDS));
 
     assertTrue(mc.asyncSetAttr(key, new CollectionAttributes(
-        null, 1L, CollectionOverflowAction.largest_trim))
+            30, 1L, CollectionOverflowAction.largest_trim))
             .get(1000, TimeUnit.MILLISECONDS));
 
     future = mc.asyncBopInsert(key, 2, null, "bbbb", new CollectionAttributes());
@@ -131,7 +131,7 @@ class BopServerMessageTest extends BaseIntegrationTest {
     assertTrue(future.get(1000, TimeUnit.MILLISECONDS));
 
     assertTrue(mc.asyncSetAttr(key, new CollectionAttributes(
-        null, 1L, CollectionOverflowAction.error))
+        30, 1L, CollectionOverflowAction.error))
         .get(1000, TimeUnit.MILLISECONDS));
 
     future = mc.asyncBopInsert(key, 1, null, "aaa", new CollectionAttributes());

--- a/src/test/manual/net/spy/memcached/collection/list/LopInsertBoundary.java
+++ b/src/test/manual/net/spy/memcached/collection/list/LopInsertBoundary.java
@@ -88,9 +88,10 @@ class LopInsertBoundary extends BaseIntegrationTest {
 
   @Test
   void testLopInsert_PrependHeadTrim() throws Exception {
-    assertTrue(mc.asyncSetAttr(key,
-            new CollectionAttributes(null, null, CollectionOverflowAction.head_trim)).get(1000,
-            TimeUnit.MILLISECONDS));
+    CollectionAttributes attr = new CollectionAttributes();
+    attr.setOverflowAction(CollectionOverflowAction.head_trim);
+    assertTrue(mc.asyncSetAttr(key, attr)
+        .get(1000, TimeUnit.MILLISECONDS));
 
     // Insert an item to make the list full
     assertTrue(mc.asyncLopInsert(key, 9, 10L, null).get(1000,
@@ -112,8 +113,9 @@ class LopInsertBoundary extends BaseIntegrationTest {
 
   @Test
   void testLopInsert_PrependOverflowError() throws Exception {
-    assertTrue(mc.asyncSetAttr(key,
-            new CollectionAttributes(null, null, CollectionOverflowAction.error))
+    CollectionAttributes attr = new CollectionAttributes();
+    attr.setOverflowAction(CollectionOverflowAction.error);
+    assertTrue(mc.asyncSetAttr(key, attr)
             .get(1000, TimeUnit.MILLISECONDS));
 
     // Insert an item to make the list full
@@ -148,9 +150,10 @@ class LopInsertBoundary extends BaseIntegrationTest {
 
   @Test
   void testLopInsert_AppendHeadTrim() throws Exception {
-    assertTrue(mc.asyncSetAttr(key,
-            new CollectionAttributes(null, null, CollectionOverflowAction.head_trim)).get(1000,
-            TimeUnit.MILLISECONDS));
+    CollectionAttributes attr = new CollectionAttributes();
+    attr.setOverflowAction(CollectionOverflowAction.head_trim);
+    assertTrue(mc.asyncSetAttr(key, attr)
+        .get(1000, TimeUnit.MILLISECONDS));
 
     // Insert an item to make the list full
     assertTrue(mc.asyncLopInsert(key, 9, 10L, null).get(1000,
@@ -172,8 +175,9 @@ class LopInsertBoundary extends BaseIntegrationTest {
 
   @Test
   void testLopInsert_AppendOverflowError() throws Exception {
-    assertTrue(mc.asyncSetAttr(key,
-            new CollectionAttributes(null, null, CollectionOverflowAction.error))
+    CollectionAttributes attr = new CollectionAttributes();
+    attr.setOverflowAction(CollectionOverflowAction.error);
+    assertTrue(mc.asyncSetAttr(key, attr)
             .get(1000, TimeUnit.MILLISECONDS));
 
     // Insert an item to make the list full
@@ -207,9 +211,10 @@ class LopInsertBoundary extends BaseIntegrationTest {
 
   @Test
   void testLopInsert_InsertHeadTrim() throws Exception {
-    assertTrue(mc.asyncSetAttr(key,
-            new CollectionAttributes(null, null, CollectionOverflowAction.head_trim)).get(1000,
-            TimeUnit.MILLISECONDS));
+    CollectionAttributes attr = new CollectionAttributes();
+    attr.setOverflowAction(CollectionOverflowAction.head_trim);
+    assertTrue(mc.asyncSetAttr(key, attr)
+        .get(1000, TimeUnit.MILLISECONDS));
 
     // Insert an item to make the list full
     assertTrue(mc.asyncLopInsert(key, 9, 10L, null).get(1000,
@@ -230,8 +235,9 @@ class LopInsertBoundary extends BaseIntegrationTest {
 
   @Test
   void testLopInsert_InsertOverflowError() throws Exception {
-    assertTrue(mc.asyncSetAttr(key,
-            new CollectionAttributes(null, null, CollectionOverflowAction.error))
+    CollectionAttributes attr = new CollectionAttributes();
+    attr.setOverflowAction(CollectionOverflowAction.error);
+    assertTrue(mc.asyncSetAttr(key, attr)
             .get(1000, TimeUnit.MILLISECONDS));
 
     // Insert an item to make the list full
@@ -244,8 +250,9 @@ class LopInsertBoundary extends BaseIntegrationTest {
 
   @Test
   void testLopInsert_SetMaxCountUnderCurrentSize() throws Exception {
-    assertTrue(mc.asyncSetAttr(key,
-            new CollectionAttributes(null, null, CollectionOverflowAction.error))
+    CollectionAttributes attr = new CollectionAttributes();
+    attr.setOverflowAction(CollectionOverflowAction.error);
+    assertTrue(mc.asyncSetAttr(key, attr)
             .get(1000, TimeUnit.MILLISECONDS));
   }
 

--- a/src/test/manual/net/spy/memcached/collection/list/LopOverflowActionTest.java
+++ b/src/test/manual/net/spy/memcached/collection/list/LopOverflowActionTest.java
@@ -168,7 +168,7 @@ class LopOverflowActionTest extends BaseIntegrationTest {
 
     // head_trim
     assertFalse(mc.asyncSetAttr(key,
-            new CollectionAttributes(null, 1L, CollectionOverflowAction.head_trim)).get(1000,
+            new CollectionAttributes(30, 1L, CollectionOverflowAction.head_trim)).get(1000,
             TimeUnit.MILLISECONDS));
 
     // test
@@ -185,7 +185,7 @@ class LopOverflowActionTest extends BaseIntegrationTest {
 
     // tail_trim
     assertFalse(mc.asyncSetAttr(key,
-            new CollectionAttributes(null, 1L, CollectionOverflowAction.tail_trim)).get(1000,
+            new CollectionAttributes(30, 1L, CollectionOverflowAction.tail_trim)).get(1000,
             TimeUnit.MILLISECONDS));
 
     // test
@@ -202,29 +202,30 @@ class LopOverflowActionTest extends BaseIntegrationTest {
 
     // Set OverflowAction
     // error
-    assertTrue(mc.asyncSetAttr(key,
-            new CollectionAttributes(null, null, CollectionOverflowAction.error))
+    CollectionAttributes attr = new CollectionAttributes();
+    attr.setOverflowAction(CollectionOverflowAction.error);
+    assertTrue(mc.asyncSetAttr(key, attr)
             .get(1000, TimeUnit.MILLISECONDS));
 
     // head_trim
-    assertTrue(mc.asyncSetAttr(key,
-            new CollectionAttributes(null, null, CollectionOverflowAction.head_trim)).get(1000,
-            TimeUnit.MILLISECONDS));
+    attr.setOverflowAction(CollectionOverflowAction.head_trim);
+    assertTrue(mc.asyncSetAttr(key, attr)
+        .get(1000, TimeUnit.MILLISECONDS));
 
     // tail_trim
-    assertTrue(mc.asyncSetAttr(key,
-            new CollectionAttributes(null, null, CollectionOverflowAction.tail_trim)).get(1000,
-            TimeUnit.MILLISECONDS));
+    attr.setOverflowAction(CollectionOverflowAction.tail_trim);
+    assertTrue(mc.asyncSetAttr(key, attr)
+        .get(1000, TimeUnit.MILLISECONDS));
 
     // smallest_trim
-    assertFalse(mc.asyncSetAttr(key,
-            new CollectionAttributes(null, null, CollectionOverflowAction.smallest_trim)).get(1000,
-            TimeUnit.MILLISECONDS));
+    attr.setOverflowAction(CollectionOverflowAction.smallest_trim);
+    assertFalse(mc.asyncSetAttr(key, attr)
+        .get(1000, TimeUnit.MILLISECONDS));
 
     // largest_trim
-    assertFalse(mc.asyncSetAttr(key,
-            new CollectionAttributes(null, null, CollectionOverflowAction.largest_trim)).get(1000,
-            TimeUnit.MILLISECONDS));
+    attr.setOverflowAction(CollectionOverflowAction.largest_trim);
+    assertFalse(mc.asyncSetAttr(key, attr)
+        .get(1000, TimeUnit.MILLISECONDS));
 
     mc.asyncLopDelete(key, 0, true).get(1000, TimeUnit.MILLISECONDS);
   }

--- a/src/test/manual/net/spy/memcached/collection/list/LopServerMessageTest.java
+++ b/src/test/manual/net/spy/memcached/collection/list/LopServerMessageTest.java
@@ -94,7 +94,7 @@ class LopServerMessageTest extends BaseIntegrationTest {
     assertTrue(future.get(1000, TimeUnit.MILLISECONDS));
 
     assertTrue(mc.asyncSetAttr(key,
-            new CollectionAttributes(null, 1L, CollectionOverflowAction.error))
+            new CollectionAttributes(30, 1L, CollectionOverflowAction.error))
             .get(1000, TimeUnit.MILLISECONDS));
 
     future = mc.asyncLopInsert(key, 1, 1, new CollectionAttributes());
@@ -111,7 +111,7 @@ class LopServerMessageTest extends BaseIntegrationTest {
     assertTrue(future.get(1000, TimeUnit.MILLISECONDS));
 
     assertTrue(mc.asyncSetAttr(key,
-            new CollectionAttributes(null, 2L, CollectionOverflowAction.error))
+            new CollectionAttributes(30, 2L, CollectionOverflowAction.error))
             .get(1000, TimeUnit.MILLISECONDS));
 
     future = mc.asyncLopInsert(key, 0, 1, new CollectionAttributes());

--- a/src/test/manual/net/spy/memcached/collection/map/MopOverflowActionTest.java
+++ b/src/test/manual/net/spy/memcached/collection/map/MopOverflowActionTest.java
@@ -110,29 +110,30 @@ class MopOverflowActionTest extends BaseIntegrationTest {
 
     // Set OverflowAction
     // error
-    assertTrue(mc.asyncSetAttr(key,
-            new CollectionAttributes(null, null, CollectionOverflowAction.error))
+    CollectionAttributes attr = new CollectionAttributes();
+    attr.setOverflowAction(CollectionOverflowAction.error);
+    assertTrue(mc.asyncSetAttr(key, attr)
             .get(1000, TimeUnit.MILLISECONDS));
 
     // head_trim
-    assertFalse(mc.asyncSetAttr(key,
-            new CollectionAttributes(null, null, CollectionOverflowAction.head_trim)).get(1000,
-            TimeUnit.MILLISECONDS));
+    attr.setOverflowAction(CollectionOverflowAction.head_trim);
+    assertFalse(mc.asyncSetAttr(key, attr)
+        .get(1000, TimeUnit.MILLISECONDS));
 
     // tail_trim
-    assertFalse(mc.asyncSetAttr(key,
-            new CollectionAttributes(null, null, CollectionOverflowAction.tail_trim)).get(1000,
-            TimeUnit.MILLISECONDS));
+    attr.setOverflowAction(CollectionOverflowAction.tail_trim);
+    assertFalse(mc.asyncSetAttr(key, attr)
+        .get(1000, TimeUnit.MILLISECONDS));
 
     // smallest_trim
-    assertFalse(mc.asyncSetAttr(key,
-            new CollectionAttributes(null, null, CollectionOverflowAction.smallest_trim)).get(1000,
-            TimeUnit.MILLISECONDS));
+    attr.setOverflowAction(CollectionOverflowAction.smallest_trim);
+    assertFalse(mc.asyncSetAttr(key, attr)
+        .get(1000, TimeUnit.MILLISECONDS));
 
     // largest_trim
-    assertFalse(mc.asyncSetAttr(key,
-            new CollectionAttributes(null, null, CollectionOverflowAction.largest_trim)).get(1000,
-            TimeUnit.MILLISECONDS));
+    attr.setOverflowAction(CollectionOverflowAction.largest_trim);
+    assertFalse(mc.asyncSetAttr(key, attr)
+        .get(1000, TimeUnit.MILLISECONDS));
 
     mc.asyncMopDelete(key, true).get(1000, TimeUnit.MILLISECONDS);
   }

--- a/src/test/manual/net/spy/memcached/collection/map/MopServerMessageTest.java
+++ b/src/test/manual/net/spy/memcached/collection/map/MopServerMessageTest.java
@@ -87,7 +87,7 @@ class MopServerMessageTest extends BaseIntegrationTest {
     future = mc.asyncMopInsert(key, "0", 0, new CollectionAttributes());
     assertTrue(future.get(1000, TimeUnit.MILLISECONDS));
 
-    future = mc.asyncSetAttr(key, new CollectionAttributes(null, 2L,
+    future = mc.asyncSetAttr(key, new CollectionAttributes(30, 2L,
                                                            CollectionOverflowAction.error));
     assertTrue(future.get(1000, TimeUnit.MILLISECONDS));
 

--- a/src/test/manual/net/spy/memcached/collection/set/SopOverflowActionTest.java
+++ b/src/test/manual/net/spy/memcached/collection/set/SopOverflowActionTest.java
@@ -87,29 +87,30 @@ class SopOverflowActionTest extends BaseIntegrationTest {
 
     // Set OverflowAction
     // error
-    assertTrue(mc.asyncSetAttr(key,
-            new CollectionAttributes(null, null, CollectionOverflowAction.error))
+    CollectionAttributes attr = new CollectionAttributes();
+    attr.setOverflowAction(CollectionOverflowAction.error);
+    assertTrue(mc.asyncSetAttr(key, attr)
             .get(1000, TimeUnit.MILLISECONDS));
 
     // head_trim
-    assertFalse(mc.asyncSetAttr(key,
-            new CollectionAttributes(null, null, CollectionOverflowAction.head_trim)).get(1000,
-            TimeUnit.MILLISECONDS));
+    attr.setOverflowAction(CollectionOverflowAction.head_trim);
+    assertFalse(mc.asyncSetAttr(key, attr)
+        .get(1000, TimeUnit.MILLISECONDS));
 
     // tail_trim
-    assertFalse(mc.asyncSetAttr(key,
-            new CollectionAttributes(null, null, CollectionOverflowAction.tail_trim)).get(1000,
-            TimeUnit.MILLISECONDS));
+    attr.setOverflowAction(CollectionOverflowAction.tail_trim);
+    assertFalse(mc.asyncSetAttr(key, attr)
+        .get(1000, TimeUnit.MILLISECONDS));
 
     // smallest_trim
-    assertFalse(mc.asyncSetAttr(key,
-            new CollectionAttributes(null, null, CollectionOverflowAction.smallest_trim)).get(1000,
+    attr.setOverflowAction(CollectionOverflowAction.smallest_trim);
+    assertFalse(mc.asyncSetAttr(key, attr).get(1000,
             TimeUnit.MILLISECONDS));
 
     // largest_trim
-    assertFalse(mc.asyncSetAttr(key,
-            new CollectionAttributes(null, null, CollectionOverflowAction.largest_trim)).get(1000,
-            TimeUnit.MILLISECONDS));
+    attr.setOverflowAction(CollectionOverflowAction.largest_trim);
+    assertFalse(mc.asyncSetAttr(key, attr)
+        .get(1000, TimeUnit.MILLISECONDS));
 
     mc.asyncSopDelete(key, "item0", false).get(1000, TimeUnit.MILLISECONDS);
   }

--- a/src/test/manual/net/spy/memcached/collection/set/SopServerMessageTest.java
+++ b/src/test/manual/net/spy/memcached/collection/set/SopServerMessageTest.java
@@ -85,7 +85,7 @@ class SopServerMessageTest extends BaseIntegrationTest {
     assertTrue(future.get(1000, TimeUnit.MILLISECONDS));
 
     assertTrue(mc.asyncSetAttr(
-        key, new CollectionAttributes(null, 1L, CollectionOverflowAction.error))
+        key, new CollectionAttributes(30, 1L, CollectionOverflowAction.error))
         .get(1000, TimeUnit.MILLISECONDS));
 
     future = mc.asyncSopInsert(key, "bbbb", new CollectionAttributes());

--- a/src/test/manual/net/spy/memcached/emptycollection/CreateEmptyBTreeTest.java
+++ b/src/test/manual/net/spy/memcached/emptycollection/CreateEmptyBTreeTest.java
@@ -63,7 +63,7 @@ class CreateEmptyBTreeTest extends BaseIntegrationTest {
 
       assertEquals(Long.valueOf(0), attr.getCount());
       assertEquals(Long.valueOf(4000), attr.getMaxCount());
-      assertEquals(Integer.valueOf(0), attr.getExpireTime());
+      assertEquals(Long.valueOf(0), attr.getExpireTime());
     } catch (Exception e) {
       e.printStackTrace();
       fail(e.getMessage());

--- a/src/test/manual/net/spy/memcached/emptycollection/CreateEmptyListTest.java
+++ b/src/test/manual/net/spy/memcached/emptycollection/CreateEmptyListTest.java
@@ -64,7 +64,7 @@ class CreateEmptyListTest extends BaseIntegrationTest {
 
       assertEquals(Long.valueOf(0), attr.getCount());
       assertEquals(Long.valueOf(4000), attr.getMaxCount());
-      assertEquals(Integer.valueOf(0), attr.getExpireTime());
+      assertEquals(Long.valueOf(0), attr.getExpireTime());
     } catch (Exception e) {
       e.printStackTrace();
       fail(e.getMessage());

--- a/src/test/manual/net/spy/memcached/emptycollection/CreateEmptyMapTest.java
+++ b/src/test/manual/net/spy/memcached/emptycollection/CreateEmptyMapTest.java
@@ -63,7 +63,7 @@ class CreateEmptyMapTest extends BaseIntegrationTest {
 
       assertEquals(Long.valueOf(0), attr.getCount());
       assertEquals(Long.valueOf(4000), attr.getMaxCount());
-      assertEquals(Integer.valueOf(0), attr.getExpireTime());
+      assertEquals(Long.valueOf(0), attr.getExpireTime());
     } catch (Exception e) {
       e.printStackTrace();
       fail(e.getMessage());

--- a/src/test/manual/net/spy/memcached/emptycollection/CreateEmptySetTest.java
+++ b/src/test/manual/net/spy/memcached/emptycollection/CreateEmptySetTest.java
@@ -64,7 +64,7 @@ class CreateEmptySetTest extends BaseIntegrationTest {
 
       assertEquals(Long.valueOf(0), attr.getCount());
       assertEquals(Long.valueOf(4000), attr.getMaxCount());
-      assertEquals(Integer.valueOf(0), attr.getExpireTime());
+      assertEquals(Long.valueOf(0), attr.getExpireTime());
     } catch (Exception e) {
       e.printStackTrace();
       fail(e.getMessage());


### PR DESCRIPTION
### 🔗 Related Issue

<!-- Please link related issue. ex) https://github.com/naver/arcus-java-client/issues/{issue_number} -->
- https://github.com/jam2in/arcus-works/issues/458

### ⌨️ What I did

<!-- Please describe this PR and what you've been working on. -->

- expiration time 파라미터 타입을 `int` &rarr; `long` 으로 변경합니다.
- 사용자가 직접 사용하는 public API는 primitive type (`long`)을 사용하여 기존 `int` 리터럴이 자동으로 변환됩니다.


#### 수정 파일

**v2 API**

- `v2/AsyncArcusCommandsIF.java`
  - `exp` 파라미터 `int` → `long`
- `v2/AsyncArcusCommands.java`
  - 인터페이스 변경에 맞춰 구현 갱신

**public API**

- `collection/Attributes.java`
  - 내부 필드 `Integer` → `Long`
  - `setExpireTime(Integer)` → `setExpireTime(long)`
  - `getExpireTime()` 반환 타입 `Integer` → `Long`
- `collection/CollectionAttributes.java`
  - 생성자 파라미터 `Integer expireTime` → `long expireTime`

**내부**

- `collection/CollectionCreate.java`
  - 생성자 파라미터 `Integer expTime` → `Long expTime`
- `collection/{List,Set,Map,BTree}Create.java`
  - 생성자 파라미터 `Integer expTime` → `Long expTime`
- `OperationFactory.java`, `ops/{Store,CAS,Mutator,Touch}Operation.java`
  - `exp` 파라미터 `int` → `long`
- `protocol/ascii/AsciiOperationFactory.java` 및 관련 impl
  - `exp` 파라미터 `int` → `long`
- `protocol/binary/BinaryOperationFactory.java` 및 관련 impl
  - `exp` 파라미터 `int` → `long`
  - binary write 시 `(int)` 캐스트로 4바이트 유지