### PR TITLE
FIX: Prevent NoSuchMethodError in TouchOperationImpl

### DIFF
--- a/src/main/java/net/spy/memcached/protocol/ascii/TouchOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/TouchOperationImpl.java
@@ -25,6 +25,7 @@ import net.spy.memcached.ops.OperationStatus;
 import net.spy.memcached.ops.StatusCode;
 import net.spy.memcached.ops.TouchOperation;
 
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.util.Collection;
 import java.util.Collections;
@@ -78,7 +79,7 @@ final class TouchOperationImpl extends OperationImpl implements TouchOperation {
     ByteBuffer bb = ByteBuffer.allocate(KeyUtil.getKeyBytes(key).length
             + String.valueOf(exp).length() + OVERHEAD);
     setArguments(bb, "touch", key, String.valueOf(exp));
-    bb.flip();
+    ((Buffer) bb).flip();
     setBuffer(bb);
   }
 


### PR DESCRIPTION
### 🔗 Related Issue

<!-- Please link related issue. ex) https://github.com/naver/arcus-java-client/issues/{issue_number} -->
- https://github.com/naver/arcus-java-client/issues/340

### ⌨️ What I did

<!-- Please describe this PR and what you've been working on. -->
- Touch 명령에서 문제가 발생하지 않도록 수정합니다.