### PR TITLE
version 1.16.2

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,34 @@
+# 2026-08-04 [version 1.16.2]
+## 🐣 New Features
+- Add beta version of CompletableFuture(v2) APIs
+- Add pluggable compression codec support with Snappy algorithm
+- Remove deprecated SMGetMode class
+
+## ⚙️ Internal Changes
+- Add isForceSerializeForCollection method to Transcoder
+- Do not skip decompress even if collection transcoder
+- Reuse callback instance for repeated Op creation
+- Unify BKey, EFlag naming
+- Unify OperationCallback patterns
+- Replace assert statements with proper exception handling
+- Align code style settings with checkstyle rules
+- Updated the devtools/maketags.sh
+- Separate CollectionAttributes into CreateAttributes, SetAttributes, ItemAttributes, UpdateAttributes to support long type exptime in v2 apis
+
+## 🐛 Bug Fixes
+- Remove Concurrency problem in locator allNodes
+- Add null/empty string behavior for the flush prefix argument
+- Prevent NoSuchMethodError in TouchOperationImpl
+
+## 📝 Documentation
+- Update JDK requirements in README
+- Update ConnectionFactoryBuilder docs
+- Use correct limit validation for compValue
+
+## ⬆️ Dependency Upgrades
+- Update log4j-core version to 2.25.4
+- Update jackson-databind version to 2.22.0
+
 # 2026-04-29 [version 1.16.1]
 ## 🐛 Bug Fixes
   - Use ScramSaslClientFactory only in SASL Authentication

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ To use it, add the following dependency to your pom.xml.
 ```xml
 <dependencies>
     <dependency>
-        <groupId>com.navercorp.arcus</groupId>
+        <groupId>com.jam2in.arcus</groupId>
         <artifactId>arcus-java-client</artifactId>
         <version>1.16.1</version>
     </dependency>

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ To use it, add the following dependency to your pom.xml.
     <dependency>
         <groupId>com.jam2in.arcus</groupId>
         <artifactId>arcus-java-client</artifactId>
-        <version>1.16.1</version>
+        <version>1.16.2</version>
     </dependency>
 </dependencies>
 ```

--- a/docs/arcus-java-client-getting-started.md
+++ b/docs/arcus-java-client-getting-started.md
@@ -36,7 +36,7 @@ ARCUS는 오픈소스 memcached를 기반으로 데이터 분산과 fault-tolera
 우선 다음과 같이 비어 있는 자바 프로젝트를 생성합니다.
 
 ```bash
-$ mvn archetype:generate -DgroupId=com.navercorp.arcus -DartifactId=arcus-quick-start -DinteractiveMode=false
+$ mvn archetype:generate -DgroupId=com.jam2in.arcus -DartifactId=arcus-quick-start -DinteractiveMode=false
 $ cd arcus-quick-start
 $ mvn eclipse:eclipse // 이클립스 IDE를 사용하는 경우 실행하여 이클립스 프로젝트를 생성하여 활용합니다.
 ```
@@ -50,7 +50,7 @@ $ mvn eclipse:eclipse // 이클립스 IDE를 사용하는 경우 실행하여 �
     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>com.navercorp.arcus</groupId>
+    <groupId>com.jam2in.arcus</groupId>
     <artifactId>arcus-quick-start</artifactId>
     <version>1.0-SNAPSHOT</version>
     <packaging>jar</packaging>
@@ -78,9 +78,9 @@ $ mvn eclipse:eclipse // 이클립스 IDE를 사용하는 경우 실행하여 �
 
         <!-- ARCUS 클라이언트 의존성을 추가합니다. -->
         <dependency>
-            <groupId>com.navercorp.arcus</groupId>
+            <groupId>com.jam2in.arcus</groupId>
             <artifactId>arcus-java-client</artifactId>
-            <version>1.16.1</version>
+            <version>1.16.2</version>
         </dependency>
         
         <!-- 로거 의존성을 추가합니다. -->
@@ -112,7 +112,7 @@ $ mvn eclipse:eclipse // 이클립스 IDE를 사용하는 경우 실행하여 �
 
 ```java
 // HelloArcusTest.java
-package com.navercorp.arcus;
+package com.jam2in.arcus;
 
 import org.junit.jupiter.api.BeforeEach;
 
@@ -137,7 +137,7 @@ public class HelloArcusTest {
 
 ```java
 // HelloArcus.java
-package com.navercorp.arcus;
+package com.jam2in.arcus;
 
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;

--- a/docs/user-guide/02-arcus-java-client.md
+++ b/docs/user-guide/02-arcus-java-client.md
@@ -12,7 +12,7 @@
 아래 예제는 ARCUS cache에 key가 “sample:testKey”이고 value가 “testValue”인 cache item을 저장한다.
 
 ```java
-package com.navercorp.arcus.example; 
+package com.jam2in.arcus.example; 
 
 import java.util.concurrent.ExecutionException; 
 import java.util.concurrent.Future; 
@@ -367,7 +367,7 @@ log4j, logback과 같은 대표적인 자바의 로그 라이브러리들은 slf
 ```xml
 <!-- slf4j + log4j 사용시 -->
 <dependency>
-    <groupId>com.navercorp.arcus</groupId>
+    <groupId>com.jam2in.arcus</groupId>
     <artifactId>arcus-java-client</artifactId>
     <version>${arcus-java-client.version}</version>
 </dependency>
@@ -391,7 +391,7 @@ log4j, logback과 같은 대표적인 자바의 로그 라이브러리들은 slf
 ```xml
 <!-- slf4j + logback 사용시 -->
 <dependency>
-    <groupId>com.navercorp.arcus</groupId>
+    <groupId>com.jam2in.arcus</groupId>
     <artifactId>arcus-java-client</artifactId>
     <version>${arcus-java-client.version}</version>
 </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.jam2in.arcus</groupId>
     <artifactId>arcus-java-client</artifactId>
-    <version>1.16.1</version>
+    <version>1.16.2</version>
     <name>Arcus Java Client</name>
     <description>Java client for Arcus memcached</description>
     <packaging>jar</packaging>

--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    <groupId>com.navercorp.arcus</groupId>
+    <groupId>com.jam2in.arcus</groupId>
     <artifactId>arcus-java-client</artifactId>
     <version>1.16.1</version>
     <name>Arcus Java Client</name>


### PR DESCRIPTION
### 🔗 Related Issue

<!-- Please link related issue. ex) https://github.com/naver/arcus-java-client/issues/{issue_number} -->
- 릴리즈를 위한 버전 커밋입니다.

### ⌨️ What I did

<!-- Please describe this PR and what you've been working on. -->
- `com.navercorp.arcus` maven 저장소에 새로운 버전이 최신화되는 속도가 느려서, 기본적으로 `com.jam2in.arcus` groupId를 사용하도록 수정했습니다.