### PR TITLE
FIX: Add null/empty string behavior for the flush prefix argument

### DIFF
--- a/src/main/java/net/spy/memcached/ArcusClient.java
+++ b/src/main/java/net/spy/memcached/ArcusClient.java
@@ -1784,6 +1784,10 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
 
   @Override
   public OperationFuture<Boolean> flush(final String prefix, final int delay) {
+    if (prefix == null) {
+      throw new IllegalArgumentException("Prefix should not be null");
+    }
+
     Collection<MemcachedNode> nodes = getFlushNodes();
 
     final BroadcastFuture<Boolean> rv
@@ -1806,7 +1810,7 @@ public class ArcusClient extends FrontCacheMemcachedClient implements ArcusClien
 
     checkState();
     for (MemcachedNode node : nodes) {
-      Operation op = opFact.flush(prefix, delay, false, cb);
+      Operation op = opFact.flush(prefix.isEmpty() ? "<null>" : prefix, delay, false, cb);
       opsMap.put(node, op);
     }
     rv.addOperations(opsMap.values());


### PR DESCRIPTION
### 🔗 Related Issue

<!-- Please link related issue. ex) https://github.com/naver/arcus-java-client/issues/{issue_number} -->
- jam2in/arcus-works#854

### ⌨️ What I did

<!-- Please describe this PR and what you've been working on. -->
- prefix가 null인 경우, exception 발생시킵니다.
- prefix가 ""(빈문자열)인 경우, 내부적으로 "\<null\>"로 변경합니다.